### PR TITLE
feat: cancel/replace by OrigClOrdID (#7)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,8 +107,9 @@ Layered projects under `src/` (build order roughly bottom-up):
   not flushed individually.
 - **Prices are implicit /10000 mantissas** on the wire (see the worked example
   in `docs/EXCHANGE-SIMULATOR.md`).
-- **EntryPoint v1 limitation:** `Cancel` and `Modify` require an explicit
-  `OrderID`; `OrigClOrdID`-only lookup is not implemented.
+- **Cancel/Replace lookup:** `Cancel` and `Modify` accept either an explicit
+  engine `OrderID` or `OrigClOrdID`. The `(EnteringFirm, ClOrdID) → OrderID`
+  index lives in `ChannelDispatcher` and is mutated only on the dispatch thread.
 - **Single-tenant:** every TCP session shares `tcp.enteringFirm` from config;
   per-session firm assignment is not implemented.
 - **Schemas are vendored.** Do not hand-edit files under `schemas/`; regenerate

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -99,9 +99,13 @@ Exposes:
 | 101         | SimpleModifyOrderV2 | 98          |
 | 105         | OrderCancelRequest  | 76          |
 
-v1 limitation: `Cancel` and `Modify` require an explicit `OrderID`.
-`OrigClOrdID`-only lookup (find the order by its original client id) is
-deferred to a later milestone.
+`Cancel` and `Modify` accept either an explicit engine-assigned `OrderID` or
+the original `OrigClOrdID` (the `ClOrdID` of the order being modified/cancelled).
+The integration layer maintains a per-channel `(EnteringFirm, ClOrdID) → OrderID`
+index that is populated when an order rests on the book and evicted when the
+order leaves (cancel or full fill). Submitting both fields is allowed; the
+explicit `OrderID` wins. If neither is present, or if the `OrigClOrdID` is
+unknown to the channel, an `ExecutionReport_Reject` is returned.
 
 ### Outbound (TCP execution reports)
 

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -118,8 +118,8 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
                 else _sink.OnDecodeError(this, rpErr ?? "decode error: SimpleModifyOrder");
                 break;
             case EntryPointFrameReader.TidOrderCancelRequest:
-                if (InboundMessageDecoder.TryDecodeCancel(body, now, out var cn, out var cnClOrd, out _, out var cnErr))
-                    _sink.EnqueueCancel(cn, this, cnClOrd);
+                if (InboundMessageDecoder.TryDecodeCancel(body, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
+                    _sink.EnqueueCancel(cn, this, cnClOrd, cnOrigClOrd);
                 else _sink.OnDecodeError(this, cnErr ?? "decode error: OrderCancelRequest");
                 break;
             default:
@@ -209,13 +209,13 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         return TryEnqueueExact(frame, n);
     }
 
-    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue)
+    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (!IsOpen) return false;
         var frame = ArrayPool<byte>.Shared.Rent(ExecutionReportEncoder.ExecReportCancelTotal);
         int n = ExecutionReportEncoder.EncodeExecReportCancel(frame.AsSpan(0, ExecutionReportEncoder.ExecReportCancelTotal),
             SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
-            e.Side, clOrdIdValue, origClOrdIdValue: 0, e.OrderId,
+            e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
             e.SecurityId, e.OrderId,
             (ulong)e.RptSeq, e.TransactTimeNanos,
             cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa);

--- a/src/B3.Exchange.EntryPoint/IEntryPointEngineSink.cs
+++ b/src/B3.Exchange.EntryPoint/IEntryPointEngineSink.cs
@@ -34,7 +34,7 @@ public interface IEntryPointResponseChannel
     bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty);
 
     /// <summary>Order canceled (client cancel, IOC remainder, replace-lost-priority).</summary>
-    bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue);
+    bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue);
 
     /// <summary>Order modified (in-place priority-preserving replace).</summary>
     bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
@@ -56,7 +56,7 @@ public interface IEntryPointResponseChannel
 public interface IEntryPointEngineSink
 {
     void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue);
