### PR TITLE
feat: snapshot channel publisher (#1)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -13,7 +13,20 @@
       "incrementalGroup": "224.0.20.84",
       "incrementalPort": 30084,
       "ttl": 1,
-      "instruments": "config/instruments-eqt.json"
+      "instruments": "config/instruments-eqt.json",
+      // Optional snapshot publisher. Multicast group/port MUST be distinct
+      // from the incremental channel; consumers subscribe to both
+      // independently and use the snapshot to bootstrap the order book on
+      // mid-session connect. cadenceMs is the per-channel rotation period —
+      // each tick publishes one instrument's complete snapshot, then the
+      // rotator advances to the next instrument.
+      "snapshot": {
+        "group": "224.0.20.184",
+        "port": 30184,
+        "ttl": 1,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      }
     }
   ]
 }

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -73,7 +73,14 @@ Exposes:
       "incrementalGroup": "224.0.20.84",
       "incrementalPort": 30084,
       "ttl": 1,
-      "instruments": "config/instruments-eqt.json"
+      "instruments": "config/instruments-eqt.json",
+      "snapshot": {
+        "group": "224.0.20.184",
+        "port": 30184,
+        "ttl": 1,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      }
     }
   ]
 }
@@ -86,6 +93,17 @@ Exposes:
   UMDF channel.
 * `instruments` — path to the instrument list (re-uses the format already
   consumed by `B3.Exchange.Instruments.InstrumentLoader`).
+* `snapshot` (optional) — per-channel snapshot publisher. When present, the
+  host opens a second multicast socket on `group:port` and a per-channel
+  `SnapshotRotator` round-robins through the channel's instruments,
+  publishing a `SnapshotFullRefresh_Header_30` + chunked
+  `SnapshotFullRefresh_Orders_MBO_71` frames every `cadenceMs`
+  milliseconds. The snapshot channel maintains its own `SequenceVersion` /
+  `SequenceNumber` state, distinct from the incremental channel.
+  `maxEntriesPerChunk` caps the per-`Orders_71` group size (defaults to
+  30, ~1.3 KB per chunk → fits a standard 1500-byte MTU). Omit the
+  `snapshot` block to publish only the incremental feed (no bootstrap for
+  mid-session consumers).
 
 ## Wire protocol
 
@@ -115,9 +133,22 @@ deferred to a later milestone.
 
 ### Outbound (UMDF multicast)
 
-Standard B3 UMDF inc packets — `PacketHeader` (16 bytes) + framed
-`Order_MBO_50`, `DeleteOrder_MBO_51`, `Trade_53` messages. Compatible with
-the existing `B3.Umdf.ConsoleApp` consumer in this repo.
+Two distinct multicast streams per channel:
+
+* **Incremental** — `PacketHeader` (16 bytes) + framed `Order_MBO_50`,
+  `DeleteOrder_MBO_51`, `Trade_53` messages. One UDP packet per inbound
+  command (events emitted while processing a single command are batched
+  into one packet ≤1400 bytes, with a monotonic `SequenceNumber`).
+* **Snapshot** (optional) — `PacketHeader` + `SnapshotFullRefresh_Header_30`
+  + one or more `SnapshotFullRefresh_Orders_MBO_71` chunk frames. A
+  per-channel rotator publishes a complete snapshot for one instrument per
+  tick, round-robining through the channel's instruments. Empty / illiquid
+  instruments emit a header-only packet with `LastRptSeq` absent (per B3
+  §7.4). Snapshot packets carry their own `SequenceVersion` / `SequenceNumber`
+  separate from the incremental channel.
+
+Both streams are compatible with the existing `B3.Umdf.ConsoleApp` consumer
+in this repo.
 
 ## Sending an order with `nc`
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -22,20 +22,26 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly HostConfig _config;
     private readonly Action<string>? _log;
     private readonly Func<ChannelConfig, IUmdfPacketSink>? _packetSinkFactory;
+    private readonly Func<ChannelConfig, SnapshotChannelConfig, IUmdfPacketSink>? _snapshotSinkFactory;
     private readonly List<ChannelDispatcher> _dispatchers = new();
     private readonly List<IDisposable> _ownedSinks = new();
+    private readonly List<Timer> _snapshotTimers = new();
     private EntryPointListener? _listener;
     private HostRouter? _router;
 
     public ExchangeHost(HostConfig config, Action<string>? log = null,
-        Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null)
+        Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null,
+        Func<ChannelConfig, SnapshotChannelConfig, IUmdfPacketSink>? snapshotSinkFactory = null)
     {
         _config = config;
         _log = log;
         _packetSinkFactory = packetSinkFactory;
+        _snapshotSinkFactory = snapshotSinkFactory;
     }
 
     public IPEndPoint? TcpEndpoint => _listener?.LocalEndpoint;
+
+    public IReadOnlyList<ChannelDispatcher> Dispatchers => _dispatchers;
 
     public Task StartAsync()
     {
@@ -54,9 +60,18 @@ public sealed class ExchangeHost : IAsyncDisposable
                 sink = new MulticastUdpPacketSink(IPAddress.Parse(ch.IncrementalGroup), ch.IncrementalPort, local, ch.Ttl);
             }
             if (sink is IDisposable d) _ownedSinks.Add(d);
+
+            // Capture the engine via a side-channel so we can build a snapshot
+            // source that reads through the live book on the dispatcher thread.
+            MatchingEngine? capturedEngine = null;
             var disp = new ChannelDispatcher(
                 channelNumber: ch.ChannelNumber,
-                engineFactory: s => new MatchingEngine(instruments, s),
+                engineFactory: s =>
+                {
+                    var e = new MatchingEngine(instruments, s);
+                    capturedEngine = e;
+                    return e;
+                },
                 packetSink: sink);
             disp.Start();
             _dispatchers.Add(disp);
@@ -67,6 +82,38 @@ public sealed class ExchangeHost : IAsyncDisposable
                 routing.Add(inst.SecurityId, disp);
             }
             _log?.Invoke($"channel {ch.ChannelNumber}: {instruments.Count} instruments → {ch.IncrementalGroup}:{ch.IncrementalPort}");
