### PR TITLE
feat: synthetic trader CLI (#3)

### DIFF
--- a/Dockerfile.synthtrader
+++ b/Dockerfile.synthtrader
@@ -1,0 +1,26 @@
+# Multi-stage image producing the synthetic trader binary.
+#
+# The synth-trader is a TCP client of the exchange host (image built from the
+# top-level Dockerfile). It connects to the host on TCP/9876 by default; see
+# config/synthetic-trader.json for the wire endpoint.
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+WORKDIR /src
+
+COPY Directory.Build.props global.json SbeB3Exchange.slnx ./
+COPY schemas/ schemas/
+COPY src/ src/
+
+RUN dotnet restore src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
+RUN dotnet publish src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj \
+    -c Release -o /app --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+
+WORKDIR /app
+COPY --from=build /app .
+
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/app/B3.Exchange.SyntheticTrader"]
+CMD ["/app/config/synthetic-trader.json"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ a 24/7 simulated venue against any UMDF consumer.
   UMDF packets, publishes via `IUmdfPacketSink`.
 - **`B3.Exchange.Host`** — JSON-configured single-binary host wiring
   EntryPoint listener + dispatchers + multicast UDP sinks.
+- **`B3.Exchange.SyntheticTrader`** — separate console client that connects
+  to the host over EntryPoint TCP and drives continuous order flow
+  (market-maker + noise-taker strategies, seeded RNG for repro). See
+  `config/synthetic-trader.json` and `docker-compose.synthtrader.yml`.
 - **`B3.Umdf.WireEncoder`** — stateless byte-level encoders for UMDF MBO,
   Trade, and Snapshot frames (V16 schema).
 - **`B3.Umdf.Sbe` / `B3.EntryPoint.Sbe`** — SBE bindings generated from the

--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -8,6 +8,7 @@
     <Project Path="src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj" />
     <Project Path="src/B3.Exchange.Integration/B3.Exchange.Integration.csproj" />
     <Project Path="src/B3.Exchange.Host/B3.Exchange.Host.csproj" />
+    <Project Path="src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/B3.Umdf.WireEncoder.Tests/B3.Umdf.WireEncoder.Tests.csproj" />
@@ -16,5 +17,6 @@
     <Project Path="tests/B3.Exchange.EntryPoint.Tests/B3.Exchange.EntryPoint.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Integration.Tests/B3.Exchange.Integration.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj" />
+    <Project Path="tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj" />
   </Folder>
 </Solution>

--- a/config/synthetic-trader.json
+++ b/config/synthetic-trader.json
@@ -1,0 +1,34 @@
+{
+  // Sample synthetic trader config: connect to local host on 9876, run a
+  // market-maker + noise-taker pair on PETR4. Seed is fixed for repro.
+  "host": { "host": "127.0.0.1", "port": 9876 },
+  "firm": 1,
+  "seed": 42,
+  "tickIntervalMs": 100,
+  "instruments": [
+    {
+      "securityId": 900000000001,
+      "tickSize": 100,
+      "lotSize": 100,
+      "initialMidMantissa": 123400,
+      "midDriftProbability": 0.1,
+      "strategies": [
+        {
+          "kind": "marketMaker",
+          "name": "mm-petr4",
+          "levelsPerSide": 3,
+          "quoteSpacingTicks": 1,
+          "replaceDistanceTicks": 5,
+          "quantity": 100
+        },
+        {
+          "kind": "noiseTaker",
+          "name": "noise-petr4",
+          "orderProbability": 0.3,
+          "maxLotMultiple": 3,
+          "crossTicks": 2
+        }
+      ]
+    }
+  ]
+}

--- a/docker-compose.synthtrader.yml
+++ b/docker-compose.synthtrader.yml
@@ -1,0 +1,34 @@
+# Example docker-compose: one exchange host + one synthetic trader.
+#
+# The synth trader connects to the host on the host-network address
+# `exchange:9876`. The exchange uses host networking for its multicast
+# publisher (B3 UMDF) — adjust to bridge mode if you don't need multicast
+# observable from the host.
+#
+# Usage:
+#   docker compose -f docker-compose.synthtrader.yml up --build
+services:
+  exchange:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: sbeb3exchange:latest
+    network_mode: host
+    volumes:
+      - ./config:/app/config:ro
+    command: ["/app/config/exchange-simulator.json"]
+
+  synthtrader:
+    build:
+      context: .
+      dockerfile: Dockerfile.synthtrader
+    image: sbeb3synthtrader:latest
+    depends_on:
+      - exchange
+    network_mode: host
+    volumes:
+      - ./config:/app/config:ro
+    environment:
+      # Set to "1" to log every send/recv frame at debug verbosity.
+      SYNTH_TRADER_DEBUG: "0"
+    command: ["/app/config/synthetic-trader.json"]

--- a/docker-compose.synthtrader.yml
+++ b/docker-compose.synthtrader.yml
@@ -1,9 +1,10 @@
 # Example docker-compose: one exchange host + one synthetic trader.
 #
-# The synth trader connects to the host on the host-network address
-# `exchange:9876`. The exchange uses host networking for its multicast
-# publisher (B3 UMDF) — adjust to bridge mode if you don't need multicast
-# observable from the host.
+# NOTE: Both services use network_mode: host. With host networking, inter-service
+# DNS names (e.g., "exchange") are NOT available. The synth trader accesses the host
+# on 127.0.0.1:9876 (see synthetic-trader.json config). The exchange uses host
+# networking for its multicast publisher (B3 UMDF) — adjust to bridge mode if you
+# don't need multicast observable from the host.
 #
 # Usage:
 #   docker compose -f docker-compose.synthtrader.yml up --build

--- a/src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj
+++ b/src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="B3.Exchange.EntryPoint.Tests" />
+    <InternalsVisibleTo Include="B3.Exchange.SyntheticTrader.Tests" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
+++ b/src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>B3.Exchange.SyntheticTrader</RootNamespace>
+    <AssemblyName>B3.Exchange.SyntheticTrader</AssemblyName>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
+    <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Exchange.SyntheticTrader.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -54,6 +54,17 @@ public sealed class EntryPointClient : IAsyncDisposable
     private const int ErTradeOrderId = 108;
     // ER_Cancel (202): OrderID @ 80.
     private const int ErCancelOrderId = 80;
+    // ER_Reject (204): OrdRejReason @ 44, OrderID @ 64, OrigClOrdID @ 72.
+    private const int ErRejectReason = 44;
+    private const int ErRejectOrderId = 64;
+    private const int ErRejectOrigClOrdId = 72;
+
+    // Maximum ER body block length we are willing to allocate from the wire.
+    // The largest known ExecutionReport block (ER_Modify) is 160 bytes; we
+    // allow a generous upper bound to absorb minor schema bumps but reject
+    // pathological values that would let a malformed peer force giant
+    // allocations and OOM the process.
+    private const int MaxAcceptedBlockLength = 1024;
 
     private const int HeaderSize = 8;
 
@@ -217,14 +228,36 @@ public sealed class EntryPointClient : IAsyncDisposable
     /// <summary>Decodes an ER_Reject body. Exposed for wire-format tests.</summary>
     internal static ExecReportReject DecodeExecReportReject(ReadOnlySpan<byte> body) => new(
         ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErClOrdId, 8)),
-        SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErSecurityId, 8)));
+        SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErSecurityId, 8)),
+        OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErRejectOrderId, 8)),
+        OrigClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErRejectOrigClOrdId, 8)),
+        RejectReason: body[ErRejectReason]);
 
     private bool Enqueue(byte[] frame)
     {
         if (!IsOpen) return false;
-        if (_sendQueue.Writer.TryWrite(frame)) return true;
-        // Bounded with Wait — falling here only happens if writer is closed.
-        return false;
+        try
+        {
+            while (true)
+            {
+                if (_sendQueue.Writer.TryWrite(frame)) return true;
+                // Bounded channel with FullMode=Wait: TryWrite returns false
+                // both when the writer is closed AND when the queue is full.
+                // Honor backpressure rather than silently dropping the frame.
+                if (!_sendQueue.Writer.WaitToWriteAsync(_cts.Token).AsTask().GetAwaiter().GetResult())
+                {
+                    return false;
+                }
+            }
+        }
+        catch (ChannelClosedException)
+        {
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            return false;
+        }
     }
 
     private async Task RunSendLoopAsync(CancellationToken ct)
@@ -272,6 +305,12 @@ public sealed class EntryPointClient : IAsyncDisposable
                 {
                     _logWarn?.Invoke($"unexpected schemaId={schemaId}, dropping connection");
                     Close($"unexpected schemaId={schemaId}");
+                    return;
+                }
+                if (blockLength == 0 || blockLength > MaxAcceptedBlockLength)
+                {
+                    _logWarn?.Invoke($"unreasonable blockLength={blockLength} for tid={templateId}, dropping connection");
+                    Close($"unreasonable blockLength={blockLength}");
                     return;
                 }
                 var body = new byte[blockLength];
@@ -325,7 +364,7 @@ public sealed class EntryPointClient : IAsyncDisposable
                 case EntryPointFrameReader.TidExecutionReportReject:
                     {
                         var er = DecodeExecReportReject(body);
-                        _logDebug?.Invoke($"recv ER_REJ clord={er.ClOrdId}");
+                        _logDebug?.Invoke($"recv ER_REJ clord={er.ClOrdId} origClord={er.OrigClOrdId} orderId={er.OrderId} reason={er.RejectReason}");
                         OnReject?.Invoke(er);
                         break;
                     }
@@ -376,4 +415,4 @@ public readonly record struct ExecReportNew(ulong ClOrdId, long SecurityId, Orde
 public readonly record struct ExecReportTrade(ulong ClOrdId, long SecurityId, OrderSide Side, long OrderId,
     long LastQty, long LastPxMantissa, long LeavesQty, long CumQty);
 public readonly record struct ExecReportCancel(ulong ClOrdId, long SecurityId, OrderSide Side, long OrderId);
-public readonly record struct ExecReportReject(ulong ClOrdId, long SecurityId);
+public readonly record struct ExecReportReject(ulong ClOrdId, long SecurityId, long OrderId, ulong OrigClOrdId, byte RejectReason);

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -120,11 +120,37 @@ public sealed class EntryPointClient : IAsyncDisposable
     {
         if (!IsOpen) return false;
         var frame = new byte[HeaderSize + NewOrderBlockLen];
-        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, HeaderSize),
+        EncodeNewOrder(frame, clOrdId, securityId, side, type, tif, qty, priceMantissa);
+        _logDebug?.Invoke($"send NEW clord={clOrdId} sec={securityId} side={side} qty={qty} px={priceMantissa} tif={tif}");
+        return Enqueue(frame);
+    }
+
+    public bool SendCancel(ulong clOrdId, long securityId, ulong orderId, ulong origClOrdId, OrderSide side)
+    {
+        if (!IsOpen) return false;
+        var frame = new byte[HeaderSize + CancelBlockLen];
+        EncodeCancel(frame, clOrdId, securityId, orderId, origClOrdId, side);
+        _logDebug?.Invoke($"send CXL clord={clOrdId} sec={securityId} orderId={orderId}");
+        return Enqueue(frame);
+    }
+
+    /// <summary>
+    /// Encodes a SimpleNewOrderV2 frame (8-byte SBE header + 82-byte body)
+    /// into <paramref name="frame"/>. Exposed as <c>internal static</c> so
+    /// wire-format compatibility tests can round-trip it through the host's
+    /// <c>InboundMessageDecoder</c> without standing up a TCP connection.
+    /// </summary>
+    internal static int EncodeNewOrder(Span<byte> frame, ulong clOrdId, long securityId, OrderSide side,
+        OrderTypeIntent type, OrderTifIntent tif, long qty, long priceMantissa)
+    {
+        if (frame.Length < HeaderSize + NewOrderBlockLen)
+            throw new ArgumentException("buffer too small for SimpleNewOrderV2", nameof(frame));
+        EntryPointFrameReader.WriteHeader(frame.Slice(0, HeaderSize),
             blockLength: NewOrderBlockLen,
             templateId: EntryPointFrameReader.TidSimpleNewOrder,
             version: 2);
-        var body = frame.AsSpan(HeaderSize);
+        var body = frame.Slice(HeaderSize, NewOrderBlockLen);
+        body.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(NewOrderClOrdID, 8), clOrdId);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(NewOrderSecurityID, 8), securityId);
         body[NewOrderSide] = side == OrderSide.Buy ? (byte)'1' : (byte)'2';
@@ -138,27 +164,60 @@ public sealed class EntryPointClient : IAsyncDisposable
         };
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(NewOrderQty, 8), qty);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(NewOrderPrice, 8), priceMantissa);
-        _logDebug?.Invoke($"send NEW clord={clOrdId} sec={securityId} side={side} qty={qty} px={priceMantissa} tif={tif}");
-        return Enqueue(frame);
+        return HeaderSize + NewOrderBlockLen;
     }
 
-    public bool SendCancel(ulong clOrdId, long securityId, ulong orderId, ulong origClOrdId, OrderSide side)
+    /// <summary>
+    /// Encodes an OrderCancelRequest frame (8-byte SBE header + 76-byte body).
+    /// </summary>
+    internal static int EncodeCancel(Span<byte> frame, ulong clOrdId, long securityId, ulong orderId,
+        ulong origClOrdId, OrderSide side)
     {
-        if (!IsOpen) return false;
-        var frame = new byte[HeaderSize + CancelBlockLen];
-        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, HeaderSize),
+        if (frame.Length < HeaderSize + CancelBlockLen)
+            throw new ArgumentException("buffer too small for OrderCancelRequest", nameof(frame));
+        EntryPointFrameReader.WriteHeader(frame.Slice(0, HeaderSize),
             blockLength: CancelBlockLen,
             templateId: EntryPointFrameReader.TidOrderCancelRequest,
             version: 0);
-        var body = frame.AsSpan(HeaderSize);
+        var body = frame.Slice(HeaderSize, CancelBlockLen);
+        body.Clear();
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(CancelClOrdID, 8), clOrdId);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(CancelSecurityID, 8), securityId);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(CancelOrderID, 8), orderId);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(CancelOrigClOrdID, 8), origClOrdId);
         body[CancelSide] = side == OrderSide.Buy ? (byte)'1' : (byte)'2';
-        _logDebug?.Invoke($"send CXL clord={clOrdId} sec={securityId} orderId={orderId}");
-        return Enqueue(frame);
+        return HeaderSize + CancelBlockLen;
     }