-    void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue);
+    void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue);
     void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue);
 
     /// <summary>Called when a frame fails decoding (unsupported template,

--- a/src/B3.Exchange.EntryPoint/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.EntryPoint/InboundMessageDecoder.cs
@@ -104,11 +104,9 @@ internal static class InboundMessageDecoder
         ulong orderId = MemoryMarshal.Read<ulong>(body.Slice(SimpleModifyOrderOffsets.OrderID, 8));
         ulong origClOrdId = MemoryMarshal.Read<ulong>(body.Slice(SimpleModifyOrderOffsets.OrigClOrdID, 8));
 
-        if (orderId == 0)
+        if (orderId == 0 && origClOrdId == 0)
         {
-            // v1 limitation: replace requires explicit OrderID (engine-assigned).
-            // Lookup by OrigClOrdID is the integration layer's responsibility.
-            error = "SimpleModifyOrder requires OrderID; OrigClOrdID-only replace not supported in v1";
+            error = "SimpleModifyOrder requires either OrderID or OrigClOrdID";
             return false;
         }
         if (priceMantissa == PriceNull)
@@ -142,9 +140,9 @@ internal static class InboundMessageDecoder
         ulong orderId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelRequestOffsets.OrderID, 8));
         ulong origClOrdId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelRequestOffsets.OrigClOrdID, 8));
 
-        if (orderId == 0)
+        if (orderId == 0 && origClOrdId == 0)
         {
-            error = "OrderCancelRequest requires OrderID; OrigClOrdID-only cancel not supported in v1";
+            error = "OrderCancelRequest requires either OrderID or OrigClOrdID";
             return false;
         }
 

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -33,10 +33,10 @@ public sealed class HostRouter : IEntryPointEngineSink
             RejectUnknownInstrument(cmd.SecurityId, reply, clOrdIdValue);
     }
 
-    public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue)
+    public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
-            disp.EnqueueCancel(cmd, reply, clOrdIdValue);
+            disp.EnqueueCancel(cmd, reply, clOrdIdValue, origClOrdIdValue);
         else
             RejectUnknownInstrument(cmd.SecurityId, reply, clOrdIdValue);
     }

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -37,6 +37,15 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
     private readonly ushort _tradeDate;
 
     private readonly Dictionary<long, OrderOwnership> _orderOwners = new();
+    /// <summary>
+    /// Per-channel reverse index from <c>(EnteringFirm, ClOrdID)</c> to engine-assigned
+    /// <c>orderId</c>. Populated when an order enters the book (<see cref="OnOrderAccepted"/>)
+    /// and evicted when it leaves (<see cref="OnOrderCanceled"/>, fully-filled
+    /// <see cref="OnOrderFilled"/>). Allows clients to send Cancel/Replace by their own
+    /// <c>OrigClOrdID</c> without tracking the engine-assigned id.
+    /// All access happens on the dispatch thread, so no synchronisation is required.
+    /// </summary>
+    private readonly Dictionary<(uint Firm, ulong ClOrdId), long> _clOrdIdIndex = new();
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
     private IEntryPointResponseChannel? _currentReply;
