### PR TITLE
feat: instrument definition publisher (#2)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -13,7 +13,17 @@
       "incrementalGroup": "224.0.20.84",
       "incrementalPort": 30084,
       "ttl": 1,
-      "instruments": "config/instruments-eqt.json"
+      "instruments": "config/instruments-eqt.json",
+      // Optional: periodic SecurityDefinition_12 publisher on a dedicated
+      // multicast group so consumers without a pre-loaded instrument list
+      // can resolve every SecurityID referenced on the incremental channel.
+      "instrumentDefinition": {
+        "channelNumber": 184,
+        "group": "224.0.21.84",
+        "port": 31084,
+        "ttl": 1,
+        "cadenceMs": 5000
+      }
     }
   ]
 }

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -73,7 +73,14 @@ Exposes:
       "incrementalGroup": "224.0.20.84",
       "incrementalPort": 30084,
       "ttl": 1,
-      "instruments": "config/instruments-eqt.json"
+      "instruments": "config/instruments-eqt.json",
+      "instrumentDefinition": {
+        "channelNumber": 184,
+        "group": "224.0.21.84",
+        "port": 31084,
+        "ttl": 1,
+        "cadenceMs": 5000
+      }
     }
   ]
 }
@@ -86,6 +93,15 @@ Exposes:
   UMDF channel.
 * `instruments` — path to the instrument list (re-uses the format already
   consumed by `B3.Exchange.Instruments.InstrumentLoader`).
+* `instrumentDefinition` *(optional)* — enables a dedicated
+  `SecurityDefinition_12` publisher on its own multicast group so
+  late-joining consumers can resolve every SecurityID seen on MBO/Trade
+  frames without a pre-loaded instrument list.
+  * `channelNumber` — UMDF channel number stamped on the InstrumentDef
+    PacketHeader. Defaults to the parent channel's number when 0.
+  * `group` / `port` / `ttl` / `localInterface` — multicast destination.
+  * `cadenceMs` — how often (ms) to re-emit the full instrument list.
+    Defaults to 5000 (5 s).
 
 ## Wire protocol
 
@@ -118,6 +134,13 @@ deferred to a later milestone.
 Standard B3 UMDF inc packets — `PacketHeader` (16 bytes) + framed
 `Order_MBO_50`, `DeleteOrder_MBO_51`, `Trade_53` messages. Compatible with
 the existing `B3.Umdf.ConsoleApp` consumer in this repo.
+
+When the optional `instrumentDefinition` block is configured per channel,
+the host also emits `SecurityDefinition_12` (`SecurityDefinition_d` in FIX
+terms) frames to a dedicated multicast group every `cadenceMs`
+milliseconds (default 5 s). One full cycle covers every configured
+instrument; frames are packed into ≤1400-byte UDP datagrams with
+monotonic `SequenceNumber`s on the InstrumentDef channel.
 
 ## Sending an order with `nc`
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -22,20 +22,27 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly HostConfig _config;
     private readonly Action<string>? _log;
     private readonly Func<ChannelConfig, IUmdfPacketSink>? _packetSinkFactory;
+    private readonly Func<ChannelConfig, InstrumentDefinitionConfig, IUmdfPacketSink>? _instrumentDefSinkFactory;
     private readonly List<ChannelDispatcher> _dispatchers = new();
+    private readonly List<InstrumentDefinitionPublisher> _instrumentDefPublishers = new();
     private readonly List<IDisposable> _ownedSinks = new();
     private EntryPointListener? _listener;
     private HostRouter? _router;
 
     public ExchangeHost(HostConfig config, Action<string>? log = null,
-        Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null)
+        Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null,
+        Func<ChannelConfig, InstrumentDefinitionConfig, IUmdfPacketSink>? instrumentDefSinkFactory = null)
     {
         _config = config;
         _log = log;
         _packetSinkFactory = packetSinkFactory;
+        _instrumentDefSinkFactory = instrumentDefSinkFactory;
     }
 
     public IPEndPoint? TcpEndpoint => _listener?.LocalEndpoint;
