### PR TITLE
feat: self-trade prevention (#14)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -13,6 +13,7 @@
       "incrementalGroup": "224.0.20.84",
       "incrementalPort": 30084,
       "ttl": 1,
+      "selfTradePrevention": "none",
       "instruments": "config/instruments-eqt.json"
     }
   ]

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -73,6 +73,7 @@ Exposes:
       "incrementalGroup": "224.0.20.84",
       "incrementalPort": 30084,
       "ttl": 1,
+      "selfTradePrevention": "none",
       "instruments": "config/instruments-eqt.json"
     }
   ]
@@ -84,6 +85,22 @@ Exposes:
   default; per-session firm assignment is not yet implemented).
 * `channels[]` — one matching engine + one outbound multicast group per
   UMDF channel.
+* `channels[].selfTradePrevention` — per-channel self-trade prevention policy
+  evaluated each time an aggressor would cross against a resting order from
+  the same `EnteringFirm`. One of:
+  * `none` (default) — trade as today; firms can self-trade.
+  * `cancel-aggressor` — cancel the aggressor's residual quantity and stop
+    further matching. Trades already executed against other firms stand. The
+    originating session receives an `ExecutionReport_Reject` with reason
+    `SelfTradePrevention`; no MBO event is emitted (the aggressor never
+    rested).
+  * `cancel-resting` — cancel the conflicting resting order and continue
+    matching the aggressor against the next maker. Each canceled resting
+    order produces a `DeleteOrder_MBO_51` and an `ExecutionReport_Cancel`
+    routed to the original resting-order owner (cancel reason
+    `SelfTradePrevention`).
+  * `cancel-both` — cancel both the conflicting resting order and the
+    aggressor's residual; stop further matching.
 * `instruments` — path to the instrument list (re-uses the format already
   consumed by `B3.Exchange.Instruments.InstrumentLoader`).
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -56,7 +56,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             if (sink is IDisposable d) _ownedSinks.Add(d);
             var disp = new ChannelDispatcher(
                 channelNumber: ch.ChannelNumber,
-                engineFactory: s => new MatchingEngine(instruments, s),
+                engineFactory: s => new MatchingEngine(instruments, s, ch.SelfTradePrevention),
                 packetSink: sink);
             disp.Start();
             _dispatchers.Add(disp);

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -28,7 +28,7 @@ public sealed class ChannelConfig
     [JsonPropertyName("localInterface")] public string? LocalInterface { get; set; }
     [JsonPropertyName("ttl")] public byte Ttl { get; set; } = 1;
     [JsonPropertyName("instruments")] public string InstrumentsFile { get; set; } = "";
-    
+
     /// <summary>
     /// Self-trade prevention policy applied by this channel's matching engine.
     /// Defaults to <c>none</c> (preserves legacy behaviour). Accepted values

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -55,7 +55,7 @@ public sealed class ChannelConfig
     [JsonPropertyName("instrumentDefinition")] public InstrumentDefinitionConfig? InstrumentDefinition { get; set; }
 }
 
-internal sealed class SelfTradePreventionJsonConverter : JsonConverter<B3.Exchange.Matching.SelfTradePrevention>
+public sealed class SelfTradePreventionJsonConverter : JsonConverter<B3.Exchange.Matching.SelfTradePrevention>
 {
     public override B3.Exchange.Matching.SelfTradePrevention Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
@@ -78,7 +78,7 @@ internal sealed class SelfTradePreventionJsonConverter : JsonConverter<B3.Exchan
             B3.Exchange.Matching.SelfTradePrevention.CancelAggressor => "cancel-aggressor",
             B3.Exchange.Matching.SelfTradePrevention.CancelResting => "cancel-resting",
             B3.Exchange.Matching.SelfTradePrevention.CancelBoth => "cancel-both",
-            _ => "none",
+            _ => throw new JsonException($"unknown SelfTradePrevention value: {value}"),
         });
     }
 }

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -28,6 +28,44 @@ public sealed class ChannelConfig
     [JsonPropertyName("localInterface")] public string? LocalInterface { get; set; }
     [JsonPropertyName("ttl")] public byte Ttl { get; set; } = 1;
     [JsonPropertyName("instruments")] public string InstrumentsFile { get; set; } = "";