@@ -97,8 +106,36 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
             switch (item.Kind)
             {
                 case WorkKind.New: _engine.Submit(item.NewOrder!); break;
-                case WorkKind.Cancel: _engine.Cancel(item.Cancel!); break;
-                case WorkKind.Replace: _engine.Replace(item.Replace!); break;
+                case WorkKind.Cancel:
+                    {
+                        var cancel = item.Cancel!;
+                        if (cancel.OrderId == 0)
+                        {
+                            if (!TryResolveByClOrdId(item.Reply, item.OrigClOrdId, out var resolvedId))
+                            {
+                                EmitUnknownOrderIdReject(cancel.ClOrdId, cancel.SecurityId, cancel.EnteredAtNanos);
+                                break;
+                            }
+                            cancel = cancel with { OrderId = resolvedId };
+                        }
+                        _engine.Cancel(cancel);
+                        break;
+                    }
+                case WorkKind.Replace:
+                    {
+                        var replace = item.Replace!;
+                        if (replace.OrderId == 0)
+                        {
+                            if (!TryResolveByClOrdId(item.Reply, item.OrigClOrdId, out var resolvedId))
+                            {
+                                EmitUnknownOrderIdReject(replace.ClOrdId, replace.SecurityId, replace.EnteredAtNanos);
+                                break;
+                            }
+                            replace = replace with { OrderId = resolvedId };
+                        }
+                        _engine.Replace(replace);
+                        break;
+                    }
                 case WorkKind.DecodeError:
                     _currentReply?.WriteExecutionReportReject(
                         new RejectEvent(_currentClOrdId.ToString(), 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
@@ -113,6 +150,23 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
             _currentClOrdId = 0;
             _currentOrigClOrdId = 0;
         }
+    }
+
+    private bool TryResolveByClOrdId(IEntryPointResponseChannel reply, ulong origClOrdId, out long orderId)
+    {
+        if (origClOrdId != 0 && _clOrdIdIndex.TryGetValue((reply.EnteringFirm, origClOrdId), out orderId))
+            return true;
+        orderId = 0;
+        return false;
+    }
+
+    private void EmitUnknownOrderIdReject(string clOrdId, long securityId, ulong nowNanos)
+    {
+        // Surface the failure directly as an ER_Reject so the client gets a
+        // clear, deterministic response instead of a silently dropped command.
+        _currentReply?.WriteExecutionReportReject(
+            new RejectEvent(clOrdId, securityId, 0, RejectReason.UnknownOrderId, nowNanos),
+            _currentClOrdId);
     }
 
     private void FlushPacket()
@@ -154,8 +208,8 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
     public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue)
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.New, reply, clOrdIdValue, 0, cmd, null, null));
 
-    public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue)
-        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, reply, clOrdIdValue, 0, null, cmd, null));
+    public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, reply, clOrdIdValue, origClOrdIdValue, null, cmd, null));
 
     public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, reply, clOrdIdValue, origClOrdIdValue, null, null, cmd));
@@ -168,7 +222,11 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
     public void OnOrderAccepted(in OrderAcceptedEvent e)
     {
         if (_currentReply != null)
-            _orderOwners[e.OrderId] = new OrderOwnership(_currentReply, _currentClOrdId);
+        {
+            _orderOwners[e.OrderId] = new OrderOwnership(_currentReply, _currentClOrdId, _currentReply.EnteringFirm);
+            if (_currentClOrdId != 0)
+                _clOrdIdIndex[(_currentReply.EnteringFirm, _currentClOrdId)] = e.OrderId;
+        }
 
         var entryType = e.Side == Side.Buy
             ? B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeBid
@@ -216,7 +274,9 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
 
         if (_orderOwners.Remove(e.OrderId, out var owner))
         {
-            owner.Reply.WriteExecutionReportCancel(e, owner.ClOrdId);
+            if (owner.ClOrdId != 0)
+                _clOrdIdIndex.Remove((owner.EnteringFirm, owner.ClOrdId));
+            owner.Reply.WriteExecutionReportCancel(e, _currentClOrdId != 0 ? _currentClOrdId : owner.ClOrdId, owner.ClOrdId);
         }
     }
 
@@ -234,7 +294,8 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
             e.SecurityId, e.OrderId, entryType, e.FinalFilledQuantity, e.RptSeq, e.TransactTimeNanos, e.PriceMantissa);
         Commit(n);
 
-        _orderOwners.Remove(e.OrderId);
+        if (_orderOwners.Remove(e.OrderId, out var owner) && owner.ClOrdId != 0)
+            _clOrdIdIndex.Remove((owner.EnteringFirm, owner.ClOrdId));
     }
 
     public void OnTrade(in TradeEvent e)
@@ -287,7 +348,7 @@ public sealed class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSin
 
     internal enum WorkKind : byte { New, Cancel, Replace, DecodeError }
 