+
+            if (ch.Snapshot != null)
+            {
+                var snap = ch.Snapshot;
+                IUmdfPacketSink snapSink;
+                if (_snapshotSinkFactory != null)
+                {
+                    snapSink = _snapshotSinkFactory(ch, snap);
+                }
+                else
+                {
+                    var local = ch.LocalInterface != null ? IPAddress.Parse(ch.LocalInterface) : null;
+                    snapSink = new MulticastUdpPacketSink(IPAddress.Parse(snap.Group), snap.Port, local, snap.Ttl ?? ch.Ttl);
+                }
+                if (snapSink is IDisposable sd) _ownedSinks.Add(sd);
+
+                var ids = instruments.Select(i => i.SecurityId).ToArray();
+                var source = new MatchingEngineSnapshotSource(capturedEngine!, ids);
+                int chunkCap = snap.MaxEntriesPerChunk ?? 30;
+                var rotator = new SnapshotRotator(
+                    channelNumber: ch.ChannelNumber,
+                    source: source,
+                    sink: snapSink,
+                    maxEntriesPerChunk: chunkCap);
+                disp.AttachSnapshotRotator(rotator);
+
+                var cadence = TimeSpan.FromMilliseconds(Math.Max(50, snap.CadenceMs));
+                var capturedDisp = disp;
+                var timer = new Timer(_ => capturedDisp.EnqueueSnapshotTick(), null, cadence, cadence);
+                _snapshotTimers.Add(timer);
+                _log?.Invoke($"channel {ch.ChannelNumber}: snapshot → {snap.Group}:{snap.Port} every {cadence.TotalMilliseconds:n0}ms");
+            }
         }
 
         _router = new HostRouter(routing);
@@ -96,6 +143,7 @@ public sealed class ExchangeHost : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        foreach (var t in _snapshotTimers) await t.DisposeAsync().ConfigureAwait(false);
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);
         foreach (var d in _dispatchers) await d.DisposeAsync().ConfigureAwait(false);
         foreach (var s in _ownedSinks) s.Dispose();

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -28,6 +28,27 @@ public sealed class ChannelConfig
     [JsonPropertyName("localInterface")] public string? LocalInterface { get; set; }
     [JsonPropertyName("ttl")] public byte Ttl { get; set; } = 1;
     [JsonPropertyName("instruments")] public string InstrumentsFile { get; set; } = "";
+
+    /// <summary>
+    /// Optional snapshot publisher configuration. When omitted, the channel
+    /// publishes only the incremental feed; consumers connecting mid-session
+    /// have no way to bootstrap the order book.
+    /// </summary>
+    [JsonPropertyName("snapshot")] public SnapshotChannelConfig? Snapshot { get; set; }
+}
+
+/// <summary>
+/// Per-channel snapshot publisher config. Multicast group/port MUST be
+/// distinct from the incremental channel — consumers subscribe to both
+/// independently.
+/// </summary>
+public sealed class SnapshotChannelConfig
+{
+    [JsonPropertyName("group")] public string Group { get; set; } = "";
+    [JsonPropertyName("port")] public int Port { get; set; }
+    [JsonPropertyName("ttl")] public byte? Ttl { get; set; }
+    [JsonPropertyName("cadenceMs")] public int CadenceMs { get; set; } = 1000;
+    [JsonPropertyName("maxEntriesPerChunk")] public int? MaxEntriesPerChunk { get; set; }
 }
 
 public static class HostConfigLoader

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -43,8 +43,17 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
     private ulong _currentClOrdId;
     private ulong _currentOrigClOrdId;
 
+    private SnapshotRotator? _snapshotRotator;
+
     private readonly CancellationTokenSource _cts = new();
     private Task? _loopTask;
+
+    /// <summary>
+    /// The snapshot rotator bound to this dispatcher, if any. Always invoked
+    /// on the dispatch thread via a <see cref="WorkKind.SnapshotRotation"/>
+    /// work item so it observes a stable book.
+    /// </summary>
+    public SnapshotRotator? SnapshotRotator => _snapshotRotator;
 
     public ChannelDispatcher(byte channelNumber, Func<IMatchingEventSink, MatchingEngine> engineFactory, IUmdfPacketSink packetSink,
         Func<ulong>? nowNanos = null, ushort tradeDate = 0, int inboundCapacity = DefaultInboundCapacity)
@@ -88,6 +97,15 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
 
     internal void ProcessOne(in WorkItem item)
     {
+        if (item.Kind == WorkKind.SnapshotRotation)
+        {
+            // Snapshot ticks bypass the per-command incremental packet buffer
+            // entirely — they have their own sink + sequence space owned by
+            // the rotator and emit one or more complete packets directly.
+            _snapshotRotator?.PublishNext();
+            return;
+        }
+
         _currentReply = item.Reply;
         _currentClOrdId = item.ClOrdId;
         _currentOrigClOrdId = item.OrigClOrdId;
@@ -162,6 +180,29 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
 
     public void OnDecodeError(IEntryPointResponseChannel reply, string error)
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.DecodeError, reply, 0, 0, null, null, null));
+
+    /// <summary>
+    /// Attaches a <see cref="SnapshotRotator"/> to this dispatcher. May only
+    /// be called once. After this returns, any caller (typically a
+    /// <see cref="System.Threading.Timer"/>) may invoke
+    /// <see cref="EnqueueSnapshotTick"/> to schedule a snapshot publish on
+    /// the dispatch thread.
+    /// </summary>
+    public void AttachSnapshotRotator(SnapshotRotator rotator)
+    {
+        ArgumentNullException.ThrowIfNull(rotator);
+        if (_snapshotRotator != null)
+            throw new InvalidOperationException("snapshot rotator already attached");
+        _snapshotRotator = rotator;
+    }
+
+    /// <summary>
+    /// Posts a snapshot tick into the inbound queue. Returns <c>false</c> if
+    /// the queue is full (snapshots are idempotent — losing a tick simply
+    /// defers the next refresh by one period). Safe to call from any thread.
+    /// </summary>
+    public bool EnqueueSnapshotTick()
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.SnapshotRotation, null!, 0, 0, null, null, null));
 
     // ====== IMatchingEventSink ======
 
