### PR TITLE
feat: operator HTTP endpoint — snapshot-now + bump-version (#6)

### DIFF
--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -176,6 +176,8 @@ healthcheck).
 | `/health/live`   | 200 if every dispatcher loop has ticked within `http.livenessStaleMs`; else 503 |
 | `/health/ready`  | 200 once every registered `IReadinessProbe` reports ready; else 503             |
 | `/metrics`       | Prometheus 0.0.4 text exposition (always 200)                                   |
+| `POST /channel/{ch}/snapshot-now`  | Operator command — forces a snapshot publish on the next dispatcher cycle. 202 on enqueue, 404 unknown channel, 503 if the dispatcher's inbound queue is full. |
+| `POST /channel/{ch}/bump-version`  | Operator command — atomically bumps the incremental + snapshot `SequenceVersion`, clears the order book, resets `RptSeq` to 0, and emits a `ChannelReset_11` frame on the incremental channel under the new version. 202 on enqueue, 404 unknown channel, 503 if the queue is full. |
 
 `/metrics` series:
 
@@ -199,6 +201,37 @@ one snapshot / definition per loaded instrument since startup.
 Until those land, the host registers a single `StartupReadinessProbe`
 that flips ready as soon as `ExchangeHost.StartAsync` returns, so
 `/health/ready` is effectively equivalent to `/health/live` for now.
+
+### Operator endpoints (issue #6)
+
+`POST /channel/{ch}/snapshot-now` and `POST /channel/{ch}/bump-version`
+are operator-driven hooks intended for exercising consumer recovery /
+epoch handling against a live simulator without restarting it. Both
+dispatch their work via the channel's bounded inbound queue, so the
+HTTP handler returns 202 as soon as the work item is enqueued (404 if
+the channel number is unknown, 503 if the queue is full).
+
+`bump-version` is the heart of the channel-reset path:
+
+1. The dispatcher clears every per-instrument book and resets the
+   engine's `RptSeq` counter to 0.
+2. The incremental `SequenceVersion` is incremented and `SequenceNumber`
+   is rebased to 0.
+3. The attached snapshot rotator's `SequenceVersion` is incremented in
+   lockstep (its `SequenceNumber` is rebased to 0 the same way).
+4. A single `ChannelReset_11` frame is emitted on the incremental
+   channel, packed into a one-message packet whose header carries the
+   NEW `SequenceVersion` and `SequenceNumber=1`.
+
+No per-order `DeleteOrder_MBO_51` frames are emitted ahead of the
+`ChannelReset` — per the schema, `ChannelReset` is the canonical signal
+for consumers to drop all per-channel state, and emitting redundant
+deletes alongside it would risk consumers seeing cancels for orders
+they have already discarded.
+
+The next snapshot publish (whether triggered by the configured cadence
+or by an operator `snapshot-now`) reflects the empty book stamped with
+the new versions.
 
 ### Docker `HEALTHCHECK`
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -214,7 +214,8 @@ public sealed class ExchangeHost : IAsyncDisposable
         {
             IReadOnlyList<IReadinessProbe> probeSnapshot;
             lock (_probesLock) probeSnapshot = _probes.ToList();
-            _http = new HttpServer(_config.Http, _metrics, probeSnapshot,
+            var dispatchersByChannel = _dispatchers.ToDictionary(d => d.ChannelNumber);
+            _http = new HttpServer(_config.Http, _metrics, probeSnapshot, dispatchersByChannel,
                 msg => _logger.LogInformation("{Message}", msg));
             await _http.StartAsync().ConfigureAwait(false);
         }

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -30,15 +30,19 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly HttpConfig _config;
     private readonly MetricsRegistry _metrics;
     private readonly IReadOnlyList<IReadinessProbe> _probes;
+    private readonly IReadOnlyDictionary<byte, ChannelDispatcher> _dispatchers;
     private readonly Action<string>? _log;
     private WebApplication? _app;
 
     public HttpServer(HttpConfig config, MetricsRegistry metrics,
-        IReadOnlyList<IReadinessProbe> probes, Action<string>? log = null)
+        IReadOnlyList<IReadinessProbe> probes,
+        IReadOnlyDictionary<byte, ChannelDispatcher> dispatchers,
+        Action<string>? log = null)
     {
         _config = config;
         _metrics = metrics;
         _probes = probes;
+        _dispatchers = dispatchers;
         _log = log;
     }
 