-    internal readonly record struct OrderOwnership(IEntryPointResponseChannel Reply, ulong ClOrdId);
+    internal readonly record struct OrderOwnership(IEntryPointResponseChannel Reply, ulong ClOrdId, uint EnteringFirm);
 
     internal sealed record WorkItem(
         WorkKind Kind,

--- a/tests/B3.Exchange.EntryPoint.Tests/InboundMessageDecoderTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/InboundMessageDecoderTests.cs
@@ -41,22 +41,78 @@ public class InboundMessageDecoderTests
     }
 
     [Fact]
-    public void RejectsCancelWithoutOrderId()
+    public void RejectsCancelWithoutOrderIdAndOrigClOrdId()
     {
         Span<byte> body = stackalloc byte[76];
         body.Clear();
         var ok = InboundMessageDecoder.TryDecodeCancel(body, 0UL, out _, out _, out _, out var err);
         Assert.False(ok);
         Assert.Contains("OrderID", err);
+        Assert.Contains("OrigClOrdID", err);
     }
 
     [Fact]
-    public void RejectsReplaceWithoutOrderId()
+    public void RejectsReplaceWithoutOrderIdAndOrigClOrdId()
     {
         Span<byte> body = stackalloc byte[98];
         body.Clear();
         var ok = InboundMessageDecoder.TryDecodeReplace(body, 0UL, out _, out _, out _, out var err);
         Assert.False(ok);
         Assert.Contains("OrderID", err);
+        Assert.Contains("OrigClOrdID", err);
+    }
+
+    [Fact]
+    public void DecodesCancelByOrigClOrdIdOnly()
+    {
+        Span<byte> body = stackalloc byte[76];
+        body.Clear();
+        ulong clOrdId = 42UL;
+        long secId = 123L;
+        ulong orderId = 0UL;          // not provided
+        ulong origClOrdId = 7UL;     // resolution key
+        MemoryMarshal.Write(body.Slice(20, 8), in clOrdId);
+        MemoryMarshal.Write(body.Slice(28, 8), in secId);
+        MemoryMarshal.Write(body.Slice(36, 8), in orderId);
+        MemoryMarshal.Write(body.Slice(44, 8), in origClOrdId);
+        body[52] = (byte)'1';
+
+        var ok = InboundMessageDecoder.TryDecodeCancel(body, 9_000UL,
+            out var cmd, out var clOrd, out var origClOrd, out var err);
+
+        Assert.True(ok, err);
+        Assert.Equal(clOrdId, clOrd);
+        Assert.Equal(origClOrdId, origClOrd);
+        Assert.Equal(0L, cmd.OrderId);   // unresolved at decode time
+        Assert.Equal(secId, cmd.SecurityId);
+    }
+
+    [Fact]
+    public void DecodesReplaceByOrigClOrdIdOnly()
+    {
+        Span<byte> body = stackalloc byte[98];
+        body.Clear();
+        ulong clOrdId = 99UL;
+        long secId = 555L;
+        long qty = 200L;
+        long price = 100_000L;
+        ulong orderId = 0UL;
+        ulong origClOrdId = 42UL;
+        MemoryMarshal.Write(body.Slice(20, 8), in clOrdId);
+        MemoryMarshal.Write(body.Slice(48, 8), in secId);
+        MemoryMarshal.Write(body.Slice(60, 8), in qty);
+        MemoryMarshal.Write(body.Slice(68, 8), in price);
+        MemoryMarshal.Write(body.Slice(76, 8), in orderId);
+        MemoryMarshal.Write(body.Slice(84, 8), in origClOrdId);
+
+        var ok = InboundMessageDecoder.TryDecodeReplace(body, 9_000UL,
+            out var cmd, out var clOrd, out var origClOrd, out var err);
+
+        Assert.True(ok, err);
+        Assert.Equal(clOrdId, clOrd);
+        Assert.Equal(origClOrdId, origClOrd);
+        Assert.Equal(0L, cmd.OrderId);
+        Assert.Equal(qty, cmd.NewQuantity);
+        Assert.Equal(price, cmd.NewPriceMantissa);
     }
 }

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -137,6 +137,111 @@ public class ExchangeHostE2ETests
         Assert.Equal(EntryPointFrameReader.TidExecutionReportReject, er.TemplateId);
     }
 