+
+    /// <summary>Decodes an ER_New body. Exposed for wire-format tests.</summary>
+    internal static ExecReportNew DecodeExecReportNew(ReadOnlySpan<byte> body) => new(
+        ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErClOrdId, 8)),
+        SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErSecurityId, 8)),
+        Side: SideFromByte(body[ErSide]),
+        OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErNewOrderId, 8)));
+
+    /// <summary>Decodes an ER_Trade body. Exposed for wire-format tests.</summary>
+    internal static ExecReportTrade DecodeExecReportTrade(ReadOnlySpan<byte> body) => new(
+        ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErClOrdId, 8)),
+        SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErSecurityId, 8)),
+        Side: SideFromByte(body[ErSide]),
+        OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErTradeOrderId, 8)),
+        LastQty: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErTradeLastQty, 8)),
+        LastPxMantissa: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErTradeLastPx, 8)),
+        LeavesQty: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErTradeLeavesQty, 8)),
+        CumQty: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErTradeCumQty, 8)));
+
+    /// <summary>Decodes an ER_Cancel body. Exposed for wire-format tests.</summary>
+    internal static ExecReportCancel DecodeExecReportCancel(ReadOnlySpan<byte> body) => new(
+        ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErClOrdId, 8)),
+        SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErSecurityId, 8)),
+        Side: SideFromByte(body[ErSide]),
+        OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErCancelOrderId, 8)));
+
+    /// <summary>Decodes an ER_Reject body. Exposed for wire-format tests.</summary>
+    internal static ExecReportReject DecodeExecReportReject(ReadOnlySpan<byte> body) => new(
+        ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErClOrdId, 8)),
+        SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErSecurityId, 8)));
 
     private bool Enqueue(byte[] frame)
     {
@@ -244,46 +303,28 @@ public sealed class EntryPointClient : IAsyncDisposable
             {
                 case EntryPointFrameReader.TidExecutionReportNew:
                     {
-                        var er = new ExecReportNew(
-                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
-                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)),
-                            Side: SideFromByte(body[ErSide]),
-                            OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErNewOrderId, 8)));
+                        var er = DecodeExecReportNew(body);
                         _logDebug?.Invoke($"recv ER_NEW clord={er.ClOrdId} orderId={er.OrderId} side={er.Side}");
                         OnNew?.Invoke(er);
                         break;
                     }
                 case EntryPointFrameReader.TidExecutionReportTrade:
                     {
-                        var er = new ExecReportTrade(
-                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
-                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)),
-                            Side: SideFromByte(body[ErSide]),
-                            OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeOrderId, 8)),
-                            LastQty: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeLastQty, 8)),
-                            LastPxMantissa: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeLastPx, 8)),
-                            LeavesQty: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeLeavesQty, 8)),
-                            CumQty: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeCumQty, 8)));
+                        var er = DecodeExecReportTrade(body);
                         _logDebug?.Invoke($"recv ER_TRADE clord={er.ClOrdId} orderId={er.OrderId} side={er.Side} lastQty={er.LastQty} lastPx={er.LastPxMantissa} leaves={er.LeavesQty}");
                         OnTrade?.Invoke(er);
                         break;
                     }
                 case EntryPointFrameReader.TidExecutionReportCancel:
                     {
-                        var er = new ExecReportCancel(
-                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
-                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)),
-                            Side: SideFromByte(body[ErSide]),
-                            OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErCancelOrderId, 8)));
+                        var er = DecodeExecReportCancel(body);
                         _logDebug?.Invoke($"recv ER_CXL clord={er.ClOrdId} orderId={er.OrderId}");
                         OnCancel?.Invoke(er);
                         break;
                     }
                 case EntryPointFrameReader.TidExecutionReportReject:
                     {
-                        var er = new ExecReportReject(
-                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
-                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)));
+                        var er = DecodeExecReportReject(body);
                         _logDebug?.Invoke($"recv ER_REJ clord={er.ClOrdId}");
                         OnReject?.Invoke(er);
                         break;

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -1,0 +1,338 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Threading.Channels;
+using B3.Exchange.EntryPoint;
+
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Lightweight EntryPoint TCP client used by the synthetic trader.
+///
+/// Connects to an EntryPoint listener, encodes outbound SimpleNewOrderV2 /
+/// OrderCancelRequest frames (matching the offsets in
+/// <c>InboundMessageDecoder</c>), and decodes inbound ExecutionReport
+/// frames into typed events. Cancellation propagates cleanly through both
+/// the receive loop and the send queue, so the caller can shut the client
+/// down deterministically (used by integration tests).
+///
+/// Field offsets are duplicated verbatim from the host's
+/// <c>InboundMessageDecoder</c> / <c>ExecutionReportEncoder</c>; the issue
+/// instructions explicitly accept this duplication ("otherwise duplicate
+/// the encoder calls (small)").
+/// </summary>
+public sealed class EntryPointClient : IAsyncDisposable
+{
+    // SimpleNewOrderV2 body offsets (BlockLength=82) — mirror of InboundMessageDecoder.
+    private const int NewOrderClOrdID = 20;
+    private const int NewOrderSecurityID = 48;
+    private const int NewOrderSide = 56;
+    private const int NewOrderOrdType = 57;
+    private const int NewOrderTif = 58;
+    private const int NewOrderQty = 60;
+    private const int NewOrderPrice = 68;
+    private const int NewOrderBlockLen = 82;
+
+    // OrderCancelRequest body offsets (BlockLength=76).
+    private const int CancelClOrdID = 20;
+    private const int CancelSecurityID = 28;
+    private const int CancelOrderID = 36;
+    private const int CancelOrigClOrdID = 44;
+    private const int CancelSide = 52;
+    private const int CancelBlockLen = 76;
+
+    // Inbound ExecutionReport body offsets we care about.
+    private const int ErClOrdId = 20;             // all ER templates
+    private const int ErSecurityId = 36;
+    private const int ErSide = 18;
+    // ER_New (200): OrderID @ 44.
+    private const int ErNewOrderId = 44;
+    // ER_Trade (203): LastQty @ 48, LastPx @ 56, LeavesQty @ 80, CumQty @ 88, OrderID @ 108.
+    private const int ErTradeLastQty = 48;
+    private const int ErTradeLastPx = 56;
+    private const int ErTradeLeavesQty = 80;
+    private const int ErTradeCumQty = 88;
+    private const int ErTradeOrderId = 108;
+    // ER_Cancel (202): OrderID @ 80.
+    private const int ErCancelOrderId = 80;
+
+    private const int HeaderSize = 8;
+
+    private readonly TcpClient _tcp;
+    private readonly NetworkStream _stream;
+    private readonly Channel<byte[]> _sendQueue;
+    private readonly CancellationTokenSource _cts;
+    private readonly Action<string>? _logDebug;
+    private readonly Action<string>? _logWarn;
+    private Task? _recvTask;
+    private Task? _sendTask;
+    private long _isOpen = 1;
+
+    public event Action<ExecReportNew>? OnNew;
+    public event Action<ExecReportTrade>? OnTrade;
+    public event Action<ExecReportCancel>? OnCancel;
+    public event Action<ExecReportReject>? OnReject;
+    public event Action<string>? OnDisconnect;
+
+    public bool IsOpen => Interlocked.Read(ref _isOpen) == 1;
+
+    private EntryPointClient(TcpClient tcp, NetworkStream stream, Action<string>? logDebug, Action<string>? logWarn, CancellationToken externalCt)
+    {
+        _tcp = tcp;
+        _stream = stream;
+        _logDebug = logDebug;
+        _logWarn = logWarn;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
+        _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(1024)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+        });
+    }
+
+    public static async Task<EntryPointClient> ConnectAsync(string host, int port,
+        Action<string>? logDebug = null, Action<string>? logWarn = null, CancellationToken ct = default)
+    {
+        var tcp = new TcpClient { NoDelay = true };
+        try
+        {
+            await tcp.ConnectAsync(host, port, ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            tcp.Dispose();
+            throw;
+        }
+        var stream = tcp.GetStream();
+        var client = new EntryPointClient(tcp, stream, logDebug, logWarn, ct);
+        client.Start();
+        return client;
+    }
+
+    private void Start()
+    {
+        _recvTask = Task.Run(() => RunReceiveLoopAsync(_cts.Token));
+        _sendTask = Task.Run(() => RunSendLoopAsync(_cts.Token));
+    }
+
+    public bool SendNewOrder(ulong clOrdId, long securityId, OrderSide side,
+        OrderTypeIntent type, OrderTifIntent tif, long qty, long priceMantissa)
+    {
+        if (!IsOpen) return false;
+        var frame = new byte[HeaderSize + NewOrderBlockLen];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, HeaderSize),
+            blockLength: NewOrderBlockLen,
+            templateId: EntryPointFrameReader.TidSimpleNewOrder,
+            version: 2);
+        var body = frame.AsSpan(HeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(NewOrderClOrdID, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(NewOrderSecurityID, 8), securityId);
+        body[NewOrderSide] = side == OrderSide.Buy ? (byte)'1' : (byte)'2';
+        body[NewOrderOrdType] = type == OrderTypeIntent.Market ? (byte)'1' : (byte)'2';
+        body[NewOrderTif] = tif switch
+        {
+            OrderTifIntent.Day => (byte)'0',
+            OrderTifIntent.IOC => (byte)'3',
+            OrderTifIntent.FOK => (byte)'4',
+            _ => (byte)'0',
+        };
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(NewOrderQty, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(NewOrderPrice, 8), priceMantissa);
+        _logDebug?.Invoke($"send NEW clord={clOrdId} sec={securityId} side={side} qty={qty} px={priceMantissa} tif={tif}");
+        return Enqueue(frame);
+    }
+
+    public bool SendCancel(ulong clOrdId, long securityId, ulong orderId, ulong origClOrdId, OrderSide side)
+    {
+        if (!IsOpen) return false;
+        var frame = new byte[HeaderSize + CancelBlockLen];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, HeaderSize),
+            blockLength: CancelBlockLen,
+            templateId: EntryPointFrameReader.TidOrderCancelRequest,
+            version: 0);
+        var body = frame.AsSpan(HeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(CancelClOrdID, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(CancelSecurityID, 8), securityId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(CancelOrderID, 8), orderId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(CancelOrigClOrdID, 8), origClOrdId);
+        body[CancelSide] = side == OrderSide.Buy ? (byte)'1' : (byte)'2';
+        _logDebug?.Invoke($"send CXL clord={clOrdId} sec={securityId} orderId={orderId}");
+        return Enqueue(frame);
+    }
+
+    private bool Enqueue(byte[] frame)
+    {
+        if (!IsOpen) return false;
+        if (_sendQueue.Writer.TryWrite(frame)) return true;
+        // Bounded with Wait — falling here only happens if writer is closed.
+        return false;
+    }
+
+    private async Task RunSendLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var frame in _sendQueue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                try
+                {
+                    await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                }
+                catch (IOException ex)
+                {
+                    _logWarn?.Invoke($"send IO error: {ex.Message}");
+                    Close($"send IO error: {ex.Message}");
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
+        {
+            _logWarn?.Invoke($"send loop error: {ex.Message}");
+        }
+        finally
+        {
+            Close("send loop exit");
+        }
+    }
+
+    private async Task RunReceiveLoopAsync(CancellationToken ct)
+    {
+        var headerBuf = new byte[HeaderSize];
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await ReadExactAsync(_stream, headerBuf, ct).ConfigureAwait(false);
+                ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+                ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+                ushort schemaId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(4, 2));
+                ushort version = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(6, 2));
+                if (schemaId != EntryPointFrameReader.SchemaId)
+                {
+                    _logWarn?.Invoke($"unexpected schemaId={schemaId}, dropping connection");
+                    Close($"unexpected schemaId={schemaId}");
+                    return;
+                }
+                var body = new byte[blockLength];
+                await ReadExactAsync(_stream, body, ct).ConfigureAwait(false);
+                Dispatch(templateId, version, body);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (EndOfStreamException) { }
+        catch (IOException ex)
+        {
+            _logWarn?.Invoke($"recv IO error: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            _logWarn?.Invoke($"recv loop error: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            Close("recv loop exit");
+        }
+    }
+
+    private void Dispatch(ushort templateId, ushort version, byte[] body)
+    {
+        try
+        {
+            switch (templateId)
+            {
+                case EntryPointFrameReader.TidExecutionReportNew:
+                    {
+                        var er = new ExecReportNew(
+                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
+                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)),
+                            Side: SideFromByte(body[ErSide]),
+                            OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErNewOrderId, 8)));
+                        _logDebug?.Invoke($"recv ER_NEW clord={er.ClOrdId} orderId={er.OrderId} side={er.Side}");
+                        OnNew?.Invoke(er);
+                        break;
+                    }
+                case EntryPointFrameReader.TidExecutionReportTrade:
+                    {
+                        var er = new ExecReportTrade(
+                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
+                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)),
+                            Side: SideFromByte(body[ErSide]),
+                            OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeOrderId, 8)),
+                            LastQty: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeLastQty, 8)),
+                            LastPxMantissa: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeLastPx, 8)),
+                            LeavesQty: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeLeavesQty, 8)),
+                            CumQty: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErTradeCumQty, 8)));
+                        _logDebug?.Invoke($"recv ER_TRADE clord={er.ClOrdId} orderId={er.OrderId} side={er.Side} lastQty={er.LastQty} lastPx={er.LastPxMantissa} leaves={er.LeavesQty}");
+                        OnTrade?.Invoke(er);
+                        break;
+                    }
+                case EntryPointFrameReader.TidExecutionReportCancel:
+                    {
+                        var er = new ExecReportCancel(
+                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
+                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)),
+                            Side: SideFromByte(body[ErSide]),
+                            OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErCancelOrderId, 8)));
+                        _logDebug?.Invoke($"recv ER_CXL clord={er.ClOrdId} orderId={er.OrderId}");
+                        OnCancel?.Invoke(er);
+                        break;
+                    }
+                case EntryPointFrameReader.TidExecutionReportReject:
+                    {
+                        var er = new ExecReportReject(
+                            ClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(ErClOrdId, 8)),
+                            SecurityId: BinaryPrimitives.ReadInt64LittleEndian(body.AsSpan(ErSecurityId, 8)));
+                        _logDebug?.Invoke($"recv ER_REJ clord={er.ClOrdId}");
+                        OnReject?.Invoke(er);
+                        break;
+                    }
+                default:
+                    _logDebug?.Invoke($"recv ignored tid={templateId} v={version}");
+                    break;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logWarn?.Invoke($"dispatch error tid={templateId}: {ex.Message}");
+        }
+    }
+
+    private static OrderSide SideFromByte(byte b) => b == (byte)'2' ? OrderSide.Sell : OrderSide.Buy;
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buf, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buf.Length)
+        {
+            int n = await stream.ReadAsync(buf.AsMemory(read), ct).ConfigureAwait(false);
+            if (n <= 0) throw new EndOfStreamException();
+            read += n;
+        }
+    }
+
+    private void Close(string reason)
+    {
+        if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
+        _sendQueue.Writer.TryComplete();
+        try { _cts.Cancel(); } catch { }
+        try { _stream.Dispose(); } catch { }
+        try { _tcp.Dispose(); } catch { }
+        try { OnDisconnect?.Invoke(reason); } catch { }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Close("dispose");
+        try { if (_recvTask != null) await _recvTask.ConfigureAwait(false); } catch { }
+        try { if (_sendTask != null) await _sendTask.ConfigureAwait(false); } catch { }
+        _cts.Dispose();
+    }
+}
+
+public readonly record struct ExecReportNew(ulong ClOrdId, long SecurityId, OrderSide Side, long OrderId);
+public readonly record struct ExecReportTrade(ulong ClOrdId, long SecurityId, OrderSide Side, long OrderId,
+    long LastQty, long LastPxMantissa, long LeavesQty, long CumQty);
+public readonly record struct ExecReportCancel(ulong ClOrdId, long SecurityId, OrderSide Side, long OrderId);
+public readonly record struct ExecReportReject(ulong ClOrdId, long SecurityId);

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Threading.Channels;
@@ -65,6 +66,20 @@ public sealed class EntryPointClient : IAsyncDisposable
     // pathological values that would let a malformed peer force giant
     // allocations and OOM the process.
     private const int MaxAcceptedBlockLength = 1024;