@@ -102,6 +106,19 @@ public sealed class HttpServer : IAsyncDisposable
         app.MapGet("/metrics", () =>
             Results.Text(_metrics.RenderProm(), "text/plain; version=0.0.4; charset=utf-8"));
 
+        // Operator endpoints (issue #6). All work is dispatched via the
+        // channel's inbound queue so the engine state mutation happens on
+        // the dispatch thread; the HTTP handler returns 202 Accepted as soon
+        // as the work item is enqueued. 404 for unknown channel; 503 if the
+        // dispatcher's bounded inbound queue is full (BoundedChannel
+        // FullMode is DropWrite, so TryWrite returns false rather than
+        // blocking the HTTP thread).
+        app.MapPost("/channel/{ch:int}/snapshot-now", (int ch, HttpContext ctx) =>
+            HandleOperatorEnqueue(ctx, ch, d => d.EnqueueOperatorSnapshotNow(), "snapshot-now"));
+
+        app.MapPost("/channel/{ch:int}/bump-version", (int ch, HttpContext ctx) =>
+            HandleOperatorEnqueue(ctx, ch, d => d.EnqueueOperatorBumpVersion(), "bump-version"));
+
         await app.StartAsync(ct).ConfigureAwait(false);
         _app = app;
 
@@ -115,6 +132,24 @@ public sealed class HttpServer : IAsyncDisposable
             LocalEndpoint = ep;
 
         _log?.Invoke($"http listening on {LocalEndpoint}");
+    }
+
+    private IResult HandleOperatorEnqueue(HttpContext ctx, int channelNumber,
+        Func<ChannelDispatcher, bool> enqueue, string opName)
+    {
+        if (channelNumber < 0 || channelNumber > 255 ||
+            !_dispatchers.TryGetValue((byte)channelNumber, out var disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown channel {channelNumber}\n", "text/plain");
+        }
+        if (!enqueue(disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {channelNumber} inbound queue full\n", "text/plain");
+        }
+        ctx.Response.StatusCode = StatusCodes.Status202Accepted;
+        return Results.Text($"accepted {opName} channel={channelNumber}\n", "text/plain");
     }
 
     private static IPEndPoint ParseEndpoint(string s)

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -153,14 +153,49 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     private void RecordHeartbeat()
         => _metrics?.RecordTick(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
 
+    private void ProcessBumpVersion()
+    {
+        // Atomic operator-initiated channel reset (issue #6). Order matters:
+        //   1. Wipe per-instrument books and reset RptSeq on the engine.
+        //   2. Bump incremental SequenceVersion + reset SequenceNumber.
+        //   3. Bump snapshot rotator's SequenceVersion (if attached).
+        //   4. Emit one ChannelReset_11 frame, flushed as a single-message
+        //      packet under the NEW SequenceVersion. Because we just reset
+        //      SequenceNumber to 0, FlushPacket() stamps SequenceNumber=1.
+        // Anything that races with this would violate the dispatch-thread
+        // invariant — ProcessOne is the sole caller and is invoked only
+        // from the dispatch loop.
+        _engine.ResetForChannelReset();
+        SequenceVersion = (ushort)(SequenceVersion + 1);
+        SequenceNumber = 0;
+        _snapshotRotator?.BumpSequenceVersion();
+
+        // Force-write the ChannelReset_11 frame using the standard
+        // ReserveOrFlush/Commit path so the packet header reflects the
+        // NEW SequenceVersion.
+        _packetWritten = 0;
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.ChannelResetBlockLength);
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteChannelResetFrame(dst, _nowNanos());
+        Commit(n);
+        FlushPacket();
+    }
+
     internal void ProcessOne(in WorkItem item)
     {
-        if (item.Kind == WorkKind.SnapshotRotation)
+        if (item.Kind == WorkKind.SnapshotRotation || item.Kind == WorkKind.OperatorSnapshotNow)
         {
             // Snapshot ticks bypass the per-command incremental packet buffer
             // entirely — they have their own sink + sequence space owned by
             // the rotator and emit one or more complete packets directly.
             _snapshotRotator?.PublishNext();
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorBumpVersion)
+        {
+            ProcessBumpVersion();
             return;
         }
 
@@ -384,6 +419,31 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     public void OnSessionClosed(IEntryPointResponseChannel reply)
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.ReleaseOwner, reply, 0, 0, null, null, null));
 
+    /// <summary>
+    /// Operator command (issue #6): forces an immediate snapshot publish on
+    /// the next available dispatcher cycle. Identical wire effect to a
+    /// <see cref="EnqueueSnapshotTick"/>; the distinct work-kind exists so
+    /// future operator commands can be metered/logged independently of the
+    /// scheduled cadence ticks. Returns <c>false</c> if the inbound queue
+    /// is full. Safe to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorSnapshotNow()
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorSnapshotNow, null!, 0, 0, null, null, null));
+
+    /// <summary>
+    /// Operator command (issue #6): atomically (a) bumps the incremental
+    /// channel's <see cref="SequenceVersion"/> + the attached snapshot
+    /// rotator's <c>SequenceVersion</c>, (b) clears every per-instrument
+    /// order book, (c) resets the engine's <c>RptSeq</c> counter to 0, and
+    /// (d) emits a single <c>ChannelReset_11</c> frame on the incremental
+    /// channel under the NEW <see cref="SequenceVersion"/>. The next
+    /// snapshot publish (whether scheduled or operator-forced) will reflect
+    /// the empty book stamped with the new versions. Returns <c>false</c>
+    /// if the inbound queue is full. Safe to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorBumpVersion()
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorBumpVersion, null!, 0, 0, null, null, null));
+
     // ====== IMatchingEventSink ======
 
     public void OnOrderAccepted(in OrderAcceptedEvent e)