+    [Fact]
+    public async Task CancelByOrigClOrdId_RoundTripsExecutionReportCancel_WithBothClOrdIdAndOrigClOrdId()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        // BUY PETR4 100 @ 12.34 with ClOrdId=4242 (rests).
+        var newOrder = BuildSimpleNewOrder(clOrdId: 4242, secId: Petr,
+            side: '1', ordType: '2', tif: '0', qty: 100, priceMantissa: 123_400);
+        await stream.WriteAsync(newOrder);
+
+        var erNew = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, erNew.TemplateId);
+
+        // Cancel by OrigClOrdID only (OrderID=0). New ClOrdId=4243.
+        var cancel = BuildOrderCancelRequest(clOrdId: 4243, secId: Petr,
+            orderId: 0, origClOrdId: 4242, side: '1');
+        await stream.WriteAsync(cancel);
+
+        var erCancel = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, erCancel.TemplateId);
+
+        // ER_Cancel body must carry both ClOrdID=4243 and OrigClOrdID=4242.
+        // Per ExecutionReportEncoder layout: ClOrdID@20, OrigClOrdID@28.
+        ulong clOrdIdField = BinaryPrimitives.ReadUInt64LittleEndian(erCancel.Body.AsSpan(20, 8));
+        ulong origClOrdIdField = BinaryPrimitives.ReadUInt64LittleEndian(erCancel.Body.AsSpan(88, 8));
+        Assert.Equal(4243UL, clOrdIdField);
+        Assert.Equal(4242UL, origClOrdIdField);
+    }
+
+    [Fact]
+    public async Task ReplaceByOrigClOrdId_LostPriority_RoundTripsCancelThenNew_WithOrigClOrdId()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        var newOrder = BuildSimpleNewOrder(clOrdId: 5000, secId: Petr,
+            side: '1', ordType: '2', tif: '0', qty: 100, priceMantissa: 123_400);
+        await stream.WriteAsync(newOrder);
+        var erNew = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, erNew.TemplateId);
+
+        // Replace by OrigClOrdID with a NEW PRICE (loses priority): expect ER_Cancel+ER_New.
+        var replace = BuildSimpleModifyOrder(clOrdId: 5001, secId: Petr,
+            side: '1', qty: 100, priceMantissa: 123_500, orderId: 0, origClOrdId: 5000);
+        await stream.WriteAsync(replace);
+
+        var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, er2.TemplateId);
+        ulong clOrd = BinaryPrimitives.ReadUInt64LittleEndian(er2.Body.AsSpan(20, 8));
+        ulong origClOrd = BinaryPrimitives.ReadUInt64LittleEndian(er2.Body.AsSpan(88, 8));
+        Assert.Equal(5001UL, clOrd);
+        Assert.Equal(5000UL, origClOrd);
+
+        var er3 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er3.TemplateId);
+    }
+
+    private static byte[] BuildOrderCancelRequest(ulong clOrdId, long secId, ulong orderId, ulong origClOrdId, char side)
+    {
+        // 8-byte SBE MessageHeader + 76-byte OrderCancelRequest (V6) body.
+        var frame = new byte[8 + 76];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+            blockLength: 76, templateId: EntryPointFrameReader.TidOrderCancelRequest, version: 0);
+
+        var body = frame.AsSpan(8);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(28, 8), secId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(36, 8), orderId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(44, 8), origClOrdId);
+        body[52] = (byte)side;
+        return frame;
+    }
+
+    private static byte[] BuildSimpleModifyOrder(ulong clOrdId, long secId, char side, long qty,
+        long priceMantissa, ulong orderId, ulong origClOrdId)
+    {
+        // 8-byte SBE MessageHeader + 98-byte SimpleModifyOrderV2 body.
+        var frame = new byte[8 + 98];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+            blockLength: 98, templateId: EntryPointFrameReader.TidSimpleModifyOrder, version: 2);
+
+        var body = frame.AsSpan(8);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(76, 8), orderId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(84, 8), origClOrdId);
+        return frame;
+    }
+
     private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
         char tif, long qty, long priceMantissa)
     {

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using B3.Exchange.EntryPoint;
 using B3.Exchange.Integration;
+using B3.Umdf.WireEncoder;
 
 namespace B3.Exchange.Host.Tests;
 

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -22,7 +22,7 @@ public class HostRouterTests
         public List<RejectEvent> Rejects { get; } = new();
         public bool WriteExecutionReportNew(in OrderAcceptedEvent e) => true;
         public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue) => true;
