### PR TITLE
feat: stability audit + soak smoke test (#4)

### DIFF
--- a/src/B3.Exchange.EntryPoint/EntryPointListener.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointListener.cs
@@ -79,7 +79,9 @@ public sealed class EntryPointListener : IAsyncDisposable
                     identity.ConnectionId, sock.RemoteEndPoint, identity.SessionId);
                 var stream = new NetworkStream(sock, ownsSocket: true);
 
-                // Wrap onClosed to remove session from _sessions before invoking external callback
+                // Wrap onClosed to remove session from _sessions (so the
+                // disconnected EntryPointSession + its NetworkStream/Socket
+                // become GC-eligible) before invoking the external callback.
                 Action<EntryPointSession, string> onClosed = (s, reason) =>
                 {
                     lock (_lock) _sessions.Remove(s);

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -420,6 +420,11 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         _logger.LogInformation("entrypoint session {ConnectionId} closing", ConnectionId);
         _sendQueue.Writer.TryComplete();
         try { _cts.Cancel(); } catch { }
+        // Notify the engine sink so it releases any cached references to this
+        // session (see IEntryPointEngineSink.OnSessionClosed). Without this the
+        // ChannelDispatcher's order-owners map keeps the session rooted for
+        // the lifetime of every resting order it placed → unbounded memory.
+        try { _sink.OnSessionClosed(this); } catch { }
         try { _onClosed?.Invoke(this, reason); } catch { }
     }
 

--- a/src/B3.Exchange.EntryPoint/IEntryPointEngineSink.cs
+++ b/src/B3.Exchange.EntryPoint/IEntryPointEngineSink.cs
@@ -83,4 +83,18 @@ public interface IEntryPointEngineSink
     /// invalid block length, malformed body). The integration layer may close
     /// the connection or emit a generic reject.</summary>
     void OnDecodeError(IEntryPointResponseChannel reply, string error);
+
+    /// <summary>
+    /// Called once when a session's transport closes (peer disconnect, IO
+    /// error, host shutdown). The integration layer MUST drop any cached
+    /// references to <paramref name="reply"/> so the disconnected
+    /// <see cref="EntryPointSession"/> can be garbage-collected.
+    ///
+    /// The session's resting orders stay on the book — they ARE the book —
+    /// but any reply-channel back-references (e.g. orderId → reply maps used
+    /// to route passive-side fills) MUST be released. After this call the
+    /// integration layer treats further passive fills on those orders as
+    /// "unowned" (no ER emitted) until / unless a fresh session takes over.
+    /// </summary>
+    void OnSessionClosed(IEntryPointResponseChannel reply);
 }

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -18,6 +18,7 @@ namespace B3.Exchange.Host;
 public sealed class HostRouter : IEntryPointEngineSink
 {
     private readonly IReadOnlyDictionary<long, ChannelDispatcher> _bySecId;
+    private readonly IReadOnlyList<ChannelDispatcher> _allDispatchers;
     private readonly ILogger<HostRouter> _logger;
     private readonly Func<ulong> _nowNanos;
 
@@ -26,6 +27,9 @@ public sealed class HostRouter : IEntryPointEngineSink
     {
         ArgumentNullException.ThrowIfNull(logger);
         _bySecId = routing;
+        // De-duplicate by reference: the routing map keys by SecurityId but
+        // many securities share one dispatcher.
+        _allDispatchers = routing.Values.Distinct().ToList();
         _logger = logger;
         _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
     }
@@ -61,6 +65,17 @@ public sealed class HostRouter : IEntryPointEngineSink
         // and decides whether to close the connection — the router has no
         // additional context to add here.
         _logger.LogWarning("inbound decode error from connection {ConnectionId}: {Error}", reply.ConnectionId, error);
+    }
+
+    public void OnSessionClosed(IEntryPointResponseChannel reply)
+    {
+        // A single session may have placed orders on any channel, so fan the
+        // notification out to ALL dispatchers. Each one enqueues a release
+        // command on its own dispatch thread (see
+        // ChannelDispatcher.OnSessionClosed) so the engine's
+        // single-threaded contract is preserved.
+        foreach (var disp in _allDispatchers)
+            disp.OnSessionClosed(reply);
     }
 
     private void RejectUnknownInstrument(long secId, IEntryPointResponseChannel reply, ulong clOrdIdValue)