@@ -285,7 +326,7 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
         _cts.Dispose();
     }
 
-    internal enum WorkKind : byte { New, Cancel, Replace, DecodeError }
+    internal enum WorkKind : byte { New, Cancel, Replace, DecodeError, SnapshotRotation }
 
     internal readonly record struct OrderOwnership(IEntryPointResponseChannel Reply, ulong ClOrdId);
 

--- a/src/B3.Exchange.Integration/ISnapshotBookSource.cs
+++ b/src/B3.Exchange.Integration/ISnapshotBookSource.cs
@@ -1,0 +1,59 @@
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Integration;
+
+/// <summary>
+/// Minimal read-only view that <see cref="SnapshotRotator"/> needs over a
+/// matching engine to materialise a per-symbol UMDF snapshot. Abstracted so
+/// the rotator can be unit-tested with a hand-rolled book without spinning
+/// a real <see cref="MatchingEngine"/>.
+///
+/// All members are invoked on the owning <see cref="ChannelDispatcher"/>'s
+/// dispatch thread — implementations need not be thread-safe.
+/// </summary>
+public interface ISnapshotBookSource
+{
+    /// <summary>Instruments published on this channel, in rotation order.</summary>
+    IReadOnlyList<long> SecurityIds { get; }
+
+    /// <summary>
+    /// The last <c>RptSeq</c> value emitted on the incremental channel.
+    /// A value of <c>0</c> indicates no incremental traffic has been
+    /// published yet (the engine has not produced any MBO / Trade event)
+    /// and the rotator should publish an "illiquid" snapshot header per
+    /// B3 §7.4 (i.e. <c>lastRptSeq</c> absent).
+    /// </summary>
+    uint CurrentRptSeq { get; }
+
+    /// <summary>
+    /// Iterates the resting orders for <paramref name="securityId"/> on the
+    /// requested side in price-time priority. Caller must fully drain the
+    /// enumerator before mutating the book.
+    /// </summary>
+    IEnumerable<RestingOrderView> EnumerateBook(long securityId, Side side);
+}
+
+/// <summary>
+/// Adapter that exposes a <see cref="MatchingEngine"/> as an
+/// <see cref="ISnapshotBookSource"/> for a known set of instruments.
+/// </summary>
+public sealed class MatchingEngineSnapshotSource : ISnapshotBookSource
+{
+    private readonly MatchingEngine _engine;
+    public IReadOnlyList<long> SecurityIds { get; }
+
+    public MatchingEngineSnapshotSource(MatchingEngine engine, IReadOnlyList<long> securityIds)
+    {
+        ArgumentNullException.ThrowIfNull(engine);
+        ArgumentNullException.ThrowIfNull(securityIds);
+        if (securityIds.Count == 0)
+            throw new ArgumentException("securityIds must be non-empty", nameof(securityIds));
+        _engine = engine;
+        SecurityIds = securityIds;
+    }
+
+    public uint CurrentRptSeq => _engine.CurrentRptSeq;
+
+    public IEnumerable<RestingOrderView> EnumerateBook(long securityId, Side side)
+        => _engine.EnumerateBook(securityId, side);
+}

