### PR TITLE
feat: EntryPoint heartbeat + idle timeout (#9)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -5,7 +5,10 @@
   //   UMDF channel. instruments file partitions instruments across channels.
   "tcp": {
     "listen": "0.0.0.0:9876",
-    "enteringFirm": 1
+    "enteringFirm": 1,
+    "heartbeatIntervalMs": 30000,
+    "idleTimeoutMs": 30000,
+    "testRequestGraceMs": 5000
   },
   "channels": [
     {

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -66,7 +66,13 @@ Exposes:
 
 ```json
 {
-  "tcp": { "listen": "0.0.0.0:9876", "enteringFirm": 1 },
+  "tcp": {
+    "listen": "0.0.0.0:9876",
+    "enteringFirm": 1,
+    "heartbeatIntervalMs": 30000,
+    "idleTimeoutMs": 30000,
+    "testRequestGraceMs": 5000
+  },
   "channels": [
     {
       "channelNumber": 84,
@@ -82,6 +88,17 @@ Exposes:
 * `tcp.listen` — bind address for the EntryPoint TCP server.
 * `tcp.enteringFirm` — uint stamped on every accepted order (single-firm
   default; per-session firm assignment is not yet implemented).
+* `tcp.heartbeatIntervalMs` — server emits a `Sequence` (templateId=9, used
+  as heartbeat by B3) when no other outbound traffic has been sent within
+  this window. Default `30000`.
+* `tcp.idleTimeoutMs` — inbound silence after which the server sends a
+  `Sequence` probe (the FIXP equivalent of FIX `TestRequest`). Default
+  `30000`.
+* `tcp.testRequestGraceMs` — additional silence the server tolerates after
+  the probe before tearing down the connection. Default `5000`. On teardown
+  the session is closed; a `BusinessReject` (templateId=206) framing the
+  reason is the responsibility of issue #11 — `EntryPointSession.Close(reason)`
+  exposes the seam.
 * `channels[]` — one matching engine + one outbound multicast group per
   UMDF channel.
 * `instruments` — path to the instrument list (re-uses the format already
@@ -98,6 +115,12 @@ Exposes:
 | 100         | SimpleNewOrderV2    | 82          |
 | 101         | SimpleModifyOrderV2 | 98          |
 | 105         | OrderCancelRequest  | 76          |
+| 9           | Sequence (heartbeat)| 4           |
+
+The `Sequence` frame doubles as the FIXP-style heartbeat: any inbound
+frame (including `Sequence`) resets the server's idle timer. Clients
+should emit `Sequence` periodically (default cadence: ≤ `idleTimeoutMs`)
+to keep the session alive.
 
 v1 limitation: `Cancel` and `Modify` require an explicit `OrderID`.
 `OrigClOrdID`-only lookup (find the order by its original client id) is
@@ -112,6 +135,13 @@ deferred to a later milestone.
 | 202         | ExecutionReport_CancelV2    | 156         |
 | 203         | ExecutionReport_TradeV2     | 154         |
 | 204         | ExecutionReport_RejectV2    | 138         |
+| 9           | Sequence (heartbeat/probe)  | 4           |
+
+The server emits `Sequence` frames in two situations: (1) periodically
+when the outbound link has been silent for `heartbeatIntervalMs`, and
+(2) as a probe when the inbound link has been silent for `idleTimeoutMs`.
+If the client does not respond within `testRequestGraceMs`, the session
+is closed.
 
 ### Outbound (UMDF multicast)
 

--- a/src/B3.Exchange.EntryPoint/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointFrameReader.cs
@@ -19,6 +19,8 @@ public static class EntryPointFrameReader
     public const ushort TidSimpleModifyOrder = 101;
     /// <summary>Inbound: OrderCancelRequest (V6 base, no version variants).</summary>
     public const ushort TidOrderCancelRequest = 105;
+    /// <summary>Session: Sequence (FIXP, also used as heartbeat). Bidirectional.</summary>
+    public const ushort TidSequence = 9;
 
     /// <summary>Outbound: ExecutionReport_New (V2).</summary>
     public const ushort TidExecutionReportNew = 200;
@@ -37,6 +39,7 @@ public static class EntryPointFrameReader
         (TidSimpleNewOrder, 2) => 82,            // SimpleNewOrderV2.MESSAGE_SIZE
         (TidSimpleModifyOrder, 2) => 98,         // SimpleModifyOrderV2.MESSAGE_SIZE
         (TidOrderCancelRequest, 0) => 76,        // OrderCancelRequest.MESSAGE_SIZE (V6 base)
+        (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.
         _ => -1
     };
 

--- a/src/B3.Exchange.EntryPoint/EntryPointListener.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointListener.cs
@@ -17,6 +17,8 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly IPEndPoint _endpoint;
     private readonly IEntryPointEngineSink _sink;
     private readonly Func<EndPoint?, AcceptedConnection> _identityFactory;
+    private readonly EntryPointSessionOptions _sessionOptions;
+    private readonly Action<EntryPointSession, string>? _onSessionClosed;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
@@ -27,11 +29,15 @@ public sealed class EntryPointListener : IAsyncDisposable
     public IPEndPoint? LocalEndpoint => (IPEndPoint?)_listener?.LocalEndpoint;
 
     public EntryPointListener(IPEndPoint endpoint, IEntryPointEngineSink sink,
-        Func<EndPoint?, AcceptedConnection>? identityFactory = null)
+        Func<EndPoint?, AcceptedConnection>? identityFactory = null,
+        EntryPointSessionOptions? sessionOptions = null,
+        Action<EntryPointSession, string>? onSessionClosed = null)
     {
         _endpoint = endpoint;
         _sink = sink;
         _identityFactory = identityFactory ?? DefaultIdentityFactory;
+        _sessionOptions = sessionOptions ?? EntryPointSessionOptions.Default;
+        _onSessionClosed = onSessionClosed;
     }
 
     private AcceptedConnection DefaultIdentityFactory(EndPoint? remote)
@@ -61,7 +67,8 @@ public sealed class EntryPointListener : IAsyncDisposable
                 sock.NoDelay = true;
                 var identity = _identityFactory(sock.RemoteEndPoint);
                 var stream = new NetworkStream(sock, ownsSocket: true);
-                var session = new EntryPointSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId, stream, _sink);
+                var session = new EntryPointSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
+                    stream, _sink, options: _sessionOptions, onClosed: _onSessionClosed);
                 lock (_lock) _sessions.Add(session);
                 session.Start();
             }

--- a/src/B3.Exchange.EntryPoint/EntryPointListener.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointListener.cs
@@ -37,6 +37,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         _sink = sink;
         _identityFactory = identityFactory ?? DefaultIdentityFactory;
         _sessionOptions = sessionOptions ?? EntryPointSessionOptions.Default;
+        _sessionOptions.Validate();
         _onSessionClosed = onSessionClosed;
     }
 
@@ -67,8 +68,16 @@ public sealed class EntryPointListener : IAsyncDisposable
                 sock.NoDelay = true;
                 var identity = _identityFactory(sock.RemoteEndPoint);
                 var stream = new NetworkStream(sock, ownsSocket: true);
+
+                // Wrap onClosed to remove session from _sessions before invoking external callback
+                Action<EntryPointSession, string> onClosed = (s, reason) =>
+                {
+                    lock (_lock) _sessions.Remove(s);
+                    _onSessionClosed?.Invoke(s, reason);
+                };
+
                 var session = new EntryPointSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
-                    stream, _sink, options: _sessionOptions, onClosed: _onSessionClosed);
+                    stream, _sink, options: _sessionOptions, onClosed: onClosed);
                 lock (_lock) _sessions.Add(session);
                 session.Start();
             }

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -29,10 +29,19 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
     private readonly Channel<byte[]> _sendQueue;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<ulong> _nowNanos;
+    private readonly EntryPointSessionOptions _options;
+    private readonly Action<EntryPointSession, string>? _onClosed;
     private long _msgSeqNum;
     private int _isOpen = 1;
+    // Watchdog state (milliseconds since process start, monotonic).
+    private long _lastInboundMs;
+    private long _lastOutboundMs;
+    // Set true while we are waiting on the grace window after sending a probe;
+    // cleared as soon as any inbound frame arrives. Prevents flooding probes.
+    private int _probeOutstanding;
     private Task? _recvTask;
     private Task? _sendTask;
+    private Task? _watchdogTask;
 
     public long ConnectionId { get; }
     public uint EnteringFirm { get; }
@@ -41,7 +50,9 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
 
     public EntryPointSession(long connectionId, uint enteringFirm, uint sessionId,
         Stream stream, IEntryPointEngineSink sink, Func<ulong>? nowNanos = null,
-        int sendQueueCapacity = DefaultSendQueueCapacity)
+        int sendQueueCapacity = DefaultSendQueueCapacity,
+        EntryPointSessionOptions? options = null,
+        Action<EntryPointSession, string>? onClosed = null)
     {
         ConnectionId = connectionId;
         EnteringFirm = enteringFirm;
@@ -49,22 +60,31 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         _stream = stream;
         _sink = sink;
         _nowNanos = nowNanos ?? DefaultNowNanos;
+        _options = options ?? EntryPointSessionOptions.Default;
+        _options.Validate();
+        _onClosed = onClosed;
         _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(sendQueueCapacity)
         {
             SingleReader = true,
             SingleWriter = false,
             FullMode = BoundedChannelFullMode.DropWrite,
         });
+        long now = NowMs();
+        Volatile.Write(ref _lastInboundMs, now);
+        Volatile.Write(ref _lastOutboundMs, now);
     }
 
     public void Start()
     {
         _recvTask = Task.Run(() => RunReceiveLoopAsync(_cts.Token));
         _sendTask = Task.Run(() => RunSendLoopAsync(_cts.Token));
+        _watchdogTask = Task.Run(() => RunWatchdogLoopAsync(_cts.Token));
     }
 
     private static ulong DefaultNowNanos()
         => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+
+    private static long NowMs() => Environment.TickCount64;
 
     private async Task RunReceiveLoopAsync(CancellationToken ct)
     {
@@ -77,13 +97,17 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
                 if (!EntryPointFrameReader.TryParseInboundHeader(headerBuf, out var info, out var hdrErr))
                 {
                     _sink.OnDecodeError(this, hdrErr ?? "invalid header");
-                    Close();
+                    Close("decode-error");
                     return;
                 }
                 var bodyBuf = ArrayPool<byte>.Shared.Rent(info.BodyLength);
                 try
                 {
                     await ReadExactlyAsync(_stream, bodyBuf.AsMemory(0, info.BodyLength), ct).ConfigureAwait(false);
+                    // Any well-framed inbound frame counts as liveness, including
+                    // session-layer Sequence (heartbeat) frames.
+                    Volatile.Write(ref _lastInboundMs, NowMs());
+                    Volatile.Write(ref _probeOutstanding, 0);
                     var body = bodyBuf.AsSpan(0, info.BodyLength);
                     DispatchInbound(info, body);
                 }
@@ -98,7 +122,7 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         catch (IOException) { }
         finally
         {
-            Close();
+            Close("recv-eof");
         }
     }
 
@@ -107,6 +131,10 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         ulong now = _nowNanos();
         switch (info.TemplateId)
         {
+            case EntryPointFrameReader.TidSequence:
+                // Session-layer heartbeat / sequence sync. Liveness already
+                // recorded by the receive loop; nothing else to do.
+                return;
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(body, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                     _sink.EnqueueNewOrder(no, this, noClOrd);
@@ -137,10 +165,11 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
                 try
                 {
                     await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                    Volatile.Write(ref _lastOutboundMs, NowMs());
                 }
                 catch (IOException)
                 {
-                    Close();
+                    Close("send-io-error");
                     return;
                 }
                 // Frames enqueued here are plain `new byte[]` (see TryEnqueueExact),
@@ -150,8 +179,80 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         catch (OperationCanceledException) { }
         finally
         {
-            Close();
+            Close("send-loop-exit");
         }
+    }
+
+    /// <summary>
+    /// Periodic watchdog that drives the FIXP-style heartbeat + idle-timeout
+    /// policy. Runs on its own task; never touches the socket directly —
+    /// instead it enqueues <c>Sequence</c> frames into the same bounded
+    /// channel the send loop drains, so all writes remain serialised.
+    /// </summary>
+    private async Task RunWatchdogLoopAsync(CancellationToken ct)
+    {
+        // Tick at a fraction of the smallest configured interval so we react
+        // promptly without busy-polling. Capped to keep tests responsive.
+        int tickMs = Math.Max(1, Math.Min(_options.HeartbeatIntervalMs,
+            Math.Min(_options.IdleTimeoutMs, _options.TestRequestGraceMs)) / 4);
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(tickMs, ct).ConfigureAwait(false);
+                if (!IsOpen) return;
+
+                long now = NowMs();
+                long sinceIn = now - Volatile.Read(ref _lastInboundMs);
+                long sinceOut = now - Volatile.Read(ref _lastOutboundMs);
+
+                // Idle teardown: if a probe is outstanding and grace elapsed
+                // without any inbound, close. The grace clock starts from the
+                // moment the probe was sent (i.e. _lastOutboundMs was bumped),
+                // so we measure the additional silence beyond idleTimeoutMs.
+                if (sinceIn >= (long)_options.IdleTimeoutMs + _options.TestRequestGraceMs)
+                {
+                    // Seam for issue #11: a future BusinessReject (templateId=206)
+                    // should be enqueued here before close so the peer learns
+                    // the reason. Today we close with a logged reason string.
+                    Close("idle-timeout");
+                    return;
+                }
+
+                // Probe (FIXP TestRequest equivalent): if we've been silent on
+                // the inbound side past the idle threshold and we haven't
+                // already sent a probe in this idle stretch, send one.
+                if (sinceIn >= _options.IdleTimeoutMs &&
+                    Interlocked.CompareExchange(ref _probeOutstanding, 1, 0) == 0)
+                {
+                    EnqueueSequence();
+                    continue;
+                }
+
+                // Regular heartbeat: only when no other outbound traffic has
+                // been sent within the heartbeat interval. This naturally
+                // suppresses heartbeats while ER traffic is flowing.
+                if (sinceOut >= _options.HeartbeatIntervalMs)
+                {
+                    EnqueueSequence();
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (Exception)
+        {
+            // Watchdog must never crash the session silently; tear down on
+            // unexpected error so the listener can drop the connection.
+            Close("watchdog-error");
+        }
+    }
+
+    private void EnqueueSequence()
+    {
+        if (!IsOpen) return;
+        var frame = new byte[SessionFrameEncoder.SequenceTotal];
+        SessionFrameEncoder.EncodeSequence(frame, NextMsgSeqNum());
+        TryEnqueue(frame);
     }
 
     private static async Task ReadExactlyAsync(Stream s, byte[] buf, CancellationToken ct)
@@ -172,7 +273,7 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
     {
         if (!IsOpen) return false;
         if (_sendQueue.Writer.TryWrite(frame)) return true;
-        Close();
+        Close("send-queue-full");
         return false;
     }
 
@@ -267,18 +368,28 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         _ => 0,
     };
 
-    public void Close()
+    public void Close() => Close("close");
+
+    /// <summary>
+    /// Closes the session with a diagnostic reason. The reason is forwarded to
+    /// the optional <c>onClosed</c> callback supplied at construction so the
+    /// listener (or tests) can log it. <see cref="Close()"/> is the
+    /// no-reason convenience overload.
+    /// </summary>
+    public void Close(string reason)
     {
         if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
         _sendQueue.Writer.TryComplete();
         try { _cts.Cancel(); } catch { }
+        try { _onClosed?.Invoke(this, reason); } catch { }
     }
 
     public async ValueTask DisposeAsync()
     {
-        Close();
+        Close("dispose");
         try { if (_recvTask != null) await _recvTask.ConfigureAwait(false); } catch { }
         try { if (_sendTask != null) await _sendTask.ConfigureAwait(false); } catch { }
+        try { if (_watchdogTask != null) await _watchdogTask.ConfigureAwait(false); } catch { }
         _cts.Dispose();
     }
 }

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -210,7 +210,8 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
                 // without any inbound, close. The grace clock starts from the
                 // moment the probe was sent (i.e. _lastOutboundMs was bumped),
                 // so we measure the additional silence beyond idleTimeoutMs.
-                if (sinceIn >= (long)_options.IdleTimeoutMs + _options.TestRequestGraceMs)
+                if (sinceIn >= (long)_options.IdleTimeoutMs + _options.TestRequestGraceMs &&
+                    Volatile.Read(ref _probeOutstanding) == 1)
                 {
                     // Seam for issue #11: a future BusinessReject (templateId=206)
                     // should be enqueued here before close so the peer learns

--- a/src/B3.Exchange.EntryPoint/EntryPointSessionOptions.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSessionOptions.cs
@@ -1,0 +1,33 @@
+namespace B3.Exchange.EntryPoint;
+
+/// <summary>
+/// Session-level timing knobs for heartbeats and idle-timeout teardown.
+///
+/// The simulator implements a simplified FIXP session layer:
+///   - server emits a <c>Sequence</c> frame (templateId=9, used as heartbeat
+///     by B3) when no other outbound traffic has been sent within
+///     <see cref="HeartbeatIntervalMs"/>;
+///   - if no inbound traffic arrives for <see cref="IdleTimeoutMs"/>, the
+///     server emits a <c>Sequence</c> probe (the FIXP equivalent of a
+///     TestRequest) and starts a grace timer of
+///     <see cref="TestRequestGraceMs"/>; if no inbound arrives in that grace
+///     window the connection is closed.
+///
+/// Defaults match the issue (#9) spec: 30 s heartbeat, 30 s idle, 5 s grace.
+/// Tests override with sub-second values to keep the suite fast.
+/// </summary>
+public sealed record EntryPointSessionOptions
+{
+    public int HeartbeatIntervalMs { get; init; } = 30_000;
+    public int IdleTimeoutMs { get; init; } = 30_000;
+    public int TestRequestGraceMs { get; init; } = 5_000;
+
+    public static EntryPointSessionOptions Default { get; } = new();
+
+    internal void Validate()
+    {
+        if (HeartbeatIntervalMs <= 0) throw new ArgumentOutOfRangeException(nameof(HeartbeatIntervalMs));
+        if (IdleTimeoutMs <= 0) throw new ArgumentOutOfRangeException(nameof(IdleTimeoutMs));
+        if (TestRequestGraceMs <= 0) throw new ArgumentOutOfRangeException(nameof(TestRequestGraceMs));
+    }
+}

--- a/src/B3.Exchange.EntryPoint/SessionFrameEncoder.cs
+++ b/src/B3.Exchange.EntryPoint/SessionFrameEncoder.cs
@@ -1,0 +1,32 @@
+using System.Runtime.InteropServices;
+
+namespace B3.Exchange.EntryPoint;
+
+/// <summary>
+/// Byte-level encoders for FIXP session-layer frames (currently just
+/// <c>Sequence</c> / heartbeat). Kept separate from
+/// <see cref="ExecutionReportEncoder"/> so the application-layer encoder
+/// stays focused on ExecutionReports.
+/// </summary>
+internal static class SessionFrameEncoder
+{
+    private const int HeaderSize = 8;
+    public const int SequenceBlock = 4;
+    public const int SequenceTotal = HeaderSize + SequenceBlock;
+
+    /// <summary>
+    /// Writes a <c>Sequence</c> (templateId=9) frame. In FIXP this message
+    /// doubles as the heartbeat: the server emits it when no other outbound
+    /// traffic has been sent within the heartbeat interval, and as a probe
+    /// after the inbound idle timeout elapses.
+    /// </summary>
+    public static int EncodeSequence(Span<byte> dst, uint nextSeqNo)
+    {
+        if (dst.Length < SequenceTotal)
+            throw new ArgumentException("buffer too small for Sequence frame", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, blockLength: SequenceBlock,
+            templateId: EntryPointFrameReader.TidSequence, version: 0);
+        MemoryMarshal.Write(dst.Slice(HeaderSize, 4), in nextSeqNo);
+        return SequenceTotal;
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -71,6 +71,12 @@ public sealed class ExchangeHost : IAsyncDisposable
 
         _router = new HostRouter(routing);
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
+        var sessionOptions = new EntryPointSessionOptions
+        {
+            HeartbeatIntervalMs = _config.Tcp.HeartbeatIntervalMs,
+            IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,
+            TestRequestGraceMs = _config.Tcp.TestRequestGraceMs,
+        };
         _listener = new EntryPointListener(listenEp, _router,
             identityFactory: remote =>
             {
@@ -79,7 +85,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                     ConnectionId: connectionId,
                     EnteringFirm: _config.Tcp.EnteringFirm,
                     SessionId: (uint)(connectionId & 0xFFFFFFFFu));
-            });
+            },
+            sessionOptions: sessionOptions,
+            onSessionClosed: (s, reason) => _log?.Invoke($"session {s.ConnectionId} closed: {reason}"));
         _listener.Start();
         _log?.Invoke($"listening on {_listener.LocalEndpoint}");
         return Task.CompletedTask;

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -18,6 +18,16 @@ public sealed class TcpConfig
 {
     [JsonPropertyName("listen")] public string Listen { get; set; } = "0.0.0.0:9876";
     [JsonPropertyName("enteringFirm")] public uint EnteringFirm { get; set; } = 1;
+    /// <summary>Server-side heartbeat (Sequence) interval in milliseconds.
+    /// A heartbeat is only emitted when no other outbound traffic has been
+    /// sent within this window. Default: 30 s.</summary>
+    [JsonPropertyName("heartbeatIntervalMs")] public int HeartbeatIntervalMs { get; set; } = 30_000;
+    /// <summary>Inbound silence in milliseconds before the server emits a
+    /// Sequence probe (FIXP TestRequest equivalent). Default: 30 s.</summary>
+    [JsonPropertyName("idleTimeoutMs")] public int IdleTimeoutMs { get; set; } = 30_000;
+    /// <summary>Additional grace window after the probe before the session is
+    /// closed for inactivity. Default: 5 s.</summary>
+    [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
 }
 
 public sealed class ChannelConfig

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
@@ -15,7 +15,7 @@ public class EntryPointHeartbeatTests
     private sealed class NoOpEngineSink : IEntryPointEngineSink
     {
         public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void OnDecodeError(IEntryPointResponseChannel reply, string error) { }
     }

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
@@ -1,0 +1,160 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.EntryPoint;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.EntryPoint.Tests;
+
+/// <summary>
+/// Integration coverage for issue #9: server-side heartbeat + idle timeout.
+/// Uses a real loopback TCP connection driven by <see cref="EntryPointListener"/>
+/// with sub-second intervals so the suite stays fast.
+/// </summary>
+public class EntryPointHeartbeatTests
+{
+    private sealed class NoOpEngineSink : IEntryPointEngineSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(IEntryPointResponseChannel reply, string error) { }
+    }
+
+    private static byte[] BuildSequenceFrame(uint nextSeq)
+    {
+        var f = new byte[12];
+        EntryPointFrameReader.WriteHeader(f, blockLength: 4, templateId: EntryPointFrameReader.TidSequence, version: 0);
+        BitConverter.GetBytes(nextSeq).CopyTo(f, 8);
+        return f;
+    }
+
+    [Fact]
+    public async Task IdleSession_IsTornDown_AfterTimeout()
+    {
+        var closures = new List<string>();
+        var sem = new SemaphoreSlim(0, 1);
+        var options = new EntryPointSessionOptions
+        {
+            HeartbeatIntervalMs = 10_000, // not relevant for this test
+            IdleTimeoutMs = 200,
+            TestRequestGraceMs = 200,
+        };
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            sessionOptions: options,
+            onSessionClosed: (s, reason) => { lock (closures) { closures.Add(reason); } sem.Release(); });
+        listener.Start();
+        var ep = listener.LocalEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+
+        // Don't send anything. Server should: send a probe at ~200ms, then
+        // close at ~400ms. Allow generous slack so the test isn't flaky.
+        bool fired = await sem.WaitAsync(TimeSpan.FromSeconds(3));
+        Assert.True(fired, "session was never closed");
+        lock (closures) Assert.Contains("idle-timeout", closures);
+
+        // Read side of the client should observe EOF after server close.
+        var ns = client.GetStream();
+        byte[] buf = new byte[64];
+        int total = 0;
+        using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        try
+        {
+            while (true)
+            {
+                int n = await ns.ReadAsync(buf.AsMemory(total, buf.Length - total), readCts.Token);
+                if (n == 0) break;
+                total += n;
+                if (total == buf.Length) break;
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch (IOException) { }
+        // We should have received exactly one Sequence probe (12 bytes) before EOF.
+        Assert.Equal(12, total);
+        // Header sanity: templateId == 9 at offset 2.
+        ushort tid = BitConverter.ToUInt16(buf, 2);
+        Assert.Equal((ushort)EntryPointFrameReader.TidSequence, tid);
+    }
+
+    [Fact]
+    public async Task ActivelyHeartbeatingSession_StaysAlive()
+    {
+        var closures = new List<string>();
+        var options = new EntryPointSessionOptions
+        {
+            HeartbeatIntervalMs = 10_000, // ignore server-emitted heartbeats here
+            IdleTimeoutMs = 200,
+            TestRequestGraceMs = 200,
+        };
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            sessionOptions: options,
+            onSessionClosed: (s, reason) => { lock (closures) { closures.Add(reason); } });
+        listener.Start();
+        var ep = listener.LocalEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var ns = client.GetStream();
+
+        // Total runtime: 2 s. Heartbeat every 100 ms = 20 cycles, well past
+        // multiple idle-timeout windows (200 ms) and grace windows (200 ms).
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        uint seq = 1;
+        try
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                var frame = BuildSequenceFrame(seq++);
+                await ns.WriteAsync(frame, cts.Token);
+                await Task.Delay(100, cts.Token);
+            }
+        }
+        catch (OperationCanceledException) { }
+
+        // Session must not have been closed during the run.
+        lock (closures) Assert.Empty(closures);
+    }
+
+    [Fact]
+    public async Task ServerEmitsHeartbeat_WhenOutboundIdle()
+    {
+        var options = new EntryPointSessionOptions
+        {
+            HeartbeatIntervalMs = 150,
+            IdleTimeoutMs = 10_000,        // disable idle teardown for this test
+            TestRequestGraceMs = 10_000,
+        };
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            sessionOptions: options);
+        listener.Start();
+        var ep = listener.LocalEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var ns = client.GetStream();
+
+        // Keep inbound alive with one Sequence frame so idle never trips —
+        // but with idle/grace at 10s the test would not run long enough to
+        // notice anyway. Just read whatever the server sends.
+        byte[] buf = new byte[12];
+        int total = 0;
+        using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        while (total < 12)
+        {
+            int n = await ns.ReadAsync(buf.AsMemory(total, 12 - total), readCts.Token);
+            if (n == 0) break;
+            total += n;
+        }
+        Assert.Equal(12, total);
+        Assert.Equal((ushort)EntryPointFrameReader.TidSequence, BitConverter.ToUInt16(buf, 2));
+        Assert.Equal((ushort)4, BitConverter.ToUInt16(buf, 0)); // BlockLength
+    }
+}


### PR DESCRIPTION
Closes #9

## Summary

Implements a simplified FIXP-style session layer for EntryPoint:

- **Inbound heartbeat**: `Sequence` (templateId=9, BlockLength=4) frames are recognised by the receive loop and consumed silently — they reset the server's idle timer.
- **Server-side watchdog** per `EntryPointSession`:
  - emits a `Sequence` heartbeat when no other outbound traffic has been sent within `heartbeatIntervalMs` (default **30 s**)
  - emits a `Sequence` probe (FIXP equivalent of FIX `TestRequest`) when inbound has been silent for `idleTimeoutMs` (default **30 s**)
  - closes the session if no inbound arrives within an additional `testRequestGraceMs` grace window (default **5 s**)
- Heartbeats/probes are enqueued into the existing bounded send-queue channel, so the send loop remains the **only** thread touching the socket.
- `EntryPointSession.Close(string reason)` overload + `EntryPointListener.onSessionClosed` callback expose the teardown reason — clean seam for issue #11 `BusinessReject` framing.
- New host config knobs: `tcp.heartbeatIntervalMs`, `tcp.idleTimeoutMs`, `tcp.testRequestGraceMs`.

## Tests (sub-second timings)

- `IdleSession_IsTornDown_AfterTimeout` — verifies probe + close after `idleTimeoutMs + testRequestGraceMs`.
- `ActivelyHeartbeatingSession_StaysAlive` — runs for 2 s with the client heartbeating every 100 ms (well past several idle/grace windows) and asserts no closure.
- `ServerEmitsHeartbeat_WhenOutboundIdle` — reads a server-emitted `Sequence` frame within the heartbeat window.

All 94 existing tests still pass; `dotnet format` clean.

## Follow-ups

- Issue #11 will replace the current log-on-close with a real `BusinessMessageReject` (templateId=206) before tearing down — the `Close(reason)` seam is in place.
- The first outbound heartbeat lands ~`heartbeatIntervalMs` after connect; if a stricter per-connect schedule is desired we'd need to seed `_lastOutboundMs` to `now - interval` (deferred — current behaviour matches FIXP intent).