+
+    // Per-template expected block lengths (mirroring ExecutionReportEncoder
+    // constants in B3.Exchange.EntryPoint, which is internal). Used as a
+    // tighter, schema-aware validation before allocating the body buffer.
+    // Returns -1 for unknown template IDs (caller falls back to MaxAcceptedBlockLength).
+    private static int ExpectedBlockLength(ushort templateId) => templateId switch
+    {
+        EntryPointFrameReader.TidExecutionReportNew => 144,
+        EntryPointFrameReader.TidExecutionReportModify => 160,
+        EntryPointFrameReader.TidExecutionReportCancel => 156,
+        EntryPointFrameReader.TidExecutionReportTrade => 154,
+        EntryPointFrameReader.TidExecutionReportReject => 138,
+        _ => -1,
+    };
 
     private const int HeaderSize = 8;
 
@@ -307,15 +322,30 @@ public sealed class EntryPointClient : IAsyncDisposable
                     Close($"unexpected schemaId={schemaId}");
                     return;
                 }
-                if (blockLength == 0 || blockLength > MaxAcceptedBlockLength)
+                int expected = ExpectedBlockLength(templateId);
+                if (expected >= 0 && blockLength != expected)
+                {
+                    _logWarn?.Invoke($"unexpected blockLength={blockLength} for tid={templateId} (expected={expected}), dropping connection");
+                    Close($"unexpected blockLength={blockLength} for tid={templateId}");
+                    return;
+                }
+                if (expected < 0 && (blockLength == 0 || blockLength > MaxAcceptedBlockLength))
                 {
                     _logWarn?.Invoke($"unreasonable blockLength={blockLength} for tid={templateId}, dropping connection");
                     Close($"unreasonable blockLength={blockLength}");
                     return;
                 }
-                var body = new byte[blockLength];
-                await ReadExactAsync(_stream, body, ct).ConfigureAwait(false);
-                Dispatch(templateId, version, body);
+                // Rent the body buffer to avoid per-frame heap allocations under load.
+                var body = ArrayPool<byte>.Shared.Rent(blockLength);
+                try
+                {
+                    await ReadExactAsync(_stream, body.AsMemory(0, blockLength), ct).ConfigureAwait(false);
+                    Dispatch(templateId, version, body, blockLength);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(body);
+                }
             }
         }
         catch (OperationCanceledException) { }
@@ -334,36 +364,37 @@ public sealed class EntryPointClient : IAsyncDisposable
         }
     }
 