--- a/src/B3.Exchange.Integration/SnapshotRotator.cs
+++ b/src/B3.Exchange.Integration/SnapshotRotator.cs
@@ -1,0 +1,156 @@
+using B3.Exchange.Matching;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Integration;
+
+/// <summary>
+/// Per-UMDF-channel snapshot publisher. Each invocation of
+/// <see cref="PublishNext"/> picks the next instrument in round-robin order,
+/// reads the resting book on both sides, and publishes a
+/// <c>SnapshotFullRefresh_Header_30</c> + as many
+/// <c>SnapshotFullRefresh_Orders_MBO_71</c> chunks as the book requires (each
+/// chunk capped at <see cref="SnapshotPacketBuilder.MaxEntriesPerChunk"/> or
+/// the caller-supplied per-chunk cap, whichever is smaller).
+///
+/// <para>
+/// Threading: <see cref="PublishNext"/> reads the matching engine's resting
+/// book and must therefore run on the owning <see cref="ChannelDispatcher"/>'s
+/// dispatch thread. The dispatcher invokes it from the inbound work loop, so
+/// it never races with order processing.
+/// </para>
+///
+/// <para>
+/// Sequence-number discipline: the snapshot channel maintains its OWN
+/// monotonic <see cref="SequenceVersion"/> + <see cref="SequenceNumber"/>
+/// state, separate from the incremental channel. A future operator command
+/// (issue #6) will bump both atomically — see
+/// <see cref="BumpSequenceVersion"/> and <see cref="ChannelDispatcher"/>.
+/// </para>
+///
+/// <para>
+/// Empty / illiquid handling: per B3 §7.4 a symbol with no incremental
+/// history publishes a snapshot header with <c>LastRptSeq</c> absent and an
+/// empty Orders_71 group. The rotator emits exactly that when the book has
+/// no resting orders AND <see cref="ISnapshotBookSource.CurrentRptSeq"/> is
+/// 0.
+/// </para>
+/// </summary>
+public sealed class SnapshotRotator
+{
+    private readonly byte _channelNumber;
+    private readonly ISnapshotBookSource _source;
+    private readonly IUmdfPacketSink _sink;
+    private readonly Func<ulong> _nowNanos;
+    private readonly int _maxEntriesPerChunk;
+    private readonly byte[] _packetBuf;
+
+    private int _rotationIndex;
+
+    public byte ChannelNumber => _channelNumber;
+    public ushort SequenceVersion { get; private set; } = 1;
+    public uint SequenceNumber { get; private set; }
+    public int RotationIndex => _rotationIndex;
+
+    public SnapshotRotator(
+        byte channelNumber,
+        ISnapshotBookSource source,
+        IUmdfPacketSink sink,
+        Func<ulong>? nowNanos = null,
+        int maxEntriesPerChunk = SnapshotPacketBuilder.MaxEntriesPerChunk,
+        int packetBufferSize = SnapshotPacketBuilder.DefaultPacketBufferSize)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(sink);
+        if (maxEntriesPerChunk < 1 || maxEntriesPerChunk > SnapshotPacketBuilder.MaxEntriesPerChunk)
+            throw new ArgumentOutOfRangeException(nameof(maxEntriesPerChunk));
+        if (packetBufferSize < 256)
+            throw new ArgumentOutOfRangeException(nameof(packetBufferSize), "buffer too small for a snapshot header");
+        _channelNumber = channelNumber;
+        _source = source;
+        _sink = sink;
+        _nowNanos = nowNanos ?? DefaultNowNanos;
+        _maxEntriesPerChunk = maxEntriesPerChunk;
+        _packetBuf = new byte[packetBufferSize];
+    }
+
+    private static ulong DefaultNowNanos()
+        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+
+    /// <summary>
+    /// Bumps both the snapshot <see cref="SequenceVersion"/> and resets the
+    /// snapshot <see cref="SequenceNumber"/> to 0. Designed to be called by
+    /// the dispatcher when the operator-issued sequence-bump command (issue
+    /// #6) lands; the dispatcher is responsible for bumping the incremental
+    /// channel state in lockstep.
+    /// </summary>
+    public void BumpSequenceVersion()
+    {
+        SequenceVersion = (ushort)(SequenceVersion + 1);
+        SequenceNumber = 0;
+    }
+
+    /// <summary>
+    /// Publishes a complete snapshot for the next instrument in the rotation.
+    /// Returns the number of UDP packets emitted (always &gt;= 1, since even
+    /// an empty book emits the header packet). Caller MUST invoke from the
+    /// dispatcher thread so that <see cref="ISnapshotBookSource.EnumerateBook"/>
+    /// observes a stable book.
+    /// </summary>
+    public int PublishNext()
+    {
+        var ids = _source.SecurityIds;
+        if (ids.Count == 0) return 0;
+        long securityId = ids[_rotationIndex % ids.Count];
+        _rotationIndex = (_rotationIndex + 1) % ids.Count;
+        return PublishFor(securityId);
+    }
+
+    /// <summary>
+    /// Publishes a complete snapshot for the supplied <paramref name="securityId"/>
+    /// without advancing the rotation cursor. Useful for tests and for
+    /// targeted re-publishes.
+    /// </summary>
+    public int PublishFor(long securityId)
+    {
+        // Materialise the book sides into pooled buffers. Snapshot ticks are
+        // low-frequency (typically every few seconds per instrument) so a
+        // per-tick allocation is acceptable; the alternative — caching
+        // per-symbol scratch lists — adds complexity for negligible benefit.
+        var bidsList = new List<UmdfWireEncoder.SnapshotEntry>();
+        var asksList = new List<UmdfWireEncoder.SnapshotEntry>();
+        foreach (var o in _source.EnumerateBook(securityId, Side.Buy))
+            bidsList.Add(SnapshotPacketBuilder.MakeBidEntry(
+                o.PriceMantissa, o.RemainingQuantity, o.InsertTimestampNanos, o.OrderId, o.EnteringFirm));
+        foreach (var o in _source.EnumerateBook(securityId, Side.Sell))
+            asksList.Add(SnapshotPacketBuilder.MakeAskEntry(
+                o.PriceMantissa, o.RemainingQuantity, o.InsertTimestampNanos, o.OrderId, o.EnteringFirm));
+
+        // B3 §7.4 illiquid case: no incremental history → publish header with
+        // LastRptSeq absent. Once any incremental event has been emitted we
+        // always stamp the live RptSeq, even if the book is empty (e.g. all
+        // orders matched and no new ones have arrived).
+        uint? lastRptSeq = _source.CurrentRptSeq == 0 ? null : _source.CurrentRptSeq;
+
+        ushort version = SequenceVersion;
+        uint firstSeq = SequenceNumber + 1;
+        ulong nowNanos = _nowNanos();
+        byte channel = _channelNumber;
+        var sink = _sink;
+
+        int packetsEmitted = SnapshotPacketBuilder.WriteSnapshot(
+            buffer: _packetBuf,
+            channelNumber: channel,
+            sequenceVersion: version,
+            firstSequenceNumber: firstSeq,
+            sendingTimeNanos: nowNanos,
+            securityId: securityId,
+            lastRptSeq: lastRptSeq,
+            bids: System.Runtime.InteropServices.CollectionsMarshal.AsSpan(bidsList),
+            asks: System.Runtime.InteropServices.CollectionsMarshal.AsSpan(asksList),
+            onPacket: pkt => sink.Publish(channel, pkt),
+            maxEntriesPerChunk: _maxEntriesPerChunk);
+
+        SequenceNumber += (uint)packetsEmitted;
+        return packetsEmitted;
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
@@ -1,0 +1,219 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using B3.Exchange.EntryPoint;
+using B3.Exchange.Integration;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// End-to-end test for the snapshot publisher: bring up <see cref="ExchangeHost"/>
+/// with a snapshot channel configured, route a few orders into the book over
+/// the EntryPoint TCP listener, force a snapshot tick by enqueuing one
+/// directly, and assert the recorded snap-sink packet decodes to the
+/// expected book state with a non-null <c>LastRptSeq</c>.
+/// </summary>
+public class ExchangeHostSnapshotE2ETests
+{
+    private const long Petr = 900_000_000_001L;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task SnapshotTick_AfterRestingOrders_PublishesBookStateOnSnapSink()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var cfg = new HostConfig
+        {
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30184,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    // Cadence is huge so the timer never fires in test wall-clock —
+                    // we trigger snapshots manually via EnqueueSnapshotTick().
+                    Snapshot = new SnapshotChannelConfig
+                    {
+                        Group = "239.255.42.85",
+                        Port = 30185,
+                        Ttl = 0,
+                        CadenceMs = 60_000,
+                        MaxEntriesPerChunk = 30,
+                    },
+                },
+            },
+        };
+        var incSink = new RecordingPacketSink();
+        var snapSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg,
+            packetSinkFactory: _ => incSink,
+            snapshotSinkFactory: (_, _) => snapSink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        // Submit two resting BUYs at different prices.
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        await stream.WriteAsync(BuildSimpleNewOrder(1001, Petr, '1', '2', '0', 100, 12_3400));
+        await ReadFrameAsync(stream, TimeSpan.FromSeconds(5)); // ER_New
+        await stream.WriteAsync(BuildSimpleNewOrder(1002, Petr, '1', '2', '0', 200, 12_0000));
+        await ReadFrameAsync(stream, TimeSpan.FromSeconds(5)); // ER_New
+
+        // Force a snapshot tick on the dispatcher and wait briefly for the
+        // dispatcher thread to drain it onto snapSink.
+        Assert.Single(host.Dispatchers);
+        Assert.True(host.Dispatchers[0].EnqueueSnapshotTick());
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (snapSink.Packets.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+
+        Assert.True(snapSink.Packets.Count >= 1, "snapshot packet not received");
+        var pkt = snapSink.Packets[0];
+
+        // PacketHeader sanity.
+        ref readonly var hdr = ref MemoryMarshal.AsRef<B3.Umdf.Mbo.Sbe.V16.PacketHeader>(pkt.AsSpan(0, WireOffsets.PacketHeaderSize));
+        Assert.Equal((byte)84, hdr.ChannelNumber);
+        Assert.Equal((ushort)1, hdr.SequenceVersion);
+        Assert.Equal(1u, hdr.SequenceNumber); // first snap packet on this channel
+
+        // Decode the SnapshotFullRefresh_Header_30 — expect 2 bids, 0 offers,
+        // and a non-null LastRptSeq (because the matching engine has emitted
+        // 2 OrderAccepted incremental events → RptSeq ≥ 2).
+        int frameOff = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+            pkt.AsSpan(frameOff, WireOffsets.SnapHeaderBlockLength), out var snapHdr));
+        Assert.Equal(Petr, (long)(ulong)snapHdr.Data.SecurityID);
+        Assert.Equal(2u, snapHdr.Data.TotNumReports);
+        Assert.Equal(2u, snapHdr.Data.TotNumBids);
+        Assert.Equal(0u, snapHdr.Data.TotNumOffers);
+        Assert.NotNull(snapHdr.Data.LastRptSeq);
+        Assert.True(snapHdr.Data.LastRptSeq >= 2u);
+
+        // Same packet must contain an Orders_71 frame with NumInGroup == 2.
+        int after = frameOff + WireOffsets.SnapHeaderBlockLength;
+        int groupNumInGroupOff = after
+            + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.SnapOrdersHeaderBlockLength + 2;
+        Assert.Equal((byte)2, pkt[groupNumInGroupOff]);
+    }
+
+    [Fact]
+    public async Task EmptyBook_PublishesIlliquidHeader()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var cfg = new HostConfig
+        {
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30186,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    Snapshot = new SnapshotChannelConfig
+                    {
+                        Group = "239.255.42.85",
+                        Port = 30187,
+                        Ttl = 0,
+                        CadenceMs = 60_000,
+                    },
+                },
+            },
+        };
+        var incSink = new RecordingPacketSink();
+        var snapSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg,
+            packetSinkFactory: _ => incSink,
+            snapshotSinkFactory: (_, _) => snapSink);
+        await host.StartAsync();
+
+        Assert.True(host.Dispatchers[0].EnqueueSnapshotTick());
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (snapSink.Packets.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+
+        Assert.True(snapSink.Packets.Count >= 1);
+        var pkt = snapSink.Packets[0];
+        int frameOff = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+            pkt.AsSpan(frameOff, WireOffsets.SnapHeaderBlockLength), out var snapHdr));
+        Assert.Equal(0u, snapHdr.Data.TotNumReports);
+        Assert.Null(snapHdr.Data.LastRptSeq); // illiquid per B3 §7.4
+    }
+
+    private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
+        char tif, long qty, long priceMantissa)
+    {
+        var frame = new byte[8 + 82];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        var body = frame.AsSpan(8);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)ordType;
+        body[58] = (byte)tif;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        return frame;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[8];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(6, 2));
+        var body = new byte[blockLength];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}