@@ -527,7 +587,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
         _cts.Dispose();
     }
 
-    internal enum WorkKind : byte { New, Cancel, Replace, DecodeError, SnapshotRotation, ReleaseOwner }
+    internal enum WorkKind : byte { New, Cancel, Replace, DecodeError, SnapshotRotation, ReleaseOwner, OperatorSnapshotNow, OperatorBumpVersion }
 
     internal readonly record struct OrderOwnership(IEntryPointResponseChannel Reply, ulong ClOrdId, uint EnteringFirm);
 

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -73,6 +73,21 @@ internal sealed class LimitOrderBook
 
     public int OrderCount => _byOrderId.Count;
 
+    /// <summary>
+    /// Removes every resting order from this book without emitting any
+    /// per-order events. Intended for operator-initiated channel resets
+    /// (issue #6) where consumers receive a single <c>ChannelReset</c>
+    /// frame and drop their local state — per-order DeleteOrder frames
+    /// would be redundant and risk consumers seeing cancels for orders
+    /// they have already discarded.
+    /// </summary>
+    public void Clear()
+    {
+        _bids.Clear();
+        _asks.Clear();
+        _byOrderId.Clear();
+    }
+
     public bool TryGet(long orderId, out RestingOrder order) => _byOrderId.TryGetValue(orderId, out order!);
 
     private SortedDictionary<long, PriceLevel> SideMap(Side side) => side == Side.Buy ? _bids : _asks;

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -66,6 +66,25 @@ public sealed class MatchingEngine
     public SelfTradePrevention SelfTradePrevention => _stp;
 
     /// <summary>
+    /// Hard reset of every per-instrument book and the engine's
+    /// <c>RptSeq</c> counter. Designed for the operator-initiated
+    /// channel-reset path (issue #6): the dispatcher invokes this on
+    /// the dispatch thread, paired with a <c>ChannelReset_11</c> emission
+    /// and a <c>SequenceVersion</c> bump on both the incremental and
+    /// snapshot channels. Order-id and trade-id allocators are
+    /// intentionally NOT reset — those identifiers must remain unique
+    /// for the lifetime of the host so audit/replay tools can distinguish
+    /// pre- and post-reset entities.
+    /// </summary>
+    public void ResetForChannelReset()
+    {
+        if (_dispatching)
+            throw new InvalidOperationException("cannot reset while a command is being dispatched");
+        foreach (var book in _booksById.Values) book.Clear();
+        _rptSeq = 0;
+    }
+
+    /// <summary>
     /// Returns the <see cref="LimitOrderBook"/>'s public snapshot iterator.
     /// Throws <see cref="KeyNotFoundException"/> if the security id is unknown.
     /// </summary>

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -328,6 +328,36 @@ public static class UmdfWireEncoder
         return total;
     }
 