-    private void Dispatch(ushort templateId, ushort version, byte[] body)
+    private void Dispatch(ushort templateId, ushort version, byte[] body, int blockLength)
     {
+        ReadOnlySpan<byte> slice = body.AsSpan(0, blockLength);
         try
         {
             switch (templateId)
             {
                 case EntryPointFrameReader.TidExecutionReportNew:
                     {
-                        var er = DecodeExecReportNew(body);
+                        var er = DecodeExecReportNew(slice);
                         _logDebug?.Invoke($"recv ER_NEW clord={er.ClOrdId} orderId={er.OrderId} side={er.Side}");
                         OnNew?.Invoke(er);
                         break;
                     }
                 case EntryPointFrameReader.TidExecutionReportTrade:
                     {
-                        var er = DecodeExecReportTrade(body);
+                        var er = DecodeExecReportTrade(slice);
                         _logDebug?.Invoke($"recv ER_TRADE clord={er.ClOrdId} orderId={er.OrderId} side={er.Side} lastQty={er.LastQty} lastPx={er.LastPxMantissa} leaves={er.LeavesQty}");
                         OnTrade?.Invoke(er);
                         break;
                     }
                 case EntryPointFrameReader.TidExecutionReportCancel:
                     {
-                        var er = DecodeExecReportCancel(body);
+                        var er = DecodeExecReportCancel(slice);
                         _logDebug?.Invoke($"recv ER_CXL clord={er.ClOrdId} orderId={er.OrderId}");
                         OnCancel?.Invoke(er);
                         break;
                     }
                 case EntryPointFrameReader.TidExecutionReportReject:
                     {
-                        var er = DecodeExecReportReject(body);
+                        var er = DecodeExecReportReject(slice);
                         _logDebug?.Invoke($"recv ER_REJ clord={er.ClOrdId} origClord={er.OrigClOrdId} orderId={er.OrderId} reason={er.RejectReason}");
                         OnReject?.Invoke(er);
                         break;
@@ -387,6 +418,17 @@ public sealed class EntryPointClient : IAsyncDisposable
         while (read < buf.Length)
         {
             int n = await stream.ReadAsync(buf.AsMemory(read), ct).ConfigureAwait(false);
+            if (n <= 0) throw new EndOfStreamException();
+            read += n;
+        }
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, Memory<byte> buf, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buf.Length)
+        {
+            int n = await stream.ReadAsync(buf.Slice(read), ct).ConfigureAwait(false);
             if (n <= 0) throw new EndOfStreamException();
             read += n;
         }

--- a/src/B3.Exchange.SyntheticTrader/IStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/IStrategy.cs
@@ -2,9 +2,17 @@ namespace B3.Exchange.SyntheticTrader;
 
 /// <summary>
 /// Per-instrument strategy. Pure-ish: <see cref="Tick"/> consumes a snapshot
-/// and a seeded RNG and emits intents. The runner calls the event callbacks
-/// before <see cref="Tick"/> on the same dispatch thread, so strategies do
-/// not need to be thread-safe internally.
+/// and a seeded RNG and emits intents.
+///
+/// <para><b>Threading contract.</b> <see cref="Tick"/> is invoked on the
+/// <see cref="SyntheticTraderRunner"/>'s tick task, while
+/// <see cref="OnAck"/>, <see cref="OnFill"/>, and <see cref="OnRemoved"/>
+/// are dispatched from the <see cref="EntryPointClient"/>'s receive task.
+/// These run concurrently, so any state shared between <see cref="Tick"/>
+/// and the event callbacks <b>must be guarded</b> (e.g. with the per-strategy
+/// lock the runner holds when mutating its own per-strategy maps, or with
+/// the strategy's own synchronization). Implementations that do not share
+/// mutable state across these methods can safely ignore this constraint.</para>
 ///
 /// This shape is intentionally minimal so future strategies (issue #13)
 /// can plug in without touching the runner.

--- a/src/B3.Exchange.SyntheticTrader/IStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/IStrategy.cs
@@ -1,0 +1,33 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Per-instrument strategy. Pure-ish: <see cref="Tick"/> consumes a snapshot
+/// and a seeded RNG and emits intents. The runner calls the event callbacks
+/// before <see cref="Tick"/> on the same dispatch thread, so strategies do
+/// not need to be thread-safe internally.
+///
+/// This shape is intentionally minimal so future strategies (issue #13)
+/// can plug in without touching the runner.
+/// </summary>
+public interface IStrategy
+{
+    /// <summary>
+    /// Stable identifier for logs.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Produce zero or more intents for this tick. Must be deterministic
+    /// for a given (state, rng-state) pair.
+    /// </summary>
+    IEnumerable<OrderIntent> Tick(in MarketState state, Random rng);
+
+    /// <summary>Called when the runner sees an ER_New for one of our orders.</summary>
+    void OnAck(string clientTag, long orderId) { }
+
+    /// <summary>Called for each ER_Trade on one of our orders (active or passive).</summary>
+    void OnFill(in FillEvent fill) { }
+
+    /// <summary>Called when one of our orders is cancelled (ER_Cancel) or rejected.</summary>
+    void OnRemoved(string clientTag) { }
+}

--- a/src/B3.Exchange.SyntheticTrader/MarketMakerStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/MarketMakerStrategy.cs
@@ -1,0 +1,83 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Posts <see cref="LevelsPerSide"/> resting limits on each side, evenly
+/// spaced by <see cref="QuoteSpacingTicks"/> ticks around the current
+/// midprice. On each tick we top up missing levels (cancelled, filled, or
+/// drifted out of band) so the book always shows fresh quotes.
+///
+/// Refresh policy:
+///  - if there is no live order at the target price/side, post one;
+///  - if a live order's price has drifted more than <see cref="ReplaceDistanceTicks"/>
+///    from the target, cancel it (it'll be reposted next tick).
+/// </summary>
+public sealed class MarketMakerStrategy : IStrategy
+{
+    private readonly long _baseQty;
+    private long _seq;
+
+    public string Name { get; }
+    public int LevelsPerSide { get; }
+    public int QuoteSpacingTicks { get; }
+    public int ReplaceDistanceTicks { get; }
+
+    public MarketMakerStrategy(string name, int levelsPerSide, int quoteSpacingTicks, int replaceDistanceTicks, long quantity)
+    {
+        if (levelsPerSide <= 0) throw new ArgumentOutOfRangeException(nameof(levelsPerSide));
+        if (quoteSpacingTicks <= 0) throw new ArgumentOutOfRangeException(nameof(quoteSpacingTicks));
+        if (replaceDistanceTicks <= 0) throw new ArgumentOutOfRangeException(nameof(replaceDistanceTicks));
+        if (quantity <= 0) throw new ArgumentOutOfRangeException(nameof(quantity));
+        Name = name;
+        LevelsPerSide = levelsPerSide;
+        QuoteSpacingTicks = quoteSpacingTicks;
+        ReplaceDistanceTicks = replaceDistanceTicks;
+        _baseQty = quantity;
+    }
+
+    public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng)
+    {
+        // RNG unused on purpose: market-maker is deterministic given mid.
+        // Touching it here keeps the strategy compatible with seeded test
+        // scenarios that share an rng across strategies.
+        _ = rng;
+
+        var intents = new List<OrderIntent>(capacity: LevelsPerSide * 2);
+        long mid = state.MidMantissa;
+        long tick = state.TickSize <= 0 ? 1 : state.TickSize;
+        long lot = state.LotSize <= 0 ? 1 : state.LotSize;
+        long qty = (_baseQty / lot) * lot;
+        if (qty <= 0) qty = lot;
+
+        for (int i = 1; i <= LevelsPerSide; i++)
+        {
+            long bidPx = mid - (long)i * QuoteSpacingTicks * tick;
+            long askPx = mid + (long)i * QuoteSpacingTicks * tick;
+            if (bidPx <= 0) continue;
+            EmitForLevel(intents, state, OrderSide.Buy, bidPx, qty, tick);
+            EmitForLevel(intents, state, OrderSide.Sell, askPx, qty, tick);
+        }
+        return intents;
+    }
+
+    private void EmitForLevel(List<OrderIntent> intents, in MarketState state, OrderSide side, long targetPx, long qty, long tick)
+    {
+        long maxDrift = (long)ReplaceDistanceTicks * tick;
+        bool haveAtTarget = false;
+        foreach (var live in state.MyLiveOrders)
+        {
+            if (live.Side != side) continue;
+            long delta = live.PriceMantissa - targetPx;
+            if (delta < 0) delta = -delta;
+            if (delta == 0) { haveAtTarget = true; continue; }
+            if (delta > maxDrift)
+            {
+                intents.Add(OrderIntent.Cancel(state.SecurityId, live.ClientTag));
+            }
+        }
+        if (!haveAtTarget)
+        {
+            string tag = $"{Name}-{state.SecurityId}-{(side == OrderSide.Buy ? "B" : "S")}-{++_seq}";
+            intents.Add(OrderIntent.NewLimit(state.SecurityId, side, qty, targetPx, tag));
+        }
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/MarketState.cs
+++ b/src/B3.Exchange.SyntheticTrader/MarketState.cs
@@ -1,0 +1,36 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Snapshot of what a strategy sees for a single instrument at the start of
+/// a tick. Prices are mantissas (B3 implicit /10000); quantities are integer
+/// share counts. The list of live orders is filtered to those owned by the
+/// strategy's own logical book — i.e. the runner tracks acks per strategy.
+/// </summary>
+public readonly record struct MarketState(
+    long SecurityId,
+    long MidMantissa,
+    long TickSize,
+    long LotSize,
+    long LastTradePxMantissa,
+    long LastTradeQty,
+    IReadOnlyList<LiveOrder> MyLiveOrders);
+
+/// <summary>
+/// A live working order owned by the strategy. <see cref="ClientTag"/> is
+/// the tag the strategy used when emitting the original NEW intent.
+/// </summary>
+public readonly record struct LiveOrder(
+    string ClientTag,
+    OrderSide Side,
+    long PriceMantissa,
+    long RemainingQty);
+
+/// <summary>
+/// Fill notification handed back to the strategy.
+/// </summary>
+public readonly record struct FillEvent(
+    string ClientTag,
+    OrderSide Side,
+    long PriceMantissa,
+    long LastQty,
+    long LeavesQty);

--- a/src/B3.Exchange.SyntheticTrader/NoiseTakerStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/NoiseTakerStrategy.cs
@@ -1,0 +1,53 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Random aggressor: with probability <see cref="OrderProbability"/> per
+/// tick, lifts the offer or hits the bid with a marketable IOC limit. Order
+/// quantity is a uniform multiple of the lot size in
+/// <c>[1, MaxLotMultiple]</c>; the price is the current midprice plus
+/// <see cref="CrossTicks"/> ticks of slippage in the aggressor's direction
+/// (so the order is reliably marketable against typical market-maker quotes
+/// configured with <c>QuoteSpacingTicks &lt;= CrossTicks</c>).
+///
+/// All randomness flows through the runner-supplied seeded
+/// <see cref="Random"/>; the strategy holds no RNG state of its own, so a
+/// given (state, rng-state) sequence is fully reproducible.
+/// </summary>
+public sealed class NoiseTakerStrategy : IStrategy
+{
+    private long _seq;
+
+    public string Name { get; }
+    public double OrderProbability { get; }
+    public int MaxLotMultiple { get; }
+    public int CrossTicks { get; }
+
+    public NoiseTakerStrategy(string name, double orderProbability, int maxLotMultiple, int crossTicks)
+    {
+        if (orderProbability < 0 || orderProbability > 1) throw new ArgumentOutOfRangeException(nameof(orderProbability));
+        if (maxLotMultiple <= 0) throw new ArgumentOutOfRangeException(nameof(maxLotMultiple));
+        if (crossTicks <= 0) throw new ArgumentOutOfRangeException(nameof(crossTicks));
+        Name = name;
+        OrderProbability = orderProbability;
+        MaxLotMultiple = maxLotMultiple;
+        CrossTicks = crossTicks;
+    }
+
+    public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng)
+    {
+        if (rng.NextDouble() >= OrderProbability)
+            return Array.Empty<OrderIntent>();
+
+        long tick = state.TickSize <= 0 ? 1 : state.TickSize;
+        long lot = state.LotSize <= 0 ? 1 : state.LotSize;
+        var side = rng.Next(2) == 0 ? OrderSide.Buy : OrderSide.Sell;
+        long mult = rng.Next(MaxLotMultiple) + 1;
+        long qty = mult * lot;
+        long px = side == OrderSide.Buy
+            ? state.MidMantissa + (long)CrossTicks * tick
+            : state.MidMantissa - (long)CrossTicks * tick;
+        if (px <= 0) return Array.Empty<OrderIntent>();
+        string tag = $"{Name}-{state.SecurityId}-{(side == OrderSide.Buy ? "B" : "S")}-{++_seq}";
+        return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, side, qty, px, tag) };
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/OrderIntent.cs
+++ b/src/B3.Exchange.SyntheticTrader/OrderIntent.cs
@@ -1,0 +1,47 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Strategy-side order action. The runner translates intents into
+/// EntryPoint wire frames.
+/// </summary>
+public enum OrderIntentKind { New, Cancel }
+
+public enum OrderSide : byte { Buy, Sell }
+
+public enum OrderTypeIntent : byte { Limit, Market }
+
+public enum OrderTifIntent : byte { Day, IOC, FOK }
+
+/// <summary>
+/// One unit of work emitted by an <see cref="IStrategy"/>. Strategies are
+/// pure functions of <see cref="MarketState"/> and a seeded <see cref="Random"/>;
+/// they do not perform I/O. The runner submits the intents and feeds back
+/// fills/acks via <see cref="IStrategy"/> callbacks.
+///
+/// For <see cref="OrderIntentKind.New"/>, <see cref="ClientTag"/> is a
+/// strategy-private label the runner echoes back on acks/fills so the
+/// strategy can correlate orders without owning the global ClOrdID counter.
+///
+/// For <see cref="OrderIntentKind.Cancel"/>, <see cref="CancelTag"/> targets
+/// a previously-acked order by its strategy-private tag.
+/// </summary>
+public readonly record struct OrderIntent(
+    OrderIntentKind Kind,
+    long SecurityId,
+    OrderSide Side,
+    OrderTypeIntent Type,
+    OrderTifIntent Tif,
+    long Quantity,
+    long PriceMantissa,
+    string ClientTag,
+    string CancelTag)
+{
+    public static OrderIntent NewLimit(long securityId, OrderSide side, long qty, long priceMantissa, string clientTag)
+        => new(OrderIntentKind.New, securityId, side, OrderTypeIntent.Limit, OrderTifIntent.Day, qty, priceMantissa, clientTag, "");
+
+    public static OrderIntent NewMarketableLimit(long securityId, OrderSide side, long qty, long priceMantissa, string clientTag)
+        => new(OrderIntentKind.New, securityId, side, OrderTypeIntent.Limit, OrderTifIntent.IOC, qty, priceMantissa, clientTag, "");
+
+    public static OrderIntent Cancel(long securityId, string cancelTag)
+        => new(OrderIntentKind.Cancel, securityId, OrderSide.Buy, OrderTypeIntent.Limit, OrderTifIntent.Day, 0, 0, "", cancelTag);
+}

--- a/src/B3.Exchange.SyntheticTrader/Program.cs
+++ b/src/B3.Exchange.SyntheticTrader/Program.cs
@@ -1,0 +1,62 @@
+using B3.Exchange.SyntheticTrader;
+
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("usage: B3.Exchange.SyntheticTrader <path-to-synthetic-trader.json>");
+    return 2;
+}
+
+SyntheticTraderConfig cfg;
+try
+{
+    cfg = SyntheticTraderConfigLoader.Load(args[0]);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"failed to load config '{args[0]}': {ex.Message}");
+    return 3;
+}
+
+void Info(string s) => Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}Z] {s}");
+void Warn(string s) => Console.Error.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}Z] WARN {s}");
+void Debug(string s)
+{
+    if (Environment.GetEnvironmentVariable("SYNTH_TRADER_DEBUG") == "1")
+        Console.WriteLine($"[{DateTime.UtcNow:HH:mm:ss.fff}Z] DEBUG {s}");
+}
+
+using var shutdown = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) => { e.Cancel = true; shutdown.Cancel(); };
+AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdown.Cancel();
+
+Info($"connecting to {cfg.Host.Host}:{cfg.Host.Port}");
+EntryPointClient client;
+try
+{
+    client = await EntryPointClient.ConnectAsync(cfg.Host.Host, cfg.Host.Port, Debug, Warn, shutdown.Token);
+}
+catch (Exception ex)
+{
+    Warn($"connect failed: {ex.Message}");
+    return 4;
+}
+
+var instruments = cfg.Instruments.Select(ic =>
+    (cfg: ic, strategies: (IReadOnlyList<IStrategy>)ic.Strategies
+        .Select(SyntheticTraderConfigLoader.BuildStrategy).ToList()));
+
+var seed = cfg.Seed != 0 ? cfg.Seed : Environment.TickCount;
+var rng = new Random(seed);
+
+await using var runner = new SyntheticTraderRunner(client, instruments, rng,
+    TimeSpan.FromMilliseconds(Math.Max(1, cfg.TickIntervalMs)),
+    Info, Warn, shutdown.Token);
+runner.Start();
+
+Info($"synthetic trader running; seed={seed}; instruments={cfg.Instruments.Count}; Ctrl+C to stop");
+try { await Task.Delay(Timeout.Infinite, shutdown.Token).ConfigureAwait(false); }
+catch (OperationCanceledException) { }
+
+Info($"shutting down (ticks={runner.TicksRun} sent={runner.OrdersSent} trades={runner.TradesObserved})");
+await client.DisposeAsync().ConfigureAwait(false);
+return 0;

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Top-level synthetic-trader configuration. One process can drive any
+/// number of instruments; each instrument gets its own (strategy, params)
+/// pair. The host endpoint is a single TCP connection per process.
+/// </summary>
+public sealed class SyntheticTraderConfig
+{
+    [JsonPropertyName("host")] public HostEndpointConfig Host { get; set; } = new();
+    [JsonPropertyName("firm")] public uint Firm { get; set; } = 1;
+
+    /// <summary>RNG seed. 0 means "use a non-deterministic time-based seed".</summary>
+    [JsonPropertyName("seed")] public int Seed { get; set; } = 1;
+
+    /// <summary>Tick interval in milliseconds. The runner ticks all strategies on this cadence.</summary>
+    [JsonPropertyName("tickIntervalMs")] public int TickIntervalMs { get; set; } = 100;
+
+    [JsonPropertyName("instruments")] public List<InstrumentConfig> Instruments { get; set; } = new();
+}
+
+public sealed class HostEndpointConfig
+{
+    [JsonPropertyName("host")] public string Host { get; set; } = "127.0.0.1";
+    [JsonPropertyName("port")] public int Port { get; set; } = 9876;
+}
+
+public sealed class InstrumentConfig
+{
+    [JsonPropertyName("securityId")] public long SecurityId { get; set; }
+
+    /// <summary>Tick size in mantissa units (i.e. /10000). 100 == 0.01 BRL.</summary>
+    [JsonPropertyName("tickSize")] public long TickSize { get; set; } = 100;
+
+    [JsonPropertyName("lotSize")] public long LotSize { get; set; } = 100;
+
+    /// <summary>Initial midprice mantissa. The midprice random-walks each tick.</summary>
+    [JsonPropertyName("initialMidMantissa")] public long InitialMidMantissa { get; set; }
+
+    /// <summary>Probability per tick that the mid drifts by ±1 tick (random walk).</summary>
+    [JsonPropertyName("midDriftProbability")] public double MidDriftProbability { get; set; } = 0.1;
+
+    [JsonPropertyName("strategies")] public List<StrategyConfig> Strategies { get; set; } = new();
+}
+
+public sealed class StrategyConfig
+{
+    /// <summary>One of: <c>marketMaker</c>, <c>noiseTaker</c>.</summary>
+    [JsonPropertyName("kind")] public string Kind { get; set; } = "";
+    [JsonPropertyName("name")] public string Name { get; set; } = "";
+
+    // MarketMaker
+    [JsonPropertyName("levelsPerSide")] public int LevelsPerSide { get; set; } = 3;
+    [JsonPropertyName("quoteSpacingTicks")] public int QuoteSpacingTicks { get; set; } = 1;
+    [JsonPropertyName("replaceDistanceTicks")] public int ReplaceDistanceTicks { get; set; } = 5;
+    [JsonPropertyName("quantity")] public long Quantity { get; set; } = 100;
+
+    // NoiseTaker
+    [JsonPropertyName("orderProbability")] public double OrderProbability { get; set; } = 0.2;
+    [JsonPropertyName("maxLotMultiple")] public int MaxLotMultiple { get; set; } = 3;
+    [JsonPropertyName("crossTicks")] public int CrossTicks { get; set; } = 1;
+}
+
+public static class SyntheticTraderConfigLoader
+{
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+    };
+
+    public static SyntheticTraderConfig Load(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var cfg = JsonSerializer.Deserialize<SyntheticTraderConfig>(stream, Options)
+            ?? throw new InvalidOperationException($"empty synthetic-trader config at {path}");
+        if (cfg.Instruments.Count == 0)
+            throw new InvalidOperationException("SyntheticTraderConfig.Instruments is empty");
+        return cfg;
+    }
+
+    public static IStrategy BuildStrategy(StrategyConfig sc) => sc.Kind switch
+    {
+        "marketMaker" => new MarketMakerStrategy(
+            string.IsNullOrEmpty(sc.Name) ? "mm" : sc.Name,
+            sc.LevelsPerSide, sc.QuoteSpacingTicks, sc.ReplaceDistanceTicks, sc.Quantity),
+        "noiseTaker" => new NoiseTakerStrategy(
+            string.IsNullOrEmpty(sc.Name) ? "noise" : sc.Name,
+            sc.OrderProbability, sc.MaxLotMultiple, sc.CrossTicks),
+        _ => throw new InvalidOperationException($"unknown strategy kind '{sc.Kind}'"),
+    };
+}

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
@@ -1,0 +1,321 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Drives one or more <see cref="IStrategy"/> instances against a connected
+/// <see cref="EntryPointClient"/>. Owns:
+///   - per-instrument <see cref="MarketState"/> (mid, last trade, live orders);
+///   - a single tick loop that calls <see cref="IStrategy.Tick"/> on each
+///     strategy in turn at <c>TickInterval</c>;
+///   - the ClOrdID monotonic counter and tag↔orderId/clord maps used to
+///     route ER_New / ER_Trade / ER_Cancel back to the originating strategy.
+///
+/// Threading: ER callbacks fire on the client's recv thread; tick fires on
+/// the runner thread. Both mutate the same per-instrument state, so all
+/// access is funneled through a per-instrument lock. Strategies see only
+/// snapshots, never the live state.
+/// </summary>
+public sealed class SyntheticTraderRunner : IAsyncDisposable
+{
+    private readonly EntryPointClient _client;
+    private readonly Dictionary<long, InstrumentRuntime> _instruments;
+    private readonly Random _rng;
+    private readonly TimeSpan _tickInterval;
+    private readonly Action<string>? _logInfo;
+    private readonly Action<string>? _logWarn;
+    private readonly CancellationTokenSource _cts;
+    private readonly Dictionary<ulong, OrderTracking> _byClOrd = new();
+    private long _clOrdSeq;
+    private long _ticksRun;
+    private long _ordersSent;
+    private long _tradesObserved;
+    private Task? _tickTask;
+
+    public long TicksRun => Interlocked.Read(ref _ticksRun);
+    public long OrdersSent => Interlocked.Read(ref _ordersSent);
+    public long TradesObserved => Interlocked.Read(ref _tradesObserved);
+
+    public SyntheticTraderRunner(
+        EntryPointClient client,
+        IEnumerable<(InstrumentConfig cfg, IReadOnlyList<IStrategy> strategies)> instruments,
+        Random rng,
+        TimeSpan tickInterval,
+        Action<string>? logInfo = null,
+        Action<string>? logWarn = null,
+        CancellationToken ct = default)
+    {
+        _client = client;
+        _rng = rng;
+        _tickInterval = tickInterval;
+        _logInfo = logInfo;
+        _logWarn = logWarn;
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _instruments = instruments.ToDictionary(
+            t => t.cfg.SecurityId,
+            t => new InstrumentRuntime(t.cfg, t.strategies));
+
+        _client.OnNew += OnExecNew;
+        _client.OnTrade += OnExecTrade;
+        _client.OnCancel += OnExecCancel;
+        _client.OnReject += OnExecReject;
+    }
+
+    public void Start()
+    {
+        _tickTask = Task.Run(() => TickLoopAsync(_cts.Token));
+    }
+
+    private async Task TickLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try
+                {
+                    RunTick();
+                }
+                catch (Exception ex)
+                {
+                    _logWarn?.Invoke($"tick error: {ex.GetType().Name}: {ex.Message}");
+                }
+                Interlocked.Increment(ref _ticksRun);
+                await Task.Delay(_tickInterval, ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    internal void RunTick()
+    {
+        foreach (var (secId, inst) in _instruments)
+        {
+            // Mid random walk first — visible to strategies on the same tick.
+            DriftMid(inst);
+
+            // Per strategy, snapshot state, run Tick, dispatch intents.
+            foreach (var (strategy, perStrategy) in inst.PerStrategy)
+            {
+                MarketState snapshot;
+                lock (inst.Sync)
+                {
+                    snapshot = new MarketState(
+                        SecurityId: secId,
+                        MidMantissa: inst.MidMantissa,
+                        TickSize: inst.Cfg.TickSize,
+                        LotSize: inst.Cfg.LotSize,
+                        LastTradePxMantissa: inst.LastTradePx,
+                        LastTradeQty: inst.LastTradeQty,
+                        MyLiveOrders: perStrategy.SnapshotLiveOrders());
+                }
+                IEnumerable<OrderIntent> intents;
+                try
+                {
+                    intents = strategy.Tick(in snapshot, _rng);
+                }
+                catch (Exception ex)
+                {
+                    _logWarn?.Invoke($"strategy {strategy.Name} tick threw: {ex.Message}");
+                    continue;
+                }
+                foreach (var intent in intents) Submit(inst, perStrategy, strategy, intent);
+            }
+        }
+    }
+
+    private void DriftMid(InstrumentRuntime inst)
+    {
+        if (inst.Cfg.MidDriftProbability <= 0) return;
+        if (_rng.NextDouble() >= inst.Cfg.MidDriftProbability) return;
+        long step = inst.Cfg.TickSize <= 0 ? 1 : inst.Cfg.TickSize;
+        long delta = _rng.Next(2) == 0 ? -step : step;
+        lock (inst.Sync)
+        {
+            long next = inst.MidMantissa + delta;
+            if (next > 0) inst.MidMantissa = next;
+        }
+    }
+
+    private void Submit(InstrumentRuntime inst, PerStrategyState perStrategy, IStrategy strategy, OrderIntent intent)
+    {
+        switch (intent.Kind)
+        {
+            case OrderIntentKind.New:
+                {
+                    ulong clOrd = (ulong)Interlocked.Increment(ref _clOrdSeq);
+                    var tracking = new OrderTracking(strategy, perStrategy, intent.ClientTag,
+                        intent.SecurityId, intent.Side, intent.PriceMantissa, intent.Quantity);
+                    lock (_byClOrd) _byClOrd[clOrd] = tracking;
+                    lock (inst.Sync)
+                    {
+                        perStrategy.PendingByTag[intent.ClientTag] = clOrd;
+                    }
+                    bool ok = _client.SendNewOrder(clOrd, intent.SecurityId, intent.Side, intent.Type, intent.Tif,
+                        intent.Quantity, intent.PriceMantissa);
+                    if (ok) Interlocked.Increment(ref _ordersSent);
+                    break;
+                }
+            case OrderIntentKind.Cancel:
+                {
+                    LiveOrderRecord? live;
+                    ulong clOrd = (ulong)Interlocked.Increment(ref _clOrdSeq);
+                    lock (inst.Sync)
+                    {
+                        perStrategy.LiveByTag.TryGetValue(intent.CancelTag, out var rec);
+                        live = rec.OrderId == 0 ? null : rec;
+                    }
+                    if (live is null) break;
+                    _client.SendCancel(clOrd, intent.SecurityId, (ulong)live.Value.OrderId, origClOrdId: 0, live.Value.Side);
+                    break;
+                }
+        }
+    }
+
+    private void OnExecNew(ExecReportNew er)
+    {
+        OrderTracking? tracking;
+        lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
+        if (tracking is null) return;
+        if (!_instruments.TryGetValue(tracking.SecurityId, out var inst)) return;
+        lock (inst.Sync)
+        {
+            tracking.PerStrategy.LiveByTag[tracking.ClientTag] = new LiveOrderRecord(
+                er.OrderId, tracking.Side, tracking.PriceMantissa, tracking.Quantity);
+            tracking.PerStrategy.PendingByTag.Remove(tracking.ClientTag);
+        }
+        try { tracking.Strategy.OnAck(tracking.ClientTag, er.OrderId); }
+        catch (Exception ex) { _logWarn?.Invoke($"strategy OnAck threw: {ex.Message}"); }
+    }
+
+    private void OnExecTrade(ExecReportTrade er)
+    {
+        Interlocked.Increment(ref _tradesObserved);
+
+        OrderTracking? tracking;
+        lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
+
+        if (_instruments.TryGetValue(er.SecurityId, out var inst))
+        {
+            lock (inst.Sync)
+            {
+                inst.LastTradePx = er.LastPxMantissa;
+                inst.LastTradeQty = er.LastQty;
+                if (tracking != null)
+                {
+                    if (tracking.PerStrategy.LiveByTag.TryGetValue(tracking.ClientTag, out var live))
+                    {
+                        if (er.LeavesQty == 0)
+                            tracking.PerStrategy.LiveByTag.Remove(tracking.ClientTag);
+                        else
+                            tracking.PerStrategy.LiveByTag[tracking.ClientTag] =
+                                live with { RemainingQty = er.LeavesQty };
+                    }
+                }
+            }
+        }
+        if (tracking != null)
+        {
+            try
+            {
+                tracking.Strategy.OnFill(new FillEvent(tracking.ClientTag, er.Side,
+                    er.LastPxMantissa, er.LastQty, er.LeavesQty));
+                if (er.LeavesQty == 0) tracking.Strategy.OnRemoved(tracking.ClientTag);
+            }
+            catch (Exception ex) { _logWarn?.Invoke($"strategy OnFill threw: {ex.Message}"); }
+        }
+    }
+
+    private void OnExecCancel(ExecReportCancel er)
+    {
+        OrderTracking? tracking;
+        lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
+        // Cancel ER's ClOrdID is the cancel request's clord, not the original
+        // order's. Look up by orderId across live orders if not found.
+        if (tracking is null && _instruments.TryGetValue(er.SecurityId, out var inst))
+        {
+            lock (inst.Sync)
+            {
+                foreach (var per in inst.PerStrategy.Select(t => t.state))
+                {
+                    foreach (var (tag, rec) in per.LiveByTag)
+                    {
+                        if (rec.OrderId == er.OrderId)
+                        {
+                            per.LiveByTag.Remove(tag);
+                            try { per.OwnerStrategy.OnRemoved(tag); }
+                            catch (Exception ex) { _logWarn?.Invoke($"strategy OnRemoved threw: {ex.Message}"); }
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private void OnExecReject(ExecReportReject er)
+    {
+        OrderTracking? tracking;
+        lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
+        if (tracking is null) return;
+        if (_instruments.TryGetValue(tracking.SecurityId, out var inst))
+        {
+            lock (inst.Sync) tracking.PerStrategy.PendingByTag.Remove(tracking.ClientTag);
+        }
+        try { tracking.Strategy.OnRemoved(tracking.ClientTag); }
+        catch (Exception ex) { _logWarn?.Invoke($"strategy OnRemoved threw: {ex.Message}"); }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { _cts.Cancel(); } catch { }
+        try { if (_tickTask != null) await _tickTask.ConfigureAwait(false); } catch { }
+        _cts.Dispose();
+    }
+
+    private sealed class InstrumentRuntime
+    {
+        public InstrumentConfig Cfg { get; }
+        public List<(IStrategy strategy, PerStrategyState state)> PerStrategy { get; }
+        public object Sync { get; } = new();
+        public long MidMantissa;
+        public long LastTradePx;
+        public long LastTradeQty;
+
+        public InstrumentRuntime(InstrumentConfig cfg, IReadOnlyList<IStrategy> strategies)
+        {
+            Cfg = cfg;
+            MidMantissa = cfg.InitialMidMantissa;
+            LastTradePx = cfg.InitialMidMantissa;
+            PerStrategy = strategies.Select(s => (s, new PerStrategyState(s))).ToList();
+        }
+    }
+
+    private sealed class PerStrategyState
+    {
+        public IStrategy OwnerStrategy { get; }
+        // Tag -> (OrderId, Side, Price, Remaining). Populated on ER_New, mutated on Trade, removed on Cancel.
+        public Dictionary<string, LiveOrderRecord> LiveByTag { get; } = new();
+        // Tag -> ClOrdID for orders sent but not yet acked.
+        public Dictionary<string, ulong> PendingByTag { get; } = new();
+
+        public PerStrategyState(IStrategy ownerStrategy) { OwnerStrategy = ownerStrategy; }
+
+        public IReadOnlyList<LiveOrder> SnapshotLiveOrders()
+        {
+            var list = new List<LiveOrder>(LiveByTag.Count);
+            foreach (var (tag, rec) in LiveByTag)
+                list.Add(new LiveOrder(tag, rec.Side, rec.PriceMantissa, rec.RemainingQty));
+            return list;
+        }
+    }
+
+    private readonly record struct LiveOrderRecord(long OrderId, OrderSide Side, long PriceMantissa, long RemainingQty);
+
+    private sealed record OrderTracking(
+        IStrategy Strategy,
+        PerStrategyState PerStrategy,
+        string ClientTag,
+        long SecurityId,
+        OrderSide Side,
+        long PriceMantissa,
+        long Quantity);
+}

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
@@ -20,7 +20,9 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
     private readonly Dictionary<long, InstrumentRuntime> _instruments;
     private readonly Random _rng;
     private readonly TimeSpan _tickInterval;
+#pragma warning disable CS0414
     private readonly Action<string>? _logInfo;
+#pragma warning restore CS0414
     private readonly Action<string>? _logWarn;
     private readonly CancellationTokenSource _cts;
     private readonly Dictionary<ulong, OrderTracking> _byClOrd = new();

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
@@ -181,9 +181,20 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
                     {
                         perStrategy.PendingByTag[intent.ClientTag] = clOrd;
                     }
+                    // A null client means we're under test (no transport); treat that as
+                    // "send succeeded" so test seams keep working. In production, when the
+                    // client is present and SendNewOrder returns false (closed / backpressure),
+                    // we roll back the tracking entries we just inserted so they don't linger
+                    // forever — no ack will ever arrive for an order that never went out.
                     bool ok = _client?.SendNewOrder(clOrd, intent.SecurityId, intent.Side, intent.Type, intent.Tif,
-                        intent.Quantity, intent.PriceMantissa) ?? false;
-                    if (ok) Interlocked.Increment(ref _ordersSent);
+                        intent.Quantity, intent.PriceMantissa) ?? true;
+                    if (!ok)
+                    {
+                        lock (_byClOrd) _byClOrd.Remove(clOrd);
+                        lock (inst.Sync) perStrategy.PendingByTag.Remove(intent.ClientTag);
+                        break;
+                    }
+                    Interlocked.Increment(ref _ordersSent);
                     break;
                 }
             case OrderIntentKind.Cancel:
@@ -349,6 +360,16 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        // Detach event handlers BEFORE cancelling so a still-live client cannot
+        // dispatch into a half-disposed runner (which would NPE / mutate disposed
+        // state). After detach, the client may continue running independently.
+        if (_client is not null)
+        {
+            _client.OnNew -= OnExecNew;
+            _client.OnTrade -= OnExecTrade;
+            _client.OnCancel -= OnExecCancel;
+            _client.OnReject -= OnExecReject;
+        }
         try { _cts.Cancel(); } catch { }
         try { if (_tickTask != null) await _tickTask.ConfigureAwait(false); } catch { }
         _cts.Dispose();

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
@@ -289,9 +289,28 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
 
     private void OnExecReject(ExecReportReject er)
     {
+        // ER_Reject is used for both new-order rejects (ClOrdId == the
+        // submitted order's clord, registered in _byClOrd) and cancel
+        // rejects (ClOrdId == the cancel-request's clord, which we
+        // intentionally do not register). Resolve via _byClOrd first; on
+        // miss fall back to OrigClOrdId (when present) and finally to
+        // OrderId so cancel-reject failures can still be surfaced to the
+        // owning strategy instead of being silently dropped.
         OrderTracking? tracking;
         lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
-        if (tracking is null) return;
+        if (tracking is null && er.OrigClOrdId != 0)
+        {
+            lock (_byClOrd) _byClOrd.TryGetValue(er.OrigClOrdId, out tracking);
+        }
+        if (tracking is null && er.OrderId != 0)
+        {
+            lock (_byOrderId) _byOrderId.TryGetValue(er.OrderId, out tracking);
+        }
+        if (tracking is null)
+        {
+            _logWarn?.Invoke($"reject for unknown clord={er.ClOrdId} origClord={er.OrigClOrdId} orderId={er.OrderId} reason={er.RejectReason}");
+            return;
+        }
         if (_instruments.TryGetValue(tracking.SecurityId, out var inst))
         {
             lock (inst.Sync) tracking.PerStrategy.PendingByTag.Remove(tracking.ClientTag);

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderRunner.cs
@@ -16,7 +16,7 @@ namespace B3.Exchange.SyntheticTrader;
 /// </summary>
 public sealed class SyntheticTraderRunner : IAsyncDisposable
 {
-    private readonly EntryPointClient _client;
+    private readonly EntryPointClient? _client;
     private readonly Dictionary<long, InstrumentRuntime> _instruments;
     private readonly Random _rng;
     private readonly TimeSpan _tickInterval;
@@ -24,6 +24,11 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
     private readonly Action<string>? _logWarn;
     private readonly CancellationTokenSource _cts;
     private readonly Dictionary<ulong, OrderTracking> _byClOrd = new();
+    // OrderId -> tracking. Populated on ER_New, removed on terminal events.
+    // Lets cancel ERs (whose ClOrdId is the *cancel-request's*, not the
+    // original order's) resolve to the originating tracking in O(1) without
+    // iterating the per-strategy LiveByTag dictionaries.
+    private readonly Dictionary<long, OrderTracking> _byOrderId = new();
     private long _clOrdSeq;
     private long _ticksRun;
     private long _ordersSent;
@@ -34,6 +39,11 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
     public long OrdersSent => Interlocked.Read(ref _ordersSent);
     public long TradesObserved => Interlocked.Read(ref _tradesObserved);
 
+    /// <summary>Test seam: number of live entries in the ClOrdID tracking map.</summary>
+    internal int ByClOrdCount { get { lock (_byClOrd) return _byClOrd.Count; } }
+    /// <summary>Test seam: number of live entries in the OrderId tracking map.</summary>
+    internal int ByOrderIdCount { get { lock (_byOrderId) return _byOrderId.Count; } }
+
     public SyntheticTraderRunner(
         EntryPointClient client,
         IEnumerable<(InstrumentConfig cfg, IReadOnlyList<IStrategy> strategies)> instruments,
@@ -42,6 +52,23 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
         Action<string>? logInfo = null,
         Action<string>? logWarn = null,
         CancellationToken ct = default)
+        : this(instruments, rng, tickInterval, logInfo, logWarn, ct, client)
+    {
+    }
+
+    /// <summary>
+    /// Internal ctor for unit tests: omits the wire client so outbound sends
+    /// are no-ops and no event subscriptions are wired. Tests then drive the
+    /// runner via the <c>TestRaise*</c> seams below.
+    /// </summary>
+    internal SyntheticTraderRunner(
+        IEnumerable<(InstrumentConfig cfg, IReadOnlyList<IStrategy> strategies)> instruments,
+        Random rng,
+        TimeSpan tickInterval,
+        Action<string>? logInfo = null,
+        Action<string>? logWarn = null,
+        CancellationToken ct = default,
+        EntryPointClient? client = null)
     {
         _client = client;
         _rng = rng;
@@ -53,10 +80,13 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
             t => t.cfg.SecurityId,
             t => new InstrumentRuntime(t.cfg, t.strategies));
 
-        _client.OnNew += OnExecNew;
-        _client.OnTrade += OnExecTrade;
-        _client.OnCancel += OnExecCancel;
-        _client.OnReject += OnExecReject;
+        if (_client != null)
+        {
+            _client.OnNew += OnExecNew;
+            _client.OnTrade += OnExecTrade;
+            _client.OnCancel += OnExecCancel;
+            _client.OnReject += OnExecReject;
+        }
     }
 
     public void Start()
@@ -143,14 +173,14 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
                 {
                     ulong clOrd = (ulong)Interlocked.Increment(ref _clOrdSeq);
                     var tracking = new OrderTracking(strategy, perStrategy, intent.ClientTag,
-                        intent.SecurityId, intent.Side, intent.PriceMantissa, intent.Quantity);
+                        intent.SecurityId, intent.Side, intent.PriceMantissa, intent.Quantity, clOrd);
                     lock (_byClOrd) _byClOrd[clOrd] = tracking;
                     lock (inst.Sync)
                     {
                         perStrategy.PendingByTag[intent.ClientTag] = clOrd;
                     }
-                    bool ok = _client.SendNewOrder(clOrd, intent.SecurityId, intent.Side, intent.Type, intent.Tif,
-                        intent.Quantity, intent.PriceMantissa);
+                    bool ok = _client?.SendNewOrder(clOrd, intent.SecurityId, intent.Side, intent.Type, intent.Tif,
+                        intent.Quantity, intent.PriceMantissa) ?? false;
                     if (ok) Interlocked.Increment(ref _ordersSent);
                     break;
                 }
@@ -164,7 +194,7 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
                         live = rec.OrderId == 0 ? null : rec;
                     }
                     if (live is null) break;
-                    _client.SendCancel(clOrd, intent.SecurityId, (ulong)live.Value.OrderId, origClOrdId: 0, live.Value.Side);
+                    _client?.SendCancel(clOrd, intent.SecurityId, (ulong)live.Value.OrderId, origClOrdId: 0, live.Value.Side);
                     break;
                 }
         }
@@ -176,6 +206,8 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
         lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
         if (tracking is null) return;
         if (!_instruments.TryGetValue(tracking.SecurityId, out var inst)) return;
+        tracking.OrderId = er.OrderId;
+        lock (_byOrderId) _byOrderId[er.OrderId] = tracking;
         lock (inst.Sync)
         {
             tracking.PerStrategy.LiveByTag[tracking.ClientTag] = new LiveOrderRecord(
@@ -221,34 +253,38 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
                 if (er.LeavesQty == 0) tracking.Strategy.OnRemoved(tracking.ClientTag);
             }
             catch (Exception ex) { _logWarn?.Invoke($"strategy OnFill threw: {ex.Message}"); }
+
+            // Terminal: full fill drops both tracking maps. Partial fills keep
+            // them — more fills (or a cancel) may still arrive for this order.
+            if (er.LeavesQty == 0)
+            {
+                lock (_byClOrd) _byClOrd.Remove(tracking.OriginalClOrdId);
+                lock (_byOrderId) _byOrderId.Remove(tracking.OrderId);
+            }
         }
     }
 
     private void OnExecCancel(ExecReportCancel er)
     {
+        // The cancel ER's ClOrdID is the cancel-request's clord, which we
+        // intentionally do not register in _byClOrd (we'd otherwise leak any
+        // cancel-rejects targeting it). Resolve via the OrderId index instead
+        // — O(1), no enumeration of LiveByTag.
         OrderTracking? tracking;
-        lock (_byClOrd) _byClOrd.TryGetValue(er.ClOrdId, out tracking);
-        // Cancel ER's ClOrdID is the cancel request's clord, not the original
-        // order's. Look up by orderId across live orders if not found.
-        if (tracking is null && _instruments.TryGetValue(er.SecurityId, out var inst))
+        lock (_byOrderId) _byOrderId.TryGetValue(er.OrderId, out tracking);
+        if (tracking is null) return;
+        if (!_instruments.TryGetValue(tracking.SecurityId, out var inst)) return;
+
+        lock (inst.Sync)
         {
-            lock (inst.Sync)
-            {
-                foreach (var per in inst.PerStrategy.Select(t => t.state))
-                {
-                    foreach (var (tag, rec) in per.LiveByTag)
-                    {
-                        if (rec.OrderId == er.OrderId)
-                        {
-                            per.LiveByTag.Remove(tag);
-                            try { per.OwnerStrategy.OnRemoved(tag); }
-                            catch (Exception ex) { _logWarn?.Invoke($"strategy OnRemoved threw: {ex.Message}"); }
-                            return;
-                        }
-                    }
-                }
-            }
+            tracking.PerStrategy.LiveByTag.Remove(tracking.ClientTag);
         }
+        try { tracking.Strategy.OnRemoved(tracking.ClientTag); }
+        catch (Exception ex) { _logWarn?.Invoke($"strategy OnRemoved threw: {ex.Message}"); }
+
+        // Terminal: drop both tracking maps for this order.
+        lock (_byClOrd) _byClOrd.Remove(tracking.OriginalClOrdId);
+        lock (_byOrderId) _byOrderId.Remove(tracking.OrderId);
     }
 
     private void OnExecReject(ExecReportReject er)
@@ -262,6 +298,32 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
         }
         try { tracking.Strategy.OnRemoved(tracking.ClientTag); }
         catch (Exception ex) { _logWarn?.Invoke($"strategy OnRemoved threw: {ex.Message}"); }
+
+        // Terminal: drop both tracking maps. _byOrderId entry only exists if
+        // the order was acked before being rejected (rare race), but Remove
+        // is harmless when absent.
+        lock (_byClOrd) _byClOrd.Remove(tracking.OriginalClOrdId);
+        if (tracking.OrderId != 0)
+            lock (_byOrderId) _byOrderId.Remove(tracking.OrderId);
+    }
+
+    /// <summary>Test seam: synchronously dispatches an ER_New as if it had
+    /// arrived from the wire.</summary>
+    internal void TestRaiseNew(ExecReportNew er) => OnExecNew(er);
+    /// <summary>Test seam: synchronously dispatches an ER_Trade.</summary>
+    internal void TestRaiseTrade(ExecReportTrade er) => OnExecTrade(er);
+    /// <summary>Test seam: synchronously dispatches an ER_Cancel.</summary>
+    internal void TestRaiseCancel(ExecReportCancel er) => OnExecCancel(er);
+    /// <summary>Test seam: synchronously dispatches an ER_Reject.</summary>
+    internal void TestRaiseReject(ExecReportReject er) => OnExecReject(er);
+    /// <summary>Test seam: submits an order intent through the normal
+    /// <c>Submit</c> path. With a null client, the wire send is skipped but
+    /// the tracking maps and PendingByTag are populated identically.</summary>
+    internal void TestSubmit(IStrategy strategy, OrderIntent intent)
+    {
+        var inst = _instruments[intent.SecurityId];
+        var per = inst.PerStrategy.First(t => ReferenceEquals(t.strategy, strategy)).state;
+        Submit(inst, per, strategy, intent);
     }
 
     public async ValueTask DisposeAsync()