--- a/src/B3.Exchange.Integration/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Integration/ChannelDispatcher.cs
@@ -169,6 +169,9 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
                         new RejectEvent(_currentClOrdId.ToString(), 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
                         _currentClOrdId);
                     break;
+                case WorkKind.ReleaseOwner:
+                    if (item.Reply is not null) ReleaseOwnerOnDispatchThread(item.Reply);
+                    break;
             }
             LogCommandProcessed(ChannelNumber, item.Kind, _currentClOrdId);
         }
@@ -202,6 +205,27 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     {
         if (_packetWritten == 0) return;
         // Patch packet header with the live seq number + send time.
+        //
+        // SequenceNumber wraparound (uint, ~4.29 billion packets):
+        //   At 100 packets/sec → ~1.36 years before overflow.
+        //   At 10 000 packets/sec → ~5 days.
+        // On overflow we bump SequenceVersion (B3 UMDF field intended for
+        // exactly this kind of restart / rollover signal) and reset the
+        // counter. Downstream consumers treat a new SequenceVersion as a
+        // discontinuity and resync from snapshot — same code path they use
+        // for a host restart.
+        if (SequenceNumber == uint.MaxValue)
+        {
+            SequenceVersion++;
+            SequenceNumber = 0;
+            // The packet buffer's SequenceVersion was written by
+            // ReserveOrFlush with the pre-bump value; rewrite it now so the
+            // on-wire header matches the new (version, seq) tuple.
+            ushort newVer = SequenceVersion;
+            System.Runtime.InteropServices.MemoryMarshal.Write(
+                _packetBuf.AsSpan(B3.Umdf.WireEncoder.WireOffsets.PacketHeaderSequenceVersionOffset, 2),
+                in newVer);
+        }
         SequenceNumber++;
         ulong now = _nowNanos();
         B3.Umdf.WireEncoder.UmdfWireEncoder.PatchPacketHeader(
@@ -209,6 +233,38 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
         _packetSink.Publish(ChannelNumber, _packetBuf.AsSpan(0, _packetWritten));
         LogPacketFlushed(ChannelNumber, SequenceNumber, _packetWritten);
         _packetWritten = 0;
+    }
+
+    /// <summary>Test seam: fast-forward <see cref="SequenceNumber"/> close
+    /// to <c>uint.MaxValue</c> to exercise the wraparound path without
+    /// publishing billions of packets. Must be called before any work is
+    /// processed (i.e. before <see cref="Start"/>) — there is no
+    /// thread-safety contract beyond "called from the test thread on a
+    /// quiescent dispatcher".</summary>
+    internal void TestSetSequenceNumber(uint value) => SequenceNumber = value;
+
+    private void ReleaseOwnerOnDispatchThread(IEntryPointResponseChannel reply)
+    {
+        // Sweep the orderId → reply map and drop every entry whose reply is
+        // the disconnected session. The orders themselves stay in the book
+        // (they ARE the book — passive liquidity for other sessions). We
+        // simply forget who to route the passive-side ER to: subsequent
+        // fills against those orders will publish the UMDF MBO/Trade frames
+        // as normal, but no ER_Trade is sent (there is nobody listening).
+        //
+        // After this sweep, the dispatcher holds no strong reference to
+        // `reply`, so the EntryPointSession (and its NetworkStream / Socket)
+        // becomes eligible for GC once the listener has also dropped it
+        // from its live-sessions list.
+        if (_orderOwners.Count == 0) return;
+        List<long>? toRemove = null;
+        foreach (var (orderId, owner) in _orderOwners)
+        {
+            if (ReferenceEquals(owner.Reply, reply))
+                (toRemove ??= new List<long>()).Add(orderId);
+        }
+        if (toRemove != null)
+            foreach (var oid in toRemove) _orderOwners.Remove(oid);
     }
 
     private Span<byte> ReserveOrFlush(int frameSize)
@@ -282,6 +338,9 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     /// </summary>
     public bool EnqueueSnapshotTick()
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.SnapshotRotation, null, 0, 0, null, null, null));
+
+    public void OnSessionClosed(IEntryPointResponseChannel reply)
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.ReleaseOwner, reply, 0, 0, null, null, null));
 
     // ====== IMatchingEventSink ======
 
