### PR TITLE
ci: enforce dotnet format and document pre-PR checklist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,22 @@ dotnet test tests/B3.Exchange.Matching.Tests --filter "FullyQualifiedName~Matchi
 dotnet test tests/B3.Exchange.Matching.Tests --filter "FullyQualifiedName~MatchingTests.SomeMethodName"
 ```
 
+### Pre-PR checklist (mirrors required CI checks)
+
+CI on `main` requires `Build & Test` and `Format check` to pass before
+auto-merge will complete. Run these locally before opening a PR — they are
+the same commands CI runs and they are fast:
+
+```bash
+dotnet restore SbeB3Exchange.slnx
+dotnet build   SbeB3Exchange.slnx --no-restore -c Release          # warnings-as-errors
+dotnet test    SbeB3Exchange.slnx --no-build   -c Release
+dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
+```
+
+If `dotnet format` reports diffs, run it without `--verify-no-changes` to
+apply the fixes, then re-run the verification.
+
 Docker:
 
 ```bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,6 @@ jobs:
     name: Format check
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
 
     steps:
       - name: Checkout

--- a/src/B3.Exchange.Instruments/InstrumentLoader.cs
+++ b/src/B3.Exchange.Instruments/InstrumentLoader.cs
@@ -145,14 +145,14 @@ public static class InstrumentLoader
                 case JsonTokenType.Number:
                     return reader.GetDecimal();
                 case JsonTokenType.String:
-                {
-                    var s = reader.GetString();
-                    if (string.IsNullOrWhiteSpace(s)) return null;
-                    if (decimal.TryParse(s, System.Globalization.NumberStyles.Number,
-                            System.Globalization.CultureInfo.InvariantCulture, out var d))
-                        return d;
-                    throw new JsonException($"Invalid decimal: '{s}'");
-                }
+                    {
+                        var s = reader.GetString();
+                        if (string.IsNullOrWhiteSpace(s)) return null;
+                        if (decimal.TryParse(s, System.Globalization.NumberStyles.Number,
+                                System.Globalization.CultureInfo.InvariantCulture, out var d))
+                            return d;
+                        throw new JsonException($"Invalid decimal: '{s}'");
+                    }
                 default:
                     throw new JsonException($"Expected number or string for decimal, got {reader.TokenType}");
             }

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -46,8 +46,15 @@ public class HostRouterTests
     {
         var inst = new Instrument
         {
-            Symbol = "TEST", SecurityId = 42, TickSize = 0.01m, LotSize = 1,
-            MinPrice = 0.01m, MaxPrice = 1000m, Currency = "BRL", Isin = "X", SecurityType = "CS"
+            Symbol = "TEST",
+            SecurityId = 42,
+            TickSize = 0.01m,
+            LotSize = 1,
+            MinPrice = 0.01m,
+            MaxPrice = 1000m,
+            Currency = "BRL",
+            Isin = "X",
+            SecurityType = "CS"
         };
         var pkt = new NoopPacketSink();
         var disp = new ChannelDispatcher(channelNumber: 1,

--- a/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
@@ -13,9 +13,15 @@ public class ChannelDispatcherTests
 
     private static Instrument Petr4 => new()
     {
-        Symbol = "PETR4", SecurityId = Petr, TickSize = 0.01m, LotSize = 100,
-        MinPrice = 0.01m, MaxPrice = 1_000m, Currency = "BRL",
-        Isin = "BRPETRACNPR6", SecurityType = "EQUITY",
+        Symbol = "PETR4",
+        SecurityId = Petr,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
     };
 
     private static long Px(decimal p) => (long)(p * 10_000m);

--- a/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
@@ -196,8 +196,15 @@ public class InstrumentRulesTests
     {
         var bad = new Instrument
         {
-            Symbol = "X", SecurityId = 1, TickSize = 0.000001m, LotSize = 1,
-            MinPrice = 1m, MaxPrice = 2m, Currency = "BRL", Isin = "X", SecurityType = "EQUITY",
+            Symbol = "X",
+            SecurityId = 1,
+            TickSize = 0.000001m,
+            LotSize = 1,
+            MinPrice = 1m,
+            MaxPrice = 2m,
+            Currency = "BRL",
+            Isin = "X",
+            SecurityType = "EQUITY",
         };
         Assert.Throws<ArgumentException>((Action)(() => { _ = new InstrumentTradingRules(bad); }));
     }
@@ -207,8 +214,15 @@ public class InstrumentRulesTests
     {
         var bad = new Instrument
         {
-            Symbol = "X", SecurityId = 1, TickSize = 0.05m, LotSize = 1,
-            MinPrice = 0.07m, MaxPrice = 1m, Currency = "BRL", Isin = "X", SecurityType = "EQUITY",
+            Symbol = "X",
+            SecurityId = 1,
+            TickSize = 0.05m,
+            LotSize = 1,
+            MinPrice = 0.07m,
+            MaxPrice = 1m,
+            Currency = "BRL",
+            Isin = "X",
+            SecurityType = "EQUITY",
         };
         Assert.Throws<ArgumentException>((Action)(() => { _ = new InstrumentTradingRules(bad); }));
     }


### PR DESCRIPTION
Follow-up to #20.

- **Format check is now blocking** in `ci.yml` (no more `continue-on-error`) and was added to the required status checks on `main` via `gh`.
- Applied the `dotnet format` fixes that the previous run flagged (whitespace only — no behavioral changes). Local `dotnet build` (Release, warnings-as-errors) and `dotnet test` both pass cleanly.
- `copilot-instructions.md` now has a **Pre-PR checklist** section that mirrors the required CI checks so future Copilot sessions run them locally before opening a PR.