+
+    /// <summary>Snapshot of the InstrumentDef publishers, primarily for tests.</summary>
+    public IReadOnlyList<InstrumentDefinitionPublisher> InstrumentDefinitionPublishers => _instrumentDefPublishers;
 
     public Task StartAsync()
     {
@@ -67,6 +74,33 @@ public sealed class ExchangeHost : IAsyncDisposable
                 routing.Add(inst.SecurityId, disp);
             }
             _log?.Invoke($"channel {ch.ChannelNumber}: {instruments.Count} instruments → {ch.IncrementalGroup}:{ch.IncrementalPort}");
+
+            if (ch.InstrumentDefinition is { } idCfg)
+            {
+                IUmdfPacketSink idSink;
+                if (_instrumentDefSinkFactory != null)
+                {
+                    idSink = _instrumentDefSinkFactory(ch, idCfg);
+                }
+                else
+                {
+                    var local = idCfg.LocalInterface != null
+                        ? IPAddress.Parse(idCfg.LocalInterface)
+                        : (ch.LocalInterface != null ? IPAddress.Parse(ch.LocalInterface) : null);
+                    idSink = new MulticastUdpPacketSink(IPAddress.Parse(idCfg.Group), idCfg.Port, local, idCfg.Ttl);
+                }
+                if (idSink is IDisposable idd) _ownedSinks.Add(idd);
+                byte idChan = idCfg.ChannelNumber == 0 ? ch.ChannelNumber : idCfg.ChannelNumber;
+                var publisher = new InstrumentDefinitionPublisher(
+                    channelNumber: idChan,
+                    instruments: instruments,
+                    sink: idSink,
+                    cadence: TimeSpan.FromMilliseconds(idCfg.CadenceMs));
+                publisher.Start();
+                _instrumentDefPublishers.Add(publisher);
+                _log?.Invoke(
+                    $"channel {ch.ChannelNumber}: instrument-def → {idCfg.Group}:{idCfg.Port} every {idCfg.CadenceMs}ms");
+            }
         }
 
         _router = new HostRouter(routing);
@@ -97,6 +131,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);
+        foreach (var p in _instrumentDefPublishers) await p.DisposeAsync().ConfigureAwait(false);
         foreach (var d in _dispatchers) await d.DisposeAsync().ConfigureAwait(false);
         foreach (var s in _ownedSinks) s.Dispose();
     }

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -28,6 +28,30 @@ public sealed class ChannelConfig
     [JsonPropertyName("localInterface")] public string? LocalInterface { get; set; }
     [JsonPropertyName("ttl")] public byte Ttl { get; set; } = 1;
     [JsonPropertyName("instruments")] public string InstrumentsFile { get; set; } = "";
+
+    /// <summary>
+    /// Optional: enables the periodic <c>SecurityDefinition_12</c> publisher
+    /// on a dedicated InstrumentDef multicast group. When omitted, no
+    /// instrument definitions are published for this channel.
+    /// </summary>
+    [JsonPropertyName("instrumentDefinition")] public InstrumentDefinitionConfig? InstrumentDefinition { get; set; }
+}
+
+public sealed class InstrumentDefinitionConfig
+{
+    /// <summary>
+    /// UMDF channel number stamped on the InstrumentDef PacketHeader.
+    /// Defaults to the parent channel's <c>ChannelNumber</c> when 0.
+    /// </summary>
+    [JsonPropertyName("channelNumber")] public byte ChannelNumber { get; set; }
+
+    [JsonPropertyName("group")] public string Group { get; set; } = "";
+    [JsonPropertyName("port")] public int Port { get; set; }
+    [JsonPropertyName("localInterface")] public string? LocalInterface { get; set; }
+    [JsonPropertyName("ttl")] public byte Ttl { get; set; } = 1;
+
+    /// <summary>Cycle period in milliseconds. Defaults to 5000 (5 s).</summary>
+    [JsonPropertyName("cadenceMs")] public int CadenceMs { get; set; } = 5_000;
 }
 
 public static class HostConfigLoader

--- a/src/B3.Exchange.Integration/B3.Exchange.Integration.csproj
+++ b/src/B3.Exchange.Integration/B3.Exchange.Integration.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
   </ItemGroup>
 