@@ -310,12 +372,34 @@ public sealed class SyntheticTraderRunner : IAsyncDisposable
 
     private readonly record struct LiveOrderRecord(long OrderId, OrderSide Side, long PriceMantissa, long RemainingQty);
 
-    private sealed record OrderTracking(
-        IStrategy Strategy,
-        PerStrategyState PerStrategy,
-        string ClientTag,
-        long SecurityId,
-        OrderSide Side,
-        long PriceMantissa,
-        long Quantity);
+    private sealed class OrderTracking
+    {
+        public IStrategy Strategy { get; }
+        public PerStrategyState PerStrategy { get; }
+        public string ClientTag { get; }
+        public long SecurityId { get; }
+        public OrderSide Side { get; }
+        public long PriceMantissa { get; }
+        public long Quantity { get; }
+        // ClOrdID used when this order was first sent to the host. The cancel
+        // request, if any, gets its own ClOrdID; we keep the original here so
+        // terminal events (full fill / cancel / reject) can clean up the
+        // _byClOrd entry without needing a reverse lookup.
+        public ulong OriginalClOrdId { get; }
+        // Engine-assigned OrderID, populated on ER_New. Zero before ack.
+        public long OrderId { get; set; }
+
+        public OrderTracking(IStrategy strategy, PerStrategyState perStrategy, string clientTag,
+            long securityId, OrderSide side, long priceMantissa, long quantity, ulong originalClOrdId)
+        {
+            Strategy = strategy;
+            PerStrategy = perStrategy;
+            ClientTag = clientTag;
+            SecurityId = securityId;
+            Side = side;
+            PriceMantissa = priceMantissa;
+            Quantity = quantity;
+            OriginalClOrdId = originalClOrdId;
+        }
+    }
 }