+        public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
         public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq) => true;
         public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue) { Rejects.Add(e); return true; }
     }

--- a/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
@@ -42,10 +42,12 @@ public class ChannelDispatcherTests
         public List<OrderCanceledEvent> Cancels { get; } = new();
         public List<RejectEvent> Rejects { get; } = new();
         public List<TradeEvent> Trades { get; } = new();
+        public bool CaptureCancelIds { get; set; }
+        public List<(ulong ClOrdId, ulong OrigClOrdId)> CancelIds { get; } = new();
         public bool WriteExecutionReportNew(in OrderAcceptedEvent e) { News.Add(e); Calls.Add("New"); return true; }
         public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
         { Trades.Add(e); Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); return true; }
-        public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue) { Cancels.Add(e); Calls.Add("Cancel"); return true; }
+        public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue) { Cancels.Add(e); Calls.Add("Cancel"); if (CaptureCancelIds) CancelIds.Add((clOrdIdValue, origClOrdIdValue)); return true; }
         public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq) { Calls.Add("Modify"); return true; }
         public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue) { Rejects.Add(e); Calls.Add("Reject"); return true; }
     }
@@ -128,7 +130,7 @@ public class ChannelDispatcherTests
         long oid = reply.News[0].OrderId;
         pkt.Packets.Clear();
 
-        disp.EnqueueCancel(new CancelOrderCommand("1", Petr, oid, 2_000UL), reply, clOrdIdValue: 1UL);
+        disp.EnqueueCancel(new CancelOrderCommand("1", Petr, oid, 2_000UL), reply, clOrdIdValue: 1UL, origClOrdIdValue: 0UL);
         DrainInbound(disp);
 
         Assert.Single(reply.Cancels);
@@ -148,6 +150,137 @@ public class ChannelDispatcherTests
 
         Assert.Single(reply.Rejects);
         Assert.Empty(pkt.Packets);