--- a/src/B3.Exchange.Integration/InstrumentDefinitionPublisher.cs
+++ b/src/B3.Exchange.Integration/InstrumentDefinitionPublisher.cs
@@ -1,0 +1,176 @@
+using B3.Exchange.Instruments;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Integration;
+
+/// <summary>
+/// Periodically emits <c>SecurityDefinition_12</c> ("SecurityDefinition_d"
+/// in FIX terms) for every configured instrument on a dedicated
+/// InstrumentDef UMDF channel. Lets late-joining consumers resolve the
+/// SecurityIDs they will see on MBO / Trade frames without a pre-loaded
+/// instrument list.
+///
+/// Threading: a single <see cref="System.Threading.PeriodicTimer"/>-driven
+/// background loop owns all writes — the same dispatcher-thread discipline
+/// the matching engine uses. <see cref="PublishOnce"/> is also serialized
+/// with the timer loop via <c>_publishLock</c> so tests can drive cycles
+/// deterministically without racing the timer.
+///
+/// Wire layout per cycle: one or more UDP datagrams, each starting with the
+/// 16-byte <c>PacketHeader</c> followed by as many SecurityDefinition_12
+/// frames as fit in <see cref="MaxPacketBytes"/>. Sequence numbers are
+/// monotonic across cycles for the lifetime of the publisher.
+/// </summary>
+public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
+{
+    /// <summary>
+    /// Hard upper bound on a single InstrumentDef UDP datagram. Same value
+    /// the incremental dispatcher uses; chosen to stay well under a 1500-byte
+    /// MTU including IP+UDP headers.
+    /// </summary>
+    public const int MaxPacketBytes = 1400;
+
+    private const int FrameSize =
+        WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecDefBodyTotal;
+
+    public byte ChannelNumber { get; }
+    public ushort SequenceVersion { get; }
+    public uint SequenceNumber { get; private set; }
+    public TimeSpan Cadence { get; }
+
+    private readonly IReadOnlyList<Instrument> _instruments;
+    private readonly IUmdfPacketSink _sink;
+    private readonly Func<ulong> _nowNanos;
+    private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
+    private readonly object _publishLock = new();
+
+    private CancellationTokenSource? _cts;
+    private Task? _loopTask;
+
+    public InstrumentDefinitionPublisher(
+        byte channelNumber,
+        IReadOnlyList<Instrument> instruments,
+        IUmdfPacketSink sink,
+        TimeSpan cadence,
+        Func<ulong>? nowNanos = null,
+        ushort sequenceVersion = 1)
+    {
+        ArgumentNullException.ThrowIfNull(instruments);
+        ArgumentNullException.ThrowIfNull(sink);
+        if (cadence <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(cadence), "cadence must be positive");
+        // SecDef frame is ~251 bytes; we need to fit at least one with the
+        // 16-byte PacketHeader inside MaxPacketBytes — guaranteed by const,
+        // but keep the assertion in case future schema bumps grow the body.
+        if (FrameSize + WireOffsets.PacketHeaderSize > MaxPacketBytes)
+            throw new InvalidOperationException(
+                $"SecurityDefinition frame ({FrameSize} bytes) does not fit in InstrumentDef packet ({MaxPacketBytes} bytes).");
+
+        ChannelNumber = channelNumber;
+        _instruments = instruments;
+        _sink = sink;
+        _nowNanos = nowNanos ?? DefaultNowNanos;
+        Cadence = cadence;
+        SequenceVersion = sequenceVersion;
+        SequenceNumber = 0;
+    }
+
+    private static ulong DefaultNowNanos()
+        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+
+    /// <summary>
+    /// Starts the periodic loop. Idempotent: a second call is a no-op.
+    /// </summary>
+    public void Start()
+    {
+        if (_loopTask != null) return;
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+        _loopTask = Task.Factory.StartNew(
+            () => RunLoopAsync(ct), CancellationToken.None,
+            TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
+    }
+
+    private async Task RunLoopAsync(CancellationToken ct)
+    {
+        // Fire one cycle immediately so consumers connecting at startup can
+        // resolve symbols within Cadence rather than after one full interval.
+        try { PublishOnce(); } catch (OperationCanceledException) { return; }
+
+        using var timer = new PeriodicTimer(Cadence);
+        try
+        {
+            while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false))
+            {
+                PublishOnce();
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    /// <summary>
+    /// Emits one full cycle synchronously (one packet per ≤1400-byte chunk
+    /// of SecurityDefinition frames). Safe to call from any thread; calls
+    /// are serialized with the periodic-timer loop.
+    /// </summary>
+    public void PublishOnce()
+    {
+        lock (_publishLock)
+        {
+            if (_instruments.Count == 0) return;
+
+            int packetWritten = StartPacket();
+            for (int i = 0; i < _instruments.Count; i++)
+            {
+                if (packetWritten + FrameSize > MaxPacketBytes)
+                {
+                    FlushPacket(packetWritten);
+                    packetWritten = StartPacket();
+                }
+
+                var inst = _instruments[i];
+                int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(
+                    _packetBuf.AsSpan(packetWritten),
+                    securityId: inst.SecurityId,
+                    symbol: inst.Symbol,
+                    isin: inst.Isin,
+                    securityTypeByte: SecurityTypeMap.ToSbeByte(inst.SecurityType),
+                    totNoRelatedSym: (uint)_instruments.Count);
+                packetWritten += n;
+            }
+            if (packetWritten > WireOffsets.PacketHeaderSize)
+                FlushPacket(packetWritten);
+        }
+    }
+
+    private int StartPacket()
+    {
+        UmdfWireEncoder.WritePacketHeader(_packetBuf,
+            ChannelNumber, SequenceVersion, sequenceNumber: 0, sendingTimeNanos: 0);
+        return WireOffsets.PacketHeaderSize;
+    }
+
+    private void FlushPacket(int written)
+    {
+        SequenceNumber++;
+        UmdfWireEncoder.PatchPacketHeader(
+            _packetBuf.AsSpan(0, WireOffsets.PacketHeaderSize),
+            SequenceNumber, _nowNanos());
+        _sink.Publish(ChannelNumber, _packetBuf.AsSpan(0, written));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_cts != null)
+        {
+            try { _cts.Cancel(); } catch { }
+        }
+        if (_loopTask != null)
+        {
+            try { await _loopTask.ConfigureAwait(false); } catch { }
+            _loopTask = null;
+        }
+        _cts?.Dispose();
+        _cts = null;
+    }
+}

--- a/src/B3.Umdf.WireEncoder/SecurityTypeMap.cs
+++ b/src/B3.Umdf.WireEncoder/SecurityTypeMap.cs
@@ -1,0 +1,46 @@
+using B3.Umdf.Mbo.Sbe.V16;
+
+namespace B3.Umdf.WireEncoder;
+
+/// <summary>
+/// Maps the FIX-style <c>securityType</c> string carried by configured
+/// instruments (e.g. "CS", "OPT", "FUT") to the SBE <see cref="SecurityType"/>
+/// uint8 enum value emitted in <c>SecurityDefinition_12</c> frames.
+///
+/// Lookup is case-insensitive. A small set of legacy aliases is honoured so
+/// existing instrument files (and ad-hoc tests) that use names like
+/// <c>"EQUITY"</c>, <c>"FUTURE"</c> or <c>"OPTION"</c> map to the closest
+/// schema enum value. Unknown strings map to <c>0</c> — the SBE NULL
+/// sentinel for this type — so consumers see "unspecified" rather than a
+/// silent mis-mapping.
+/// </summary>
+public static class SecurityTypeMap
+{
+    /// <summary>SBE NULL sentinel for the SecurityType uint8 enum.</summary>
+    public const byte Unspecified = 0;
+
+    /// <summary>
+    /// Returns the SBE enum byte for <paramref name="securityType"/>, or
+    /// <see cref="Unspecified"/> when the string is null/empty/unknown.
+    /// </summary>
+    public static byte ToSbeByte(string? securityType)
+    {
+        if (string.IsNullOrWhiteSpace(securityType)) return Unspecified;
+
+        // Direct enum names first.
+        if (Enum.TryParse<SecurityType>(securityType, ignoreCase: true, out var direct))
+            return (byte)direct;
+
+        // Common legacy aliases used in this repo's instrument files / tests.
+        return securityType.ToUpperInvariant() switch
+        {
+            "EQUITY" => (byte)SecurityType.CS,
+            "STOCK" => (byte)SecurityType.CS,
+            "PREFERRED" => (byte)SecurityType.PS,
+            "FUTURE" => (byte)SecurityType.FUT,
+            "OPTION" => (byte)SecurityType.OPT,
+            "INDEXOPTION" => (byte)SecurityType.INDEXOPT,
+            _ => Unspecified,
+        };
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+    <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using B3.Exchange.EntryPoint;
 using B3.Exchange.Integration;
+using B3.Umdf.WireEncoder;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -135,6 +136,85 @@ public class ExchangeHostE2ETests
 
         var er = await ReadFrameAsync(stream, TimeSpan.FromSeconds(2));
         Assert.Equal(EntryPointFrameReader.TidExecutionReportReject, er.TemplateId);
+    }
+
+    [Fact]
+    public async Task InstrumentDefinitionPublisher_EmitsAllInstrumentsWithinOneCycle()
+    {
+        var (cfg, mboSink) = BuildConfig();
+        // Enable InstrumentDef publisher with a short cadence so the host
+        // emits a full cycle inside the test deadline.
+        cfg.Channels[0].InstrumentDefinition = new InstrumentDefinitionConfig
+        {
+            ChannelNumber = 184,
+            Group = "239.255.43.184",
+            Port = 31184,
+            Ttl = 0,
+            CadenceMs = 50,
+        };
+
+        var idSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg,
+            packetSinkFactory: _ => mboSink,
+            instrumentDefSinkFactory: (_, _) => idSink);
+        await host.StartAsync();
+
+        // Wait up to 2s for the first cycle.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            lock (idSink.Packets)
+            {
+                if (idSink.Packets.Count > 0) break;
+            }
+            await Task.Delay(20);
+        }
+
+        // Decode every SecurityDefinition_12 frame across all packets and
+        // assert the consumer can resolve every configured SecurityID +
+        // Symbol — i.e. a fresh subscriber learns the instrument table from
+        // the bus alone.
+        var instruments = B3.Exchange.Instruments.InstrumentLoader.LoadFromFile(
+            cfg.Channels[0].InstrumentsFile);
+        var expectedSecIds = instruments.Select(i => i.SecurityId).ToHashSet();
+        var expectedSymbols = instruments.Select(i => i.Symbol).ToHashSet();
+
+        var seenSecIds = new HashSet<long>();
+        var seenSymbols = new HashSet<string>();
+
+        const int FrameOffset = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        const int FrameSize = FrameOffset + WireOffsets.SecDefBodyTotal;
+
+        byte[][] snapshot;
+        lock (idSink.Packets) snapshot = idSink.Packets.ToArray();
+        Assert.NotEmpty(snapshot);
+
+        foreach (var packet in snapshot)
+        {
+            // PacketHeader stamps configured InstrumentDef channel number.
+            Assert.Equal((byte)184, packet[WireOffsets.PacketHeaderChannelOffset]);
+            int p = WireOffsets.PacketHeaderSize;
+            while (p + FrameSize <= packet.Length)
+            {
+                var bodySpan = packet.AsSpan(p + FrameOffset, WireOffsets.SecDefBlockLength);
+                long secId = MemoryMarshal.Read<long>(bodySpan.Slice(WireOffsets.SecDefSecurityIdOffset, 8));
+                seenSecIds.Add(secId);
+                var symBytes = bodySpan.Slice(WireOffsets.SecDefSymbolOffset, 20);
+                int n = symBytes.IndexOf((byte)0);
+                if (n < 0) n = symBytes.Length;
+                seenSymbols.Add(System.Text.Encoding.ASCII.GetString(symBytes.Slice(0, n)));
+                p += FrameSize;
+
+                // Every emitted frame should also be SBE-decodable.
+                Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.TryParse(bodySpan, out _));
+            }
+        }
+
+        Assert.Superset(expectedSecIds, seenSecIds);
+        Assert.True(expectedSecIds.IsSubsetOf(seenSecIds),
+            $"missing SecurityIDs: {string.Join(",", expectedSecIds.Except(seenSecIds))}");
+        Assert.True(expectedSymbols.IsSubsetOf(seenSymbols),
+            $"missing symbols: {string.Join(",", expectedSymbols.Except(seenSymbols))}");
     }
 
     private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,

