### PR TITLE
chore: add CI, CodeQL, Dependabot, auto-merge, MCP config and Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,109 @@
+# Copilot instructions for SbeB3Exchange
+
+Stateful B3 exchange simulator. Inbound: B3 EntryPoint SBE over TCP. Outbound:
+B3 UMDF wire format over UDP multicast, plus SBE ExecutionReports back to the
+TCP client. Companion to the external `SbeB3UmdfConsumer` repo.
+
+## Toolchain
+
+- .NET SDK pinned in `global.json` (`10.0.201`, `rollForward: latestFeature`).
+  Target framework is `net10.0` (set in `Directory.Build.props`).
+- `Nullable`, `ImplicitUsings`, and **`TreatWarningsAsErrors=true`** are on
+  globally — a new warning fails the build.
+- xUnit (`xunit` v2) is the test framework. The `Xunit` namespace is added via
+  `<Using Include="Xunit" />` in each test csproj, so test files do not need
+  `using Xunit;`.
+
+## Build / test / run
+
+```bash
+dotnet build SbeB3Exchange.slnx
+dotnet test  SbeB3Exchange.slnx
+dotnet run --project src/B3.Exchange.Host -- config/exchange-simulator.json
+```
+
+Run a single test project / class / method:
+
+```bash
+dotnet test tests/B3.Exchange.Matching.Tests
+dotnet test tests/B3.Exchange.Matching.Tests --filter "FullyQualifiedName~MatchingTests"
+dotnet test tests/B3.Exchange.Matching.Tests --filter "FullyQualifiedName~MatchingTests.SomeMethodName"
+```
+
+Docker:
+
+```bash
+docker build -t sbeb3exchange:latest .
+docker run --rm --network host -v $(pwd)/config:/app/config sbeb3exchange:latest
+```
+
+The host needs host networking for the multicast publish socket and the
+EntryPoint TCP listener (default `0.0.0.0:9876`).
+
+## Architecture (big picture)
+
+```
+TCP client ─► EntryPointSession ─► HostRouter ─► ChannelDispatcher ─► MatchingEngine
+                                    (by SecurityId)        │
+                                                           ├─► UMDF MBO/Trade frames ─► UDP multicast
+                                                           └─► ExecutionReports ──────► back to TCP client
+```
+
+Layered projects under `src/` (build order roughly bottom-up):
+
+1. `B3.EntryPoint.Sbe` / `B3.Umdf.Sbe` — generated SBE bindings from
+   `schemas/b3-entrypoint-messages-8.4.2.xml` and
+   `schemas/b3-market-data-messages-2.2.0.xml`. Vendored copies; keep in sync
+   with `SbeB3UmdfConsumer` when upgrading.
+2. `B3.Umdf.WireEncoder` — stateless byte-level encoders for UMDF MBO / Trade /
+   Snapshot frames (V16 schema).
+3. `B3.Exchange.Instruments` — JSON instrument loader.
+4. `B3.Exchange.Matching` — single-thread per-symbol limit order book.
+   `MatchingEngine` owns one `LimitOrderBook` per `SecurityId`, monotonic
+   order/trade-id allocators, and an `RptSeq` incremented on every emitted
+   event. **Not thread-safe by design.**
+5. `B3.Exchange.EntryPoint` — TCP listener, framed SBE inbound decoder,
+   ExecutionReport encoder. Each TCP session implements
+   `IEntryPointResponseChannel`.
+6. `B3.Exchange.Integration` — `ChannelDispatcher`: bounded inbound queue +
+   single dispatch thread per channel. Pumps decoded commands into the engine,
+   buffers emitted UMDF events for the duration of one command, then flushes
+   them as a single packet (≤1400 bytes, `PacketHeader` + N inc messages) to
+   `IUmdfPacketSink`.
+7. `B3.Exchange.Host` — JSON-configured single-binary host wiring the
+   EntryPoint listener + dispatchers + `MulticastUdpPacketSink`s.
+
+## Key conventions / gotchas
+
+- **Single-threaded engine, per channel.** `MatchingEngine` and the
+  `IMatchingEventSink` callbacks always run on the `ChannelDispatcher`'s
+  dedicated dispatch thread. Never call into the engine from another thread;
+  enqueue a command instead.
+- **Channel = `SecurityId` partition.** `HostRouter` routes commands to a
+  dispatcher by the order's `SecurityId`. One matching engine and one outbound
+  multicast group per UMDF channel.
+- **`orderId → reply-channel` map.** `ChannelDispatcher` keeps an
+  `OrderOwnership` map so PASSIVE-side execution reports (a resting order
+  filled by another session's aggressor) route back to the originating TCP
+  session.
+- **One UMDF packet per command.** Events emitted while processing a single
+  command are packed into one UMDF packet with a monotonic `SequenceNumber`,
+  not flushed individually.
+- **Prices are implicit /10000 mantissas** on the wire (see the worked example
+  in `docs/EXCHANGE-SIMULATOR.md`).
+- **EntryPoint v1 limitation:** `Cancel` and `Modify` require an explicit
+  `OrderID`; `OrigClOrdID`-only lookup is not implemented.
+- **Single-tenant:** every TCP session shares `tcp.enteringFirm` from config;
+  per-session firm assignment is not implemented.
+- **Schemas are vendored.** Do not hand-edit files under `schemas/`; regenerate
+  the SBE bindings in `B3.*.Sbe` when upgrading and mirror the change in
+  `SbeB3UmdfConsumer`.
+
+## Configuration
+
+`config/exchange-simulator.json` — `tcp.listen`, `tcp.enteringFirm`, and a
+`channels[]` array. Each channel entry binds a UMDF channel number to a
+multicast group/port/TTL and an instrument list (re-uses the format consumed
+by `B3.Exchange.Instruments.InstrumentLoader`). See
+`docs/EXCHANGE-SIMULATOR.md` for the full schema and a Python sample that
+sends a `SimpleNewOrderV2` over `nc`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      xunit:
+        patterns:
+          - "xunit*"
+      microsoft-test:
+        patterns:
+          - "Microsoft.NET.Test.*"
+          - "coverlet.*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,41 @@
+name: Auto-merge
+
+# Enables PR auto-merge for trusted automated PRs (Dependabot, Copilot)
+# once required status checks pass. Branch protection on `main` should
+# require the CI checks before merge — auto-merge will then complete the
+# merge automatically when they go green.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize, labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable-automerge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.draft == false &&
+      (
+        github.event.pull_request.user.login == 'dependabot[bot]' ||
+        github.event.pull_request.user.login == 'github-actions[bot]' ||
+        github.event.pull_request.user.login == 'Copilot' ||
+        contains(github.event.pull_request.labels.*.name, 'automerge')
+      )
+
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Approve Dependabot patch/minor updates
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore SbeB3Exchange.slnx
+
+      - name: Build (Release, warnings-as-errors)
+        run: dotnet build SbeB3Exchange.slnx --no-restore -c Release
+
+      - name: Test
+        run: >
+          dotnet test SbeB3Exchange.slnx
+          --no-build -c Release
+          --logger "trx;LogFileName=test-results.trx"
+          --logger "console;verbosity=normal"
+          --collect:"XPlat Code Coverage"
+          --results-directory ./TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults/**/*
+          if-no-files-found: ignore
+          retention-days: 14
+
+  format:
+    name: Format check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Restore (needed by dotnet format)
+        run: dotnet restore SbeB3Exchange.slnx
+
+      - name: dotnet format --verify-no-changes
+        run: dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+
+      - name: Build (Release)
+        run: |
+          dotnet restore SbeB3Exchange.slnx
+          dotnet build SbeB3Exchange.slnx --no-restore -c Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,42 @@
+name: "Copilot Setup Steps"
+
+# Re-run automatically when this file changes so we can validate it,
+# and allow manual runs from the Actions tab.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Show .NET info
+        run: dotnet --info
+
+      - name: Restore solution
+        run: dotnet restore SbeB3Exchange.slnx
+
+      - name: Build solution (warm caches, surface errors early)
+        run: dotnet build SbeB3Exchange.slnx --no-restore -c Debug
+
+      - name: Run tests (smoke)
+        run: dotnet test SbeB3Exchange.slnx --no-build -c Debug --nologo

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,8 @@ project.fragment.lock.json
 *.swp
 *.swo
 *~
-.vscode/
+.vscode/*
+!.vscode/mcp.json
 
 ## OS
 .DS_Store

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,18 @@
+{
+  "servers": {
+    "github": {
+      "type": "copilot",
+      "description": "GitHub MCP — repos, issues, PRs, Actions, code search (companion repo SbeB3UmdfConsumer)"
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/home/pedrotravi/SbeB3Exchange"
+      ],
+      "type": "stdio",
+      "description": "Filesystem MCP — structured access to schemas/, config/, src/, tests/"
+    }
+  }
+}


### PR DESCRIPTION
Configures the repo to reflect the SbeB3Exchange solution:

- **Copilot guidance**: `.github/copilot-instructions.md` (architecture, conventions, build/test commands).
- **Cloud agent env**: `.github/workflows/copilot-setup-steps.yml` pre-warms the agent with the SDK pinned by `global.json` + restore/build/test.
- **CI**: `.github/workflows/ci.yml` runs Release build (warnings-as-errors) and `dotnet test` with TRX + coverage artifacts and NuGet cache. Non-blocking `dotnet format --verify-no-changes` job.
- **CodeQL**: weekly + per-PR analysis for C#.
- **Auto-merge**: `.github/workflows/automerge.yml` enables `gh pr merge --auto --squash` for Dependabot/Copilot/`automerge`-labelled PRs once required checks pass; auto-approves Dependabot PRs.
- **Dependabot**: weekly NuGet (grouped xunit + Microsoft.NET.Test.* / coverlet), GitHub Actions, and Docker updates.
- **MCP**: `.vscode/mcp.json` registers GitHub MCP (built-in) and a filesystem MCP rooted at this repo.
- **.gitignore**: tracks `.vscode/mcp.json` while keeping the rest of `.vscode/` ignored.

Repo-level settings already applied via `gh`: auto-merge enabled, squash-only, delete branch on merge, Actions can approve PRs, branch protection on `main` requires the `Build & Test` check + linear history + conversation resolution.