+    }
+
+    [Fact]
+    public void Cancel_ByOrigClOrdId_ResolvesViaSessionMap()
+    {
+        var (disp, pkt) = NewDispatcher();
+        var reply = new RecordingReply();
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long oid = reply.News[0].OrderId;
+        pkt.Packets.Clear();
+
+        // Cancel without OrderID — only OrigClOrdID = 1.
+        disp.EnqueueCancel(new CancelOrderCommand("99", Petr, OrderId: 0, 2_000UL),
+            reply, clOrdIdValue: 99UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        Assert.Single(reply.Cancels);
+        Assert.Equal(oid, reply.Cancels[0].OrderId);
+        Assert.Empty(reply.Rejects);
+        Assert.Single(pkt.Packets); // DeleteOrder UMDF frame
+    }
+
+    [Fact]
+    public void Cancel_ByUnknownOrigClOrdId_EmitsRejectAndNoUmdfPacket()
+    {
+        var (disp, pkt) = NewDispatcher();
+        var reply = new RecordingReply();
+
+        disp.EnqueueCancel(new CancelOrderCommand("42", Petr, OrderId: 0, 1_000UL),
+            reply, clOrdIdValue: 42UL, origClOrdIdValue: 12345UL);
+        DrainInbound(disp);
+
+        var rej = Assert.Single(reply.Rejects);
+        Assert.Equal(RejectReason.UnknownOrderId, rej.Reason);
+        Assert.Empty(pkt.Packets);
+    }
+
+    [Fact]
+    public void Replace_ByOrigClOrdId_LostPriority_ResolvesViaSessionMap()
+    {
+        var (disp, pkt) = NewDispatcher();
+        var reply = new RecordingReply();
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long origOid = reply.News[0].OrderId;
+        pkt.Packets.Clear();
+
+        // Replace with NEW PRICE (loses priority): only OrigClOrdID provided.
+        disp.EnqueueReplace(
+            new ReplaceOrderCommand("2", Petr, OrderId: 0, NewPriceMantissa: Px(11m), NewQuantity: 100, EnteredAtNanos: 2_000UL),
+            reply, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        // Engine emits OrderCanceled (lost priority) + OrderAccepted.
+        Assert.Single(reply.Cancels);
+        Assert.Equal(origOid, reply.Cancels[0].OrderId);
+        Assert.Equal(2, reply.News.Count);   // initial accept + replacement accept
+        Assert.Empty(reply.Rejects);
+
+        // Old ClOrdId evicted; new ClOrdId now resolves the new orderId.
+        long newOid = reply.News[1].OrderId;
+        Assert.NotEqual(origOid, newOid);
+
+        // Subsequent cancel by the OLD ClOrdId must fail (evicted).
+        disp.EnqueueCancel(new CancelOrderCommand("3", Petr, OrderId: 0, 3_000UL),
+            reply, clOrdIdValue: 3UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+        Assert.Single(reply.Rejects);
+        Assert.Equal(RejectReason.UnknownOrderId, reply.Rejects[^1].Reason);
+
+        // Cancel by NEW ClOrdId resolves to newOid.
+        disp.EnqueueCancel(new CancelOrderCommand("4", Petr, OrderId: 0, 4_000UL),
+            reply, clOrdIdValue: 4UL, origClOrdIdValue: 2UL);
+        DrainInbound(disp);
+        Assert.Equal(2, reply.Cancels.Count);
+        Assert.Equal(newOid, reply.Cancels[^1].OrderId);
+    }
+
+    [Fact]
+    public void FullyFilledOrder_EvictsClOrdIdMap()
+    {
+        var (disp, pkt) = NewDispatcher();
+        var maker = new RecordingReply();
+        var taker = new RecordingReply();
+
+        // Maker rests an order tagged with ClOrdId=10.
+        disp.EnqueueNewOrder(new NewOrderCommand("10", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            maker, clOrdIdValue: 10UL);
+        DrainInbound(disp);
+        Assert.Single(maker.News);
+
+        // Taker fully consumes the maker's order.
+        disp.EnqueueNewOrder(new NewOrderCommand("20", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 2_000UL),
+            taker, clOrdIdValue: 20UL);
+        DrainInbound(disp);
+
+        Assert.Single(maker.Trades);
+
+        // The maker's ClOrdId must be evicted from the (firm, ClOrdId) → orderId map:
+        // a Cancel by OrigClOrdID=10 must now reject with UnknownOrderId.
+        disp.EnqueueCancel(new CancelOrderCommand("11", Petr, OrderId: 0, 3_000UL),
+            maker, clOrdIdValue: 11UL, origClOrdIdValue: 10UL);
+        DrainInbound(disp);
+
+        var rej = Assert.Single(maker.Rejects);
+        Assert.Equal(RejectReason.UnknownOrderId, rej.Reason);
+    }
+
+    [Fact]
+    public void Cancel_OnSelf_ER_CarriesBothClOrdIdAndOrigClOrdId()
+    {
+        var (disp, _) = NewDispatcher();
+        var reply = new RecordingReply { CaptureCancelIds = true };
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        disp.EnqueueCancel(new CancelOrderCommand("99", Petr, OrderId: 0, 2_000UL),
+            reply, clOrdIdValue: 99UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        Assert.Single(reply.CancelIds);
+        var (clOrd, origClOrd) = reply.CancelIds[0];
+        Assert.Equal(99UL, clOrd);
+        Assert.Equal(1UL, origClOrd);
     }
 
     private static void DrainInbound(ChannelDispatcher disp)

--- a/tests/B3.Exchange.Integration.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/SnapshotRotatorTests.cs
@@ -338,7 +338,7 @@ internal sealed class ChannelDispatcherTests_RecordingReply : B3.Exchange.EntryP
     public bool IsOpen => true;
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e) => true;
     public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue) => true;
+    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq) => true;
     public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue) => true;
 }