--- a/tests/B3.Exchange.Integration.Tests/InstrumentDefinitionPublisherTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/InstrumentDefinitionPublisherTests.cs
@@ -1,0 +1,194 @@
+using System.Runtime.InteropServices;
+using B3.Exchange.Instruments;
+using B3.Exchange.Integration;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Integration.Tests;
+
+/// <summary>
+/// Verifies that <see cref="InstrumentDefinitionPublisher"/> emits one
+/// SecurityDefinition_12 frame per configured instrument, packs them into
+/// ≤1400-byte packets, and uses monotonic SequenceNumbers across cycles.
+/// </summary>
+public class InstrumentDefinitionPublisherTests
+{
+    private const int FrameOffset = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+    private const int FrameSize = FrameOffset + WireOffsets.SecDefBodyTotal;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    private static Instrument Inst(string sym, long secId, string isin, string type = "CS") => new()
+    {
+        Symbol = sym,
+        SecurityId = secId,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = isin,
+        SecurityType = type,
+    };
+
+    [Fact]
+    public void PublishOnce_EmitsOneFramePerInstrument_AcrossPackets()
+    {
+        var instruments = new List<Instrument>
+        {
+            Inst("PETR4", 900_000_000_001L, "BRPETRACNPR6"),
+            Inst("VALE3", 900_000_000_002L, "BRVALEACNOR0"),
+            Inst("ITUB4", 900_000_000_003L, "BRITUBACNPR1"),
+        };
+        var sink = new RecordingPacketSink();
+        var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 184, instruments, sink,
+            cadence: TimeSpan.FromSeconds(60), nowNanos: () => 12345UL);
+
+        pub.PublishOnce();
+
+        Assert.NotEmpty(sink.Packets);
+
+        var seenSecIds = new List<long>();
+        var seenSymbols = new List<string>();
+        uint expectedSeq = 1;
+
+        foreach (var packet in sink.Packets)
+        {
+            Assert.True(packet.Length <= InstrumentDefinitionPublisher.MaxPacketBytes);
+
+            // PacketHeader: channel & sequence checks.
+            Assert.Equal((byte)184, packet[WireOffsets.PacketHeaderChannelOffset]);
+            uint seq = MemoryMarshal.Read<uint>(
+                packet.AsSpan(WireOffsets.PacketHeaderSequenceNumberOffset, 4));
+            Assert.Equal(expectedSeq++, seq);
+
+            int p = WireOffsets.PacketHeaderSize;
+            while (p + FrameSize <= packet.Length)
+            {
+                var bodySpan = packet.AsSpan(p + FrameOffset, WireOffsets.SecDefBlockLength);
+                long secId = MemoryMarshal.Read<long>(bodySpan.Slice(WireOffsets.SecDefSecurityIdOffset, 8));
+                seenSecIds.Add(secId);
+                var symBytes = bodySpan.Slice(WireOffsets.SecDefSymbolOffset, 20);
+                int n = symBytes.IndexOf((byte)0);
+                if (n < 0) n = symBytes.Length;
+                seenSymbols.Add(System.Text.Encoding.ASCII.GetString(symBytes.Slice(0, n)));
+                p += FrameSize;
+            }
+        }
+
+        Assert.Equal(new[] { 900_000_000_001L, 900_000_000_002L, 900_000_000_003L }, seenSecIds);
+        Assert.Equal(new[] { "PETR4", "VALE3", "ITUB4" }, seenSymbols);
+    }
+
+    [Fact]
+    public void PublishOnce_FramesAreSbeReadable()
+    {
+        var instruments = new List<Instrument> { Inst("PETR4", 900_000_000_001L, "BRPETRACNPR6") };
+        var sink = new RecordingPacketSink();
+        var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 200, instruments, sink, TimeSpan.FromMinutes(1), () => 1UL);
+
+        pub.PublishOnce();
+
+        Assert.Single(sink.Packets);
+        var packet = sink.Packets[0];
+        var bodySpan = packet.AsSpan(WireOffsets.PacketHeaderSize + FrameOffset, WireOffsets.SecDefBlockLength);
+
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.TryParse(bodySpan, out var rdr));
+        Assert.Equal(900_000_000_001L, (long)rdr.Data.SecurityID.Value);
+    }
+
+    [Fact]
+    public void PublishOnce_SequenceNumbersAreMonotonicAcrossCycles()
+    {
+        var instruments = new List<Instrument>
+        {
+            Inst("PETR4", 1L, "BRPETRACNPR6"),
+        };
+        var sink = new RecordingPacketSink();
+        var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 99, instruments, sink, TimeSpan.FromMinutes(1), () => 0UL);
+
+        pub.PublishOnce();
+        pub.PublishOnce();
+        pub.PublishOnce();
+
+        Assert.Equal(3, sink.Packets.Count);
+        for (int i = 0; i < 3; i++)
+        {
+            uint seq = MemoryMarshal.Read<uint>(
+                sink.Packets[i].AsSpan(WireOffsets.PacketHeaderSequenceNumberOffset, 4));
+            Assert.Equal((uint)(i + 1), seq);
+        }
+        Assert.Equal(3u, pub.SequenceNumber);
+    }
+
+    [Fact]
+    public void PublishOnce_PacksManyInstrumentsIntoMultiplePackets()
+    {
+        // ~5 SecDef frames per packet (251 bytes each + 16-byte header < 1400);
+        // 12 instruments → at least 3 packets.
+        var instruments = new List<Instrument>();
+        for (int i = 0; i < 12; i++)
+        {
+            instruments.Add(Inst($"SYM{i:00}", 1_000_000L + i, "BR" + i.ToString("D10")));
+        }
+        var sink = new RecordingPacketSink();
+        var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 7, instruments, sink, TimeSpan.FromMinutes(1), () => 0UL);
+
+        pub.PublishOnce();
+
+        Assert.True(sink.Packets.Count >= 3, $"expected ≥3 packets, got {sink.Packets.Count}");
+        int totalFrames = 0;
+        foreach (var p in sink.Packets)
+        {
+            int frames = (p.Length - WireOffsets.PacketHeaderSize) / FrameSize;
+            totalFrames += frames;
+        }
+        Assert.Equal(12, totalFrames);
+    }
+
+    [Fact]
+    public async Task Start_FiresImmediatelyAndPeriodically()
+    {
+        var instruments = new List<Instrument> { Inst("PETR4", 1L, "BRPETRACNPR6") };
+        var sink = new RecordingPacketSink();
+        await using var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 1, instruments, sink, TimeSpan.FromMilliseconds(50), () => 0UL);
+
+        pub.Start();
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            lock (sink.Packets)
+            {
+                if (sink.Packets.Count >= 2) break;
+            }
+            await Task.Delay(20);
+        }
+        lock (sink.Packets)
+        {
+            Assert.True(sink.Packets.Count >= 2,
+                $"expected ≥2 packets within 2s, got {sink.Packets.Count}");
+        }
+    }
+
+    [Fact]
+    public void Constructor_RejectsNonPositiveCadence()
+    {
+        var instruments = new List<Instrument> { Inst("X", 1L, "ISIN0001") };
+        var sink = new RecordingPacketSink();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new InstrumentDefinitionPublisher(
+            1, instruments, sink, TimeSpan.Zero));
+    }
+}