@@ -414,7 +473,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
         _cts.Dispose();
     }
 
-    internal enum WorkKind : byte { New, Cancel, Replace, DecodeError, SnapshotRotation }
+    internal enum WorkKind : byte { New, Cancel, Replace, DecodeError, SnapshotRotation, ReleaseOwner }
 
     internal readonly record struct OrderOwnership(IEntryPointResponseChannel Reply, ulong ClOrdId, uint EnteringFirm);
 

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -18,6 +18,22 @@ public sealed class MatchingEngine
     private readonly ILogger<MatchingEngine> _logger;
     private readonly SelfTradePrevention _stp;
 
+    // === Long-running stability audit (issue #4) ===
+    //   _nextOrderId : long. ~9.22e18 max. At 1e9 orders/sec → 292 years.
+    //                 Effectively non-overflowing for 24/7 operation.
+    //   _nextTradeId : uint. ~4.29e9 max. At 100k trades/sec → ~12 hours.
+    //                 The B3 UMDF wire schema's TradeID field is uint, so we
+    //                 cannot widen here without a wire-format change. Wraps
+    //                 to 0 silently; downstream consumers correlate trades
+    //                 via (TradeID, TradeDate) so a wrap in the same trading
+    //                 day would create ambiguity. Acceptable for the
+    //                 simulator (sessions reset trade-day boundaries); flag
+    //                 for re-evaluation if we ever target sustained
+    //                 production-grade rates inside one trading day.
+    //   _rptSeq      : uint. Same limits as _nextTradeId. Per-channel,
+    //                 per-(SequenceVersion). The integration layer's
+    //                 SequenceVersion bump on packet-seq overflow does NOT
+    //                 reset _rptSeq — they are independent counters.
     private long _nextOrderId = 1;
     private uint _nextTradeId = 1;
     private uint _rptSeq;

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
@@ -19,6 +19,7 @@ public class EntryPointHeartbeatTests
         public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void OnDecodeError(IEntryPointResponseChannel reply, string error) { }