--- a/tests/B3.Exchange.Integration.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/SnapshotRotatorTests.cs
@@ -1,0 +1,344 @@
+using System.Runtime.InteropServices;
+using B3.Exchange.Integration;
+using B3.Exchange.Matching;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.WireEncoder;
+using Side = B3.Exchange.Matching.Side;
+
+namespace B3.Exchange.Integration.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SnapshotRotator"/> using a hand-rolled
+/// <see cref="ISnapshotBookSource"/>. These verify rotation order, packet
+/// header fields, the empty-illiquid case, and snap-channel sequence
+/// stepping. End-to-end integration with a real <see cref="MatchingEngine"/>
+/// is covered by <c>ExchangeHostE2ETests</c>.
+/// </summary>
+public class SnapshotRotatorTests
+{
+    private const int PacketHeaderSize = WireOffsets.PacketHeaderSize;
+    private const int FrameOffset = PacketHeaderSize
+                                    + WireOffsets.FramingHeaderSize
+                                    + WireOffsets.SbeMessageHeaderSize;
+
+    private sealed class FakeSource : ISnapshotBookSource
+    {
+        public IReadOnlyList<long> SecurityIds { get; init; } = Array.Empty<long>();
+        public uint CurrentRptSeq { get; set; }
+        public Dictionary<(long, Side), List<RestingOrderView>> Books { get; } = new();
+
+        public IEnumerable<RestingOrderView> EnumerateBook(long securityId, Side side)
+            => Books.TryGetValue((securityId, side), out var l) ? l : Enumerable.Empty<RestingOrderView>();
+    }
+
+    private sealed class CapturingSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Packets.Add(packet.ToArray());
+    }
+
+    private static RestingOrderView Order(long oid, Side side, long px, long qty, ulong nanos = 1_000UL, uint firm = 7)
+        => new(oid, side, px, qty, firm, nanos);
+
+    [Fact]
+    public void EmptyBook_NoPriorIncrementals_EmitsIlliquidHeaderOnly()
+    {
+        var src = new FakeSource { SecurityIds = new[] { 42L } };
+        var sink = new CapturingSink();
+        var rot = new SnapshotRotator(channelNumber: 84, source: src, sink: sink, nowNanos: () => 1234UL);
+
+        int packets = rot.PublishNext();
+
+        Assert.Equal(1, packets);
+        Assert.Single(sink.Packets);
+        Assert.Equal(1u, rot.SequenceNumber);
+
+        var pkt = sink.Packets[0];
+        ref readonly var hdr = ref MemoryMarshal.AsRef<PacketHeader>(pkt.AsSpan(0, PacketHeaderSize));
+        Assert.Equal((byte)84, hdr.ChannelNumber);
+        Assert.Equal((ushort)1, hdr.SequenceVersion);
+        Assert.Equal(1u, hdr.SequenceNumber);
+        Assert.Equal(1234UL, hdr.SendingTime);
+
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+            pkt.AsSpan(FrameOffset, WireOffsets.SnapHeaderBlockLength), out var snapHdr));
+        Assert.Equal(42L, (long)(ulong)snapHdr.Data.SecurityID);
+        Assert.Equal(0u, snapHdr.Data.TotNumReports);
+        Assert.Null(snapHdr.Data.LastRptSeq); // illiquid: §7.4
+    }
+
+    [Fact]
+    public void NonEmptyBook_BuildsHeaderPlusOrdersFrame_WithLastRptSeq()
+    {
+        var src = new FakeSource
+        {
+            SecurityIds = new[] { 42L },
+            CurrentRptSeq = 17,
+        };
+        src.Books[(42L, Side.Buy)] = new()
+        {
+            Order(1, Side.Buy, 100_0000, 500),
+            Order(2, Side.Buy, 99_5000, 200),
+        };
+        src.Books[(42L, Side.Sell)] = new()
+        {
+            Order(3, Side.Sell, 101_0000, 300),
+        };
+
+        var sink = new CapturingSink();
+        var rot = new SnapshotRotator(channelNumber: 84, source: src, sink: sink);
+
+        int packets = rot.PublishNext();
+        Assert.Equal(1, packets);
+        Assert.Single(sink.Packets);
+
+        var pkt = sink.Packets[0];
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+            pkt.AsSpan(FrameOffset, WireOffsets.SnapHeaderBlockLength), out var snapHdr));
+        Assert.Equal(3u, snapHdr.Data.TotNumReports);
+        Assert.Equal(2u, snapHdr.Data.TotNumBids);
+        Assert.Equal(1u, snapHdr.Data.TotNumOffers);
+        Assert.Equal(17u, snapHdr.Data.LastRptSeq);
+
+        // Same packet must carry an Orders_71 frame with NumInGroup == 3.
+        int after = FrameOffset + WireOffsets.SnapHeaderBlockLength;
+        int groupNumInGroupOff = after
+            + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.SnapOrdersHeaderBlockLength + 2;
+        Assert.Equal((byte)3, pkt[groupNumInGroupOff]);
+    }
+
+    [Fact]
+    public void RoundRobinsThroughInstruments_AndAdvancesSnapSequence()
+    {
+        var src = new FakeSource { SecurityIds = new[] { 11L, 22L, 33L } };
+        var sink = new CapturingSink();
+        var rot = new SnapshotRotator(channelNumber: 5, source: src, sink: sink);
+
+        for (int i = 0; i < 4; i++) rot.PublishNext(); // wraps after 3
+
+        Assert.Equal(4, sink.Packets.Count);
+        // Each tick → 1 packet (empty book), so SequenceNumber == 4.
+        Assert.Equal(4u, rot.SequenceNumber);
+
+        // SecurityIDs read out of each header packet must follow the rotation
+        // order 11, 22, 33, 11.
+        long[] expected = new[] { 11L, 22L, 33L, 11L };
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+                sink.Packets[i].AsSpan(FrameOffset, WireOffsets.SnapHeaderBlockLength), out var hdr));
+            Assert.Equal(expected[i], (long)(ulong)hdr.Data.SecurityID);
+            ref readonly var packetHdr = ref MemoryMarshal.AsRef<PacketHeader>(sink.Packets[i].AsSpan(0, PacketHeaderSize));
+            Assert.Equal((uint)(i + 1), packetHdr.SequenceNumber);
+        }
+    }
+
+    [Fact]
+    public void LargeBook_ChunksIntoMultiplePacketsAndStepsSequence()
+    {
+        var src = new FakeSource { SecurityIds = new[] { 7L }, CurrentRptSeq = 99 };
+        var bids = new List<RestingOrderView>();
+        for (int i = 0; i < 400; i++) bids.Add(Order(i + 1, Side.Buy, 100_0000 - i, 100));
+        var asks = new List<RestingOrderView>();
+        for (int i = 0; i < 200; i++) asks.Add(Order(10_000 + i, Side.Sell, 101_0000 + i, 100));
+        src.Books[(7L, Side.Buy)] = bids;
+        src.Books[(7L, Side.Sell)] = asks;
+
+        var sink = new CapturingSink();
+        var rot = new SnapshotRotator(channelNumber: 84, source: src, sink: sink);
+
+        int packets = rot.PublishNext();
+        Assert.True(packets >= 2, $"expected multi-packet snapshot, got {packets}");
+        Assert.Equal((uint)packets, rot.SequenceNumber);
+
+        // PacketHeader.SequenceNumber stepped 1..N within this snapshot.
+        for (int i = 0; i < packets; i++)
+        {
+            ref readonly var pkthdr = ref MemoryMarshal.AsRef<PacketHeader>(sink.Packets[i].AsSpan(0, PacketHeaderSize));
+            Assert.Equal((uint)(i + 1), pkthdr.SequenceNumber);
+        }
+
+        // Sum NumInGroup across every Orders_71 frame in every packet → 600.
+        int totalEntries = 0;
+        for (int i = 0; i < packets; i++)
+        {
+            var pkt = sink.Packets[i];
+            int p = PacketHeaderSize;
+            if (i == 0) p += WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SnapHeaderBlockLength;
+            while (p < pkt.Length)
+            {
+                ushort frameLen = MemoryMarshal.Read<ushort>(pkt.AsSpan(p, 2));
+                if (frameLen == 0) break;
+                int groupNumInGroupOff = p + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize
+                                       + WireOffsets.SnapOrdersHeaderBlockLength + 2;
+                totalEntries += pkt[groupNumInGroupOff];
+                p += frameLen;
+            }
+        }
+        Assert.Equal(600, totalEntries);
+    }
+
+    [Fact]
+    public void BumpSequenceVersion_BumpsVersionAndResetsSequenceNumber()
+    {
+        var src = new FakeSource { SecurityIds = new[] { 1L } };
+        var sink = new CapturingSink();
+        var rot = new SnapshotRotator(channelNumber: 1, source: src, sink: sink);
+
+        rot.PublishNext();
+        rot.PublishNext();
+        Assert.Equal(2u, rot.SequenceNumber);
+        Assert.Equal((ushort)1, rot.SequenceVersion);
+
+        rot.BumpSequenceVersion();
+
+        Assert.Equal((ushort)2, rot.SequenceVersion);
+        Assert.Equal(0u, rot.SequenceNumber);
+
+        rot.PublishNext();
+        // Next packet: SequenceVersion=2, SequenceNumber=1
+        ref readonly var hdr = ref MemoryMarshal.AsRef<PacketHeader>(sink.Packets[^1].AsSpan(0, PacketHeaderSize));
+        Assert.Equal((ushort)2, hdr.SequenceVersion);
+        Assert.Equal(1u, hdr.SequenceNumber);
+    }
+
+    [Fact]
+    public void BookWithRptSeqButNoOrders_PublishesHeaderWithLastRptSeq()
+    {
+        // Liquid history but currently empty book (e.g. all orders matched).
+        // Per scope: only the no-history case is illiquid; otherwise stamp
+        // the live RptSeq.
+        var src = new FakeSource { SecurityIds = new[] { 42L }, CurrentRptSeq = 5 };
+        var sink = new CapturingSink();
+        var rot = new SnapshotRotator(channelNumber: 1, source: src, sink: sink);
+
+        rot.PublishNext();
+
+        var pkt = sink.Packets[0];
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+            pkt.AsSpan(FrameOffset, WireOffsets.SnapHeaderBlockLength), out var hdr));
+        Assert.Equal(0u, hdr.Data.TotNumReports);
+        Assert.Equal(5u, hdr.Data.LastRptSeq);
+    }
+}
+
+/// <summary>
+/// Verifies that <see cref="ChannelDispatcher.EnqueueSnapshotTick"/> drives
+/// the attached <see cref="SnapshotRotator"/> on the dispatcher thread (no
+/// concurrency with order processing).
+/// </summary>
+public class ChannelDispatcherSnapshotTests
+{
+    private const long Petr = 900_000_000_001L;
+    private static B3.Exchange.Instruments.Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Petr,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private sealed class CapturingSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Packets.Add(packet.ToArray());
+    }
+
+    [Fact]
+    public void SnapshotTick_PublishedOnDispatcherThread_AndIsolatedFromIncrementalSink()
+    {
+        var incSink = new CapturingSink();
+        var snapSink = new CapturingSink();
+        MatchingEngine? engine = null;
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: s => { engine = new MatchingEngine(new[] { Petr4 }, s); return engine; },
+            packetSink: incSink, nowNanos: () => 1UL, tradeDate: 1);
+        var rotator = new SnapshotRotator(channelNumber: 1,
+            source: new MatchingEngineSnapshotSource(engine!, new[] { Petr }),
+            sink: snapSink, nowNanos: () => 1UL);
+        disp.AttachSnapshotRotator(rotator);
+
+        // Synchronously drive: enqueue tick → drain.
+        Assert.True(disp.EnqueueSnapshotTick());
+        Drain(disp);
+
+        Assert.Single(snapSink.Packets);          // snapshot went to snap-sink only
+        Assert.Empty(incSink.Packets);            // incremental sink untouched
+        Assert.Equal(1u, rotator.SequenceNumber); // snap-channel seq advanced
+        Assert.Equal(0u, disp.SequenceNumber);    // inc-channel seq untouched
+    }
+
+    [Fact]
+    public void SnapshotTick_ReadsLiveRestingOrders_FromMatchingEngine()
+    {
+        var incSink = new CapturingSink();
+        var snapSink = new CapturingSink();
+        MatchingEngine? engine = null;
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: s => { engine = new MatchingEngine(new[] { Petr4 }, s); return engine; },
+            packetSink: incSink, nowNanos: () => 1UL, tradeDate: 1);
+        var rotator = new SnapshotRotator(channelNumber: 1,
+            source: new MatchingEngineSnapshotSource(engine!, new[] { Petr }),
+            sink: snapSink, nowNanos: () => 1UL);
+        disp.AttachSnapshotRotator(rotator);
+
+        // Submit a couple of resting orders so the snapshot has content.
+        var reply = new ChannelDispatcherTests_RecordingReply();
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, 10_0000, 100, 7, 1UL),
+            reply, clOrdIdValue: 1UL);
+        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, 9_0000, 200, 7, 2UL),
+            reply, clOrdIdValue: 2UL);
+        disp.EnqueueNewOrder(new NewOrderCommand("3", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, 11_0000, 300, 7, 3UL),
+            reply, clOrdIdValue: 3UL);
+        Drain(disp);
+        snapSink.Packets.Clear();
+
+        // Now request the snapshot.
+        Assert.True(disp.EnqueueSnapshotTick());
+        Drain(disp);
+
+        Assert.Single(snapSink.Packets);
+        var pkt = snapSink.Packets[0];
+        int frameOff = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SnapshotFullRefresh_Header_30Data.TryParse(
+            pkt.AsSpan(frameOff, WireOffsets.SnapHeaderBlockLength), out var hdr));
+        Assert.Equal(3u, hdr.Data.TotNumReports);
+        Assert.Equal(2u, hdr.Data.TotNumBids);
+        Assert.Equal(1u, hdr.Data.TotNumOffers);
+        // After 3 OrderAccepted events the engine's RptSeq is 3.
+        Assert.Equal(3u, hdr.Data.LastRptSeq);
+    }
+
+    private static void Drain(ChannelDispatcher disp)
+    {
+        var field = typeof(ChannelDispatcher).GetField("_inbound", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var inbound = field.GetValue(disp)!;
+        var readerProp = inbound.GetType().GetProperty("Reader")!;
+        var reader = readerProp.GetValue(inbound)!;
+        var tryRead = reader.GetType().GetMethod("TryRead")!;
+        var args = new object?[] { null };
+        var processOne = typeof(ChannelDispatcher).GetMethod("ProcessOne", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        while ((bool)tryRead.Invoke(reader, args)!)
+        {
+            processOne.Invoke(disp, new[] { args[0] });
+        }
+    }
+}
+
+internal sealed class ChannelDispatcherTests_RecordingReply : B3.Exchange.EntryPoint.IEntryPointResponseChannel
+{
+    public long ConnectionId => 1;
+    public uint EnteringFirm => 7;
+    public bool IsOpen => true;
+    public bool WriteExecutionReportNew(in OrderAcceptedEvent e) => true;
+    public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
+    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue) => true;
+    public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq) => true;
+    public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue) => true;
+}