+    /// <summary>
+    /// Writes <c>ChannelReset_11</c> (V16): framing header + SBE header + 12-byte body.
+    /// MatchEventIndicator is set to bit 5 (RecoveryMsg) | bit 7 (EndOfEvent),
+    /// per the schema's documented "bits applied to this message" annotation,
+    /// signalling consumers that this is a hard reset / end-of-event boundary.
+    /// Returns total bytes written.
+    /// </summary>
+    public static int WriteChannelResetFrame(
+        Span<byte> dst,
+        ulong mdEntryTimestampNanos)
+    {
+        const int total = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.ChannelResetBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.ChannelReset_11Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.ChannelResetBlockLength);
+        body.Clear();
+
+        // MatchEventIndicator: bit 5 (RecoveryMsg, value 0x20) | bit 7 (EndOfEvent, value 0x80) = 0xA0.
+        body[WireOffsets.ChannelResetBodyMatchEventIndicatorOffset] = 0xA0;
+        MemoryMarshal.Write(body.Slice(WireOffsets.ChannelResetBodyMdEntryTimestampOffset, 8), in mdEntryTimestampNanos);
+
+        return total;
+    }
+
     private static void WriteFramingHeader(Span<byte> dst, int totalFrameLength)
     {
         ushort messageLength = checked((ushort)totalFrameLength);

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -80,6 +80,14 @@ public static class WireOffsets
     public const int SnapOrdersGroupSizeEncodingSize = 3;      // BlockLength(ushort) + NumInGroup(byte)
     public const int SnapOrdersEntrySize = 42;                 // per-entry (V16 layout)
 
+    // ---- ChannelReset_11 (V16) ----
+    // Body: MatchEventIndicator @0 (4 bytes — UMDF wire treats the bitset as
+    // a 4-byte block, see schema offset="4" on MDEntryTimestamp), then
+    // MDEntryTimestamp @4 (8 bytes ulong nanos). Total 12 bytes.
+    public const int ChannelResetBlockLength = 12;
+    public const int ChannelResetBodyMatchEventIndicatorOffset = 0;
+    public const int ChannelResetBodyMdEntryTimestampOffset = 4;
+
     // ---- SecurityDefinition_12 (V16) ----
     public const int SecDefBlockLength = 230;
     public const int SecDefSecurityIdOffset = 0;

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -134,4 +134,67 @@ public class HttpServerTests
         }
         Assert.Equal(System.Net.HttpStatusCode.ServiceUnavailable, last);
     }
+
+    [Fact]
+    public async Task OperatorBumpVersion_Returns202_AndEmitsChannelResetOnIncrementalSink()
+    {
+        var (cfg, _) = BuildConfig();
+        var incSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => incSink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+
+        var resp = await client.PostAsync("/channel/84/bump-version", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.Accepted, resp.StatusCode);
+
+        // Wait for the dispatcher to drain the bump-version work item.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (incSink.Packets.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+
+        Assert.True(incSink.Packets.Count >= 1, "expected ChannelReset packet on incremental sink");
+        var packet = incSink.Packets[0];
+
+        // SBE TemplateId == 11 (ChannelReset_11). PacketHeader=16, Framing=4,
+        // SBE MessageHeader: BlockLength(2) + TemplateId(2) ...
+        int sbeHdrStart = 16 + 4;
+        ushort templateId = System.Runtime.InteropServices.MemoryMarshal.Read<ushort>(
+            packet.AsSpan(sbeHdrStart + 2, 2));
+        Assert.Equal((ushort)11, templateId);
+
+        // SequenceVersion bumped from the default 1 to 2.
+        ushort version = System.Runtime.InteropServices.MemoryMarshal.Read<ushort>(packet.AsSpan(2, 2));
+        Assert.Equal((ushort)2, version);
+    }
+
+    [Fact]
+    public async Task OperatorSnapshotNow_Returns202_AndUnknownChannelReturns404()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+
+        var ok = await client.PostAsync("/channel/84/snapshot-now", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.Accepted, ok.StatusCode);
+
+        var unknown = await client.PostAsync("/channel/200/snapshot-now", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, unknown.StatusCode);
+
+        var unknownBump = await client.PostAsync("/channel/200/bump-version", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, unknownBump.StatusCode);
+    }
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
 }