+    /// <summary>
+    /// Self-trade prevention policy applied by this channel's matching engine.
+    /// Defaults to <c>none</c> (preserves legacy behaviour). Accepted values
+    /// (case-insensitive): <c>none</c>, <c>cancel-aggressor</c>,
+    /// <c>cancel-resting</c>, <c>cancel-both</c>.
+    /// </summary>
+    [JsonPropertyName("selfTradePrevention")]
+    [JsonConverter(typeof(SelfTradePreventionJsonConverter))]
+    public B3.Exchange.Matching.SelfTradePrevention SelfTradePrevention { get; set; }
+        = B3.Exchange.Matching.SelfTradePrevention.None;
+}
+
+internal sealed class SelfTradePreventionJsonConverter : JsonConverter<B3.Exchange.Matching.SelfTradePrevention>
+{
+    public override B3.Exchange.Matching.SelfTradePrevention Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var s = reader.GetString();
+        return s?.ToLowerInvariant() switch
+        {
+            null or "" or "none" => B3.Exchange.Matching.SelfTradePrevention.None,
+            "cancel-aggressor" => B3.Exchange.Matching.SelfTradePrevention.CancelAggressor,
+            "cancel-resting" => B3.Exchange.Matching.SelfTradePrevention.CancelResting,
+            "cancel-both" => B3.Exchange.Matching.SelfTradePrevention.CancelBoth,
+            _ => throw new JsonException($"unknown selfTradePrevention value '{s}' (expected: none|cancel-aggressor|cancel-resting|cancel-both)"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, B3.Exchange.Matching.SelfTradePrevention value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value switch
+        {
+            B3.Exchange.Matching.SelfTradePrevention.None => "none",
+            B3.Exchange.Matching.SelfTradePrevention.CancelAggressor => "cancel-aggressor",
+            B3.Exchange.Matching.SelfTradePrevention.CancelResting => "cancel-resting",
+            B3.Exchange.Matching.SelfTradePrevention.CancelBoth => "cancel-both",
+            _ => "none",
+        });
+    }
 }
 
 public static class HostConfigLoader

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -7,7 +7,8 @@ public enum TimeInForce : byte { Day, IOC, FOK }
 public enum OrderType : byte { Limit, Market }
 
 /// <summary>
-/// Reasons a matching command can be rejected without any state change.
+/// Reasons a matching command can be rejected. Some rejects occur before any state change;
+/// others (e.g., <see cref="SelfTradePrevention"/>) may occur after fills against other firms.
 /// </summary>
 public enum RejectReason : byte
 {

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -22,6 +22,33 @@ public enum RejectReason : byte
     MarketNoLiquidity,
     MarketNotImmediateOrCancel,
     InvalidTimeInForceForMarket,
+    /// <summary>The aggressor would have crossed against a resting order from
+    /// the same <see cref="NewOrderCommand.EnteringFirm"/> and the channel's
+    /// <see cref="SelfTradePrevention"/> policy is configured to cancel the
+    /// aggressor's residual quantity.</summary>
+    SelfTradePrevention,
+}
+
+/// <summary>
+/// Per-channel self-trade prevention policy. Evaluated by the engine each time
+/// an aggressor would cross against a resting order whose
+/// <c>EnteringFirm</c> matches the aggressor's. Default <see cref="None"/>
+/// preserves the original "trade as today" behaviour.
+/// </summary>
+public enum SelfTradePrevention : byte
+{
+    /// <summary>No self-trade prevention; aggressor and maker trade normally.</summary>
+    None,
+    /// <summary>Cancel the aggressor's remaining (post-other-firm-fills) residual
+    /// and stop further matching. Trades already executed against other firms
+    /// stand. The conflicting resting order is left untouched.</summary>
+    CancelAggressor,
+    /// <summary>Cancel the conflicting resting order and continue matching the
+    /// aggressor against the next maker (which may be from a different firm).</summary>
+    CancelResting,
+    /// <summary>Cancel both the conflicting resting order and the aggressor's
+    /// residual; stop further matching.</summary>
+    CancelBoth,
 }
 
 /// <summary>
@@ -38,6 +65,10 @@ public enum CancelReason : byte
     /// <summary>Replace lost time priority — old resting order is logically deleted
     /// before the new one is inserted (caller emits DEL+NEW MBO frames).</summary>
     ReplaceLostPriority,