### PR DESCRIPTION
Closes #1

## Summary

Adds a per-channel snapshot publisher so a fresh consumer that connects
mid-session can bootstrap the order book.

### Design
- **`SnapshotRotator`** (`B3.Exchange.Integration`) — round-robins through a
  channel's instruments, reads the book on the dispatcher thread, and
  publishes a `SnapshotFullRefresh_Header_30` + chunked
  `SnapshotFullRefresh_Orders_MBO_71` frames via the existing
  `SnapshotPacketBuilder`. Owns its own `SequenceVersion` + `SequenceNumber`
  state for the snapshot channel; `BumpSequenceVersion()` is exposed so the
  future operator command (issue #6) can bump both incremental and snapshot
  sequence atomically.
- **Dispatcher-thread discipline** — new `WorkKind.SnapshotRotation` work
  item + `ChannelDispatcher.EnqueueSnapshotTick()`. A `Timer` per snapshot
  channel posts ticks; the bounded inbound queue's existing `DropWrite`
  policy means a tick lost while the channel is busy simply defers the next
  refresh by one period (snapshots are idempotent). This guarantees no
  concurrency between snapshot reads and order processing.
- **`MatchingEngineSnapshotSource`** — small adapter wrapping `MatchingEngine`
  + the channel's instrument id list. The rotator depends on the
  `ISnapshotBookSource` abstraction so it is unit-testable without a live
  engine.
- **Snap-channel sequence numbers** are independent of the incremental
  channel's `SequenceNumber` and live on the rotator. The incremental
  channel's `ChannelDispatcher.SequenceNumber` is untouched by snapshot
  ticks.
- **Empty / illiquid instruments** (no resting orders AND no incremental
  history yet) emit a header-only packet with `LastRptSeq` absent per
  B3 §7.4.

### Files added
- `src/B3.Exchange.Integration/ISnapshotBookSource.cs` — abstraction +
  `MatchingEngineSnapshotSource` adapter.
- `src/B3.Exchange.Integration/SnapshotRotator.cs` — the rotator.
- `tests/B3.Exchange.Integration.Tests/SnapshotRotatorTests.cs` — rotation
  order, illiquid case, large-book chunking, snap-channel sequence
  stepping, `BumpSequenceVersion`, plus dispatcher integration tests
  proving the snap sink and incremental sink are isolated and that the
  rotator reads live resting orders through the matching engine.
- `tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs` — host
  E2E: bring up `ExchangeHost` with snapshot config, route orders over
  TCP, force a snapshot tick, decode the recorded snap-sink packet.

### Files modified
- `src/B3.Exchange.Integration/ChannelDispatcher.cs` — `WorkKind.SnapshotRotation`,
  `AttachSnapshotRotator`, `EnqueueSnapshotTick`.
- `src/B3.Exchange.Host/HostConfig.cs` — optional `snapshot` block.
- `src/B3.Exchange.Host/ExchangeHost.cs` — wires snapshot sink + rotator +
  per-channel timer; exposes `Dispatchers` for tests / future operator
  endpoint.
- `config/exchange-simulator.json`, `docs/EXCHANGE-SIMULATOR.md` — sample
  snapshot block + docs (incremental vs snapshot streams, illiquid case).

### Pre-PR checklist
\`\`\`
dotnet restore SbeB3Exchange.slnx              ✓
dotnet build   SbeB3Exchange.slnx -c Release    ✓ (0 warn / 0 err)
dotnet test    SbeB3Exchange.slnx -c Release    ✓ (101/101 passed)
dotnet format  SbeB3Exchange.slnx --verify-no-changes ✓
\`\`\`

### Out of scope / follow-ups
- Operator command to bump `SequenceVersion` atomically across both
  channels — issue #6.
- Per-session `enteringFirm` (still single-tenant — scope unchanged).
- `OrigClOrdID`-only Cancel/Modify lookup — unchanged.