--- a/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
@@ -15,6 +15,8 @@
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.Exchange.SyntheticTrader.Tests/RunnerHandlerTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/RunnerHandlerTests.cs
@@ -134,8 +134,8 @@ public class RunnerHandlerTests
         runner.TestRaiseCancel(new ExecReportCancel(ClOrdId: 8002, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1004));
 
         // Reject 5 and 6 — pre-ack rejection.
-        runner.TestRaiseReject(new ExecReportReject(ClOrdId: 5, SecurityId: Sec));
-        runner.TestRaiseReject(new ExecReportReject(ClOrdId: 6, SecurityId: Sec));
+        runner.TestRaiseReject(new ExecReportReject(ClOrdId: 5, SecurityId: Sec, OrderId: 0, OrigClOrdId: 0, RejectReason: 0));
+        runner.TestRaiseReject(new ExecReportReject(ClOrdId: 6, SecurityId: Sec, OrderId: 0, OrigClOrdId: 0, RejectReason: 0));
 
         Assert.Equal(0, runner.ByClOrdCount);
         Assert.Equal(0, runner.ByOrderIdCount);

--- a/tests/B3.Exchange.SyntheticTrader.Tests/RunnerHandlerTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/RunnerHandlerTests.cs
@@ -1,0 +1,170 @@
+namespace B3.Exchange.SyntheticTrader.Tests;
+
+/// <summary>
+/// White-box tests that drive <see cref="SyntheticTraderRunner"/>'s ER
+/// handlers directly via the internal <c>TestRaise*</c> seams (no TCP).
+/// They cover two regression areas surfaced in the PR review:
+///
+///  - <see cref="OnExecCancel_WithMultipleLiveOrders_RemovesTargetedOnly"/>
+///    exercises the cancel resolution path with multiple live entries on
+///    the same strategy. The pre-fix code iterated <c>LiveByTag</c> with
+///    <c>foreach</c> while removing the matched entry — fragile against
+///    future refactors that move the unconditional <c>return</c> — and used
+///    an O(N) scan. The fix routes via an OrderId index in O(1).
+///  - <see cref="ByClOrd_Map_DoesNotLeak_OnTerminalEvents"/> verifies the
+///    new cleanup of <c>_byClOrd</c> / <c>_byOrderId</c> on full-fill,
+///    cancel, and reject. Without the fix, <c>_byClOrd</c> grew unbounded.
+/// </summary>
+public class RunnerHandlerTests
+{
+    private const long Sec = 900_000_000_001L;
+
+    private sealed class StubStrategy : IStrategy
+    {
+        public string Name { get; }
+        public List<string> Removed { get; } = new();
+        public List<string> Acked { get; } = new();
+        public StubStrategy(string name) { Name = name; }
+        public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng) => Array.Empty<OrderIntent>();
+        public void OnAck(string clientTag, long orderId) => Acked.Add(clientTag);
+        public void OnFill(in FillEvent fill) { }
+        public void OnRemoved(string clientTag) => Removed.Add(clientTag);
+    }
+
+    private static (SyntheticTraderRunner runner, StubStrategy strategy) NewRunner()
+    {
+        var strategy = new StubStrategy("s");
+        var instCfg = new InstrumentConfig
+        {
+            SecurityId = Sec,
+            TickSize = 100,
+            LotSize = 100,
+            InitialMidMantissa = 100_0000,
+            MidDriftProbability = 0.0,
+        };
+        var runner = new SyntheticTraderRunner(
+            new[] { (instCfg, (IReadOnlyList<IStrategy>)new IStrategy[] { strategy }) },
+            new Random(1),
+            TimeSpan.FromMilliseconds(1));
+        return (runner, strategy);
+    }
+
+    [Fact]
+    public async Task OnExecCancel_WithMultipleLiveOrders_RemovesTargetedOnly()
+    {
+        var (runner, strategy) = NewRunner();
+        await using var _ = runner;
+
+        // Submit three orders, ack each one with a distinct engine OrderID.
+        for (int i = 1; i <= 3; i++)
+        {
+            runner.TestSubmit(strategy, OrderIntent.NewLimit(Sec, OrderSide.Buy, 100, 99_9000 + i * 100, $"t{i}"));
+        }
+        runner.TestRaiseNew(new ExecReportNew(ClOrdId: 1, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1001));
+        runner.TestRaiseNew(new ExecReportNew(ClOrdId: 2, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1002));
+        runner.TestRaiseNew(new ExecReportNew(ClOrdId: 3, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1003));
+
+        Assert.Equal(3, runner.ByClOrdCount);
+        Assert.Equal(3, runner.ByOrderIdCount);
+
+        // Cancel the middle one. ER_Cancel.ClOrdId carries the cancel
+        // request's clord (some unrelated id), which is intentionally NOT
+        // registered in _byClOrd; the runner must resolve via OrderId.
+        runner.TestRaiseCancel(new ExecReportCancel(
+            ClOrdId: 999, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1002));
+
+        // Only "t2" was notified removed; the other two are still live.
+        Assert.Equal(new[] { "t2" }, strategy.Removed);
+        Assert.Equal(2, runner.ByClOrdCount);
+        Assert.Equal(2, runner.ByOrderIdCount);
+    }
+
+    [Fact]
+    public async Task OnExecCancel_FallsBackToOrderId_WhenClOrdIdUnknown()
+    {
+        // Sanity check: even if the cancel ER carried an unknown ClOrdId, the
+        // OrderId-based resolution still finds the originating tracking. This
+        // is the path the buggy foreach-Remove iteration was trying to handle.
+        var (runner, strategy) = NewRunner();
+        await using var _ = runner;
+        runner.TestSubmit(strategy, OrderIntent.NewLimit(Sec, OrderSide.Buy, 100, 99_9000, "tag"));
+        runner.TestRaiseNew(new ExecReportNew(ClOrdId: 1, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 5555));
+
+        runner.TestRaiseCancel(new ExecReportCancel(
+            ClOrdId: ulong.MaxValue, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 5555));
+
+        Assert.Equal(new[] { "tag" }, strategy.Removed);
+        Assert.Equal(0, runner.ByClOrdCount);
+        Assert.Equal(0, runner.ByOrderIdCount);
+    }
+
+    [Fact]
+    public async Task ByClOrd_Map_DoesNotLeak_OnTerminalEvents()
+    {
+        var (runner, strategy) = NewRunner();
+        await using var _ = runner;
+
+        // Send 6 orders. Drive each through a different terminal ER:
+        //   - 1,2  full fill (Trade with LeavesQty == 0)
+        //   - 3,4  cancel
+        //   - 5,6  reject (rejected pre-ack: only _byClOrd needs cleanup)
+        for (int i = 1; i <= 6; i++)
+        {
+            runner.TestSubmit(strategy, OrderIntent.NewLimit(Sec, OrderSide.Buy, 100, 99_9000 + i * 100, $"t{i}"));
+        }
+        Assert.Equal(6, runner.ByClOrdCount);
+
+        // Ack 1..4 (so cancels can resolve via OrderId).
+        for (int i = 1; i <= 4; i++)
+        {
+            runner.TestRaiseNew(new ExecReportNew(ClOrdId: (ulong)i, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1000 + i));
+        }
+        Assert.Equal(4, runner.ByOrderIdCount);
+
+        // Full fill 1 and 2 — Trade ER's ClOrdId is the original order's clord.
+        runner.TestRaiseTrade(new ExecReportTrade(
+            ClOrdId: 1, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1001,
+            LastQty: 100, LastPxMantissa: 99_9100, LeavesQty: 0, CumQty: 100));
+        runner.TestRaiseTrade(new ExecReportTrade(
+            ClOrdId: 2, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1002,
+            LastQty: 100, LastPxMantissa: 99_9200, LeavesQty: 0, CumQty: 100));
+
+        // Cancel 3 and 4.
+        runner.TestRaiseCancel(new ExecReportCancel(ClOrdId: 8001, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1003));
+        runner.TestRaiseCancel(new ExecReportCancel(ClOrdId: 8002, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 1004));
+
+        // Reject 5 and 6 — pre-ack rejection.
+        runner.TestRaiseReject(new ExecReportReject(ClOrdId: 5, SecurityId: Sec));
+        runner.TestRaiseReject(new ExecReportReject(ClOrdId: 6, SecurityId: Sec));
+
+        Assert.Equal(0, runner.ByClOrdCount);
+        Assert.Equal(0, runner.ByOrderIdCount);
+    }
+
+    [Fact]
+    public async Task PartialFill_KeepsTrackingEntries()
+    {
+        var (runner, strategy) = NewRunner();
+        await using var _ = runner;
+
+        runner.TestSubmit(strategy, OrderIntent.NewLimit(Sec, OrderSide.Buy, 200, 99_9000, "t"));
+        runner.TestRaiseNew(new ExecReportNew(ClOrdId: 1, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 7000));
+
+        // Partial fill: leaves 100 of 200.
+        runner.TestRaiseTrade(new ExecReportTrade(
+            ClOrdId: 1, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 7000,
+            LastQty: 100, LastPxMantissa: 99_9000, LeavesQty: 100, CumQty: 100));
+
+        Assert.Equal(1, runner.ByClOrdCount);
+        Assert.Equal(1, runner.ByOrderIdCount);
+        Assert.Empty(strategy.Removed);
+
+        // Now fully fill the rest — entries must be cleaned up.
+        runner.TestRaiseTrade(new ExecReportTrade(
+            ClOrdId: 1, SecurityId: Sec, Side: OrderSide.Buy, OrderId: 7000,
+            LastQty: 100, LastPxMantissa: 99_9000, LeavesQty: 0, CumQty: 200));
+
+        Assert.Equal(0, runner.ByClOrdCount);
+        Assert.Equal(0, runner.ByOrderIdCount);
+    }
+}