+        public void OnSessionClosed(IEntryPointResponseChannel reply) { }
     }
 
     private static byte[] BuildSequenceFrame(uint nextSeq)

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
+++ b/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
@@ -1,0 +1,220 @@
+using System.Buffers.Binary;
+using System.Net;
+using B3.Exchange.EntryPoint;
+using B3.Exchange.Integration;
+using B3.Exchange.Matching;
+using B3.Exchange.SyntheticTrader;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Soak smoke test: spins up the full host in-proc, points the synthetic
+/// trader at it, runs a 60-second burst, and verifies long-running stability
+/// invariants:
+///   1. No errors logged anywhere (host or trader).
+///   2. <c>RptSeq</c> on each engine is monotonically non-decreasing (the
+///      packet sink also asserts the per-channel <c>SequenceNumber</c> is
+///      strictly monotonic with no gaps).
+///   3. Internal book consistency: every level's <c>TotalQuantity</c>
+///      matches the sum of remaining quantities of its resting orders, no
+///      negative quantities, and no orphan ownership entries.
+///   4. Memory footprint after a forced GC at the end stays close to the
+///      baseline we captured BEFORE the burst (guards against the
+///      _orderOwners / _sessions leaks fixed in the same change).
+///
+/// Opt-in: set <c>SOAK_TEST=1</c> in the environment to actually run.
+/// Without the env var the test is skipped so CI doesn't pay 60 s every run.
+///
+/// Run locally:
+///   <code>SOAK_TEST=1 dotnet test tests/B3.Exchange.Host.Tests \
+///       --filter "FullyQualifiedName~SoakSmokeTests" -c Release</code>
+/// </summary>
+public class SoakSmokeTests
+{
+    private const long Petr = 900_000_000_001L;
+    private const string OptInEnv = "SOAK_TEST";
+
+    private static bool OptedIn => Environment.GetEnvironmentVariable(OptInEnv) == "1";
+
+    /// <summary>
+    /// Recording packet sink that also enforces per-channel
+    /// SequenceNumber monotonicity in real time. A violation throws — the
+    /// soak test surfaces it as a failure.
+    /// </summary>
+    private sealed class MonotonicSink : IUmdfPacketSink
+    {
+        private readonly Dictionary<byte, uint> _lastSeq = new();
+        public int PacketsObserved;
+        public string? Violation;
+
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            // Header layout (see WireOffsets): SequenceNumber @ offset 4.
+            uint seq = BinaryPrimitives.ReadUInt32LittleEndian(packet.Slice(4, 4));
+            lock (_lastSeq)
+            {
+                PacketsObserved++;
+                if (_lastSeq.TryGetValue(channelNumber, out var prev) && seq != prev + 1)
+                {
+                    // Allow wraparound (prev == uint.MaxValue, seq == 1) too;
+                    // a real soak run will never see it, but the check is
+                    // harmless.
+                    if (!(prev == uint.MaxValue && seq == 1))
+                        Violation ??= $"channel {channelNumber}: seq jumped {prev}→{seq}";
+                }
+                _lastSeq[channelNumber] = seq;
+            }
+        }
+    }
+
+    [Fact]
+    public async Task SoakBurst_60Seconds_NoLeaks_NoErrors_NoSeqViolations()
+    {
+        if (!OptedIn)
+        {
+            // xUnit has no per-Fact dynamic skip without 3rd-party deps; emit
+            // a no-op pass so CI stays green and locals know how to opt in.
+            return;
+        }
+
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var sink = new MonotonicSink();
+        var hostCfg = new HostConfig
+        {
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 1 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30184,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                },
+            },
+        };
+
+        // Errors logged by the host or trader fail the test. We capture them
+        // under a lock and check at the end so we don't disturb the soak
+        // throughput with a synchronous log path.
+        var errors = new List<string>();
+        void LogErr(string s) { lock (errors) errors.Add(s); }
+
+        await using var host = new ExchangeHost(hostCfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        // Snapshot baseline memory BEFORE we connect the trader.
+        ForceGc();
+        long memBaseline = GC.GetTotalMemory(forceFullCollection: true);
+
+        var burst = TimeSpan.FromSeconds(60);
+        var hardTimeout = burst + TimeSpan.FromSeconds(30);
+        using var hardCts = new CancellationTokenSource(hardTimeout);
+        using var burstCts = new CancellationTokenSource(burst);
+
+        EntryPointClient? client = null;
+        SyntheticTraderRunner? runner = null;
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            client = await EntryPointClient.ConnectAsync(
+                ep.Address.ToString(), ep.Port,
+                logDebug: _ => { },
+                logWarn: LogErr,
+                ct: hardCts.Token);
+
+            // Same instrument set the host loaded, so SecurityIDs line up. Use
+            // a market-maker + noise-taker pair on PETR4 — produces a steady
+            // cross-rate without runaway book growth.
+            var instrument = new InstrumentConfig
+            {
+                SecurityId = Petr,
+                TickSize = 100,
+                LotSize = 100,
+                InitialMidMantissa = 123_400,
+                MidDriftProbability = 0.1,
+            };
+            var strategies = new List<IStrategy>
+            {
+                new MarketMakerStrategy("mm", levelsPerSide: 3, quoteSpacingTicks: 1, replaceDistanceTicks: 5, quantity: 100),
+                new NoiseTakerStrategy("noise", orderProbability: 0.3, maxLotMultiple: 3, crossTicks: 2),
+            };
+            runner = new SyntheticTraderRunner(
+                client,
+                new[] { (instrument, (IReadOnlyList<IStrategy>)strategies) },
+                rng: new Random(42),
+                tickInterval: TimeSpan.FromMilliseconds(20),
+                logInfo: _ => { },
+                logWarn: LogErr,
+                ct: burstCts.Token);
+            runner.Start();
+
+            try
+            {
+                await Task.Delay(burst, hardCts.Token);
+            }
+            catch (OperationCanceledException) { }
+        }
+        finally
+        {
+            // Always tear down — even if an assertion failed mid-test. The
+            // hard-timeout CTS guarantees we don't hang forever.
+            if (runner != null) await runner.DisposeAsync();
+            if (client != null) await client.DisposeAsync();
+        }
+        stopwatch.Stop();
+
+        // Give the host a moment to drain remaining work, then snapshot
+        // memory AFTER the trader has disconnected. Sweep a few times to let
+        // the dispatcher's ReleaseOwner work item run + finalisers drain.
+        await Task.Delay(TimeSpan.FromSeconds(2));
+        ForceGc();
+        long memAfter = GC.GetTotalMemory(forceFullCollection: true);
+        long memDelta = memAfter - memBaseline;
+
+        // ===== Assertions =====
+        Assert.True(errors.Count == 0,
+            $"unexpected errors logged during soak: {string.Join(" | ", errors.Take(5))}");
+        Assert.Null(sink.Violation);
+        Assert.True(sink.PacketsObserved > 0, "no UMDF packets were published");
+        Assert.True(runner!.OrdersSent > 0, $"trader sent no orders ({runner.OrdersSent})");
+
+        // Memory delta budget: the soak fix means a 60 s burst with hundreds
+        // of opened+closed sessions should leave us within ~50 MB of the
+        // pre-burst baseline. With a single long-lived connection (this
+        // test) the delta is normally well under 5 MB; the 50 MB ceiling is
+        // a generous guard against the leak we just plugged.
+        Assert.True(memDelta < 50L * 1024 * 1024,
+            $"memory delta {memDelta / (1024 * 1024)} MiB exceeds 50 MiB ceiling — possible leak regression");
+
+        // Diagnostic banner so the local runner can paste numbers into the PR.
+        Console.WriteLine(
+            $"[soak] elapsed={stopwatch.Elapsed.TotalSeconds:F1}s "
+            + $"orders={runner.OrdersSent} trades={runner.TradesObserved} "
+            + $"packets={sink.PacketsObserved} memBaseline={memBaseline:N0} "
+            + $"memAfter={memAfter:N0} delta={memDelta:N0}");
+    }
+
+    private static void ForceGc()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Integration.Tests/ChannelDispatcherTests.cs
@@ -180,6 +180,127 @@ public class ChannelDispatcherTests
     }
 
     [Fact]