+    /// <summary>Resting order removed by the channel's <see cref="SelfTradePrevention"/>
+    /// policy because an incoming aggressor from the same firm would have
+    /// crossed against it.</summary>
+    SelfTradePrevention,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -90,6 +90,26 @@ public sealed class MatchingEngine
                 long fillable = book.FillableQuantityAgainst(cmd.Side, cmd.PriceMantissa, isMarket: cmd.Type == OrderType.Market);
                 if (fillable < cmd.Quantity)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.FokUnfillable, cmd.EnteredAtNanos); return; }
+
+                // If STP is enabled, FOK must check for self-trades: orders from the same firm
+                // would be prevented from matching, so reject FOK as unfillable if any exist.
+                if (_stp != SelfTradePrevention.None)
+                {
+                    bool isMarketOrder = cmd.Type == OrderType.Market;
+                    foreach (var level in book.OppositeLevels(cmd.Side))
+                    {
+                        if (!isMarketOrder && !LimitOrderBook.PriceCrosses(cmd.Side, level.PriceMantissa, cmd.PriceMantissa))
+                            break;
+
+                        var order = level.Head;
+                        while (order is not null)
+                        {
+                            if (order.EnteringFirm == cmd.EnteringFirm)
+                            { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.FokUnfillable, cmd.EnteredAtNanos); return; }
+                            order = order.Next;
+                        }
+                    }
+                }
             }
 
             // Market order with empty opposite book: reject early — we never want a

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -14,6 +14,7 @@ public sealed class MatchingEngine
     private readonly Dictionary<long, InstrumentTradingRules> _rulesById;
     private readonly Dictionary<long, LimitOrderBook> _booksById;
     private readonly IMatchingEventSink _sink;
+    private readonly SelfTradePrevention _stp;
 
     private long _nextOrderId = 1;
     private uint _nextTradeId = 1;
@@ -21,11 +22,13 @@ public sealed class MatchingEngine
 
     private bool _dispatching;
 