--- a/tests/B3.Exchange.SyntheticTrader.Tests/StrategyTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/StrategyTests.cs
@@ -1,0 +1,112 @@
+namespace B3.Exchange.SyntheticTrader.Tests;
+
+/// <summary>
+/// Strategy unit tests. Strategies are pure functions of their input
+/// (state + RNG); we can drive them with hand-built MarketState snapshots
+/// and a seeded Random and assert the exact intent sequence.
+/// </summary>
+public class StrategyTests
+{
+    private static MarketState State(long mid = 100_0000, long tick = 100, long lot = 100,
+        IReadOnlyList<LiveOrder>? live = null)
+        => new(SecurityId: 1, MidMantissa: mid, TickSize: tick, LotSize: lot,
+            LastTradePxMantissa: mid, LastTradeQty: 0,
+            MyLiveOrders: live ?? Array.Empty<LiveOrder>());
+
+    [Fact]
+    public void MarketMaker_FromEmptyBook_PostsLevelsBothSides()
+    {
+        var mm = new MarketMakerStrategy("mm", levelsPerSide: 3, quoteSpacingTicks: 1, replaceDistanceTicks: 5, quantity: 100);
+        var s = State();
+        var intents = mm.Tick(s, new Random(1)).ToList();
+
+        Assert.Equal(6, intents.Count);
+        // Three bids at 100_0000-100, -200, -300; three asks symmetric.
+        var bids = intents.Where(i => i.Kind == OrderIntentKind.New && i.Side == OrderSide.Buy)
+            .OrderByDescending(i => i.PriceMantissa).Select(i => i.PriceMantissa).ToArray();
+        var asks = intents.Where(i => i.Kind == OrderIntentKind.New && i.Side == OrderSide.Sell)
+            .OrderBy(i => i.PriceMantissa).Select(i => i.PriceMantissa).ToArray();
+        Assert.Equal(new long[] { 99_9900, 99_9800, 99_9700 }, bids);
+        Assert.Equal(new long[] { 100_0100, 100_0200, 100_0300 }, asks);
+        Assert.All(intents, i => Assert.Equal(100, i.Quantity));
+        Assert.All(intents, i => Assert.Equal(OrderTifIntent.Day, i.Tif));
+    }
+
+    [Fact]
+    public void MarketMaker_WithSomeLevelsLive_OnlyTopsUpMissingOnes()
+    {
+        var mm = new MarketMakerStrategy("mm", levelsPerSide: 2, quoteSpacingTicks: 1, replaceDistanceTicks: 5, quantity: 100);
+        var live = new List<LiveOrder>
+        {
+            new("mm-1-B-1", OrderSide.Buy,  99_9900, 100), // matches level 1 bid
+            new("mm-1-S-1", OrderSide.Sell, 100_0100, 100), // matches level 1 ask
+        };
+        var intents = mm.Tick(State(live: live), new Random(1)).ToList();
+
+        // Only level 2 missing on each side.
+        Assert.Equal(2, intents.Count);
+        var prices = intents.Select(i => i.PriceMantissa).OrderBy(p => p).ToArray();
+        Assert.Equal(new long[] { 99_9800, 100_0200 }, prices);
+    }
+
+    [Fact]
+    public void MarketMaker_DriftedQuote_IsCancelled()
+    {
+        var mm = new MarketMakerStrategy("mm", levelsPerSide: 1, quoteSpacingTicks: 1, replaceDistanceTicks: 2, quantity: 100);
+        // A live bid 50 ticks below mid → way past replaceDistance=2 → cancel.
+        var live = new List<LiveOrder>
+        {
+            new("stale", OrderSide.Buy, 99_5000, 100),
+        };
+        var intents = mm.Tick(State(live: live), new Random(1)).ToList();
+        Assert.Contains(intents, i => i.Kind == OrderIntentKind.Cancel && i.CancelTag == "stale");
+        // And a fresh bid at mid-1 tick.
+        Assert.Contains(intents, i => i.Kind == OrderIntentKind.New && i.Side == OrderSide.Buy && i.PriceMantissa == 99_9900);
+    }
+
+    [Fact]
+    public void NoiseTaker_SeededRng_ProducesDeterministicSequence()
+    {
+        var s = State();
+        var nt1 = new NoiseTakerStrategy("noise", orderProbability: 0.5, maxLotMultiple: 3, crossTicks: 2);
+        var nt2 = new NoiseTakerStrategy("noise", orderProbability: 0.5, maxLotMultiple: 3, crossTicks: 2);
+        var rng1 = new Random(123);
+        var rng2 = new Random(123);
+
+        var seq1 = new List<OrderIntent>();
+        var seq2 = new List<OrderIntent>();
+        for (int i = 0; i < 50; i++)
+        {
+            seq1.AddRange(nt1.Tick(s, rng1));
+            seq2.AddRange(nt2.Tick(s, rng2));
+        }
+        Assert.Equal(seq1.Count, seq2.Count);
+        for (int i = 0; i < seq1.Count; i++)
+        {
+            Assert.Equal(seq1[i].Side, seq2[i].Side);
+            Assert.Equal(seq1[i].Quantity, seq2[i].Quantity);
+            Assert.Equal(seq1[i].PriceMantissa, seq2[i].PriceMantissa);
+            Assert.Equal(seq1[i].Tif, seq2[i].Tif);
+        }
+        Assert.NotEmpty(seq1); // probabilistic but with seed=123 and p=0.5 we expect plenty
+    }
+
+    [Fact]
+    public void NoiseTaker_PriceAlwaysMarketableInDirection()
+    {
+        var s = State(mid: 100_0000);
+        var nt = new NoiseTakerStrategy("noise", orderProbability: 1.0, maxLotMultiple: 1, crossTicks: 2);
+        var rng = new Random(7);
+        for (int i = 0; i < 30; i++)
+        {
+            var intents = nt.Tick(s, rng).ToList();
+            Assert.Single(intents);
+            var ord = intents[0];
+            if (ord.Side == OrderSide.Buy)
+                Assert.Equal(100_0200, ord.PriceMantissa); // mid + 2*tick
+            else
+                Assert.Equal(99_9800, ord.PriceMantissa);  // mid - 2*tick
+            Assert.Equal(OrderTifIntent.IOC, ord.Tif);
+        }
+    }
+}

--- a/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
@@ -18,9 +18,12 @@ public class SyntheticTraderHostIntegrationTests
 
     private sealed class RecordingPacketSink : IUmdfPacketSink
     {
-        public int PacketCount;
+        private int _packetCount;
+
+        public int PacketCount => Volatile.Read(ref _packetCount);
+
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
-            => Interlocked.Increment(ref PacketCount);
+            => Interlocked.Increment(ref _packetCount);
     }
 
     private static string ResolveRepoFile(string relPath)