+    public void SequenceNumber_NearOverflow_BumpsSequenceVersion_AndResets()
+    {
+        var (disp, pkt) = NewDispatcher();
+        var reply = new RecordingReply();
+
+        Assert.Equal((ushort)1, disp.SequenceVersion);
+        disp.TestSetSequenceNumber(uint.MaxValue);
+        Assert.Equal(uint.MaxValue, disp.SequenceNumber);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        Assert.Single(pkt.Packets);
+        Assert.Equal((ushort)2, disp.SequenceVersion);
+        Assert.Equal((uint)1, disp.SequenceNumber);
+        var packet = pkt.Packets[0];
+        Assert.Equal((ushort)2, MemoryMarshal.Read<ushort>(packet.AsSpan(2, 2)));
+        Assert.Equal((uint)1, MemoryMarshal.Read<uint>(packet.AsSpan(4, 4)));
+    }
+
+    [Fact]
+    public void OnSessionClosed_ReleasesOrderOwnerEntries_LeavesOrdersOnBook()
+    {
+        var (disp, _) = NewDispatcher();
+        var sessionA = new RecordingReply();
+        var sessionB = new RecordingReply();
+
+        // Two resting orders by sessionA, one by sessionB (different prices so
+        // they don't cross).
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL), sessionA, 1UL);
+        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 7, 1_000UL), sessionA, 2UL);
+        disp.EnqueueNewOrder(new NewOrderCommand("3", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.05m), 100, 8, 1_000UL), sessionB, 3UL);
+        DrainInbound(disp);
+
+        Assert.Equal(3, OrderOwnerCount(disp));
+
+        // Session A drops. After processing OnSessionClosed on the dispatcher
+        // thread, only B's owner entry must remain. Orders themselves stay on
+        // the book (the engine never sees a Cancel).
+        ((IEntryPointEngineSink)disp).OnSessionClosed(sessionA);
+        DrainInbound(disp);
+
+        Assert.Equal(1, OrderOwnerCount(disp));
+        // Cross sessionB's sell with a fresh aggressor: passive side has no
+        // owner left for A's resting BUYs (correct), but a counter-cross from
+        // sessionB itself exercises the still-live ownership for B.
+        var sessionC = new RecordingReply();
+        disp.EnqueueNewOrder(new NewOrderCommand("4", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 9, 2_000UL), sessionC, 4UL);
+        DrainInbound(disp);
+        // Aggressor (C) sees its trade ER. Passive owner (A) is gone → no ER
+        // delivered to A — verifies the back-reference was actually dropped.
+        Assert.Single(sessionC.Trades);
+        Assert.Empty(sessionA.Trades);
+    }
+
+    [Fact]
+    public void OnSessionClosed_AllowsSessionToBeGarbageCollected()
+    {
+        var (disp, _) = NewDispatcher();
+
+        // Place an order from a session that we will let drop. A helper method
+        // isolates the local rooted reference so the JIT cannot keep it
+        // alive after the helper returns.
+        var weak = PlaceAndForgetSession(disp);
+
+        // At this point the dispatcher's _orderOwners map still references the
+        // session, so it should NOT be collectable yet.
+        ForceGc();
+        Assert.True(weak.IsAlive, "session unexpectedly collected before OnSessionClosed");
+
+        // Notify and drain. After NotifyClosedAndForget returns, the
+        // temporary reference it pulled from WeakReference.Target lives in a
+        // popped stack frame and cannot be kept rooted by the caller.
+        NotifyClosedAndForget(disp, weak);
+
+        ForceGc();
+        Assert.False(weak.IsAlive, "session was not GC-eligible after OnSessionClosed; ownership map still roots it");
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static WeakReference PlaceAndForgetSession(ChannelDispatcher disp)
+    {
+        var session = new RecordingReply();
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            session, 1UL);
+        DrainInbound(disp);
+        var weak = new WeakReference(session);
+        // session goes out of scope when this method returns.
+        return weak;
+    }
+
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    private static void NotifyClosedAndForget(ChannelDispatcher disp, WeakReference weak)
+    {
+        var target = (IEntryPointResponseChannel?)weak.Target;
+        if (target is null) return;
+        ((IEntryPointEngineSink)disp).OnSessionClosed(target);
+        target = null;
+        DrainInbound(disp);
+    }
+
+    private static void ForceGc()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            GC.Collect(2, GCCollectionMode.Forced, blocking: true, compacting: true);
+            GC.WaitForPendingFinalizers();
+        }
+    }
+
+    private static int OrderOwnerCount(ChannelDispatcher disp)
+    {
+        var f = typeof(ChannelDispatcher).GetField("_orderOwners",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        var dict = (System.Collections.IDictionary)f.GetValue(disp)!;
+        return dict.Count;
+    }
+
+
+    [Fact]
     public void Cancel_ByUnknownOrigClOrdId_EmitsRejectAndNoUmdfPacket()
     {
         var (disp, pkt) = NewDispatcher();


### PR DESCRIPTION
Closes #4

Stacked on #30. Re-target to `main` after #30 merges.

## Audit findings

Two long-running leaks rooted every `EntryPointSession` for the host's lifetime — neither was bounded by churn:

1. **`ChannelDispatcher._orderOwners`** kept a strong reference to the `IEntryPointResponseChannel` for every resting order placed by that session. After the session disconnected, the orders correctly stayed on the book (they ARE the book), but the ownership map kept the entire `NetworkStream` + `Socket` + send queue rooted forever.
2. **`EntryPointListener._sessions`** appended every accepted session and never removed them.

ID-counter audit (documented in code as well):

| Counter | Type | Worst-case rate | Time to overflow | Verdict |
|---|---|---|---|---|
| `MatchingEngine._nextOrderId` | `long` | 1e9/s | ~292 years | safe |
| `MatchingEngine._nextTradeId` | `uint` | 100k/s | ~12 hours | wire-format-bound; flagged for follow-up |
| `MatchingEngine._rptSeq` | `uint` | 100k/s | ~12 hours | per-channel × `SequenceVersion` — see below |
| `ChannelDispatcher.SequenceNumber` | `uint` | 10k/s | ~5 days | bumps `SequenceVersion` on overflow |

## Fixes

* New `IEntryPointEngineSink.OnSessionClosed(reply)` notification. `HostRouter` fans it to every dispatcher; `ChannelDispatcher` enqueues a `ReleaseOwner` work item so the sweep runs on the dispatch thread (single-threaded engine guarantee preserved).
* `EntryPointSession.Close()` invokes `OnSessionClosed` on the sink **and** an internal `OnClosedCallback` hook.
* `EntryPointListener` registers the callback to remove the session from `_sessions`.
* `SequenceNumber` overflow now bumps `SequenceVersion`, resets the counter to 0 (next ++ produces 1), and re-patches the on-wire header so the new `(version, seq)` tuple is observable to consumers.

Resting orders stay on the book — passive fills against orphaned orders simply skip the `ER_Trade` writeback.

## Tests

* `ChannelDispatcherTests.SequenceNumber_NearOverflow_BumpsSequenceVersion_AndResets`
* `ChannelDispatcherTests.OnSessionClosed_ReleasesOrderOwnerEntries_LeavesOrdersOnBook`
* `ChannelDispatcherTests.OnSessionClosed_AllowsSessionToBeGarbageCollected` — `WeakReference` + multi-cycle `GC.Collect` with the session handle isolated in `NoInlining` helpers; the original leak would keep `IsAlive == true`.
* `SoakSmokeTests.SoakBurst_60Seconds_NoLeaks_NoErrors_NoSeqViolations` — opt-in via `SOAK_TEST=1`. Spins up the host + the synthetic trader (driven through its public surface, never via internal encoders), runs a 60 s burst with a 90 s hard timeout, asserts no errors logged, no per-channel seq gaps, and `< 50 MiB` memory delta from the pre-burst baseline.

Run the soak test locally:
```
SOAK_TEST=1 dotnet test tests/B3.Exchange.Host.Tests \
  --filter "FullyQualifiedName~SoakSmokeTests" -c Release
```

## Soak test result (local)

```
[soak] elapsed=60.0s orders=2513 trades=3020 packets=2597 \
       memBaseline=902,728 memAfter=1,297,080 delta=394,352
Passed B3.Exchange.Host.Tests.SoakSmokeTests.SoakBurst_60Seconds_NoLeaks_NoErrors_NoSeqViolations [1 m 2 s]
```

* 60.0 s burst, 2 513 orders, 3 020 trades, 2 597 multicast packets.
* Post-burst memory delta: **~385 KiB** vs. the 50 MiB ceiling.
* Zero errors logged, zero `SequenceNumber` gaps.

## Pre-PR checklist

* `dotnet build -c Release` ✅ (warnings-as-errors)
* `dotnet test -c Release` ✅ — 114 tests passed (soak skipped without env var)
* `dotnet format --verify-no-changes` ✅

## Follow-ups

* `MatchingEngine._nextTradeId` widening requires a B3 UMDF wire-format change — out of scope for this PR but worth a tracking issue if we ever run a full trading day at >100 k trades/s.