-    public MatchingEngine(IEnumerable<Instrument> instruments, IMatchingEventSink sink)
+    public MatchingEngine(IEnumerable<Instrument> instruments, IMatchingEventSink sink,
+        SelfTradePrevention selfTradePrevention = SelfTradePrevention.None)
     {
         ArgumentNullException.ThrowIfNull(instruments);
         ArgumentNullException.ThrowIfNull(sink);
         _sink = sink;
+        _stp = selfTradePrevention;
         _rulesById = new Dictionary<long, InstrumentTradingRules>();
         _booksById = new Dictionary<long, LimitOrderBook>();
         foreach (var i in instruments)
@@ -38,6 +41,7 @@ public sealed class MatchingEngine
 
     public uint CurrentRptSeq => _rptSeq;
     public long PeekNextOrderId => _nextOrderId;
+    public SelfTradePrevention SelfTradePrevention => _stp;
 
     /// <summary>
     /// Returns the <see cref="LimitOrderBook"/>'s public snapshot iterator.
@@ -184,6 +188,7 @@ public sealed class MatchingEngine
         long aggressorOrderIdForTrades = _nextOrderId++;
         bool isMarket = cmd.Type == OrderType.Market;
         long limitPx = cmd.PriceMantissa;
+        bool stpAggressorCanceled = false;
 
         // Walk opposite levels in priority order. We snapshot the level list to a
         // local copy (LimitOrderBook.OppositeLevels) so removing a level mid-iter
@@ -191,6 +196,7 @@ public sealed class MatchingEngine
         foreach (var level in book.OppositeLevels(cmd.Side))
         {
             if (aggressorRemaining == 0) break;
+            if (stpAggressorCanceled) break;
             if (!isMarket && !LimitOrderBook.PriceCrosses(cmd.Side, level.PriceMantissa, limitPx)) break;
 
             // Within a level, consume FIFO from Head.
@@ -198,6 +204,29 @@ public sealed class MatchingEngine
             while (maker is not null && aggressorRemaining > 0)
             {
                 var next = maker.Next; // capture before mutation
+
+                // Self-trade prevention: maker and aggressor share EnteringFirm.
+                if (_stp != SelfTradePrevention.None && maker.EnteringFirm == cmd.EnteringFirm)
+                {
+                    switch (_stp)
+                    {
+                        case SelfTradePrevention.CancelResting:
+                            // Cancel the conflicting maker and continue matching
+                            // the aggressor against the next maker / level.
+                            EmitCanceled(book, maker, cmd.EnteredAtNanos, CancelReason.SelfTradePrevention);
+                            maker = next;
+                            continue;
+                        case SelfTradePrevention.CancelBoth:
+                            EmitCanceled(book, maker, cmd.EnteredAtNanos, CancelReason.SelfTradePrevention);
+                            stpAggressorCanceled = true;
+                            break;
+                        case SelfTradePrevention.CancelAggressor:
+                            stpAggressorCanceled = true;
+                            break;
+                    }
+                    break;
+                }
+
                 long tradeQty = Math.Min(aggressorRemaining, maker.RemainingQuantity);
                 long tradePx = maker.PriceMantissa;
 
@@ -258,6 +287,17 @@ public sealed class MatchingEngine
 
         // Aggressor has remainder?
         if (aggressorRemaining == 0) return;
+
+        if (stpAggressorCanceled)
+        {
+            // STP canceled the aggressor's residual. The aggressor never rested
+            // on the book, so no MBO event is emitted (mirrors the IOC-remainder
+            // pattern). The originating session is informed via a Reject ER —
+            // any trades already executed against other firms still stand.
+            Reject(cmd.ClOrdId, cmd.SecurityId, aggressorOrderIdForTrades,
+                RejectReason.SelfTradePrevention, cmd.EnteredAtNanos);
+            return;
+        }
 
         if (isMarket)
         {

--- a/tests/B3.Exchange.Matching.Tests/SelfTradePreventionTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/SelfTradePreventionTests.cs
@@ -1,0 +1,221 @@
+using B3.Exchange.Instruments;
+
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+public class SelfTradePreventionTests
+{
+    private const uint FirmA = 11;
+    private const uint FirmB = 22;
+
+    private static MatchingEngine NewEngine(SelfTradePrevention stp, out RecordingSink sink)
+    {
+        sink = new RecordingSink();
+        return new MatchingEngine(new[] { Petr4 }, sink, stp);
+    }
+
+    [Fact]
+    public void Default_None_AllowsSelfTrade()
+    {
+        var eng = NewEngine(SelfTradePrevention.None, out var sink);
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1000));
+        sink.Clear();
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 2000));
+
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(FirmA, trade.AggressorFirm);
+        Assert.Equal(FirmA, trade.RestingFirm);
+        Assert.Single(sink.Filled);
+        Assert.Empty(sink.Rejects);
+        Assert.Empty(sink.Canceled);
+    }
+
+    // ---------- cancel-aggressor ----------
+
+    [Fact]
+    public void CancelAggressor_FullSelfTrade_NoTradeAggressorRejected()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelAggressor, out var sink);
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1000));
+        sink.Clear();
+        uint baseRpt = eng.CurrentRptSeq;
+        long expectedAggressorOrderId = eng.PeekNextOrderId;
+
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 2000));
+
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Filled);
+        Assert.Empty(sink.QtyReduced);
+        Assert.Empty(sink.Canceled);          // resting was NOT canceled
+        Assert.Empty(sink.Accepted);          // aggressor never rested
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.SelfTradePrevention, rej.Reason);
+        Assert.Equal(expectedAggressorOrderId, rej.OrderIdOrZero);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));   // s1 still resting, untouched
+        Assert.Equal(baseRpt, eng.CurrentRptSeq);     // Reject does NOT bump RptSeq
+    }
+
+    [Fact]
+    public void CancelAggressor_PartialFillAgainstOtherFirm_ThenSelfTradeStops()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelAggressor, out var sink);
+        // Best ask = FirmB at 10.00 (100). Then FirmA at 10.00 (200) behind.
+        eng.Submit(new NewOrderCommand("sB", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmB, 1000));
+        eng.Submit(new NewOrderCommand("sA", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 200, FirmA, 1100));
+        sink.Clear();
+
+        // FirmA buys 300 — fills 100 vs FirmB, then hits FirmA at same level → cancel-aggressor.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 300, FirmA, 2000));
+
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(FirmB, trade.RestingFirm);
+        Assert.Equal(100, trade.Quantity);
+        Assert.Single(sink.Filled);                       // sB fully filled
+        var rej = Assert.Single(sink.Rejects);            // residual canceled
+        Assert.Equal(RejectReason.SelfTradePrevention, rej.Reason);
+        Assert.Empty(sink.Canceled);                      // sA untouched
+        Assert.Empty(sink.Accepted);                      // aggressor never rests
+        Assert.Equal(1, eng.OrderCount(PetrSecId));       // sA still there
+    }
+
+    // ---------- cancel-resting ----------
+
+    [Fact]
+    public void CancelResting_RemovesConflict_ThenContinuesMatching()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelResting, out var sink);
+        // Best ask: FirmA 100 @10.00 (will be canceled), then FirmB 100 @10.00.
+        eng.Submit(new NewOrderCommand("sA", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1000));
+        eng.Submit(new NewOrderCommand("sB", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmB, 1100));
+        sink.Clear();
+
+        // FirmA buys 100 — should cancel sA, then trade against sB.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 2000));
+
+        var cancel = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.SelfTradePrevention, cancel.Reason);
+        Assert.Equal(100, cancel.RemainingQuantityAtCancel);
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(FirmB, trade.RestingFirm);
+        Assert.Equal(100, trade.Quantity);
+        Assert.Single(sink.Filled);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void CancelResting_MultipleSelfMakers_AllCanceled_ThenRest()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelResting, out var sink);
+        // Two FirmA makers, then a FirmA maker behind a FirmB maker is unrealistic;
+        // here all asks at 10.00 are FirmA. Buy from FirmA at 10.00 should cancel both,
+        // then since aggressor is Day with remainder, it rests on the bid side.
+        eng.Submit(new NewOrderCommand("sA1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1000));
+        eng.Submit(new NewOrderCommand("sA2", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1100));
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 200, FirmA, 2000));
+
+        Assert.Equal(2, sink.Canceled.Count);
+        Assert.All(sink.Canceled, c => Assert.Equal(CancelReason.SelfTradePrevention, c.Reason));
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Filled);
+        var acc = Assert.Single(sink.Accepted); // aggressor rests
+        Assert.Equal(200, acc.RemainingQuantity);
+        Assert.Equal(Side.Buy, acc.Side);
+        Assert.Equal(1, eng.OrderCount(PetrSecId)); // only the new bid resting
+    }
+
+    [Fact]
+    public void CancelResting_MultiLevel_MixedFirms()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelResting, out var sink);
+        // Asks: 10.00 → FirmA 100 (cancel), 10.01 → FirmB 100 (trade), 10.02 → FirmA 100 (cancel).
+        eng.Submit(new NewOrderCommand("sA1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.00m), 100, FirmA, 1000));
+        eng.Submit(new NewOrderCommand("sB", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.01m), 100, FirmB, 1100));
+        eng.Submit(new NewOrderCommand("sA2", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.02m), 100, FirmA, 1200));
+        sink.Clear();
+
+        // FirmA buy 300 @10.05 → walks all three levels.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10.05m), 300, FirmA, 2000));
+
+        Assert.Equal(2, sink.Canceled.Count);
+        Assert.All(sink.Canceled, c => Assert.Equal(CancelReason.SelfTradePrevention, c.Reason));
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(Px(10.01m), trade.PriceMantissa);
+        Assert.Equal(FirmB, trade.RestingFirm);
+        Assert.Single(sink.Filled);
+        // aggressor still has 200 unfilled → rests as a bid
+        var acc = Assert.Single(sink.Accepted);
+        Assert.Equal(200, acc.RemainingQuantity);
+        Assert.Equal(Side.Buy, acc.Side);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+    }
+
+    // ---------- cancel-both ----------
+
+    [Fact]
+    public void CancelBoth_FullSelfTrade_BothCanceled()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelBoth, out var sink);
+        eng.Submit(new NewOrderCommand("sA", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1000));
+        sink.Clear();
+        long expectedAggressorOrderId = eng.PeekNextOrderId;
+
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 2000));
+
+        var cancel = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.SelfTradePrevention, cancel.Reason);
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.SelfTradePrevention, rej.Reason);
+        Assert.Equal(expectedAggressorOrderId, rej.OrderIdOrZero);
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Filled);
+        Assert.Empty(sink.Accepted);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void CancelBoth_PartialFillAgainstOtherFirm_ThenBothCanceled()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelBoth, out var sink);
+        eng.Submit(new NewOrderCommand("sB", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmB, 1000));
+        eng.Submit(new NewOrderCommand("sA", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 200, FirmA, 1100));
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 300, FirmA, 2000));
+
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(FirmB, trade.RestingFirm);
+        Assert.Single(sink.Filled);                                    // sB filled
+        var cancel = Assert.Single(sink.Canceled);                     // sA canceled
+        Assert.Equal(CancelReason.SelfTradePrevention, cancel.Reason);
+        var rej = Assert.Single(sink.Rejects);                         // aggressor residual
+        Assert.Equal(RejectReason.SelfTradePrevention, rej.Reason);
+        Assert.Empty(sink.Accepted);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    // ---------- bookkeeping invariants ----------
+
+    [Fact]
+    public void CancelResting_RptSeqAndIdsRemainMonotonic()
+    {
+        var eng = NewEngine(SelfTradePrevention.CancelResting, out var sink);
+        eng.Submit(new NewOrderCommand("sA", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 1000));
+        eng.Submit(new NewOrderCommand("sB", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmB, 1100));
+        // Two Accepted events so far → RptSeq=2, no trades emitted.
+        Assert.Equal(2u, eng.CurrentRptSeq);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, FirmA, 2000));
+
+        // Expect: Canceled(sA, rpt=3), Trade(rpt=4), Filled(sB, rpt=5).
+        Assert.Equal(3u, sink.Canceled[0].RptSeq);
+        Assert.Equal(4u, sink.Trades[0].RptSeq);
+        Assert.Equal(5u, sink.Filled[0].RptSeq);
+        Assert.Equal(5u, eng.CurrentRptSeq);
+        Assert.Equal(1u, sink.Trades[0].TradeId);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/SelfTradePreventionTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/SelfTradePreventionTests.cs
@@ -1,5 +1,3 @@
-using B3.Exchange.Instruments;
-
 namespace B3.Exchange.Matching.Tests;
 
 using static TestFactory;