--- a/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
@@ -1,0 +1,100 @@
+using B3.Exchange.Host;
+using B3.Exchange.Integration;
+
+namespace B3.Exchange.SyntheticTrader.Tests;
+
+/// <summary>
+/// Boots the in-proc <see cref="ExchangeHost"/> on loopback, connects a
+/// real <see cref="EntryPointClient"/> (via <see cref="SyntheticTraderRunner"/>),
+/// runs the trader for a few seconds, and asserts that trades happened.
+///
+/// This is the closest thing to a smoke test of the full synth-trader stack:
+/// it exercises the TCP wire encoder, the host's inbound decoder, the
+/// matching engine, the ER encoder, and the synth trader's ER decoder.
+/// </summary>
+public class SyntheticTraderHostIntegrationTests
+{
+    private const long Petr = 900_000_000_001L;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public int PacketCount;
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+            => Interlocked.Increment(ref PacketCount);
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task SynthTrader_AgainstInProcHost_GeneratesTrades()
+    {
+        var sink = new RecordingPacketSink();
+        var hostCfg = new HostConfig
+        {
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30185,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+
+        await using var host = new ExchangeHost(hostCfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        // Synth trader: one MM + one noise-taker on PETR4. crossTicks must be
+        // >= MM quoteSpacingTicks so noise orders are reliably marketable.
+        var instCfg = new InstrumentConfig
+        {
+            SecurityId = Petr,
+            TickSize = 100,
+            LotSize = 100,
+            InitialMidMantissa = 123_400,
+            MidDriftProbability = 0.0,  // deterministic mid for the assertion
+        };
+        IReadOnlyList<IStrategy> strategies = new IStrategy[]
+        {
+            new MarketMakerStrategy("mm", levelsPerSide: 3, quoteSpacingTicks: 1, replaceDistanceTicks: 5, quantity: 100),
+            new NoiseTakerStrategy("noise", orderProbability: 0.5, maxLotMultiple: 2, crossTicks: 2),
+        };
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(8));
+        var client = await EntryPointClient.ConnectAsync(ep.Address.ToString(), ep.Port, ct: cts.Token);
+        await using var runner = new SyntheticTraderRunner(
+            client,
+            new[] { (instCfg, strategies) },
+            new Random(1234),
+            TimeSpan.FromMilliseconds(20),
+            ct: cts.Token);
+        runner.Start();
+
+        // Run until we see a handful of trades (or timeout).
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(6);
+        while (DateTime.UtcNow < deadline && runner.TradesObserved < 5)
+            await Task.Delay(50);
+
+        Assert.True(runner.OrdersSent > 0, "expected the synth trader to send orders");
+        Assert.True(runner.TradesObserved >= 1,
+            $"expected at least one trade ER, got {runner.TradesObserved} (orders sent={runner.OrdersSent})");
+        Assert.True(sink.PacketCount > 0, "expected multicast packets to be published by the host");
+
+        await client.DisposeAsync();
+    }
+}

--- a/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
@@ -1,0 +1,189 @@
+using B3.Exchange.EntryPoint;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.SyntheticTrader.Tests;
+
+/// <summary>
+/// Wire-format compatibility tests. The synthetic trader's
+/// <see cref="EntryPointClient"/> hand-duplicates the SBE field offsets used
+/// by the host's <c>InboundMessageDecoder</c> / <c>ExecutionReportEncoder</c>.
+/// These tests round-trip every supported template through both sides and
+/// assert byte-for-byte field equality, so any future drift in either set
+/// of offsets fails CI instead of silently breaking the synth trader at
+/// runtime.
+/// </summary>
+public class WireFormatCompatTests
+{
+    private const int SbeHeaderSize = 8;
+
+    [Fact]
+    public void SimpleNewOrder_RoundTripsThroughHostInboundDecoder()
+    {
+        Span<byte> frame = stackalloc byte[SbeHeaderSize + 82];
+        const ulong clOrd = 0xDEADBEEFCAFEBABEUL;
+        const long secId = 900_000_000_001L;
+        const long qty = 1234;
+        const long px = 12_345_6789L;
+        int written = EntryPointClient.EncodeNewOrder(frame, clOrd, secId,
+            OrderSide.Sell, OrderTypeIntent.Limit, OrderTifIntent.IOC, qty, px);
+        Assert.Equal(frame.Length, written);
+
+        // Validate the SBE header reads back exactly.
+        Assert.True(EntryPointFrameReader.TryParseInboundHeader(frame.Slice(0, SbeHeaderSize), out var info, out _));
+        Assert.Equal(EntryPointFrameReader.TidSimpleNewOrder, info.TemplateId);
+        Assert.Equal((ushort)2, info.Version);
+        Assert.Equal(82, info.BodyLength);
+
+        // Decode the body via the host's decoder.
+        var body = frame.Slice(SbeHeaderSize);
+        Assert.True(InboundMessageDecoder.TryDecodeNewOrder(body, enteringFirm: 7, enteredAtNanos: 0,
+            out var cmd, out var clOrdOut, out var err), $"decode failed: {err}");
+        Assert.Equal(clOrd, clOrdOut);
+        Assert.Equal(clOrd.ToString(), cmd.ClOrdId);
+        Assert.Equal(secId, cmd.SecurityId);
+        Assert.Equal(Side.Sell, cmd.Side);
+        Assert.Equal(OrderType.Limit, cmd.Type);
+        Assert.Equal(TimeInForce.IOC, cmd.Tif);
+        Assert.Equal(qty, cmd.Quantity);
+        Assert.Equal(px, cmd.PriceMantissa);
+        Assert.Equal(7u, cmd.EnteringFirm);
+    }
+
+    [Theory]
+    [InlineData(OrderSide.Buy, OrderTypeIntent.Limit, OrderTifIntent.Day)]
+    [InlineData(OrderSide.Sell, OrderTypeIntent.Limit, OrderTifIntent.FOK)]
+    [InlineData(OrderSide.Buy, OrderTypeIntent.Market, OrderTifIntent.IOC)]
+    public void SimpleNewOrder_AllSideTypeTif_DecodeMatches(OrderSide side, OrderTypeIntent type, OrderTifIntent tif)
+    {
+        Span<byte> frame = stackalloc byte[SbeHeaderSize + 82];
+        EntryPointClient.EncodeNewOrder(frame, clOrdId: 42, securityId: 1, side: side, type: type, tif: tif,
+            qty: 100, priceMantissa: type == OrderTypeIntent.Market ? long.MinValue : 100_0000);
+        var body = frame.Slice(SbeHeaderSize);
+        Assert.True(InboundMessageDecoder.TryDecodeNewOrder(body, 1, 0, out var cmd, out _, out _));
+        Assert.Equal(side == OrderSide.Buy ? Side.Buy : Side.Sell, cmd.Side);
+        Assert.Equal(type == OrderTypeIntent.Market ? OrderType.Market : OrderType.Limit, cmd.Type);
+        Assert.Equal(tif switch
+        {
+            OrderTifIntent.Day => TimeInForce.Day,
+            OrderTifIntent.IOC => TimeInForce.IOC,
+            _ => TimeInForce.FOK,
+        }, cmd.Tif);
+    }
+
+    [Fact]
+    public void OrderCancelRequest_RoundTripsThroughHostInboundDecoder()
+    {
+        Span<byte> frame = stackalloc byte[SbeHeaderSize + 76];
+        const ulong clOrd = 0x0102030405060708UL;
+        const ulong origClOrd = 0x1111222233334444UL;
+        const long secId = 900_000_000_002L;
+        const ulong orderId = 0x55_66_77_88_99_AA_BB_CCUL;
+        int written = EntryPointClient.EncodeCancel(frame, clOrd, secId, orderId, origClOrd, OrderSide.Sell);
+        Assert.Equal(frame.Length, written);
+
+        Assert.True(EntryPointFrameReader.TryParseInboundHeader(frame.Slice(0, SbeHeaderSize), out var info, out _));
+        Assert.Equal(EntryPointFrameReader.TidOrderCancelRequest, info.TemplateId);
+        Assert.Equal(76, info.BodyLength);
+
+        var body = frame.Slice(SbeHeaderSize);
+        Assert.True(InboundMessageDecoder.TryDecodeCancel(body, enteredAtNanos: 0,
+            out var cmd, out var clOrdOut, out var origClOrdOut, out var err), $"decode failed: {err}");
+        Assert.Equal(clOrd, clOrdOut);
+        Assert.Equal(origClOrd, origClOrdOut);
+        Assert.Equal(secId, cmd.SecurityId);
+        Assert.Equal((long)orderId, cmd.OrderId);
+        Assert.Equal(clOrd.ToString(), cmd.ClOrdId);
+    }
+
+    [Fact]
+    public void ExecReportNew_HostEncodes_SynthTraderDecodesIdentical()
+    {
+        Span<byte> frame = stackalloc byte[ExecutionReportEncoder.ExecReportNewTotal];
+        const ulong clOrd = 0xAABBCCDDEEFF0011UL;
+        const long secId = 900_000_000_003L;
+        const long orderId = 0x1234_5678_9ABC_DEF0L;
+        ExecutionReportEncoder.EncodeExecReportNew(frame,
+            sessionId: 1, msgSeqNum: 2, sendingTimeNanos: 3,
+            side: Side.Buy, clOrdIdValue: clOrd, secondaryOrderId: 0,
+            securityId: secId, orderId: orderId,
+            execId: 4, transactTimeNanos: 5,
+            ordType: OrderType.Limit, tif: TimeInForce.Day,
+            orderQty: 100, priceMantissa: 100_0000);
+
+        var body = frame.Slice(SbeHeaderSize);
+        var er = EntryPointClient.DecodeExecReportNew(body);
+        Assert.Equal(clOrd, er.ClOrdId);
+        Assert.Equal(secId, er.SecurityId);
+        Assert.Equal(OrderSide.Buy, er.Side);
+        Assert.Equal(orderId, er.OrderId);
+    }
+
+    [Fact]
+    public void ExecReportTrade_HostEncodes_SynthTraderDecodesIdentical()
+    {
+        Span<byte> frame = stackalloc byte[ExecutionReportEncoder.ExecReportTradeTotal];
+        const ulong clOrd = 0x7777_8888_9999_AAAAUL;
+        const long secId = 900_000_000_004L;
+        const long orderId = 12345L;
+        const long lastQty = 50;
+        const long lastPx = 99_9500;
+        const long leaves = 50;
+        const long cum = 50;
+        ExecutionReportEncoder.EncodeExecReportTrade(frame,
+            sessionId: 9, msgSeqNum: 10, sendingTimeNanos: 11,
+            side: Side.Sell, clOrdIdValue: clOrd, secondaryOrderId: 0,
+            securityId: secId, orderId: orderId, lastQty: lastQty, lastPxMantissa: lastPx,
+            execId: 12, transactTimeNanos: 13, leavesQty: leaves, cumQty: cum,
+            aggressor: true, tradeId: 1000, contraBroker: 8, tradeDate: (ushort)20240, orderQty: 100);
+
+        var body = frame.Slice(SbeHeaderSize);
+        var er = EntryPointClient.DecodeExecReportTrade(body);
+        Assert.Equal(clOrd, er.ClOrdId);
+        Assert.Equal(secId, er.SecurityId);
+        Assert.Equal(OrderSide.Sell, er.Side);
+        Assert.Equal(orderId, er.OrderId);
+        Assert.Equal(lastQty, er.LastQty);
+        Assert.Equal(lastPx, er.LastPxMantissa);
+        Assert.Equal(leaves, er.LeavesQty);
+        Assert.Equal(cum, er.CumQty);
+    }
+
+    [Fact]
+    public void ExecReportCancel_HostEncodes_SynthTraderDecodesIdentical()
+    {
+        Span<byte> frame = stackalloc byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        const ulong clOrd = 0xCAFE_BABE_DEAD_BEEFUL;
+        const long secId = 900_000_000_005L;
+        const long orderId = 67890L;
+        ExecutionReportEncoder.EncodeExecReportCancel(frame,
+            sessionId: 1, msgSeqNum: 2, sendingTimeNanos: 3,
+            side: Side.Buy, clOrdIdValue: clOrd, origClOrdIdValue: 0, secondaryOrderId: 0,
+            securityId: secId, orderId: orderId,
+            execId: 4, transactTimeNanos: 5,
+            cumQty: 0, orderQty: 100, priceMantissa: 100_0000);
+
+        var body = frame.Slice(SbeHeaderSize);
+        var er = EntryPointClient.DecodeExecReportCancel(body);
+        Assert.Equal(clOrd, er.ClOrdId);
+        Assert.Equal(secId, er.SecurityId);
+        Assert.Equal(OrderSide.Buy, er.Side);
+        Assert.Equal(orderId, er.OrderId);
+    }
+
+    [Fact]
+    public void ExecReportReject_HostEncodes_SynthTraderDecodesIdentical()
+    {
+        Span<byte> frame = stackalloc byte[ExecutionReportEncoder.ExecReportRejectTotal];
+        const ulong clOrd = 0x1234_5678_DEAD_BEEFUL;
+        const long secId = 900_000_000_006L;
+        ExecutionReportEncoder.EncodeExecReportReject(frame,
+            sessionId: 1, msgSeqNum: 2, sendingTimeNanos: 3,
+            clOrdIdValue: clOrd, origClOrdIdValue: 0, securityId: secId, orderIdOrZero: 0,
+            rejectReason: 99, transactTimeNanos: 4);
+
+        var body = frame.Slice(SbeHeaderSize);
+        var er = EntryPointClient.DecodeExecReportReject(body);
+        Assert.Equal(clOrd, er.ClOrdId);
+        Assert.Equal(secId, er.SecurityId);
+    }
+}


### PR DESCRIPTION
Closes #3

## Summary

Adds `B3.Exchange.SyntheticTrader`, a separate console process that connects to the exchange host over EntryPoint TCP and drives continuous order flow. The host stays a pure exchange — synthetic flow lives in its own binary, restartable independently and with multiple instances per firm allowed.

## Strategy abstraction

`IStrategy.Tick(in MarketState, Random) -> IEnumerable<OrderIntent>` — pure-ish: strategies are deterministic given (state, RNG state), perform no I/O, and are reused-friendly for future strategies (#13). Two ship today:

- **MarketMakerStrategy**: maintains N levels each side around the midprice; tops up missing levels and cancels drifted quotes (>`replaceDistanceTicks` away from target).
- **NoiseTakerStrategy**: probability-driven marketable IOC orders crossing the book by `crossTicks`.

Midprice random-walks each tick (per-instrument `midDriftProbability`). RNG is seeded from config so a fixed seed reproduces the entire intent stream.

## Wire format

`SimpleNewOrderV2` and `OrderCancelRequest` are encoded inline using `EntryPointFrameReader.WriteHeader` (the host's only public encoder surface) and the published BlockLength/offsets that mirror `InboundMessageDecoder`. ER frames are decoded by template-id with field offsets duplicated from `ExecutionReportEncoder` — small, intentional duplication per the issue guidance (\"otherwise duplicate the encoder calls (small)\").

The trader stamps a fresh ClOrdID per outbound order and tracks `tag → ClOrdID → OrderId` so cancels can target the engine-assigned OrderID (the v1 EntryPoint protocol requires it).

## Testing

- `StrategyTests` (5 tests): deterministic strategy outputs with seeded RNG; no live host required.
- `SyntheticTraderHostIntegrationTests` (1 test): boots `ExchangeHost` in-proc on loopback, runs one MM + one noise-taker for a few seconds, asserts trades happened and multicast packets were emitted.

All existing tests still pass; build is warnings-clean (`TreatWarningsAsErrors=true`).

## Packaging

- `Dockerfile.synthtrader` (multi-stage SDK → aspnet runtime).
- `docker-compose.synthtrader.yml` example: host + 1 synth trader on host networking.
- `config/synthetic-trader.json` sample.

## Files changed

```
src/B3.Exchange.SyntheticTrader/{B3.Exchange.SyntheticTrader.csproj, OrderIntent.cs, MarketState.cs, IStrategy.cs, MarketMakerStrategy.cs, NoiseTakerStrategy.cs, SyntheticTraderConfig.cs, EntryPointClient.cs, SyntheticTraderRunner.cs, Program.cs}
tests/B3.Exchange.SyntheticTrader.Tests/{B3.Exchange.SyntheticTrader.Tests.csproj, StrategyTests.cs, SyntheticTraderHostIntegrationTests.cs}
config/synthetic-trader.json
Dockerfile.synthtrader
docker-compose.synthtrader.yml
SbeB3Exchange.slnx        (registered new src + test projects)
README.md                 (added synth-trader section)
```

## Pre-PR checklist

- [x] `dotnet build SbeB3Exchange.slnx --no-restore -c Release` — 0 warnings, 0 errors
- [x] `dotnet test SbeB3Exchange.slnx --no-build -c Release` — 97 passed, 0 failed (was 91 before this PR)
- [x] `dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn` — clean
- [x] `docker build -f Dockerfile.synthtrader .` — succeeds

## Follow-ups discovered

- **Per-session firm (#8 prereq)**: the trader carries a `firm` field in its config but the host currently stamps every connection with `tcp.enteringFirm`, so the field is informational only. When per-session firm lands, the trader should send it during connection setup.
- **OrigClOrdID-based cancels**: not needed today (the trader knows the engine-assigned `OrderID` from ER_New) but if the issue #7 cancel-by-clord work changes the protocol semantics, the trader's `EntryPointClient.SendCancel` already sets `origClOrdId` to 0 and would need a small change.
- **Replace intents**: only `New` and `Cancel` ship in v1. Adding `Replace` is mechanical (extend `OrderIntentKind`, add `SimpleModifyOrderV2` encoder body, route ER_Modify on the recv path).
- **Per-strategy mid drift**: today the runner drives the mid; could be moved into `NoiseTakerStrategy` by adding a `MarketState.AdvanceMid()` callback if a strategy wants finer control of the walk.