### PR DESCRIPTION
Closes #7

## Summary

Lifts the v1 limitation that required `SimpleModifyOrder` and `OrderCancelRequest` to carry an explicit engine-assigned `OrderID`. Clients can now identify the order they want to cancel/replace by its original `ClOrdID` (`OrigClOrdID`), as is standard for FIX integrations.

## Design

- **Map location:** `ChannelDispatcher` owns a per-channel `Dictionary<(uint EnteringFirm, ulong ClOrdID), long orderId>`. It is read and mutated only on the single dispatch thread (in `ProcessOne` and the `IMatchingEventSink` callbacks), so no synchronisation is required.
- **Decode-side:** `InboundMessageDecoder.TryDecodeReplace/TryDecodeCancel` now allow `OrderID == 0` when `OrigClOrdID != 0`. The decoded command's `OrderId` stays at `0`; the `OrigClOrdID` rides on the existing `origClOrdIdValue` out parameter and `WorkItem` field.
- **Resolution:** `ProcessOne` checks for `OrderId == 0` and looks up `(reply.EnteringFirm, item.OrigClOrdId)`. On hit, the command is rewritten with the resolved id; on miss, an `ER_Reject(UnknownOrderId)` is emitted.
- **Population/eviction:** entries are added on `OnOrderAccepted` and removed on `OnOrderCanceled` (covers explicit cancel + replace-lost-priority of the old order) and on `OnOrderFilled` (full fill). `OrderOwnership` was extended with `EnteringFirm` so we can build the reverse-map key on eviction.
- **ER_Cancel:** now carries both `ClOrdID` (the cancel request's id) and `OrigClOrdID` (the resting order's original id). The `IEntryPointEngineSink` and `EntryPointSession` signatures were extended accordingly; `HostRouter` and the test mocks updated.

The `(firm, ClOrdID)` key is forward-compatible with #8 (per-session firm assignment) — only the source of `firm` changes.

## Tests added

- `InboundMessageDecoderTests`: accept cancel/replace by `OrigClOrdID` only; reject when both ids are zero.
- `ChannelDispatcherTests`: cancel by `OrigClOrdID`; unknown `OrigClOrdID` → `ER_Reject(UnknownOrderId)`; replace-lost-priority by `OrigClOrdID` with eviction of the old ClOrdID and registration of the new one; fully-filled order evicts its ClOrdID; ER_Cancel carries both ClOrdID/OrigClOrdID.
- `ExchangeHostE2ETests`: full TCP round-trip for cancel-by-OrigClOrdID and replace-by-OrigClOrdID, asserting both fields on the ER_Cancel wire body.

## Pre-PR checklist

- `dotnet build -c Release` ✅ (warnings-as-errors clean)
- `dotnet test -c Release` ✅ (100/100 pass — 9 new)
- `dotnet format --verify-no-changes` ✅

## Follow-ups discovered

- Priority-preserved replace (`OnOrderQuantityReduced` triggered by a Replace command) does not currently emit an `ER_Modify` to the order owner — only the lost-priority path produces an ER. Out of scope for this issue; worth a separate ticket.
- The `(firm, ClOrdID)` map is per-channel; if/when a single session sends orders that span channels (already supported via `HostRouter`), the same ClOrdID is namespace-isolated per channel. That matches the spirit of UMDF channel partitioning, but worth documenting if it surprises clients.