### PR DESCRIPTION
Closes #14

## Summary

Adds a per-channel `SelfTradePrevention` policy evaluated inline in the matching-engine cross loop whenever an aggressor would cross against a resting order from the same `EnteringFirm`.

### Modes
- `none` *(default)* — preserves current behaviour; firms can self-trade.
- `cancel-aggressor` — stop matching; cancel the aggressor's residual via `RejectEvent` (`RejectReason.SelfTradePrevention`). Trades already executed against other firms stand. Resting maker is left untouched.
- `cancel-resting` — cancel the conflicting maker (`CancelReason.SelfTradePrevention`, normal MBO DEL + ER cancel) and continue matching against the next maker / level.
- `cancel-both` — cancel the conflicting maker AND the aggressor residual; stop matching.

In `cancel-aggressor` / `cancel-both`, the aggressor never rests on the book, so no MBO event is emitted for it (mirrors IOC-remainder behaviour). The originating TCP session is notified via Reject ER.

### Wiring
- New `ChannelConfig.selfTradePrevention` field (kebab-case JSON via custom converter); `ExchangeHost` passes it to `MatchingEngine`.
- Sample `config/exchange-simulator.json` and `docs/EXCHANGE-SIMULATOR.md` updated.

### Tests
9 new tests in `SelfTradePreventionTests.cs` covering full self-trade, partial fill vs. other firm followed by STP, multi-level cross with mixed firms, multiple consecutive self makers, and RptSeq / TradeId monotonicity. All 110 existing tests continue to pass; `dotnet format --verify-no-changes` is clean.

### Follow-ups
- Per-session firm assignment (#8) is still pending; until then a real TCP client cannot exercise STP because all sessions share `tcp.enteringFirm`. STP is therefore tested at the engine level today.
- The aggressor cancellation path uses `RejectEvent` rather than emitting a synthetic NEW+DEL MBO pair. If the consumer ever needs an explicit UMDF cancel for the aggressor, that would be a follow-up that introduces a dedicated event variant.