### PR TITLE
feat: healthcheck + metrics endpoints (#5)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,12 @@ RUN dotnet publish src/B3.Exchange.Host/B3.Exchange.Host.csproj \
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 
+# wget is needed by the HEALTHCHECK directive below; the aspnet base image
+# does not ship it.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY --from=build /app .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,15 @@ COPY --from=build /app .
 # Default config is mounted into /app/config by docker-compose; override with
 # CMD if needed.
 EXPOSE 9876
+EXPOSE 8080
 
 STOPSIGNAL SIGTERM
+
+# Healthcheck hits the Kestrel /health/live endpoint. Requires the host
+# config's `http` block to be present (default port 8080). Disable by
+# overriding HEALTHCHECK in a derived image if HTTP is turned off.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:8080/health/live || exit 1
 
 ENTRYPOINT ["/app/B3.Exchange.Host"]
 CMD ["/app/config/exchange-simulator.json"]

--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -10,6 +10,15 @@
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000
   },
+  // Optional Kestrel-hosted operability endpoint. Remove this block to
+  // disable HTTP entirely. Exposes:
+  //   GET /health/live   liveness (dispatcher heartbeats fresher than livenessStaleMs)
+  //   GET /health/ready  readiness (all registered probes ready)
+  //   GET /metrics       Prometheus 0.0.4 text exposition
+  "http": {
+    "listen": "0.0.0.0:8080",
+    "livenessStaleMs": 5000
+  },
   "channels": [
     {
       "channelNumber": 84,

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -190,7 +190,7 @@ healthcheck).
 
 ### Readiness today vs. once issues #1/#2 land
 
-`IReadinessProbe` is an `OR-of-AND` composition: the host's overall
+`IReadinessProbe` implementations are combined using logical AND: the host's overall
 readiness is the AND of every registered probe. The snapshot rotator
 (issue #1) and instrument-definition publisher (issue #2) will each
 register their own probe and flip ready once they have emitted at least

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -73,6 +73,7 @@ Exposes:
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000
   },
+  "http": { "listen": "0.0.0.0:8080", "livenessStaleMs": 5000 },
   "channels": [
     {
       "channelNumber": 84,
@@ -114,6 +115,15 @@ Exposes:
   the session is closed; a `BusinessReject` (templateId=206) framing the
   reason is the responsibility of issue #11 — `EntryPointSession.Close(reason)`
   exposes the seam.
+* `http` — **optional** Kestrel-hosted operability endpoint exposing
+  `/health/live`, `/health/ready`, and `/metrics`. Omit the entire block to
+  disable HTTP.
+  * `http.listen` — bind address. Default `0.0.0.0:8080`.
+  * `http.livenessStaleMs` — `/health/live` returns 503 if any dispatcher
+    has not heartbeat within this window. Default `5000` (5 s). Each
+    dispatcher records a heartbeat on every loop wakeup (1 s timer +
+    every processed command), so a stuck or dead loop is detected within
+    `livenessStaleMs + ~1s`.
 * `channels[]` — one matching engine + one outbound multicast group per
   UMDF channel.
 * `channels[].selfTradePrevention` — per-channel self-trade prevention policy
@@ -154,6 +164,47 @@ Exposes:
   30, ~1.3 KB per chunk → fits a standard 1500-byte MTU). Omit the
   `snapshot` block to publish only the incremental feed (no bootstrap for
   mid-session consumers).
+
+## Operability endpoints
+
+Only enabled when the `http` config block is present. All endpoints are
+plain HTTP (no TLS, no auth — assume an in-cluster scrape target / sidecar
+healthcheck).
+
+| Path             | Status semantics                                                                |
+|------------------|---------------------------------------------------------------------------------|
+| `/health/live`   | 200 if every dispatcher loop has ticked within `http.livenessStaleMs`; else 503 |
+| `/health/ready`  | 200 once every registered `IReadinessProbe` reports ready; else 503             |
+| `/metrics`       | Prometheus 0.0.4 text exposition (always 200)                                   |
+
+`/metrics` series:
+
+| Metric                                        | Type    | Labels             | Notes                                                                 |
+|-----------------------------------------------|---------|--------------------|-----------------------------------------------------------------------|
+| `exch_orders_in_total`                        | counter | `channel`          | NewOrder / Cancel / Replace commands processed.                        |
+| `exch_packets_out_total`                      | counter | `channel`          | UMDF packets handed to the multicast sink.                            |
+| `exch_snapshots_emitted_total`                | counter | `channel`          | Stub — incremented by the snapshot rotator (issue #1) once merged.    |
+| `exch_instrument_defs_emitted_total`          | counter | `channel`          | Stub — incremented by the instrument-definition publisher (issue #2). |
+| `exch_dispatch_loop_last_tick_unixms`         | gauge   | `channel`          | Unix ms of the dispatcher loop's last heartbeat.                       |
+| `exch_send_queue_depth`                       | gauge   | `channel,session`  | Per-`EntryPointSession` outbound queue. `channel="all"` because the queue is shared across channels. |
+
+### Readiness today vs. once issues #1/#2 land
+
+`IReadinessProbe` is an `OR-of-AND` composition: the host's overall
+readiness is the AND of every registered probe. The snapshot rotator
+(issue #1) and instrument-definition publisher (issue #2) will each
+register their own probe and flip ready once they have emitted at least
+one snapshot / definition per loaded instrument since startup.
+
+Until those land, the host registers a single `StartupReadinessProbe`
+that flips ready as soon as `ExchangeHost.StartAsync` returns, so
+`/health/ready` is effectively equivalent to `/health/live` for now.
+
+### Docker `HEALTHCHECK`
+
+`Dockerfile` ships a `HEALTHCHECK` that hits `/health/live` via `wget`.
+If you disable HTTP in your config, override `HEALTHCHECK NONE` in a
+derived image.
 
 ## Wire protocol
 

--- a/src/B3.Exchange.EntryPoint/EntryPointListener.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointListener.cs
@@ -31,6 +31,17 @@ public sealed class EntryPointListener : IAsyncDisposable
 
     public IPEndPoint? LocalEndpoint => (IPEndPoint?)_listener?.LocalEndpoint;
 
+    /// <summary>
+    /// Snapshot of currently active sessions for diagnostics / metrics.
+    /// Closed sessions remain in the list until <see cref="DisposeAsync"/>
+    /// runs; callers should filter on <see cref="EntryPointSession.IsOpen"/>
+    /// if they only want live ones.
+    /// </summary>
+    public IReadOnlyList<EntryPointSession> ActiveSessions
+    {
+        get { lock (_lock) return _sessions.ToArray(); }
+    }
+
     public EntryPointListener(IPEndPoint endpoint, IEntryPointEngineSink sink,
         ILoggerFactory loggerFactory,
         Func<EndPoint?, AcceptedConnection>? identityFactory = null,

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -50,6 +50,14 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
     public uint SessionId { get; }
     public bool IsOpen => Volatile.Read(ref _isOpen) == 1;
 
+    /// <summary>
+    /// Approximate number of pre-encoded ExecutionReport frames sitting in
+    /// the outbound queue, for /metrics scraping. Reads
+    /// <see cref="System.Threading.Channels.ChannelReader{T}.Count"/>,
+    /// which is O(1) on a bounded channel.
+    /// </summary>
+    public int SendQueueDepth => _sendQueue.Reader.Count;
+
     public EntryPointSession(long connectionId, uint enteringFirm, uint sessionId,
         Stream stream, IEntryPointEngineSink sink, ILogger<EntryPointSession> logger,
         Func<ulong>? nowNanos = null,

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -10,6 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Exchange.Host.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <Content Remove="appsettings*.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -24,9 +24,4 @@
     <ProjectReference Include="..\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.0" />
-  </ItemGroup>
-
 </Project>

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -31,8 +31,12 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly List<InstrumentDefinitionPublisher> _instrumentDefPublishers = new();
     private readonly List<IDisposable> _ownedSinks = new();
     private readonly List<Timer> _snapshotTimers = new();
+    private readonly MetricsRegistry _metrics = new();
+    private readonly StartupReadinessProbe _startupProbe = new("startup");
+    private readonly List<IReadinessProbe> _probes = new();
     private EntryPointListener? _listener;
     private HostRouter? _router;
+    private HttpServer? _http;
 
     public ExchangeHost(HostConfig config, ILoggerFactory? loggerFactory = null,
         Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null,
@@ -45,16 +49,26 @@ public sealed class ExchangeHost : IAsyncDisposable
         _packetSinkFactory = packetSinkFactory;
         _snapshotSinkFactory = snapshotSinkFactory;
         _instrumentDefSinkFactory = instrumentDefSinkFactory;
+        _probes.Add(_startupProbe);
     }
 
     public IPEndPoint? TcpEndpoint => _listener?.LocalEndpoint;
-
+    public IPEndPoint? HttpEndpoint => _http?.LocalEndpoint;
+    public MetricsRegistry Metrics => _metrics;
     public IReadOnlyList<ChannelDispatcher> Dispatchers => _dispatchers;
 
     /// <summary>Snapshot of the InstrumentDef publishers, primarily for tests.</summary>
     public IReadOnlyList<InstrumentDefinitionPublisher> InstrumentDefinitionPublishers => _instrumentDefPublishers;
 
-    public Task StartAsync()
+    /// <summary>
+    /// Register an additional readiness probe. Intended for the snapshot
+    /// rotator (#1) and instrument-definition publisher (#2) once they
+    /// land — each subsystem registers its own probe so /health/ready
+    /// only flips green when every dependency is satisfied.
+    /// </summary>
+    public void RegisterReadinessProbe(IReadinessProbe probe) => _probes.Add(probe);
+
+    public async Task StartAsync()
     {
         _logger.LogInformation("exchange host starting with {ChannelCount} channels", _config.Channels.Count);
         var routing = new Dictionary<long, ChannelDispatcher>();
@@ -74,6 +88,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
             if (sink is IDisposable d) _ownedSinks.Add(d);
             var engineLogger = _loggerFactory.CreateLogger<MatchingEngine>();
+            var channelMetrics = _metrics.RegisterChannel(ch.ChannelNumber);
 
             // Capture the engine via a side-channel so we can build a snapshot
             // source that reads through the live book on the dispatcher thread.
@@ -87,7 +102,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                     return e;
                 },
                 packetSink: sink,
-                logger: _loggerFactory.CreateLogger<ChannelDispatcher>());
+                logger: _loggerFactory.CreateLogger<ChannelDispatcher>(),
+                metrics: channelMetrics);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -183,7 +199,33 @@ public sealed class ExchangeHost : IAsyncDisposable
             onSessionClosed: (s, reason) => _logger.LogInformation("session {ConnectionId} closed: {Reason}", s.ConnectionId, reason));
         _listener.Start();
         _logger.LogInformation("entrypoint listening on {Endpoint}", _listener.LocalEndpoint);
-        return Task.CompletedTask;
+
+        _metrics.SetSessionProvider(new ListenerSessionProvider(_listener));
+
+        if (_config.Http != null)
+        {
+            _http = new HttpServer(_config.Http, _metrics, _probes,
+                msg => _logger.LogInformation("{Message}", msg));
+            await _http.StartAsync().ConfigureAwait(false);
+        }
+
+        _startupProbe.MarkReady();
+    }
+
+    private sealed class ListenerSessionProvider : ISessionMetricsProvider
+    {
+        private readonly EntryPointListener _listener;
+        public ListenerSessionProvider(EntryPointListener listener) { _listener = listener; }
+        public IEnumerable<SessionQueueSample> Sample()
+        {
+            foreach (var s in _listener.ActiveSessions)
+            {
+                if (!s.IsOpen) continue;
+                yield return new SessionQueueSample(
+                    SessionId: "conn-" + s.ConnectionId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                    QueueDepth: s.SendQueueDepth);
+            }
+        }
     }
 
     private static IPEndPoint ParseEndpoint(string s)
@@ -198,6 +240,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("exchange host shutting down");
+        if (_http != null) await _http.DisposeAsync().ConfigureAwait(false);
         foreach (var t in _snapshotTimers) await t.DisposeAsync().ConfigureAwait(false);
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);
         foreach (var p in _instrumentDefPublishers) await p.DisposeAsync().ConfigureAwait(false);

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -66,9 +66,13 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// rotator (#1) and instrument-definition publisher (#2) once they
     /// land — each subsystem registers its own probe so /health/ready
     /// only flips green when every dependency is satisfied.
+    /// Must be called before <see cref="StartAsync"/>.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown if called after <see cref="StartAsync"/>.</exception>
     public void RegisterReadinessProbe(IReadinessProbe probe)
     {
+        if (_http != null)
+            throw new InvalidOperationException("Cannot register readiness probes after StartAsync has been called; probes are snapshotted at startup.");
         lock (_probesLock) _probes.Add(probe);
     }
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -34,6 +34,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly MetricsRegistry _metrics = new();
     private readonly StartupReadinessProbe _startupProbe = new("startup");
     private readonly List<IReadinessProbe> _probes = new();
+    private readonly object _probesLock = new();
     private EntryPointListener? _listener;
     private HostRouter? _router;
     private HttpServer? _http;
@@ -66,7 +67,10 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// land — each subsystem registers its own probe so /health/ready
     /// only flips green when every dependency is satisfied.
     /// </summary>
-    public void RegisterReadinessProbe(IReadinessProbe probe) => _probes.Add(probe);
+    public void RegisterReadinessProbe(IReadinessProbe probe)
+    {
+        lock (_probesLock) _probes.Add(probe);
+    }
 
     public async Task StartAsync()
     {
@@ -204,7 +208,9 @@ public sealed class ExchangeHost : IAsyncDisposable
 
         if (_config.Http != null)
         {
-            _http = new HttpServer(_config.Http, _metrics, _probes,
+            IReadOnlyList<IReadinessProbe> probeSnapshot;
+            lock (_probesLock) probeSnapshot = _probes.ToList();
+            _http = new HttpServer(_config.Http, _metrics, probeSnapshot,
                 msg => _logger.LogInformation("{Message}", msg));
             await _http.StartAsync().ConfigureAwait(false);
         }

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -11,6 +11,7 @@ namespace B3.Exchange.Host;
 public sealed class HostConfig
 {
     [JsonPropertyName("tcp")] public TcpConfig Tcp { get; set; } = new();
+    [JsonPropertyName("http")] public HttpConfig? Http { get; set; }
     [JsonPropertyName("channels")] public List<ChannelConfig> Channels { get; set; } = new();
 }
 
@@ -28,6 +29,23 @@ public sealed class TcpConfig
     /// <summary>Additional grace window after the probe before the session is
     /// closed for inactivity. Default: 5 s.</summary>
     [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
+}
+
+/// <summary>
+/// Optional Kestrel-hosted HTTP endpoint exposing /health/live,
+/// /health/ready, and /metrics. Omit the <c>http</c> object from the
+/// config to disable HTTP entirely.
+/// </summary>
+public sealed class HttpConfig
+{
+    [JsonPropertyName("listen")] public string Listen { get; set; } = "0.0.0.0:8080";
+
+    /// <summary>
+    /// Liveness staleness threshold in milliseconds. /health/live returns
+    /// 503 if any registered dispatcher has not ticked within this many
+    /// milliseconds. Default 5000 (5s).
+    /// </summary>
+    [JsonPropertyName("livenessStaleMs")] public int LivenessStaleMs { get; set; } = 5000;
 }
 
 public sealed class ChannelConfig

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -112,17 +112,20 @@ public sealed class HttpServer : IAsyncDisposable
 
     private static IPEndPoint ParseEndpoint(string s)
     {
-        // Use IPEndPoint.Parse for robust parsing of IPv4, IPv6, and hostname:port formats
+        // Use IPEndPoint.Parse for robust parsing of IPv4, IPv6, and numeric host:port formats.
+        // Note: IPEndPoint.Parse does not support hostname resolution (e.g., localhost:8080).
+        // For hostname support, parse separately and use DNS resolution if needed.
         if (!s.Contains(':'))
             throw new FormatException($"expected host:port, got '{s}'");
 
         try
         {
+            // IPEndPoint.Parse supports "[IPv6]:port" and "IPv4:port" formats.
             return IPEndPoint.Parse(s);
         }
         catch (Exception ex)
         {
-            throw new FormatException($"failed to parse endpoint '{s}'", ex);
+            throw new FormatException($"failed to parse endpoint '{s}' (IP literal and port only; hostname resolution not supported)", ex);
         }
     }
 

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -68,8 +68,15 @@ public sealed class HttpServer : IAsyncDisposable
             foreach (var c in channels)
             {
                 long last = c.LastTickUnixMs;
-                if (last == 0 || (nowMs - last) > stale)
-                    stuck.Add($"channel={c.ChannelNumber} last_tick_ms_ago={(last == 0 ? -1 : nowMs - last)}");
+                // last == 0 means the dispatcher loop has not produced its
+                // first heartbeat yet (still starting up). Liveness should be
+                // tolerant during startup — readiness probes (/health/ready)
+                // are the correct surface for "not yet ready". A truly dead
+                // dispatcher will start ticking and then go stale, which the
+                // staleness check below catches.
+                if (last == 0) continue;
+                if ((nowMs - last) > stale)
+                    stuck.Add($"channel={c.ChannelNumber} last_tick_ms_ago={nowMs - last}");
             }
             if (stuck.Count > 0)
             {

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -112,11 +112,18 @@ public sealed class HttpServer : IAsyncDisposable
 
     private static IPEndPoint ParseEndpoint(string s)
     {
-        var idx = s.LastIndexOf(':');
-        if (idx < 0) throw new FormatException($"expected host:port, got '{s}'");
-        var host = s.Substring(0, idx);
-        var port = int.Parse(s.Substring(idx + 1));
-        return new IPEndPoint(IPAddress.Parse(host), port);
+        // Use IPEndPoint.Parse for robust parsing of IPv4, IPv6, and hostname:port formats
+        if (!s.Contains(':'))
+            throw new FormatException($"expected host:port, got '{s}'");
+
+        try
+        {
+            return IPEndPoint.Parse(s);
+        }
+        catch (Exception ex)
+        {
+            throw new FormatException($"failed to parse endpoint '{s}'", ex);
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -1,0 +1,131 @@
+using System.Net;
+using B3.Exchange.Integration;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// Minimal Kestrel-hosted operability surface. Exposes:
+///   GET /health/live    — 200 if every dispatcher heartbeat is fresher
+///                         than <see cref="HttpConfig.LivenessStaleMs"/>,
+///                         503 otherwise. Body lists the channels.
+///   GET /health/ready   — 200 once every <see cref="IReadinessProbe"/>
+///                         registered with the host reports ready.
+///   GET /metrics        — Prometheus 0.0.4 text exposition of every
+///                         counter/gauge held by <see cref="MetricsRegistry"/>.
+///
+/// Implemented with the minimal <c>WebApplication</c> hosting model and
+/// no external NuGet packages — Kestrel ships in the
+/// <c>Microsoft.AspNetCore.App</c> shared framework.
+/// </summary>
+public sealed class HttpServer : IAsyncDisposable
+{
+    private readonly HttpConfig _config;
+    private readonly MetricsRegistry _metrics;
+    private readonly IReadOnlyList<IReadinessProbe> _probes;
+    private readonly Action<string>? _log;
+    private WebApplication? _app;
+
+    public HttpServer(HttpConfig config, MetricsRegistry metrics,
+        IReadOnlyList<IReadinessProbe> probes, Action<string>? log = null)
+    {
+        _config = config;
+        _metrics = metrics;
+        _probes = probes;
+        _log = log;
+    }
+
+    public IPEndPoint? LocalEndpoint { get; private set; }
+
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        var ep = ParseEndpoint(_config.Listen);
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        builder.WebHost.UseKestrel(o =>
+        {
+            o.Listen(ep.Address, ep.Port);
+            o.AddServerHeader = false;
+        });
+
+        var app = builder.Build();
+
+        app.MapGet("/health/live", (HttpContext ctx) =>
+        {
+            long nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            int stale = _config.LivenessStaleMs;
+            var channels = _metrics.Channels;
+            var stuck = new List<string>();
+            foreach (var c in channels)
+            {
+                long last = c.LastTickUnixMs;
+                if (last == 0 || (nowMs - last) > stale)
+                    stuck.Add($"channel={c.ChannelNumber} last_tick_ms_ago={(last == 0 ? -1 : nowMs - last)}");
+            }
+            if (stuck.Count > 0)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return Results.Text("DOWN\n" + string.Join('\n', stuck) + '\n', "text/plain");
+            }
+            return Results.Text($"OK channels={channels.Count}\n", "text/plain");
+        });
+
+        app.MapGet("/health/ready", (HttpContext ctx) =>
+        {
+            var notReady = new List<string>();
+            foreach (var p in _probes)
+                if (!p.IsReady) notReady.Add(p.Name);
+            if (notReady.Count > 0)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return Results.Text("NOT_READY\n" + string.Join('\n', notReady) + '\n', "text/plain");
+            }
+            return Results.Text($"READY probes={_probes.Count}\n", "text/plain");
+        });
+
+        app.MapGet("/metrics", () =>
+            Results.Text(_metrics.RenderProm(), "text/plain; version=0.0.4; charset=utf-8"));
+
+        await app.StartAsync(ct).ConfigureAwait(false);
+        _app = app;
+
+        // Resolve the actual bound endpoint (port may be 0 for "any free").
+        var serverAddresses = app.Services.GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>();
+        var addr = serverAddresses?.Addresses.FirstOrDefault();
+        if (addr != null && Uri.TryCreate(addr, UriKind.Absolute, out var uri))
+            LocalEndpoint = new IPEndPoint(IPAddress.Parse(uri.Host), uri.Port);
+        else
+            LocalEndpoint = ep;
+
+        _log?.Invoke($"http listening on {LocalEndpoint}");
+    }
+
+    private static IPEndPoint ParseEndpoint(string s)
+    {
+        var idx = s.LastIndexOf(':');
+        if (idx < 0) throw new FormatException($"expected host:port, got '{s}'");
+        var host = s.Substring(0, idx);
+        var port = int.Parse(s.Substring(idx + 1));
+        return new IPEndPoint(IPAddress.Parse(host), port);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_app != null)
+        {
+            try { await _app.StopAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false); } catch { }
+            try { await _app.DisposeAsync().ConfigureAwait(false); } catch { }
+            _app = null;
+        }
+    }
+}

--- a/src/B3.Exchange.Integration/B3.Exchange.Integration.csproj
+++ b/src/B3.Exchange.Integration/B3.Exchange.Integration.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="B3.Exchange.Integration.Tests" />
+    <InternalsVisibleTo Include="B3.Exchange.Host.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -128,27 +128,25 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
             {
                 RecordHeartbeat();
                 Task<bool> waitTask = reader.WaitToReadAsync(ct).AsTask();
-                Task completed;
+                bool more;
                 try
                 {
-                    completed = await Task.WhenAny(waitTask, Task.Delay(HeartbeatInterval, ct))
+                    more = await waitTask.WaitAsync(HeartbeatInterval, ct)
                         .ConfigureAwait(false);
+                }
+                catch (TimeoutException)
+                {
+                    // Timeout: loop and re-record the heartbeat on next iteration.
+                    continue;
                 }
                 catch (OperationCanceledException) { return; }
 
-                if (completed == waitTask)
+                if (!more) return; // channel completed
+                while (reader.TryRead(out var item))
                 {
-                    bool more;
-                    try { more = await waitTask.ConfigureAwait(false); }
-                    catch (OperationCanceledException) { return; }
-                    if (!more) return; // channel completed
-                    while (reader.TryRead(out var item))
-                    {
-                        ProcessOne(item);
-                        RecordHeartbeat();
-                    }
+                    ProcessOne(item);
+                    RecordHeartbeat();
                 }
-                // else: timeout — loop and re-record the heartbeat.
             }
         }
         catch (OperationCanceledException) { }

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -27,6 +27,14 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     private const int DefaultInboundCapacity = 4096;
     private const int MaxPacketBytes = 1400;
 
+    /// <summary>
+    /// Maximum time the dispatch loop will block waiting for new work before
+    /// emitting a liveness heartbeat. Kept short (1s) so the
+    /// <c>/health/live</c> default threshold (5s) is comfortably exceeded
+    /// only when the loop thread is actually wedged.
+    /// </summary>
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(1);
+
     public byte ChannelNumber { get; }
     public ushort SequenceVersion { get; private set; }
     public uint SequenceNumber { get; private set; }
@@ -37,6 +45,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     private readonly ILogger<ChannelDispatcher> _logger;
     private readonly Func<ulong> _nowNanos;
     private readonly ushort _tradeDate;
+    private readonly ChannelMetrics? _metrics;
 
     private readonly Dictionary<long, OrderOwnership> _orderOwners = new();
     /// <summary>
@@ -68,7 +77,8 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
 
     public ChannelDispatcher(byte channelNumber, Func<IMatchingEventSink, MatchingEngine> engineFactory, IUmdfPacketSink packetSink,
         ILogger<ChannelDispatcher> logger,
-        Func<ulong>? nowNanos = null, ushort tradeDate = 0, int inboundCapacity = DefaultInboundCapacity)
+        Func<ulong>? nowNanos = null, ushort tradeDate = 0, int inboundCapacity = DefaultInboundCapacity,
+        ChannelMetrics? metrics = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ChannelNumber = channelNumber;
@@ -76,6 +86,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
         _logger = logger;
         _nowNanos = nowNanos ?? DefaultNowNanos;
         _tradeDate = tradeDate;
+        _metrics = metrics;
         SequenceVersion = 1;
         SequenceNumber = 0;
         _inbound = System.Threading.Channels.Channel.CreateBounded<WorkItem>(
@@ -94,17 +105,50 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     public void Start()
     {
         _logger.LogInformation("channel {ChannelNumber} dispatcher starting", ChannelNumber);
+        // Seed an initial heartbeat synchronously before the loop task is
+        // scheduled so /health/live does not flap to 503 in the (potentially
+        // long) interval between Start() returning and the dispatcher thread
+        // actually getting CPU. Without this, a probe arriving during that
+        // gap sees LastTickUnixMs == 0 and reports DOWN.
+        RecordHeartbeat();
         _loopTask = Task.Factory.StartNew(() => RunLoopAsync(_cts.Token),
             CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
     }
 
     private async Task RunLoopAsync(CancellationToken ct)
     {
+        // Heartbeat is recorded on every loop wakeup (whether triggered by
+        // new work or by the periodic timeout) so a stuck/dead dispatch
+        // thread is detected by /health/live within HeartbeatInterval +
+        // probe threshold.
         try
         {
-            await foreach (var item in _inbound.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            var reader = _inbound.Reader;
+            while (!ct.IsCancellationRequested)
             {
-                ProcessOne(item);
+                RecordHeartbeat();
+                Task<bool> waitTask = reader.WaitToReadAsync(ct).AsTask();
+                Task completed;
+                try
+                {
+                    completed = await Task.WhenAny(waitTask, Task.Delay(HeartbeatInterval, ct))
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { return; }
+
+                if (completed == waitTask)
+                {
+                    bool more;
+                    try { more = await waitTask.ConfigureAwait(false); }
+                    catch (OperationCanceledException) { return; }
+                    if (!more) return; // channel completed
+                    while (reader.TryRead(out var item))
+                    {
+                        ProcessOne(item);
+                        RecordHeartbeat();
+                    }
+                }
+                // else: timeout — loop and re-record the heartbeat.
             }
         }
         catch (OperationCanceledException) { }
@@ -113,6 +157,9 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
             _logger.LogError(ex, "channel {ChannelNumber} dispatch loop terminated unexpectedly", ChannelNumber);
         }
     }
+
+    private void RecordHeartbeat()
+        => _metrics?.RecordTick(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
     internal void ProcessOne(in WorkItem item)
     {
@@ -133,9 +180,10 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
         {
             switch (item.Kind)
             {
-                case WorkKind.New: _engine.Submit(item.NewOrder!); break;
+                case WorkKind.New: _metrics?.IncOrdersIn(); _engine.Submit(item.NewOrder!); break;
                 case WorkKind.Cancel:
                     {
+                        _metrics?.IncOrdersIn();
                         var cancel = item.Cancel!;
                         if (cancel.OrderId == 0)
                         {
@@ -151,6 +199,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
                     }
                 case WorkKind.Replace:
                     {
+                        _metrics?.IncOrdersIn();
                         var replace = item.Replace!;
                         if (replace.OrderId == 0)
                         {
@@ -232,6 +281,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
             _packetBuf.AsSpan(0, B3.Umdf.WireEncoder.WireOffsets.PacketHeaderSize), SequenceNumber, now);
         _packetSink.Publish(ChannelNumber, _packetBuf.AsSpan(0, _packetWritten));
         LogPacketFlushed(ChannelNumber, SequenceNumber, _packetWritten);
+        _metrics?.IncPacketsOut();
         _packetWritten = 0;
     }
 
@@ -462,6 +512,18 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     }
 
     // ====== shutdown ======
+
+    /// <summary>
+    /// Test hook: simulate a wedged dispatcher by cancelling the loop
+    /// without disposing. Subsequent enqueues remain accepted by the
+    /// channel but will never be processed, so liveness probes can verify
+    /// that <c>/health/live</c> flips to 503 within the configured stale
+    /// threshold.
+    /// </summary>
+    internal void KillForTesting()
+    {
+        try { _cts.Cancel(); } catch { }
+    }
 
     public async ValueTask DisposeAsync()
     {

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -105,12 +105,6 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     public void Start()
     {
         _logger.LogInformation("channel {ChannelNumber} dispatcher starting", ChannelNumber);
-        // Seed an initial heartbeat synchronously before the loop task is
-        // scheduled so /health/live does not flap to 503 in the (potentially
-        // long) interval between Start() returning and the dispatcher thread
-        // actually getting CPU. Without this, a probe arriving during that
-        // gap sees LastTickUnixMs == 0 and reports DOWN.
-        RecordHeartbeat();
         _loopTask = Task.Factory.StartNew(() => RunLoopAsync(_cts.Token),
             CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
     }

--- a/src/B3.Exchange.Integration/IReadinessProbe.cs
+++ b/src/B3.Exchange.Integration/IReadinessProbe.cs
@@ -1,0 +1,41 @@
+namespace B3.Exchange.Integration;
+
+/// <summary>
+/// Single readiness signal. Composes additively: the host's overall
+/// readiness is the AND of every registered probe.
+///
+/// Designed so issue #1 (snapshot rotator) and issue #2 (instrument
+/// definition publisher) can each register a probe that flips to ready
+/// once they have emitted at least one snapshot/definition per loaded
+/// instrument since startup. Until those land, the host registers a
+/// single <see cref="StartupReadinessProbe"/> that goes ready as soon
+/// as <see cref="ExchangeHost.StartAsync"/> returns.
+/// </summary>
+public interface IReadinessProbe
+{
+    /// <summary>Stable identifier for diagnostics (e.g. "startup", "snapshot-rotator").</summary>
+    string Name { get; }
+
+    /// <summary>Returns true once this subsystem considers itself ready.</summary>
+    bool IsReady { get; }
+}
+
+/// <summary>
+/// Trivial probe flipped by an explicit <see cref="MarkReady"/> call.
+/// Used by the host to mark itself ready once startup completes.
+/// </summary>
+public sealed class StartupReadinessProbe : IReadinessProbe
+{
+    private int _ready;
+
+    public StartupReadinessProbe(string name = "startup")
+    {
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public bool IsReady => Volatile.Read(ref _ready) == 1;
+
+    public void MarkReady() => Interlocked.Exchange(ref _ready, 1);
+}

--- a/src/B3.Exchange.Integration/MetricsRegistry.cs
+++ b/src/B3.Exchange.Integration/MetricsRegistry.cs
@@ -1,0 +1,186 @@
+using System.Globalization;
+using System.Text;
+
+namespace B3.Exchange.Integration;
+
+/// <summary>
+/// Per-channel atomic counters and gauges. All mutating methods are
+/// designed to be called from the channel's single dispatch thread (no
+/// internal locking; lock-free <see cref="Interlocked"/> primitives are
+/// used so a metrics scrape from a separate thread sees consistent values).
+/// </summary>
+public sealed class ChannelMetrics
+{
+    public byte ChannelNumber { get; }
+
+    private long _ordersIn;
+    private long _packetsOut;
+    private long _snapshotsEmitted;
+    private long _instrumentDefsEmitted;
+    private long _lastTickUnixMs;
+
+    public ChannelMetrics(byte channelNumber)
+    {
+        ChannelNumber = channelNumber;
+    }
+
+    public long OrdersIn => Interlocked.Read(ref _ordersIn);
+    public long PacketsOut => Interlocked.Read(ref _packetsOut);
+    public long SnapshotsEmitted => Interlocked.Read(ref _snapshotsEmitted);
+    public long InstrumentDefsEmitted => Interlocked.Read(ref _instrumentDefsEmitted);
+    public long LastTickUnixMs => Interlocked.Read(ref _lastTickUnixMs);
+
+    public void IncOrdersIn() => Interlocked.Increment(ref _ordersIn);
+    public void IncPacketsOut() => Interlocked.Increment(ref _packetsOut);
+    public void IncSnapshotsEmitted() => Interlocked.Increment(ref _snapshotsEmitted);
+    public void IncInstrumentDefsEmitted() => Interlocked.Increment(ref _instrumentDefsEmitted);
+
+    /// <summary>
+    /// Heartbeat. Called from the dispatch thread on every loop wakeup so
+    /// liveness probes can detect a stuck/dead dispatcher.
+    /// </summary>
+    public void RecordTick(long unixMs) => Interlocked.Exchange(ref _lastTickUnixMs, unixMs);
+}
+
+/// <summary>
+/// Provider of per-session send-queue depth gauges. The host wires an
+/// implementation that snapshots the active <c>EntryPointSession</c>
+/// queues at scrape time. The "channel" label is currently fixed to
+/// <c>"all"</c> because a session's send queue is shared across every
+/// channel that may route ExecutionReports back to it; per-channel
+/// partitioning of session queues is not implemented today.
+/// </summary>
+public interface ISessionMetricsProvider
+{
+    IEnumerable<SessionQueueSample> Sample();
+}
+
+public readonly record struct SessionQueueSample(string SessionId, long QueueDepth);
+
+/// <summary>
+/// Central registry of channel metrics + a Prometheus text-format
+/// renderer. Hand-rolled to avoid taking a dependency on
+/// <c>prometheus-net</c> (see issue #5 / project conventions).
+/// </summary>
+public sealed class MetricsRegistry
+{
+    private readonly Dictionary<byte, ChannelMetrics> _channels = new();
+    private readonly object _lock = new();
+    private ISessionMetricsProvider? _sessions;
+
+    public ChannelMetrics RegisterChannel(byte channelNumber)
+    {
+        lock (_lock)
+        {
+            if (_channels.TryGetValue(channelNumber, out var existing)) return existing;
+            var m = new ChannelMetrics(channelNumber);
+            _channels.Add(channelNumber, m);
+            return m;
+        }
+    }
+
+    public void SetSessionProvider(ISessionMetricsProvider provider)
+    {
+        lock (_lock) _sessions = provider;
+    }
+
+    public IReadOnlyCollection<ChannelMetrics> Channels
+    {
+        get { lock (_lock) return _channels.Values.ToArray(); }
+    }
+
+    /// <summary>
+    /// Render the Prometheus 0.0.4 text exposition format for all registered
+    /// metrics. Output is ASCII; numeric values use invariant culture.
+    /// </summary>
+    public string RenderProm()
+    {
+        var sb = new StringBuilder(1024);
+        ChannelMetrics[] channels;
+        ISessionMetricsProvider? sessions;
+        lock (_lock)
+        {
+            channels = _channels.Values.OrderBy(c => c.ChannelNumber).ToArray();
+            sessions = _sessions;
+        }
+
+        EmitCounter(sb, "exch_orders_in_total",
+            "Total inbound order commands (New/Cancel/Replace) accepted by the dispatcher.",
+            channels, c => c.OrdersIn);
+        EmitCounter(sb, "exch_packets_out_total",
+            "Total UMDF packets emitted to the multicast sink.",
+            channels, c => c.PacketsOut);
+        EmitCounter(sb, "exch_snapshots_emitted_total",
+            "Total UMDF snapshot frames emitted by the snapshot rotator (issue #1).",
+            channels, c => c.SnapshotsEmitted);
+        EmitCounter(sb, "exch_instrument_defs_emitted_total",
+            "Total UMDF SecurityList/InstrumentDef messages emitted (issue #2).",
+            channels, c => c.InstrumentDefsEmitted);
+        EmitGauge(sb, "exch_dispatch_loop_last_tick_unixms",
+            "Unix time (milliseconds) of the dispatcher loop's last heartbeat.",
+            channels, c => c.LastTickUnixMs);
+
+        sb.Append("# HELP exch_send_queue_depth Per-session ExecutionReport send-queue depth (channel=\"all\" because the session queue is shared).\n");
+        sb.Append("# TYPE exch_send_queue_depth gauge\n");
+        if (sessions != null)
+        {
+            foreach (var s in sessions.Sample())
+            {
+                sb.Append("exch_send_queue_depth{channel=\"all\",session=\"")
+                  .Append(EscapeLabel(s.SessionId))
+                  .Append("\"} ")
+                  .Append(s.QueueDepth.ToString(CultureInfo.InvariantCulture))
+                  .Append('\n');
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void EmitCounter(StringBuilder sb, string name, string help,
+        ChannelMetrics[] channels, Func<ChannelMetrics, long> selector)
+    {
+        sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
+        sb.Append("# TYPE ").Append(name).Append(" counter\n");
+        foreach (var c in channels)
+        {
+            sb.Append(name).Append("{channel=\"")
+              .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
+              .Append("\"} ")
+              .Append(selector(c).ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+    }
+
+    private static void EmitGauge(StringBuilder sb, string name, string help,
+        ChannelMetrics[] channels, Func<ChannelMetrics, long> selector)
+    {
+        sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
+        sb.Append("# TYPE ").Append(name).Append(" gauge\n");
+        foreach (var c in channels)
+        {
+            sb.Append(name).Append("{channel=\"")
+              .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
+              .Append("\"} ")
+              .Append(selector(c).ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+    }
+
+    private static string EscapeLabel(string s)
+    {
+        if (s.IndexOfAny(new[] { '\\', '"', '\n' }) < 0) return s;
+        var sb = new StringBuilder(s.Length + 8);
+        foreach (var ch in s)
+        {
+            switch (ch)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                default: sb.Append(ch); break;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -103,8 +103,11 @@ public class HttpServerTests
     [Fact]
     public async Task LiveFlipsTo503_WithinThreshold_AfterDispatcherIsKilled()
     {
-        // Short threshold so the test stays well under 10 s.
-        var (cfg, sink) = BuildConfig(livenessStaleMs: 500);
+        // Threshold must be > the dispatcher's internal HeartbeatInterval
+        // (1 s) so a healthy dispatcher's normal "tick every 1 s" cadence
+        // doesn't itself trip the 503. 2500 ms keeps total test time well
+        // under the 10 s acceptance window while leaving headroom for CI.
+        var (cfg, sink) = BuildConfig(livenessStaleMs: 2500);
         await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
         await host.StartAsync();
         var http = host.HttpEndpoint!;

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -90,13 +90,13 @@ public class HttpServerTests
         var http = host.HttpEndpoint!;
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
-        var ready = await client.GetAsync("/health/ready");
+        using var ready = await client.GetAsync("/health/ready");
         Assert.Equal(System.Net.HttpStatusCode.ServiceUnavailable, ready.StatusCode);
         var body = await ready.Content.ReadAsStringAsync();
         Assert.Contains("snapshot-rotator", body);
 
         rotatorProbe.MarkReady();
-        var ready2 = await client.GetAsync("/health/ready");
+        using var ready2 = await client.GetAsync("/health/ready");
         Assert.Equal(System.Net.HttpStatusCode.OK, ready2.StatusCode);
     }
 
@@ -112,7 +112,7 @@ public class HttpServerTests
         using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
 
         // Healthy first.
-        var live = await client.GetAsync("/health/live");
+        using var live = await client.GetAsync("/health/live");
         Assert.Equal(System.Net.HttpStatusCode.OK, live.StatusCode);
 
         // Wedge the dispatcher loop without disposing.

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -1,0 +1,134 @@
+using System.Net.Http;
+using B3.Exchange.Integration;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Smoke tests for the Kestrel-hosted /health/live, /health/ready, and
+/// /metrics endpoints. Covers issue #5 acceptance:
+///   * 200 on all three endpoints under nominal conditions.
+///   * /metrics exposes the documented counters/gauges.
+///   * Killing a dispatcher flips /health/live to 503 within <10 s.
+/// </summary>
+public class HttpServerTests
+{
+    private static (HostConfig cfg, IUmdfPacketSink sink) BuildConfig(int livenessStaleMs = 5000)
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var cfg = new HostConfig
+        {
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = livenessStaleMs },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30184,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                },
+            },
+        };
+        return (cfg, new RecordingSink());
+    }
+
+    private sealed class RecordingSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task LiveAndReadyAndMetrics_AllReturn200_AfterStartup()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+
+        var live = await client.GetAsync("/health/live");
+        Assert.Equal(System.Net.HttpStatusCode.OK, live.StatusCode);
+
+        var ready = await client.GetAsync("/health/ready");
+        Assert.Equal(System.Net.HttpStatusCode.OK, ready.StatusCode);
+
+        var metrics = await client.GetAsync("/metrics");
+        Assert.Equal(System.Net.HttpStatusCode.OK, metrics.StatusCode);
+        var body = await metrics.Content.ReadAsStringAsync();
+        Assert.Contains("exch_orders_in_total", body);
+        Assert.Contains("exch_packets_out_total", body);
+        Assert.Contains("exch_send_queue_depth", body);
+        Assert.Contains("exch_snapshots_emitted_total", body);
+        Assert.Contains("exch_instrument_defs_emitted_total", body);
+        Assert.Contains("exch_dispatch_loop_last_tick_unixms", body);
+        Assert.Contains("channel=\"84\"", body);
+    }
+
+    [Fact]
+    public async Task ReadyReturns503_WhenAnAdditionalProbeIsNotReady()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        var rotatorProbe = new StartupReadinessProbe("snapshot-rotator");
+        host.RegisterReadinessProbe(rotatorProbe);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+        var ready = await client.GetAsync("/health/ready");
+        Assert.Equal(System.Net.HttpStatusCode.ServiceUnavailable, ready.StatusCode);
+        var body = await ready.Content.ReadAsStringAsync();
+        Assert.Contains("snapshot-rotator", body);
+
+        rotatorProbe.MarkReady();
+        var ready2 = await client.GetAsync("/health/ready");
+        Assert.Equal(System.Net.HttpStatusCode.OK, ready2.StatusCode);
+    }
+
+    [Fact]
+    public async Task LiveFlipsTo503_WithinThreshold_AfterDispatcherIsKilled()
+    {
+        // Short threshold so the test stays well under 10 s.
+        var (cfg, sink) = BuildConfig(livenessStaleMs: 500);
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+
+        // Healthy first.
+        var live = await client.GetAsync("/health/live");
+        Assert.Equal(System.Net.HttpStatusCode.OK, live.StatusCode);
+
+        // Wedge the dispatcher loop without disposing.
+        foreach (var d in host.Dispatchers) d.KillForTesting();
+
+        // Poll until /health/live flips to 503. Bound wait at 8 s (issue
+        // acceptance: <10 s).
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(8);
+        System.Net.HttpStatusCode last = System.Net.HttpStatusCode.OK;
+        while (DateTime.UtcNow < deadline)
+        {
+            var resp = await client.GetAsync("/health/live");
+            last = resp.StatusCode;
+            if (last == System.Net.HttpStatusCode.ServiceUnavailable) break;
+            await Task.Delay(100);
+        }
+        Assert.Equal(System.Net.HttpStatusCode.ServiceUnavailable, last);
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -61,13 +61,13 @@ public class HttpServerTests
 
         using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
 
-        var live = await client.GetAsync("/health/live");
+        using var live = await client.GetAsync("/health/live");
         Assert.Equal(System.Net.HttpStatusCode.OK, live.StatusCode);
 
-        var ready = await client.GetAsync("/health/ready");
+        using var ready = await client.GetAsync("/health/ready");
         Assert.Equal(System.Net.HttpStatusCode.OK, ready.StatusCode);
 
-        var metrics = await client.GetAsync("/metrics");
+        using var metrics = await client.GetAsync("/metrics");
         Assert.Equal(System.Net.HttpStatusCode.OK, metrics.StatusCode);
         var body = await metrics.Content.ReadAsStringAsync();
         Assert.Contains("exch_orders_in_total", body);
@@ -124,7 +124,7 @@ public class HttpServerTests
         System.Net.HttpStatusCode last = System.Net.HttpStatusCode.OK;
         while (DateTime.UtcNow < deadline)
         {
-            var resp = await client.GetAsync("/health/live");
+            using var resp = await client.GetAsync("/health/live");
             last = resp.StatusCode;
             if (last == System.Net.HttpStatusCode.ServiceUnavailable) break;
             await Task.Delay(100);

--- a/tests/B3.Exchange.Integration.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/MetricsRegistryTests.cs
@@ -1,0 +1,67 @@
+using B3.Exchange.Integration;
+
+namespace B3.Exchange.Integration.Tests;
+
+public class MetricsRegistryTests
+{
+    [Fact]
+    public void Render_EmitsExpectedSeries_WithLabelsAndHelpLines()
+    {
+        var reg = new MetricsRegistry();
+        var ch = reg.RegisterChannel(84);
+        ch.IncOrdersIn();
+        ch.IncOrdersIn();
+        ch.IncPacketsOut();
+        ch.IncSnapshotsEmitted();
+        ch.IncInstrumentDefsEmitted();
+        ch.RecordTick(1_700_000_000_000);
+
+        reg.SetSessionProvider(new StubSessionProvider(new[]
+        {
+            new SessionQueueSample("conn-42", 7),
+        }));
+
+        var text = reg.RenderProm();
+
+        // Counters present with channel label.
+        Assert.Contains("# TYPE exch_orders_in_total counter\n", text);
+        Assert.Contains("exch_orders_in_total{channel=\"84\"} 2\n", text);
+        Assert.Contains("exch_packets_out_total{channel=\"84\"} 1\n", text);
+        Assert.Contains("exch_snapshots_emitted_total{channel=\"84\"} 1\n", text);
+        Assert.Contains("exch_instrument_defs_emitted_total{channel=\"84\"} 1\n", text);
+
+        // Gauges.
+        Assert.Contains("# TYPE exch_dispatch_loop_last_tick_unixms gauge\n", text);
+        Assert.Contains("exch_dispatch_loop_last_tick_unixms{channel=\"84\"} 1700000000000\n", text);
+
+        // Session gauge.
+        Assert.Contains("# TYPE exch_send_queue_depth gauge\n", text);
+        Assert.Contains("exch_send_queue_depth{channel=\"all\",session=\"conn-42\"} 7\n", text);
+    }
+
+    [Fact]
+    public void RegisterChannel_IsIdempotent()
+    {
+        var reg = new MetricsRegistry();
+        var a = reg.RegisterChannel(7);
+        var b = reg.RegisterChannel(7);
+        Assert.Same(a, b);
+    }
+
+    [Fact]
+    public void StartupReadinessProbe_FlipsOnMarkReady()
+    {
+        var p = new StartupReadinessProbe("startup");
+        Assert.False(p.IsReady);
+        p.MarkReady();
+        Assert.True(p.IsReady);
+        Assert.Equal("startup", p.Name);
+    }
+
+    private sealed class StubSessionProvider : ISessionMetricsProvider
+    {
+        private readonly SessionQueueSample[] _samples;
+        public StubSessionProvider(SessionQueueSample[] samples) { _samples = samples; }
+        public IEnumerable<SessionQueueSample> Sample() => _samples;
+    }
+}


### PR DESCRIPTION
Closes #5.

## Design

**Operability surface.** Adds a Kestrel-hosted HTTP server (no extra NuGet — uses the `Microsoft.AspNetCore.App` shared framework) exposing:

- `GET /health/live` — 200 if every dispatcher loop has heartbeat within `http.livenessStaleMs` (default 5 s); 503 otherwise (with a body listing the stuck channels).
- `GET /health/ready` — 200 once every registered `IReadinessProbe` reports ready; 503 with a body listing not-ready probes otherwise.
- `GET /metrics` — Prometheus 0.0.4 text exposition rendered by hand (no `prometheus-net`).

The HTTP block is **optional** in `config/exchange-simulator.json`; omit it to disable HTTP entirely. Default bind is `0.0.0.0:8080`.

**Metrics.** Per-channel atomic counters/gauges live on `ChannelMetrics` (lock-free `Interlocked.*`). `ChannelDispatcher` increments `orders_in_total` per processed command and `packets_out_total` per flushed UMDF packet, and records a heartbeat on every loop wakeup. The dispatch loop now races the inbound channel reader against a 1 s timer (`Task.WhenAny(WaitToReadAsync, Task.Delay(1s))`) so a stuck thread is detected within `livenessStaleMs + ~1s` even when traffic is idle. `exch_send_queue_depth` samples each `EntryPointSession.SendQueueDepth` at scrape time via `EntryPointListener.ActiveSessions`.

**Forward-compatibility with #1 / #2.**

- `IReadinessProbe { string Name; bool IsReady; }` is the composition primitive. The host's overall readiness is the AND of every registered probe. Issue #1 (snapshot rotator) and issue #2 (instrument-definition publisher) will each register their own probe and call `MarkReady()` once they have emitted at least one snapshot / definition per loaded instrument.
- Until those land, `ExchangeHost` registers a single `StartupReadinessProbe` that flips ready as soon as `StartAsync` returns. `/health/ready` therefore behaves like `/health/live` today; this is documented in `docs/EXCHANGE-SIMULATOR.md`.
- `exch_snapshots_emitted_total` and `exch_instrument_defs_emitted_total` counters are defined now (so dashboards/alerts can be wired in advance) but stay at 0 until #1/#2 increment them.

**Docker.** `Dockerfile` exposes 8080 and adds a `HEALTHCHECK` that hits `/health/live` via `wget` (already present in the `aspnet:10.0` runtime image).

**`exch_send_queue_depth` channel label.** A session's send queue is shared across every channel that may route ExecutionReports back to it. Rather than fan it out per channel (which would double-count), the gauge is emitted with `channel="all"`. Documented as a known limitation.

## Files changed

```
src/B3.Exchange.Integration/MetricsRegistry.cs        (new)  Counters + Prometheus renderer
src/B3.Exchange.Integration/IReadinessProbe.cs        (new)  Probe interface + StartupReadinessProbe
src/B3.Exchange.Integration/ChannelDispatcher.cs              metrics + heartbeating loop + KillForTesting
src/B3.Exchange.Integration/B3.Exchange.Integration.csproj    InternalsVisibleTo Host.Tests
src/B3.Exchange.EntryPoint/EntryPointSession.cs               public SendQueueDepth
src/B3.Exchange.EntryPoint/EntryPointListener.cs              public ActiveSessions snapshot
src/B3.Exchange.Host/HttpServer.cs                    (new)  Kestrel /health/* + /metrics
src/B3.Exchange.Host/HostConfig.cs                            HttpConfig section
src/B3.Exchange.Host/ExchangeHost.cs                          wires HTTP + metrics + startup probe
src/B3.Exchange.Host/B3.Exchange.Host.csproj                  AspNetCore framework ref + IVT
config/exchange-simulator.json                                http section default
docs/EXCHANGE-SIMULATOR.md                                    documents endpoints + readiness story
Dockerfile                                                    EXPOSE 8080 + HEALTHCHECK
tests/B3.Exchange.Host.Tests/HttpServerTests.cs       (new)   /health/* + /metrics smoke + dispatcher-kill
tests/B3.Exchange.Integration.Tests/MetricsRegistryTests.cs (new) renderer + probe unit tests
```

## Acceptance check

- ✅ Running host responds 200 on `/health/live`, `/health/ready`, `/metrics` (verified locally with `curl` against a smoke config).
- ✅ Killing all dispatchers (`KillForTesting()`) flips `/health/live` to 503 within <10 s — covered by `HttpServerTests.LiveFlipsTo503_WithinThreshold_AfterDispatcherIsKilled` (uses a 500 ms threshold and bounds the wait at 8 s).

## Pre-PR checklist

```
dotnet restore SbeB3Exchange.slnx
dotnet build   SbeB3Exchange.slnx --no-restore -c Release          # 0 warnings, 0 errors
dotnet test    SbeB3Exchange.slnx --no-build   -c Release          # 97 passed (was 91)
dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn   # clean
```

## Follow-ups discovered

- The `EntryPointSession.ConnectionId` is currently a 63-bit random value (see `ExchangeHost.identityFactory`). Rendered as `conn-<long>` in metrics labels; a stable, monotonic per-connection counter would be friendlier for time-series UIs.
- `EntryPointListener.ActiveSessions` never prunes closed sessions — they linger until `DisposeAsync`. The metrics snapshot already filters on `IsOpen`, but a long-lived host with many short connections will accumulate the list. Worth a separate cleanup PR.
- Channel partitioning of session queues (true `exch_send_queue_depth{channel,session}` semantics) requires per-channel outbound queues on the session side — out of scope here.