--- a/tests/B3.Umdf.WireEncoder.Tests/SecurityTypeMapTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/SecurityTypeMapTests.cs
@@ -1,0 +1,35 @@
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Umdf.WireEncoder.Tests;
+
+public class SecurityTypeMapTests
+{
+    [Theory]
+    [InlineData("CS", (byte)SecurityType.CS)]
+    [InlineData("cs", (byte)SecurityType.CS)]
+    [InlineData("PS", (byte)SecurityType.PS)]
+    [InlineData("OPT", (byte)SecurityType.OPT)]
+    [InlineData("FUT", (byte)SecurityType.FUT)]
+    [InlineData("ETF", (byte)SecurityType.ETF)]
+    public void DirectEnumNames_MapToSbeByte(string input, byte expected)
+        => Assert.Equal(expected, SecurityTypeMap.ToSbeByte(input));
+
+    [Theory]
+    [InlineData("EQUITY", (byte)SecurityType.CS)]
+    [InlineData("equity", (byte)SecurityType.CS)]
+    [InlineData("STOCK", (byte)SecurityType.CS)]
+    [InlineData("FUTURE", (byte)SecurityType.FUT)]
+    [InlineData("OPTION", (byte)SecurityType.OPT)]
+    [InlineData("PREFERRED", (byte)SecurityType.PS)]
+    public void Aliases_MapToSbeByte(string input, byte expected)
+        => Assert.Equal(expected, SecurityTypeMap.ToSbeByte(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("NOT_A_TYPE")]
+    public void UnknownOrEmpty_MapToUnspecified(string? input)
+        => Assert.Equal(SecurityTypeMap.Unspecified, SecurityTypeMap.ToSbeByte(input));
+}


### PR DESCRIPTION
Closes #2

## Summary

Adds a periodic `SecurityDefinition_12` (FIX `d`) publisher so consumers
without a pre-loaded instrument list can resolve every SecurityID seen on
the incremental MBO/Trade channel.

## Design

* **`InstrumentDefinitionPublisher`** (`src/B3.Exchange.Integration`):
  single `PeriodicTimer`-driven background loop, fires once at `Start()`
  and then every `cadence`. `PublishOnce()` is serialised with the timer
  loop via a lock so tests can drive cycles deterministically.
* One full cycle packs `SecurityDefinition_12` frames into one or more
  `<=1400`-byte UDP packets. Each packet carries a UMDF `PacketHeader`
  with a monotonic `SequenceNumber` on the dedicated InstrumentDef channel.
* Dedicated multicast group / port (separate from the incremental MBO
  channel), wired up by `ExchangeHost` from a new optional
  `instrumentDefinition` block in `exchange-simulator.json`. Defaults:
  `cadenceMs=5000`, channel inherits parent when omitted.
* Reuses the existing `UmdfWireEncoder.WriteSecurityDefinitionFrame`
  helper. Adds `SecurityTypeMap` to map FIX-style `Instrument.SecurityType`
  strings (e.g. `CS`, `OPT`, plus aliases like `EQUITY`/`FUTURE`) to the
  SBE `SecurityType` uint8 enum.

## Acceptance

* **Encoder helper unit tests**: `SecurityTypeMapTests` (6 cases) +
  pre-existing `UmdfWireEncoderTests.SecurityDefinition_Roundtrip_BasicFields`.
* **Publisher unit tests**: `InstrumentDefinitionPublisherTests` (6 cases)
  cover frame-per-instrument layout, SBE decodability, monotonic seqnums,
  multi-packet packing, periodic `Start()` loop, and arg validation.
* **Integration test**: `ExchangeHostE2ETests
  .InstrumentDefinitionPublisher_EmitsAllInstrumentsWithinOneCycle` asserts
  the host emits a SecurityDefinition for every configured instrument
  within one cycle and the bytes are SBE-decodable.

## Files changed

* `src/B3.Umdf.WireEncoder/SecurityTypeMap.cs` *(new)*
* `src/B3.Exchange.Integration/InstrumentDefinitionPublisher.cs` *(new)*
* `src/B3.Exchange.Integration/B3.Exchange.Integration.csproj` — adds Instruments project ref
* `src/B3.Exchange.Host/HostConfig.cs` — adds `InstrumentDefinitionConfig`
* `src/B3.Exchange.Host/ExchangeHost.cs` — wires publisher per channel
* `config/exchange-simulator.json` — sample InstrumentDef block
* `docs/EXCHANGE-SIMULATOR.md` — documents new config + outbound channel
* `tests/B3.Umdf.WireEncoder.Tests/SecurityTypeMapTests.cs` *(new)*
* `tests/B3.Exchange.Integration.Tests/InstrumentDefinitionPublisherTests.cs` *(new)*
* `tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs` — adds e2e test
* `tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj` — adds WireEncoder ref

## Pre-PR checklist

`dotnet restore` / `build -c Release` / `test -c Release --no-build` /
`format --verify-no-changes` all pass locally — 114 tests, 0 warnings,
no format diffs.

## Follow-ups

* Wire SnapshotRotator (issue #1) onto the same dispatcher-thread pattern
  this publisher establishes.
* Mapping currently exposes only a subset of SecurityDefinition_12
  fields (SecurityID, Symbol, ISIN, SecurityType, ValidityTimestamp,
  MaturityDate). Extend with TickSize / LotSize / MinPrice / MaxPrice from
  `Instrument` once consumers need them.