--- a/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
@@ -160,7 +160,7 @@ public class ChannelDispatcherTests
     public void Cancel_ByOrigClOrdId_ResolvesViaSessionMap()
     {
         var (disp, pkt) = NewDispatcher();
-        var reply = new RecordingReply();
+        var reply = new RecordingReply { CaptureCancelIds = true };
 
         disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
             reply, clOrdIdValue: 1UL);
@@ -406,6 +406,80 @@ public class ChannelDispatcherTests
         var (clOrd, origClOrd) = reply.CancelIds[0];
         Assert.Equal(99UL, clOrd);
         Assert.Equal(1UL, origClOrd);
+    }
+
+    [Fact]
+    public void OperatorBumpVersion_ClearsBook_BumpsVersions_EmitsChannelResetPacket()
+    {
+        var (disp, pkt) = NewDispatcher();
+        var reply = new RecordingReply();
+
+        // Seed two resting orders so the book has state to clear.
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply, clOrdIdValue: 1UL);
+        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(11m), 200, 7, 1_001UL),
+            reply, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+
+        ushort versionBefore = disp.SequenceVersion;
+        uint seqBefore = disp.SequenceNumber;
+        Assert.Equal(2, pkt.Packets.Count);
+        Assert.Equal(2, GetEngine(disp).OrderCount(Petr));
+        Assert.True(GetEngine(disp).CurrentRptSeq > 0);
+        pkt.Packets.Clear();
+
+        Assert.True(disp.EnqueueOperatorBumpVersion());
+        DrainInbound(disp);
+
+        // Book wiped, RptSeq reset.
+        Assert.Equal(0, GetEngine(disp).OrderCount(Petr));
+        Assert.Equal(0u, GetEngine(disp).CurrentRptSeq);
+
+        // SequenceVersion bumped on the dispatcher (incremental). Snapshot
+        // rotator is not attached in this test (no rotator wired) — the
+        // attach path is exercised in the host-level integration test.
+        Assert.Equal((ushort)(versionBefore + 1), disp.SequenceVersion);
+        // SequenceNumber rebased: starts at 0 then the ChannelReset flush
+        // increments it to 1.
+        Assert.Equal(1u, disp.SequenceNumber);
+        Assert.NotEqual(seqBefore, disp.SequenceNumber);
+
+        // Exactly one packet emitted: PacketHeader + framing + sbeHdr +
+        // ChannelReset_11 body (12).
+        Assert.Single(pkt.Packets);
+        var packet = pkt.Packets[0];
+        int expectedLen = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize + WireOffsets.ChannelResetBlockLength;
+        Assert.Equal(expectedLen, packet.Length);
+
+        // Packet header reflects the NEW SequenceVersion.
+        Assert.Equal((ushort)(versionBefore + 1), MemoryMarshal.Read<ushort>(packet.AsSpan(WireOffsets.PacketHeaderSequenceVersionOffset, 2)));
+        Assert.Equal(1u, MemoryMarshal.Read<uint>(packet.AsSpan(WireOffsets.PacketHeaderSequenceNumberOffset, 4)));
+
+        // SBE TemplateId == 11.
+        int sbeHdrStart = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize;
+        ushort templateId = MemoryMarshal.Read<ushort>(packet.AsSpan(sbeHdrStart + 2, 2));
+        Assert.Equal((ushort)11, templateId);
+    }
+
+    [Fact]
+    public void OperatorSnapshotNow_OnDispatcherWithoutRotator_IsNoOp()
+    {
+        // Without a snapshot rotator attached the work item is consumed but
+        // produces no incremental packets — verifies the dispatch path is
+        // safe in the no-rotator case (the host wires the rotator only when
+        // the channel has a snapshot config).
+        var (disp, pkt) = NewDispatcher();
+        Assert.True(disp.EnqueueOperatorSnapshotNow());
+        DrainInbound(disp);
+        Assert.Empty(pkt.Packets);
+    }
+
+    private static MatchingEngine GetEngine(ChannelDispatcher disp)
+    {
+        var f = typeof(ChannelDispatcher).GetField("_engine",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (MatchingEngine)f.GetValue(disp)!;
     }
 
     private static void DrainInbound(ChannelDispatcher disp)


### PR DESCRIPTION
Closes #6

**Stacked on #26 + #27.** Re-target this PR to `main` once both prerequisites merge — the merge commit at the base of this branch will then drop on rebase.

## Summary

Two new operator-driven HTTP POST endpoints on the Kestrel-hosted operability surface introduced by #5 (#26):

| Endpoint | Behaviour |
|---|---|
| `POST /channel/{ch}/snapshot-now` | Forces an immediate snapshot publish on the next dispatcher cycle (uses the rotator from #1 / #27). |
| `POST /channel/{ch}/bump-version` | Atomic channel reset: clears every per-instrument book, resets `RptSeq` to 0, bumps both the incremental and snapshot `SequenceVersion`, rebases `SequenceNumber` to 0, and emits a single `ChannelReset_11` frame on the incremental channel under the new version. |

All operator work is dispatched via a new `WorkKind.OperatorBumpVersion` / `WorkKind.OperatorSnapshotNow` work item enqueued onto the existing bounded inbound queue, so engine-state mutation always happens on the dispatch thread — the single-threaded engine invariant is preserved. The HTTP handler returns 202 as soon as the work item is enqueued (404 for an unknown channel, 503 if the queue is full).

## Design decisions

* **No per-order `DeleteOrder_MBO_51` frames before `ChannelReset_11`.** Per the schema (`b3-market-data-messages-2.2.0.xml`), `ChannelReset_11` is the canonical signal for consumers to drop all per-channel state. Emitting redundant deletes alongside it would risk consumers seeing cancels for orders they have already discarded. One frame, one packet, atomic.
* **`ChannelReset_11` (not `ChannelReset_2`).** The schema only defines template id 11 for the channel-reset message; the issue title's `_2` was treated as a typo.
* **Order-id and trade-id allocators are NOT reset.** They remain monotonic across resets so audit/replay tools can distinguish pre- and post-reset entities.
* **`MatchEventIndicator = 0xA0`** (bit 5 RecoveryMsg | bit 7 EndOfEvent) per the schema annotation.
* **`snapshot-now` reuses the rotator's `PublishNext()`.** No separate code path; the new `WorkKind.OperatorSnapshotNow` is distinct from `SnapshotRotation` purely so future operator-command metering can distinguish the two.

## Tests

Integration tests (`B3.Exchange.Integration.Tests` 15 → 17, `B3.Exchange.Host.Tests` 9 → 11):

* Unit: `OperatorBumpVersion_ClearsBook_BumpsVersions_EmitsChannelResetPacket` — book is wiped, `RptSeq` reset, `SequenceVersion` advanced, exactly one `ChannelReset_11` packet emitted with the new version stamped on the packet header.
* Unit: `OperatorSnapshotNow_OnDispatcherWithoutRotator_IsNoOp` — safe no-op path.
* Integration: `OperatorBumpVersion_Returns202_AndEmitsChannelResetOnIncrementalSink` — POST against an in-proc `ExchangeHost` produces 202 and a `ChannelReset_11` packet on the incremental sink with `SequenceVersion=2`.
* Integration: `OperatorSnapshotNow_Returns202_AndUnknownChannelReturns404`.

## Files changed

* `src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs`, `WireOffsets.cs` — `WriteChannelResetFrame` + offsets.
* `src/B3.Exchange.Matching/MatchingEngine.cs`, `LimitOrderBook.cs` — `ResetForChannelReset()`, `Clear()`.
* `src/B3.Exchange.Integration/ChannelDispatcher.cs` — `EnqueueOperatorBumpVersion`, `EnqueueOperatorSnapshotNow`, `ProcessBumpVersion`, two new `WorkKind` values.
* `src/B3.Exchange.Host/HttpServer.cs` — two POST routes; constructor now takes a `{ChannelNumber → ChannelDispatcher}` map.
* `src/B3.Exchange.Host/ExchangeHost.cs` — wires the dispatcher map into `HttpServer`.
* `docs/EXCHANGE-SIMULATOR.md` — operator endpoints in the routing table + a dedicated subsection.
* Tests in `tests/B3.Exchange.Integration.Tests` and `tests/B3.Exchange.Host.Tests`.

## Pre-PR checklist

```
dotnet restore SbeB3Exchange.slnx                                                ✓
dotnet build   SbeB3Exchange.slnx --no-restore -c Release                        ✓ (0 warnings)
dotnet test    SbeB3Exchange.slnx --no-build   -c Release                        ✓ (111 tests passed)
dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn ✓
```