### PR TITLE
docs: B3 EntryPoint compliance audit

### DIFF
--- a/docs/B3-ENTRYPOINT-ARCHITECTURE.md
+++ b/docs/B3-ENTRYPOINT-ARCHITECTURE.md
@@ -1,0 +1,717 @@
+# B3 EntryPoint — Target Architecture (Ephemeral)
+
+Sister document to [`B3-ENTRYPOINT-COMPLIANCE.md`](B3-ENTRYPOINT-COMPLIANCE.md).
+The compliance doc says **what's broken**; this doc says **how we will fix it
+coherently**, so the 19+ open spec-compliance issues converge on a single
+target shape instead of each landing as an isolated patch.
+
+> **Scope note.** This document targets the **ephemeral** (in-memory) version
+> of the simulator. Persistence (WAL + snapshot, recovery on restart) is
+> deliberately out of scope and tracked separately in
+> [Appendix A](#appendix-a--persistence-deferred-for-v2). The
+> architectural boundaries proposed here are designed so persistence can be
+> added later **without rework** to the gateway/core split.
+
+> **Reading order.** §1 (Why) → §2 (Current vs. target) → §3 (Component
+> split — the spine) → §4 (Domain model). §10 (Migration plan) maps the
+> existing `GAP-NN` issues to phases.
+
+---
+
+## 1. Why this doc exists
+
+The compliance audit surfaced 19 actionable gaps (#39–#57). Roughly 12 of
+them touch shared session state (sequence counters, retransmission buffer,
+keep-alive scheduler, CoD timer, session-versioned credentials, order
+ownership, …). Closing each in isolation would create overlapping notions
+of "session" all over `EntryPointSession`, `ChannelDispatcher`, and the
+host.
+
+Two architectural decisions made during scoping drive everything below:
+
+1. **The simulator stops being single-tenant.** Multiple firms × multiple
+   sessions per firm, each with its own credentials, throttle, CoD config.
+   Session identity is independent of any single TCP connection.
+2. **Order-entry edge concerns are split from the matching core.** Wire
+   framing, FIXP state machine, retransmission, and authentication live in
+   a dedicated **Gateway** component with a strict contract to the
+   **Core**. They share no mutable state. (Mirrors B3's real deployment
+   shape.)
+
+Together these push the codebase from *"per-TCP `EntryPointSession`"* to a
+proper component model with explicit session lifecycle and a typed
+contract between layers.
+
+---
+
+## 2. Current vs. target — 30-second tour
+
+### Current
+
+```
+TCP client ──► EntryPointSession ──► HostRouter ──► ChannelDispatcher ──► MatchingEngine
+                  (TCP socket           (by SecurityID)         (in-memory book)
+                   = "session"
+                   = MsgSeqNum
+                   = OrderOwnership target)
+```
+
+- One `EntryPointSession` per TCP connection. Conflates: TCP socket + FIXP
+  identity + outbound sequence counter + per-session config.
+- No FIXP handshake. Application messages flow on TCP `accept`.
+- Outbound sequence is a local `_msgSeqNum` per-instance — dies with the
+  socket.
+- Single `EnteringFirm` from config.
+- `ChannelDispatcher` holds direct references to `IEntryPointResponseChannel`
+  (TCP-bound), so matching code transitively depends on the wire schema.
+
+### Target
+
+```
+                ┌────────────────── B3.Exchange.Gateway ──────────────────┐
+                │  TcpListener → TcpTransport ─┐                          │
+                │                               │                          │
+                │              ┌──── FixpSession (1 per logical session) ─│──┐
+TCP socket ─────┤              │      • SOFH framing                       │  │
+                │              │      • FIXP state machine                 │  │
+                │              │      • MsgSeqNum + retx buffer (RAM)      │  │
+                │              │      • Auth, throttle, CoD timer          │  │
+                │              └────────────┬──────────────────────────────│  │
+                │                           │ (ICoreInbound)               │  │
+                └───────────────────────────│──────────────────────────────┘  │
+                                            ▼                                  │
+                ┌─────────────────── B3.Exchange.Core ──────────────────────┐  │
+                │   HostRouter → ChannelDispatcher → MatchingEngine          │  │
+                │   (1 dispatcher per UMDF channel; engine owns books)       │  │
+                │                                                            │  │
+                │   ─► IUmdfPacketSink ─► MulticastUdpPacketSink ─► UDP MC   │  │
+                │                                                            │  │
+                │   ─► IGatewayInbound.Deliver(SessionId, ExecutionEvent) ───│──┘
+                └────────────────────────────────────────────────────────────┘
+
+                    Contract (B3.Exchange.Contracts):
+                      • InboundOrderCommand / CancelCommand / ModifyCommand   (Gateway → Core)
+                      • ExecutionEvent / RejectEvent / BusinessRejectEvent    (Core → Gateway)
+                      • SessionId, FirmId, ClOrdID  (neutral primitives, no SBE)
+```
+
+Key differences:
+
+- **Two assemblies, two responsibility cones.** Gateway owns the wire and
+  the session. Core owns matching and market-data publication.
+- **No SBE in the Core.** Core consumes neutral DTOs; the SBE EntryPoint
+  schema is a Gateway-only dependency.
+- **`FixpSession` outlives `TcpTransport`.** A reconnect (`Establish`
+  within the same `sessionVerId`) reattaches a fresh transport to the same
+  session, preserving outbound seq + retx buffer.
+- **Order ownership lives in the Gateway** (`OrderId → SessionId`). Core
+  stamps `SessionId` on each `ExecutionEvent`; Gateway resolves the live
+  `FixpSession` at delivery time.
+
+---
+
+## 3. Component split — Gateway / Core / Contracts
+
+This is the architectural backbone. Three assemblies, strict contract
+between them, no shared mutable state. The split is designed as if it were
+an IPC boundary even though both run in-process — so a future move to a
+multi-process deployment is mechanical, not a rewrite.
+
+### 3.1 Project layout
+
+```
+src/
+  B3.Exchange.Contracts/             ← NEW
+    SessionId.cs
+    FirmId.cs
+    Commands/
+      InboundOrderCommand.cs
+      InboundCancelCommand.cs
+      InboundModifyCommand.cs
+    Events/
+      ExecutionEvent.cs
+      RejectEvent.cs
+      BusinessRejectEvent.cs
+    ICoreInbound.cs                  ← Gateway → Core
+    IGatewayInbound.cs               ← Core → Gateway
+
+  B3.Exchange.Gateway/               ← NEW (replaces B3.Exchange.EntryPoint)
+    TcpListener.cs
+    TcpTransport.cs                  ← owns Socket + send queue
+    FixpSession.cs                   ← single-thread actor
+    FixpStateMachine.cs
+    RetransmitBuffer.cs              ← in-RAM ring per session
+    SessionRegistry.cs
+    FirmRegistry.cs
+    OrderOwnershipMap.cs             ← OrderId → SessionId (per-channel)
+    Framing/
+      SofhFrameReader.cs             ← #39 (GAP-01)
+      SofhFrameWriter.cs
+      InboundDecoder.cs
+      OutboundEncoder.cs             ← ER + reject + business-reject
+    Auth/
+      CredentialValidator.cs         ← #43 (GAP-05)
+    GatewayHost.cs                   ← wires listener → sessions → ICoreInbound
+
+  B3.Exchange.Core/                  ← RENAMED from B3.Exchange.Integration
+    HostRouter.cs
+    ChannelDispatcher.cs             ← no longer holds IEntryPointResponseChannel
+    InstrumentDefinitionPublisher.cs
+    SnapshotRotator.cs
+    Multicast/
+      MulticastUdpPacketSink.cs
+    CoreHost.cs                      ← exposes ICoreInbound, accepts IGatewayInbound
+
+  B3.Exchange.Matching/              ← unchanged
+  B3.Exchange.Instruments/           ← unchanged
+  B3.Umdf.WireEncoder/               ← unchanged
+  B3.EntryPoint.Sbe/                 ← Gateway-only consumer now
+  B3.Umdf.Sbe/                       ← Core-only consumer
+
+  B3.Exchange.Host/                  ← wires Gateway + Core together
+```
+
+### 3.2 The Gateway↔Core contract
+
+The contract is **two interfaces and a handful of neutral DTOs**.
+
+```csharp
+// B3.Exchange.Contracts
+
+public readonly record struct SessionId(string Value);
+public readonly record struct FirmId(string Value);
+
+public sealed record InboundOrderCommand(
+    SessionId   Session,
+    FirmId      Firm,
+    string      ClOrdID,
+    int         SecurityId,
+    Side        Side,
+    OrderType   Type,
+    long        PriceMantissa,    // /10000
+    long        Quantity,
+    TimeInForce Tif,
+    long        ReceivedAtNs);
+
+public sealed record InboundCancelCommand(
+    SessionId Session, FirmId Firm,
+    string    ClOrdID,
+    string?   OrigClOrdID,        // either this OR ExplicitOrderId
+    long?     ExplicitOrderId,
+    int       SecurityId,
+    long      ReceivedAtNs);
+
+public sealed record InboundModifyCommand(/* analogous */);
+
+public sealed record ExecutionEvent(
+    SessionId Session,            // routing back to originator
+    long      OrderId,
+    long      TradeId,
+    string    ClOrdID,
+    ExecType  ExecType,           // New, PartialFill, Fill, Cancelled, Replaced
+    long      LastQty,
+    long      LastPx,
+    long      LeavesQty,
+    long      CumQty,
+    long      EmittedAtNs);
+
+public sealed record RejectEvent(
+    SessionId      Session,
+    string         ClOrdID,
+    OrdRejReason   Reason,
+    string?        Text);
+
+public sealed record BusinessRejectEvent(/* per spec §3, #50 */);
+
+public interface ICoreInbound
+{
+    void Submit(InboundOrderCommand   cmd);
+    void Submit(InboundCancelCommand  cmd);
+    void Submit(InboundModifyCommand  cmd);
+}
+
+public interface IGatewayInbound
+{
+    void Deliver(ExecutionEvent       evt);
+    void Deliver(RejectEvent          evt);
+    void Deliver(BusinessRejectEvent  evt);
+}
+```
+
+Properties of the contract:
+
+- **No SBE types.** Neutral primitives only. Contracts assembly references
+  nothing wire-specific.
+- **Async by message-passing semantics.** Implementations enqueue work to
+  the receiver's dispatch loop and return immediately. No callbacks, no
+  shared locks across the boundary.
+- **`SessionId` is the only routing key Core knows.** Core never holds a
+  reference to a transport, socket, or `FixpSession` instance. It only
+  produces events stamped with `SessionId`.
+- **Order ownership is Gateway-side.** When Core emits an
+  `ExecutionEvent`, the Gateway looks up the live `FixpSession` for that
+  `SessionId`, encodes the ER frame with that session's outbound seq, and
+  enqueues to its `TcpTransport`. If the session is `Suspended` (TCP gone
+  but session alive), the ER is still recorded in the retx buffer and
+  delivered on next `Establish`.
+
+### 3.3 What the boundary buys us
+
+| Benefit | How |
+| --- | --- |
+| Independent evolution | EntryPoint spec changes touch Gateway only; matching changes touch Core only. |
+| Clean tests | Test Gateway with a fake `ICoreInbound`; test Core with a fake `IGatewayInbound`. No SBE in matching tests. |
+| Future multi-process | Replace in-process `ICoreInbound` impl with an IPC proxy (Unix socket / shmem ring). DTOs are already serializable. |
+| Failure isolation hooks | Gateway can disconnect a misbehaving session without touching Core; Core can pause a channel without touching sessions. |
+| Mirrors B3 reality | EntryPoint gateway and matching engine are separate processes at B3. |
+
+---
+
+## 4. Domain model
+
+Lives in `B3.Exchange.Gateway` (except where noted). Concrete types, not
+just nouns.
+
+### 4.1 `Firm`
+Static config-loaded record. Identity for a participant (corretora).
+
+```csharp
+public sealed record Firm(
+    FirmId  Id,                        // e.g. "FIRM01"
+    string  Name,
+    int     EnteringFirmCode);         // numeric code embedded in SBE headers
+```
+
+### 4.2 `SessionCredential`
+Static config-loaded record. One per `(firm, sessionId)` pair.
+
+```csharp
+public sealed record SessionCredential(
+    SessionId           SessionId,
+    FirmId              Firm,
+    string              AccessKey,            // dev: plain compare; prod: hashed (deferred)
+    IReadOnlyList<IPNetwork>?  AllowedSourceCidrs,  // optional whitelist
+    SessionPolicy       Policy);               // throttle, CoD default, etc.
+
+public sealed record SessionPolicy(
+    int  ThrottleMessagesPerSecond,
+    int  KeepAliveIntervalMs,
+    CancelOnDisconnectType DefaultCoD,
+    int  RetransmitBufferSize);                // bounded ring
+```
+
+### 4.3 `FixpSession`
+The heart of the Gateway. Single-threaded actor. **One per
+`(firm, sessionId)` pair**, not per TCP connection. Survives transport
+disconnect.
+
+```csharp
+public sealed class FixpSession
+{
+    public SessionId Id { get; }
+    public FirmId    Firm { get; }
+    public FixpState State { get; private set; }   // see §5
+    public long      SessionVerId { get; private set; }
+    public uint      OutboundSeq { get; private set; }   // next-to-send
+    public uint      InboundExpectedSeq { get; private set; }
+
+    private readonly RetransmitBuffer _retx;
+    private readonly Channel<SessionWorkItem> _work;     // single dispatch loop
+    private TcpTransport? _transport;                    // null when Suspended
+
+    // From transport (after framing/decoding):
+    public void OnFrame(InboundFrame frame) => _work.Writer.TryWrite(...);
+
+    // From Core (via IGatewayInbound):
+    public void Deliver(ExecutionEvent evt) => _work.Writer.TryWrite(...);
+
+    // Lifecycle:
+    public void AttachTransport(TcpTransport t);
+    public void DetachTransport(DisconnectReason r);
+}
+```
+
+Invariants enforced on the dispatch loop:
+
+1. `OutboundSeq` allocation, retx-buffer append, and TcpTransport enqueue
+   happen **atomically** in the same critical section (the dispatch
+   thread).
+2. `InboundExpectedSeq` is updated only after the frame is fully decoded
+   and forwarded to `ICoreInbound`.
+3. State transitions are funneled through `FixpStateMachine.Apply` — no
+   ad-hoc state mutations.
+
+### 4.4 `TcpTransport`
+Owns one `Socket`. Knows nothing about FIXP semantics — just frames
+bytes in (delivers `RawFrame` to attached `FixpSession`) and bytes out
+(consumes a bounded send queue). Replaceable.
+
+```csharp
+public sealed class TcpTransport
+{
+    public TransportId Id { get; }
+    public IPEndPoint  RemoteEndPoint { get; }
+
+    public event Action<RawFrame>?    FrameReceived;
+    public event Action<DisconnectReason>? Disconnected;
+
+    public bool TryEnqueue(ReadOnlyMemory<byte> wireBytes);   // bounded; false ⇒ overflow
+    public void Close(DisconnectReason r);
+}
+```
+
+The lifecycle is:
+1. `TcpListener` accepts → creates `TcpTransport`.
+2. `TcpTransport` reads first frame (`Negotiate`) → hands to
+   `SessionRegistry.Resolve(credentials)` → returns or creates a
+   `FixpSession`.
+3. `FixpSession.AttachTransport(transport)`. From here the transport just
+   pumps bytes; the session owns semantics.
+
+### 4.5 `SessionRegistry`
+In-RAM map `SessionId → FixpSession`. Populated lazily on first
+`Negotiate` for a credential present in `FirmRegistry`. Authority for
+"does this session exist and is it active?".
+
+### 4.6 `FirmRegistry`
+In-RAM map `FirmId → Firm` plus `(SessionId → SessionCredential)`. Loaded
+once from config at startup; immutable thereafter (for ephemeral). Future:
+hot-reload via admin endpoint.
+
+### 4.7 `OrderOwnershipMap` (per channel)
+`OrderId → SessionId`. Lives in the Gateway's per-channel state, populated
+on order acknowledgement, consulted on every inbound `ExecutionEvent` from
+Core. Bounded by the working order set; entries dropped on terminal events
+(Filled, Cancelled, Expired, Rejected).
+
+---
+
+## 5. State machine
+
+`FixpSession.State` is an explicit enum; transitions are the ONLY way to
+mutate state.
+
+```
+       ┌────────────┐  Negotiate(valid)         ┌──────────────┐
+       │   Idle     │ ────────────────────────► │  Negotiated  │
+       └────────────┘                            └──────┬───────┘
+              ▲                                          │
+              │ NegotiateReject                          │ Establish(valid)
+              │                                          ▼
+              │                                  ┌──────────────┐
+              │                                  │ Established  │◄──┐
+              │                                  └──────┬───────┘   │
+              │                                         │           │ Establish (re-attach
+              │                          TCP loss /     │           │  same sessionVerId)
+              │                          Terminate      ▼           │
+              │                                  ┌──────────────┐   │
+              │                                  │  Suspended   │ ──┘
+              │                                  │ (transport   │
+              │                                  │  detached;   │
+              │                                  │  retx held)  │
+              │                                  └──────┬───────┘
+              │                                         │ Terminate /
+              │                                         │ session-end /
+              │                                         │ daily reset
+              │                                         ▼
+              │                                  ┌──────────────┐
+              └────────────────────────────────  │  Terminated  │
+                                                 └──────────────┘
+```
+
+**Acceptance matrix** (subset; full table goes in code XML doc):
+
+| State | Negotiate | Establish | Application msg | Sequence | Terminate | RetransmitRequest |
+| --- | --- | --- | --- | --- | --- | --- |
+| Idle | ✓ → Negotiated / NegotiateReject | NotApplied | Reject + Terminate (UNNEGOTIATED) | – | ✓ | – |
+| Negotiated | NegotiateReject(ALREADY_NEGOTIATED) | ✓ → Established / EstablishReject | Reject + Terminate (UNESTABLISHED) | NotApplied | ✓ | – |
+| Established | NegotiateReject | EstablishReject | ✓ | ✓ | ✓ → Terminated | ✓ (replay from retx) |
+| Suspended | NegotiateReject(ALREADY_NEGOTIATED) | ✓ → Established (re-attach) | – (no transport) | – | ✓ → Terminated | – (deferred to re-establish) |
+| Terminated | terminal | terminal | terminal | terminal | terminal | terminal |
+
+Closes #42 (GAP-04), #43 (GAP-05), #44 (GAP-06 keep-alive flows from
+this).
+
+---
+
+## 6. Threading model
+
+| Thread / loop | Owner | Responsibilities |
+| --- | --- | --- |
+| `TcpListener` accept loop | Gateway | Accept → wrap in `TcpTransport` → handoff. |
+| `TcpTransport` recv loop | Gateway, 1/transport | Read socket, SOFH-frame, raise `FrameReceived`. **Does not decode SBE.** |
+| `TcpTransport` send loop | Gateway, 1/transport | Drain send queue → write socket. Bounded queue with `DropWrite` → on overflow, request session `Terminate`. |
+| `FixpSession` dispatch loop | Gateway, 1/session | Owns ALL session state mutation: state-machine transitions, decode-then-forward, allocate `OutboundSeq` + retx-append + transport-enqueue (atomic triple), retx replay, throttle accounting. |
+| `ChannelDispatcher` work loop | Core, 1/channel | Unchanged. Single-thread per `SecurityID`-channel. |
+| `SnapshotRotator` timer | Core, 1/channel | Unchanged. |
+| Keep-alive scheduler | Gateway, 1/session (timer or piggy-backed on dispatch loop) | Emits `Sequence` heartbeats, monitors inbound silence → `Terminate`. |
+| Cancel-on-Disconnect timer | Gateway, 1/session | On `Detach`, schedules cancel-all after `cod.gracePeriodMs`; cancelled if `Establish` re-attaches in time. |
+
+**Critical guarantee:** the `(allocate seq → retx append → transport
+enqueue)` triple is on the FixpSession dispatch loop and is the ONLY path
+that writes outbound. There is no other producer for outbound seq numbers.
+
+---
+
+## 7. Authentication (ephemeral)
+
+Simplified for the in-memory phase; structured to upgrade later.
+
+- **Credential format on the wire** (per spec §4.5.2): `Negotiate.credentials`
+  is a JSON blob `{"auth_type":"basic","username":"<sessionId>","access_key":"<token>"}`.
+- **Validation** (`CredentialValidator`):
+  1. `username` exists in `SessionRegistry` and matches a
+     `SessionCredential`.
+  2. `access_key` matches stored value (plain string compare in dev).
+  3. Source IP is in `AllowedSourceCidrs` if specified.
+  4. `sessionVerId` is strictly greater than the last seen for this
+     session (in-memory counter; fresh after restart).
+  5. Session is not already `Established` with a different transport
+     (else `NegotiateReject(ALREADY_NEGOTIATED, currentSessionVerId)`).
+- **No per-message auth.** Once `Established`, the session is trusted
+  until `Terminated`.
+- **Dev mode flag** (`auth.devMode: true` in config) bypasses access_key
+  check entirely; logs a warning on startup. Useful for tests and local
+  exploration.
+- **Future (deferred):** bcrypt-hashed access keys at rest, hot-reload of
+  credentials via admin endpoint, optional TLS. Listed in
+  [Appendix A](#appendix-a--persistence-deferred-for-v2).
+
+---
+
+## 8. Configuration schema
+
+Extends today's `exchange-simulator.json`. Old single-tenant `tcp` block
+is replaced.
+
+```jsonc
+{
+  "tcp": {
+    "listen": "0.0.0.0:9876",
+    "maxConcurrentTransports": 64
+  },
+  "auth": {
+    "devMode": false
+  },
+  "firms": [
+    {
+      "id": "FIRM01",
+      "name": "Acme Corretora",
+      "enteringFirmCode": 8
+    }
+  ],
+  "sessions": [
+    {
+      "sessionId": "SESS-001",
+      "firmId": "FIRM01",
+      "accessKey": "dev-shared-secret",
+      "allowedSourceCidrs": ["127.0.0.1/32", "10.0.0.0/8"],
+      "policy": {
+        "throttleMessagesPerSecond": 200,
+        "keepAliveIntervalMs": 1000,
+        "defaultCancelOnDisconnect": "SESSION_END",
+        "retransmitBufferSize": 10000
+      }
+    }
+  ],
+  "channels": [
+    /* unchanged from today: per-UMDF-channel multicast group + instruments */
+  ]
+}
+```
+
+Validation at startup:
+- Every `sessions[].firmId` resolves against `firms[]`.
+- `sessionId` values are unique.
+- `auth.devMode=true` AND any `sessions[].accessKey` is non-empty → log a
+  warning ("dev mode bypasses access_key").
+
+---
+
+## 9. Operator surface
+
+For the ephemeral phase, the existing HTTP server (`HostConfig.http`)
+gains read-only diagnostics:
+
+- `GET /sessions` — list all known sessions: `id`, `firmId`, `state`,
+  `sessionVerId`, `outboundSeq`, `inboundExpectedSeq`, `retxBufferDepth`,
+  `attachedTransportId?`, `lastActivityAtMs`.
+- `GET /sessions/{id}` — same, single session.
+- `GET /firms` — list firms.
+- Existing `/health/*` and `/metrics` continue to work; metrics gain
+  per-session counters (`fixp_session_outbound_messages_total{session_id}`,
+  `fixp_session_retx_replay_total`, `fixp_session_state{session_id}`,
+  etc.).
+
+Mutating endpoints (force-terminate, reset session, etc.) are **deferred**
+to v2 — they imply persistence semantics we don't want to commit to yet.
+
+---
+
+## 10. Migration plan
+
+Five phases. Each phase is mergeable on its own — simulator continues to
+work end-to-end after every phase. Each phase closes a known set of
+GAP-NN issues.
+
+### Phase 0 — Wire framing hardening (no architecture changes)
+- Add SOFH (12-byte total header) — #39 (GAP-01).
+- Consume variable-length data after SBE fixed block — #40 (GAP-02).
+- Enforce `messageLength ≤ 512` — #41 (GAP-03 part 1).
+- Send `Terminate` on framing/decoding errors — #41 (GAP-03 part 2).
+
+Touches `EntryPointFrameReader`, `EntryPointSession.Close()`. Single PR,
+small surface. Lands first because it's prerequisite for any wire-level
+testing of later phases.
+
+### Phase 1 — Component split (the big one)
+- Create `B3.Exchange.Contracts` with DTOs and interfaces (§3.2).
+- Create `B3.Exchange.Gateway`; move all of `B3.Exchange.EntryPoint`
+  into it; rename old `EntryPointSession` to `LegacyTcpSession` and
+  carve out `TcpTransport` + `FixpSession` skeletons.
+- Rename `B3.Exchange.Integration` → `B3.Exchange.Core`. Strip all
+  references to `IEntryPointResponseChannel` from `ChannelDispatcher`;
+  replace with `IGatewayInbound` from contracts.
+- Wire both via `B3.Exchange.Host` using in-process implementations of
+  the interfaces.
+- Move `OrderOwnershipMap` from Core to Gateway; Core now stamps
+  `SessionId` on every event.
+
+No new spec compliance closed in this phase, but **all subsequent phases
+become cleanly localized** to the Gateway.
+
+### Phase 2 — FIXP session lifecycle
+- `SessionRegistry` + `FirmRegistry` from config — closes #8 (multi-firm)
+  by construction.
+- `FixpStateMachine` enum + transition matrix.
+- `Negotiate` / `NegotiateResponse` / `NegotiateReject` — #42 (GAP-04).
+- `Establish` / `EstablishAck` / `EstablishReject` — #43 (GAP-05).
+- `CredentialValidator` (dev mode + plain compare) — #43.
+- `Terminate` flow + `TerminationCode` enum — extends Phase 0.
+
+### Phase 3 — Reliable delivery (in-memory)
+- `RetransmitBuffer` (bounded ring per session) — #46 (GAP-08).
+- `Sequence` keep-alive heartbeats both directions — #44 (GAP-06).
+- `NotApplied` on inbound gap — #45 (GAP-07).
+- `RetransmitRequest` handling: replay from retx buffer, set `PossResend`
+  flag — #46 (GAP-08), #GAP-13.
+- Suspended ↔ Established re-attach via re-`Establish`.
+
+### Phase 4 — Operational hardening
+- Cancel-on-Disconnect timer — #47 (GAP-09).
+- Daily reset (in-memory): drain → bump `SessionVerId` → reset seqs →
+  resume — #51 (GAP-15).
+- Throttle enforcement — #52 (GAP-16).
+- `BusinessMessageReject` for malformed application messages — #50
+  (GAP-14).
+- Improve `OrdRejReason` mapping — #54 (GAP-18 / fixes the all-zeros
+  stub).
+- Operator HTTP endpoints (§9).
+
+### Closure summary
+
+| Phase | Issues closed |
+| --- | --- |
+| 0 | #39, #40, #41 |
+| 1 | (none directly; enables) |
+| 2 | #8, #42, #43, #16 (supersede), #57 (sessionVerId in-mem) |
+| 3 | #44, #45, #46 |
+| 4 | #47, #50, #51, #52, #54 + #11 (supersede), #9 (supersede) |
+
+Issues not in any phase are tracked separately (e.g. STP / cross-prevention
+in #14 → matching-side, scheduled independently).
+
+---
+
+## 11. Test strategy
+
+Three test surfaces, mirroring the component split.
+
+### 11.1 Gateway unit tests (`tests/B3.Exchange.Gateway.Tests`)
+- `FixpStateMachine` transition matrix (one test per cell).
+- `RetransmitBuffer`: append/replay correctness, ring eviction, replay
+  with `PossResend` flag, request beyond retained range → reject.
+- `CredentialValidator`: each rejection branch.
+- `SofhFrameReader`: malformed frames produce specific `Terminate`
+  codes.
+- `FixpSession` dispatch loop: under concurrent inbound from transport
+  + outbound from Core, outbound seq is gap-free and retx contents
+  match send order.
+
+### 11.2 Core unit tests (`tests/B3.Exchange.Core.Tests`)
+- ChannelDispatcher tests now use a fake `IGatewayInbound` collector
+  (no SBE in test code).
+- Existing matching tests continue unchanged (no Gateway dependency).
+
+### 11.3 End-to-end tests (`tests/B3.Exchange.E2E.Tests`)
+- Spin up `Host` in-process bound to ephemeral port; drive a real TCP
+  client speaking SBE + SOFH against it.
+- Scenarios: full session lifecycle, gap recovery, CoD trigger, daily
+  reset mid-session, throttle reject.
+- Use `SbeB3UmdfConsumer` style decoder to verify multicast output.
+
+---
+
+## 12. Open questions
+
+These are deliberately deferred — flagged so we don't paint ourselves
+into a corner.
+
+1. **Single `FixpSession` instance vs. one per `(sessionId, sessionVerId)`?**
+   Spec lets a session be re-negotiated (new `sessionVerId`) on the same
+   `sessionId`. Current proposal: one instance, mutable
+   `SessionVerId`, retx buffer cleared on `sessionVerId` bump. Simpler.
+2. **Gateway↔Core back-pressure.** If Core is slow, Gateway's calls into
+   `ICoreInbound.Submit` should never block the FixpSession dispatch
+   loop. Proposal: Core's implementation is "enqueue to ChannelDispatcher
+   bounded queue; if full, return failure → Gateway emits
+   `BusinessMessageReject(SYSTEM_BUSY)` to the originator". Confirm in
+   Phase 1.
+3. **Multiple TCP transports for one session.** Spec implies at most one
+   active transport per `sessionId`. Concurrent `Negotiate` from a
+   second source while one is `Established` → reject second. Confirm
+   exact spec wording in Phase 2.
+4. **Daily reset coordination.** When a daily reset happens, does the
+   Core need to coordinate (drain channels) before sessions clear seqs?
+   Proposal: Core reset and Gateway reset are independent events
+   triggered on the same wall-clock; drain happens at each loop's own
+   pace. Confirm in Phase 4.
+5. **Should `OrderOwnershipMap` survive `Suspended` state?** Yes —
+   otherwise ER for filled-while-disconnected orders would have nowhere
+   to go on re-attach. Just need to bound it (eviction on terminal
+   states already does this).
+
+---
+
+## Appendix A — Persistence (deferred for v2)
+
+Out of scope for the ephemeral architecture above. Captured here so the
+boundaries set in §3 remain compatible with future durability.
+
+**Sketch:** WAL + snapshot, event-sourced, per channel and per session.
+
+- **Channel WAL**: tee of UMDF Inc_* frames + inbound EntryPoint frames,
+  ordered by wall-clock + journal seq. Mirrors the snapshot+incremental
+  pattern UMDF already uses for consumers.
+- **Session WAL**: per-session lifecycle events + outbound ER frames +
+  keep-alive beats. Enables retx buffer to survive process restart.
+- **Snapshots**: periodic + on clean shutdown + at daily reset. Snapshot
+  payload reuses UMDF snapshot frame serialization where applicable.
+- **Recovery**: load latest snapshot, replay WAL forward (do NOT re-emit
+  to wire), reopen listeners, clients reconnect with fresh `Establish`.
+- **`fsync` policy**: configurable (`every-batch` default, `every-event`,
+  `periodic`).
+
+The `B3.Exchange.Core` and `B3.Exchange.Gateway` boundaries in §3 are
+unchanged by this — persistence is added via a `IWalAppender` interface
+injected into both, with separate WAL files per concern. The Contracts
+assembly is unaffected.
+
+Other items deferred to v2:
+- Bcrypt-hashed `accessKey` at rest.
+- Hot-reload of `firms` / `sessions` / `instruments` via admin
+  endpoints.
+- Mutating operator endpoints (force-terminate, reset session).
+- Optional TLS between client and gateway.
+- Multi-process Gateway/Core deployment (the §3 contract makes this
+  mechanical; deferring the operational work).

--- a/docs/B3-ENTRYPOINT-ARCHITECTURE.md
+++ b/docs/B3-ENTRYPOINT-ARCHITECTURE.md
@@ -590,21 +590,21 @@ become cleanly localized** to the Gateway.
 - `Terminate` flow + `TerminationCode` enum — extends Phase 0.
 
 ### Phase 3 — Reliable delivery (in-memory)
-- `RetransmitBuffer` (bounded ring per session) — #46 (GAP-08).
+- `RetransmitBuffer` (bounded ring per session) — #43 (GAP-08).
 - `Sequence` keep-alive heartbeats both directions — #44 (GAP-06).
-- `NotApplied` on inbound gap — #45 (GAP-07).
+- `NotApplied` on inbound gap — #42 (GAP-07).
 - `RetransmitRequest` handling: replay from retx buffer, set `PossResend`
-  flag — #46 (GAP-08), #GAP-13.
+  flag — #43 (GAP-08), GAP-13.
 - Suspended ↔ Established re-attach via re-`Establish`.
 
 ### Phase 4 — Operational hardening
-- Cancel-on-Disconnect timer — #47 (GAP-09).
+- Cancel-on-Disconnect timer — #50 (GAP-18).
 - Daily reset (in-memory): drain → bump `SessionVerId` → reset seqs →
-  resume — #51 (GAP-15).
-- Throttle enforcement — #52 (GAP-16).
+  resume — #44 (GAP-09).
+- Throttle enforcement — #52 (GAP-20).
 - `BusinessMessageReject` for malformed application messages — #50
   (GAP-14).
-- Improve `OrdRejReason` mapping — #54 (GAP-18 / fixes the all-zeros
+- Improve `OrdRejReason` mapping — #49 (GAP-17 / fixes the all-zeros
   stub).
 - Operator HTTP endpoints (§9).
 
@@ -614,9 +614,9 @@ become cleanly localized** to the Gateway.
 | --- | --- |
 | 0 | #39, #40, #41 |
 | 1 | (none directly; enables) |
-| 2 | #8, #42, #43, #16 (supersede), #57 (sessionVerId in-mem) |
-| 3 | #44, #45, #46 |
-| 4 | #47, #50, #51, #52, #54 + #11 (supersede), #9 (supersede) |
+| 2 | #8, #42, #43, #16 (supersede) |
+| 3 | #42, #43, #44 |
+| 4 | #49, #50, #51, #52 + #11 (supersede), #9 (supersede) |
 
 Issues not in any phase are tracked separately (e.g. STP / cross-prevention
 in #14 → matching-side, scheduled independently).

--- a/docs/B3-ENTRYPOINT-COMPLIANCE.md
+++ b/docs/B3-ENTRYPOINT-COMPLIANCE.md
@@ -1,0 +1,164 @@
+# B3 Binary EntryPoint — Compliance Audit
+
+Audit of how `src/B3.Exchange.EntryPoint` and friends compare to the official
+B3 spec. This is the canonical "what's missing / what's wrong vs. the wire
+protocol" reference for the simulator — issues that track individual gaps
+should link back to a row in the table below by `#GAP-NN`.
+
+## Sources audited
+
+| Document | Version | Notes |
+| --- | --- | --- |
+| [BinaryEntryPoint Messaging Guidelines][guidelines] | 8.4.2.1 (2026-03-20) | Behavioural reference (handshake, COD, throttle, validations). |
+| [`schemas/b3-entrypoint-messages-8.4.2.xml`][schema] | 8.4.2 | The SBE schema vendored in this repo. |
+
+[guidelines]: https://www.b3.com.br/data/files/4E/C3/97/F9/2DA1D910A3ABA1D9AC094EA8/BinaryEntryPoint-MessageSpecificationGuidelines-8.4.2.1-enUS.pdf
+[schema]: ../schemas/b3-entrypoint-messages-8.4.2.xml
+
+Auditor: initial pass at commit `f36028a` (2026-04-30). Refresh this section
+when the table is re-validated against a newer spec revision.
+
+## How to read this document
+
+- **Severity** — `critical` = real B3 client cannot interop today;
+  `high` = wire is OK but mandated behaviour missing;
+  `medium` = compliance gap with workaround;
+  `low` = realism polish, often already framed as a non-goal.
+- **Status** — `missing` (not implemented), `partial` (implemented with caveats),
+  `deviation` (implemented differently from spec on purpose), `bug` (implemented
+  wrong).
+- **Issue** — GitHub issue tracking the fix. Empty if not yet filed.
+
+## Decisions and conscious deviations
+
+These are **intentional** simplifications. They are listed here to keep them
+out of the gap table and to make the rationale auditable.
+
+- **Continuous trading only.** No auction phases / TradingSessionStatus
+  cycle. (See [#19](https://github.com/pedrosakuma/SbeB3Exchange/issues/19).)
+- **No persistence.** Books reset on restart; consumers re-bootstrap via the
+  snapshot channel + sequence-version bump.
+- **Routing by `SecurityID`** instead of by `marketSegmentID` from the inbound
+  business header. Practical equivalent because every instrument in the
+  simulator maps 1:1 to a UMDF channel; spec allows both as long as the
+  matching engine receives the message.
+- **Single `EnteringFirm` per host** (today) — multi-firm is tracked by #8.
+- **No order types beyond Limit / Market**, no GTC/GTD/MOC/MOA, no iceberg,
+  no stop. These are explicitly out of scope in the current roadmap (#19),
+  but each remains catalogued in the gap table for future re-scoping.
+
+## Canonical session flows (for reference)
+
+The five flows from spec §5. `[OK]` means the simulator reproduces the flow
+end-to-end today; `[GAP-NN]` points to the entry in the table that breaks it.
+
+### §5.1 Normal connectivity
+
+```
+    Client                                Gateway
+      |  ── TCP handshake ────────────►    |
+      |  ── Negotiate ───────────────►     |   [GAP-04]
+      |  ◄── NegotiateResponse ─────       |   [GAP-04]
+      |  ── Establish ───────────────►     |   [GAP-05]
+      |  ◄── EstablishAck ──────────       |   [GAP-05]
+      |  ── App messages ───────────►      |   (partial — see §4.6 gaps)
+      |  ◄── App messages ──────────       |
+      |  ── Terminate ──────────────►      |   [GAP-06]
+      |  ◄── Terminate ─────────────        |   [GAP-06]
+      |  ── TCP FIN ────────────────►       |
+```
+
+### §5.2 Invalid credentials in negotiation
+
+Requires `Negotiate` + `NegotiateReject(CREDENTIALS)` + `Terminate`. All three
+missing — see [GAP-04].
+
+### §5.3 Loss of connectivity during the session
+
+Requires the client to re-`Establish` with the previously negotiated
+`sessionVerID`. Not supported today ([GAP-05], [GAP-07]).
+
+### §5.4 Client-side total failure
+
+Requires `NegotiateReject(ALREADY_NEGOTIATED, currentSessionVerID)` so the
+client can recover its `sessionVerID`. Missing ([GAP-04]).
+
+### §5.5 Gateway failures
+
+Requires `Sequence` + retransmission + `BACKUP_TAKEOVER_IN_PROGRESS`
+termination code. Missing ([GAP-06], [GAP-08]).
+
+## Gap table
+
+### Wire format (CRITICAL — no real B3 client can interoperate today)
+
+| # | Spec § | Item | Status | Gap | Severity | Issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| GAP-01 | 4.4 | **Simple Open Framing Header (SOFH)** — 4 bytes (`messageLength` LE + `encodingType=0xEB50`) prepended to every SBE frame; total wire header is **12 bytes**, not 8. | bug | `EntryPointFrameReader` reads only the 8-byte SBE `MessageHeader`. First inbound byte from a real client is interpreted as part of `BlockLength`. | critical | — |
+| GAP-02 | 3.5, 4.6.5 | **Variable-length data trailing the fixed block** (`memo`, `credentials`, `clientIP`, `clientAppName`, `clientAppVersion`). Each is `length(uint8)` + `varData`. Total frame size is `SOFH.messageLength`, not `8 + BlockLength`. | bug | `EntryPointSession.RunReceiveLoopAsync` reads exactly `BlockLength` bytes of body. If the client sends a memo or credentials, those bytes are then consumed as the next message's SBE header → desync, then connection drop. | critical | — |
+| GAP-03 | 4.5.7, 4.10 | **`Terminate` with `terminationCode`** on framing/decoding errors (`16=INVALID_SOFH`, `17=DECODING_ERROR`, `15=UNRECOGNIZED_MESSAGE`, `11=INVALID_SESSIONID`, `13=INVALID_TIMESTAMP`, …). Also enforce SOFH `messageLength ≤ 512` per spec. | missing | On any decode error we silently `Close()` the socket. Spec mandates a `Terminate` with a specific code first. | critical | — |
+
+### FIXP session lifecycle
+
+| # | Spec § | Item | Status | Gap | Severity | Issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| GAP-04 | 4.5.2 | **`Negotiate` / `NegotiateResponse` / `NegotiateReject`** — JSON `credentials` blob (`auth_type`, `username`, `access_key`), `sessionVerID`, daily reset, and the seven reject codes (incl. `ALREADY_NEGOTIATED` carrying `currentSessionVerID`). | missing | The simulator goes straight from TCP `accept` to processing application messages. | high | partial overlap with #16 (which is too generic — mentions "Logon" not Negotiate). |
+| GAP-05 | 4.5.3 | **`Establish` / `EstablishAck` / `EstablishReject`** with `keepAliveInterval`, `nextSeqNo`, `cancelOnDisconnect{Type,TimeoutWindow}` and the eight reject codes. | missing | Same as above — no establishment phase. | high | partial overlap with #16. |
+| GAP-06 | 4.5.4, 4.5.7 | **`Sequence` (heartbeat + reset)** + **`Terminate`** message (with codes from `TerminationCode` enum — see schema lines 384–404). Spec recommends terminating after 3× `keepAliveInterval` of silence. | missing | No heartbeats, no idle teardown of the kind the spec defines. | high | overlap with #9 (heartbeat only — does not cover Terminate codes / Sequence semantics). |
+| GAP-07 | 4.5.5, 4.6.2 | **Inbound `MsgSeqNum` tracking + `NotApplied`** — gap detection emits `NotApplied(fromSeqNo, count)` and updates expected next seq. Outbound seq is per-`SessionID/SessionVerID`, reset daily. | missing | We accept any `MsgSeqNum` in any order. Outbound seq is per-session in-process (see `_msgSeqNum` in `EntryPointSession`) but never reset / persisted across reconnect. | high | — |
+| GAP-08 | 4.5.6 | **`RetransmitRequest` / `Retransmission`** with `RetransmitRejectCode` enum (schema 406–416). Max 1000 messages per request, single in-flight. | missing | No retransmission support — a consumer that loses bytes mid-session has no recovery path. | high | — |
+| GAP-09 | 4.5.1 | **Daily reset** — outbound + inbound seq reset to 1 at the start of each trading day. | missing | Sequence numbers grow unboundedly across the lifetime of the host process. | medium | — |
+
+### Application-level header
+
+| # | Spec § | Item | Status | Gap | Severity | Issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| GAP-10 | 4.6.3.1 | **Inbound `sessionID` validation** — spec §4.10 mandates `BusinessMessageReject(33003, "Wrong sessionID in businessHeader")` on mismatch. | missing | `InboundMessageDecoder` reads the order body fields starting at offset 20 (after the 20-byte business header) but never reads / validates `sessionID`, `msgSeqNum`, or `sendingTime`. | high | — |
+| GAP-11 | 4.6.4 | **`receivedTime` (tag 35544)** optional field added in schema v3 to ER\_New / ER\_Modify / ER\_Cancel. Carries the gateway-reception timestamp. | missing | `ExecutionReportEncoder` does not emit `receivedTime`. Spec's intent is that latency-tracking clients see ingress vs. egress timestamps. | medium | — |
+| GAP-12 | 4.6.3.1 | **`marketSegmentID` for routing** — spec says the gateway uses this header field to route to the matching engine. | deviation | Simulator routes by `SecurityID` (1:1 with channel in our config). Working, but a real B3 client that relies on cross-segment instrument codes will be surprised. | low | documented in "Conscious deviations" — keep here for traceability. |
+| GAP-13 | 4.6.3.2 | **`OutboundBusinessHeader.eventIndicator`** — bit flags (`PossResend`, `LowPriority`). Encoder writes `0` literally; never sets `PossResend` (we have no retransmission anyway → see GAP-08). | partial | OK as long as the simulator never replays. Once retransmission lands, this needs to be set on replayed frames. | low | depends on GAP-08. |
+
+### Application-level messages
+
+| # | Spec § | Item | Status | Gap | Severity | Issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| GAP-14 | 4.6.1 | **`BusinessMessageReject` (template 206)** for application-level rejects (bad sessionID, throttle violations, varData too long, line breaks in deskID/senderLocation/enteringTrader/executingTrader). | missing | Today every error path emits `ExecutionReport_Reject` (template 204) regardless of the spec class. | high | partial overlap with #11. |
+| GAP-15 | 4.6.1 | **`NewOrderSingle` (102)** and **`OrderCancelReplaceRequest` (104)** — the full templates with iceberg/stop/strategy fields. Spec lists these as the canonical messages; `Simple*` variants are explicitly the low-feature subset. | missing | We only support `SimpleNewOrder` (100) and `SimpleModifyOrder` (101). | medium | — |
+| GAP-16 | 4.6.1 | **`NewOrderCross` (106)**. | missing | No cross-order support. | low | — |
+| GAP-17 | 8.2 | **`OrdRejReason` mapping** — codes `1=UnknownSymbol`, `3=OrderExceedsLimit`, `5=UnknownOrder`, `6=DuplicateOrder`, `11=UnsupportedOrderCharacteristic`, etc. | bug | `EntryPointSession.MapRejectReason` maps every engine `RejectReason` to `0` (generic broker option). | medium | — |
+
+### Operational / risk features
+
+| # | Spec § | Item | Status | Gap | Severity | Issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| GAP-18 | 4.7 | **Cancel-on-Disconnect (CoD)** — `CancelOnDisconnectType` (4 modes) + `CODTimeoutWindow` in `Establish`. Cancels non-GT working orders on triggering events; spec §4.7.3 enumerates gateway-forced disconnects that also fire CoD if enabled. | missing | No CoD support. | high | — |
+| GAP-19 | 4.8 | **Mass Cancel (`OrderMassActionRequest` 701 / `OrderMassActionReport` 702)** with filters Side / SecurityID / OrdTagID / Asset, plus mass-cancel-on-behalf. | missing | No mass cancel. | high | — |
+| GAP-20 | 4.9 | **Throttle** — sliding window of N messages / M ms, per session. Reject violations with `BusinessMessageReject "Throttle limit exceeded"`. | missing | Inbound queue is bounded but throttling per spec is not implemented; rejections do not surface to the client. | medium | — |
+| GAP-21 | 4.10 | **Other basic gateway validations** — `<CR>`/`<LF>` check on deskID/senderLocation/enteringTrader/executingTrader; varData length checks on `memo`/`deskID`. | missing | Pre-requisite is GAP-02 (we don't read varData at all today). | medium | depends on GAP-02. |
+
+### Order types / TIF / advanced functionality
+
+These are tracked here for completeness; most are explicit non-goals today.
+
+| # | Spec § | Item | Status | Severity | Issue |
+| --- | --- | --- | --- | --- | --- |
+| GAP-22 | 7.1.1–7.1.6 | Stop / StopLimit / Market-with-leftover-as-Limit (`K`) / RLP (`W`) order types | missing | low (non-goal) | — |
+| GAP-23 | 7.1.7–7.1.14 | `GTC` / `GTD` / `MOC` / `MOA` time-in-force | missing | low (non-goal) | — |
+| GAP-24 | 7.1.16–7.1.17 | Iceberg / disclosed quantity, MinQty | missing | low (non-goal) | — |
+| GAP-25 | 7.1.20 | In-flight modification semantics (priority loss rules) | partial | medium | — |
+| GAP-26 | 8.3 | Daily GTC/GTD restatement | missing | low (depends on GAP-23) | — |
+| GAP-27 | 15.4 | Self-Trading Prevention | missing | medium | covered by #14 |
+| GAP-28 | 15.5 | Market Protections | missing | low (non-goal) | — |
+| GAP-29 | 15.1 | User-Defined Spreads (UDS) | missing | low | — |
+| GAP-30 | 16.6 | Sweep & Cross | missing | low | — |
+
+## Maintenance notes
+
+- When opening a GitHub issue for any row above, append the issue number to
+  the **Issue** column and reference `docs/B3-ENTRYPOINT-COMPLIANCE.md#gap-NN`
+  from the issue body so future readers can navigate both directions.
+- When a row is fully resolved, leave the row in place but flip its **Status**
+  to `done` and link the merged PR.
+- When auditing a new spec revision, refresh the *Sources audited* table and
+  walk every row — the spec evolves (the change log on page 9 of the PDF is a
+  good starting point).

--- a/docs/B3-ENTRYPOINT-COMPLIANCE.md
+++ b/docs/B3-ENTRYPOINT-COMPLIANCE.md
@@ -3,7 +3,7 @@
 Audit of how `src/B3.Exchange.EntryPoint` and friends compare to the official
 B3 spec. This is the canonical "what's missing / what's wrong vs. the wire
 protocol" reference for the simulator — issues that track individual gaps
-should link back to a row in the table below by `#GAP-NN`.
+should link back to a row in the table below by `#gap-NN`.
 
 ## Sources audited
 
@@ -94,47 +94,47 @@ termination code. Missing ([GAP-06], [GAP-08]).
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-01 | 4.4 | **Simple Open Framing Header (SOFH)** — 4 bytes (`messageLength` LE + `encodingType=0xEB50`) prepended to every SBE frame; total wire header is **12 bytes**, not 8. | bug | `EntryPointFrameReader` reads only the 8-byte SBE `MessageHeader`. First inbound byte from a real client is interpreted as part of `BlockLength`. | critical | [#39](https://github.com/pedrosakuma/SbeB3Exchange/issues/39) |
-| GAP-02 | 3.5, 4.6.5 | **Variable-length data trailing the fixed block** (`memo`, `credentials`, `clientIP`, `clientAppName`, `clientAppVersion`). Each is `length(uint8)` + `varData`. Total frame size is `SOFH.messageLength`, not `8 + BlockLength`. | bug | `EntryPointSession.RunReceiveLoopAsync` reads exactly `BlockLength` bytes of body. If the client sends a memo or credentials, those bytes are then consumed as the next message's SBE header → desync, then connection drop. | critical | [#40](https://github.com/pedrosakuma/SbeB3Exchange/issues/40) |
-| GAP-03 | 4.5.7, 4.10 | **`Terminate` with `terminationCode`** on framing/decoding errors (`16=INVALID_SOFH`, `17=DECODING_ERROR`, `15=UNRECOGNIZED_MESSAGE`, `11=INVALID_SESSIONID`, `13=INVALID_TIMESTAMP`, …). Also enforce SOFH `messageLength ≤ 512` per spec. | missing | On any decode error we silently `Close()` the socket. Spec mandates a `Terminate` with a specific code first. | critical | [#41](https://github.com/pedrosakuma/SbeB3Exchange/issues/41) |
+| <a id="gap-01"></a>GAP-01 | 4.4 | **Simple Open Framing Header (SOFH)** — 4 bytes (`messageLength` LE + `encodingType=0xEB50`) prepended to every SBE frame; total wire header is **12 bytes**, not 8. | bug | `EntryPointFrameReader` reads only the 8-byte SBE `MessageHeader`. First inbound byte from a real client is interpreted as part of `BlockLength`. | critical | [#39](https://github.com/pedrosakuma/SbeB3Exchange/issues/39) |
+| <a id="gap-02"></a>GAP-02 | 3.5, 4.6.5 | **Variable-length data trailing the fixed block** (`memo`, `credentials`, `clientIP`, `clientAppName`, `clientAppVersion`). Each is `length(uint8)` + `varData`. Total frame size is `SOFH.messageLength`, not `8 + BlockLength`. | bug | `EntryPointSession.RunReceiveLoopAsync` reads exactly `BlockLength` bytes of body. If the client sends a memo or credentials, those bytes are then consumed as the next message's SBE header → desync, then connection drop. | critical | [#40](https://github.com/pedrosakuma/SbeB3Exchange/issues/40) |
+| <a id="gap-03"></a>GAP-03 | 4.5.7, 4.10 | **`Terminate` with `terminationCode`** on framing/decoding errors (`16=INVALID_SOFH`, `17=DECODING_ERROR`, `15=UNRECOGNIZED_MESSAGE`, `11=INVALID_SESSIONID`, `13=INVALID_TIMESTAMP`, …). Also enforce SOFH `messageLength ≤ 512` per spec. | missing | On any decode error we silently `Close()` the socket. Spec mandates a `Terminate` with a specific code first. | critical | [#41](https://github.com/pedrosakuma/SbeB3Exchange/issues/41) |
 
 ### FIXP session lifecycle
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-04 | 4.5.2 | **`Negotiate` / `NegotiateResponse` / `NegotiateReject`** — JSON `credentials` blob (`auth_type`, `username`, `access_key`), `sessionVerID`, daily reset, and the seven reject codes (incl. `ALREADY_NEGOTIATED` carrying `currentSessionVerID`). | missing | The simulator goes straight from TCP `accept` to processing application messages. | high | [#42](https://github.com/pedrosakuma/SbeB3Exchange/issues/42) (refines #16) |
-| GAP-05 | 4.5.3 | **`Establish` / `EstablishAck` / `EstablishReject`** with `keepAliveInterval`, `nextSeqNo`, `cancelOnDisconnect{Type,TimeoutWindow}` and the eight reject codes. | missing | Same as above — no establishment phase. | high | [#43](https://github.com/pedrosakuma/SbeB3Exchange/issues/43) (refines #16) |
-| GAP-06 | 4.5.4, 4.5.7 | **`Sequence` (heartbeat + reset)** + **`Terminate`** message (with codes from `TerminationCode` enum — see schema lines 384–404). Spec recommends terminating after 3× `keepAliveInterval` of silence. | missing | No heartbeats, no idle teardown of the kind the spec defines. | high | [#44](https://github.com/pedrosakuma/SbeB3Exchange/issues/44) (refines #9) |
-| GAP-07 | 4.5.5, 4.6.2 | **Inbound `MsgSeqNum` tracking + `NotApplied`** — gap detection emits `NotApplied(fromSeqNo, count)` and updates expected next seq. Outbound seq is per-`SessionID/SessionVerID`, reset daily. | missing | We accept any `MsgSeqNum` in any order. Outbound seq is per-session in-process (see `_msgSeqNum` in `EntryPointSession`) but never reset / persisted across reconnect. | high | [#42](https://github.com/pedrosakuma/SbeB3Exchange/issues/42) |
-| GAP-08 | 4.5.6 | **`RetransmitRequest` / `Retransmission`** with `RetransmitRejectCode` enum (schema 406–416). Max 1000 messages per request, single in-flight. | missing | No retransmission support — a consumer that loses bytes mid-session has no recovery path. | high | [#43](https://github.com/pedrosakuma/SbeB3Exchange/issues/43) |
-| GAP-09 | 4.5.1 | **Daily reset** — outbound + inbound seq reset to 1 at the start of each trading day. | missing | Sequence numbers grow unboundedly across the lifetime of the host process. | medium | [#44](https://github.com/pedrosakuma/SbeB3Exchange/issues/44) |
+| <a id="gap-04"></a>GAP-04 | 4.5.2 | **`Negotiate` / `NegotiateResponse` / `NegotiateReject`** — JSON `credentials` blob (`auth_type`, `username`, `access_key`), `sessionVerID`, daily reset, and the seven reject codes (incl. `ALREADY_NEGOTIATED` carrying `currentSessionVerID`). | missing | The simulator goes straight from TCP `accept` to processing application messages. | high | [#42](https://github.com/pedrosakuma/SbeB3Exchange/issues/42) (refines #16) |
+| <a id="gap-05"></a>GAP-05 | 4.5.3 | **`Establish` / `EstablishAck` / `EstablishReject`** with `keepAliveInterval`, `nextSeqNo`, `cancelOnDisconnect{Type,TimeoutWindow}` and the eight reject codes. | missing | Same as above — no establishment phase. | high | [#43](https://github.com/pedrosakuma/SbeB3Exchange/issues/43) (refines #16) |
+| <a id="gap-06"></a>GAP-06 | 4.5.4, 4.5.7 | **`Sequence` (heartbeat + reset)** + **`Terminate`** message (with codes from `TerminationCode` enum — see schema lines 384–404). Spec recommends terminating after 3× `keepAliveInterval` of silence. | missing | No heartbeats, no idle teardown of the kind the spec defines. | high | [#44](https://github.com/pedrosakuma/SbeB3Exchange/issues/44) (refines #9) |
+| <a id="gap-07"></a>GAP-07 | 4.5.5, 4.6.2 | **Inbound `MsgSeqNum` tracking + `NotApplied`** — gap detection emits `NotApplied(fromSeqNo, count)` and updates expected next seq. Outbound seq is per-`SessionID/SessionVerID`, reset daily. | missing | We accept any `MsgSeqNum` in any order. Outbound seq is per-session in-process (see `_msgSeqNum` in `EntryPointSession`) but never reset / persisted across reconnect. | high | [#42](https://github.com/pedrosakuma/SbeB3Exchange/issues/42) |
+| <a id="gap-08"></a>GAP-08 | 4.5.6 | **`RetransmitRequest` / `Retransmission`** with `RetransmitRejectCode` enum (schema 406–416). Max 1000 messages per request, single in-flight. | missing | No retransmission support — a consumer that loses bytes mid-session has no recovery path. | high | [#43](https://github.com/pedrosakuma/SbeB3Exchange/issues/43) |
+| <a id="gap-09"></a>GAP-09 | 4.5.1 | **Daily reset** — outbound + inbound seq reset to 1 at the start of each trading day. | missing | Sequence numbers grow unboundedly across the lifetime of the host process. | medium | [#44](https://github.com/pedrosakuma/SbeB3Exchange/issues/44) |
 
 ### Application-level header
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-10 | 4.6.3.1 | **Inbound `sessionID` validation** — spec §4.10 mandates `BusinessMessageReject(33003, "Wrong sessionID in businessHeader")` on mismatch. | missing | `InboundMessageDecoder` reads the order body fields starting at offset 20 (after the 20-byte business header) but never reads / validates `sessionID`, `msgSeqNum`, or `sendingTime`. | high | [#45](https://github.com/pedrosakuma/SbeB3Exchange/issues/45) |
-| GAP-11 | 4.6.4 | **`receivedTime` (tag 35544)** optional field added in schema v3 to ER\_New / ER\_Modify / ER\_Cancel. Carries the gateway-reception timestamp. | missing | `ExecutionReportEncoder` does not emit `receivedTime`. Spec's intent is that latency-tracking clients see ingress vs. egress timestamps. | medium | [#46](https://github.com/pedrosakuma/SbeB3Exchange/issues/46) |
-| GAP-12 | 4.6.3.1 | **`marketSegmentID` for routing** — spec says the gateway uses this header field to route to the matching engine. | deviation | Simulator routes by `SecurityID` (1:1 with channel in our config). Working, but a real B3 client that relies on cross-segment instrument codes will be surprised. | low | documented in "Conscious deviations" — keep here for traceability. |
-| GAP-13 | 4.6.3.2 | **`OutboundBusinessHeader.eventIndicator`** — bit flags (`PossResend`, `LowPriority`). Encoder writes `0` literally; never sets `PossResend` (we have no retransmission anyway → see GAP-08). | partial | OK as long as the simulator never replays. Once retransmission lands, this needs to be set on replayed frames. | low | depends on GAP-08. |
+| <a id="gap-10"></a>GAP-10 | 4.6.3.1 | **Inbound `sessionID` validation** — spec §4.10 mandates `BusinessMessageReject(33003, "Wrong sessionID in businessHeader")` on mismatch. | missing | `InboundMessageDecoder` reads the order body fields starting at offset 20 (after the 20-byte business header) but never reads / validates `sessionID`, `msgSeqNum`, or `sendingTime`. | high | [#45](https://github.com/pedrosakuma/SbeB3Exchange/issues/45) |
+| <a id="gap-11"></a>GAP-11 | 4.6.4 | **`receivedTime` (tag 35544)** optional field added in schema v3 to ER\_New / ER\_Modify / ER\_Cancel. Carries the gateway-reception timestamp. | missing | `ExecutionReportEncoder` does not emit `receivedTime`. Spec's intent is that latency-tracking clients see ingress vs. egress timestamps. | medium | [#46](https://github.com/pedrosakuma/SbeB3Exchange/issues/46) |
+| <a id="gap-12"></a>GAP-12 | 4.6.3.1 | **`marketSegmentID` for routing** — spec says the gateway uses this header field to route to the matching engine. | deviation | Simulator routes by `SecurityID` (1:1 with channel in our config). Working, but a real B3 client that relies on cross-segment instrument codes will be surprised. | low | documented in "Conscious deviations" — keep here for traceability. |
+| <a id="gap-13"></a>GAP-13 | 4.6.3.2 | **`OutboundBusinessHeader.eventIndicator`** — bit flags (`PossResend`, `LowPriority`). Encoder writes `0` literally; never sets `PossResend` (we have no retransmission anyway → see GAP-08). | partial | OK as long as the simulator never replays. Once retransmission lands, this needs to be set on replayed frames. | low | depends on GAP-08. |
 
 ### Application-level messages
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-14 | 4.6.1 | **`BusinessMessageReject` (template 206)** for application-level rejects (bad sessionID, throttle violations, varData too long, line breaks in deskID/senderLocation/enteringTrader/executingTrader). | missing | Today every error path emits `ExecutionReport_Reject` (template 204) regardless of the spec class. | high | [#50](https://github.com/pedrosakuma/SbeB3Exchange/issues/50) (refines #11) |
-| GAP-15 | 4.6.1 | **`NewOrderSingle` (102)** and **`OrderCancelReplaceRequest` (104)** — the full templates with iceberg/stop/strategy fields. Spec lists these as the canonical messages; `Simple*` variants are explicitly the low-feature subset. | missing | We only support `SimpleNewOrder` (100) and `SimpleModifyOrder` (101). | medium | [#47](https://github.com/pedrosakuma/SbeB3Exchange/issues/47) |
-| GAP-16 | 4.6.1 | **`NewOrderCross` (106)**. | missing | No cross-order support. | low | [#48](https://github.com/pedrosakuma/SbeB3Exchange/issues/48) |
-| GAP-17 | 8.2 | **`OrdRejReason` mapping** — codes `1=UnknownSymbol`, `3=OrderExceedsLimit`, `5=UnknownOrder`, `6=DuplicateOrder`, `11=UnsupportedOrderCharacteristic`, etc. | bug | `EntryPointSession.MapRejectReason` maps every engine `RejectReason` to `0` (generic broker option). | medium | [#49](https://github.com/pedrosakuma/SbeB3Exchange/issues/49) |
+| <a id="gap-14"></a>GAP-14 | 4.6.1 | **`BusinessMessageReject` (template 206)** for application-level rejects (bad sessionID, throttle violations, varData too long, line breaks in deskID/senderLocation/enteringTrader/executingTrader). | missing | Today every error path emits `ExecutionReport_Reject` (template 204) regardless of the spec class. | high | [#50](https://github.com/pedrosakuma/SbeB3Exchange/issues/50) (refines #11) |
+| <a id="gap-15"></a>GAP-15 | 4.6.1 | **`NewOrderSingle` (102)** and **`OrderCancelReplaceRequest` (104)** — the full templates with iceberg/stop/strategy fields. Spec lists these as the canonical messages; `Simple*` variants are explicitly the low-feature subset. | missing | We only support `SimpleNewOrder` (100) and `SimpleModifyOrder` (101). | medium | [#47](https://github.com/pedrosakuma/SbeB3Exchange/issues/47) |
+| <a id="gap-16"></a>GAP-16 | 4.6.1 | **`NewOrderCross` (106)**. | missing | No cross-order support. | low | [#48](https://github.com/pedrosakuma/SbeB3Exchange/issues/48) |
+| <a id="gap-17"></a>GAP-17 | 8.2 | **`OrdRejReason` mapping** — codes `1=UnknownSymbol`, `3=OrderExceedsLimit`, `5=UnknownOrder`, `6=DuplicateOrder`, `11=UnsupportedOrderCharacteristic`, etc. | bug | `EntryPointSession.MapRejectReason` maps every engine `RejectReason` to `0` (generic broker option). | medium | [#49](https://github.com/pedrosakuma/SbeB3Exchange/issues/49) |
 
 ### Operational / risk features
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-18 | 4.7 | **Cancel-on-Disconnect (CoD)** — `CancelOnDisconnectType` (4 modes) + `CODTimeoutWindow` in `Establish`. Cancels non-GT working orders on triggering events; spec §4.7.3 enumerates gateway-forced disconnects that also fire CoD if enabled. | missing | No CoD support. | high | [#50](https://github.com/pedrosakuma/SbeB3Exchange/issues/50) |
-| GAP-19 | 4.8 | **Mass Cancel (`OrderMassActionRequest` 701 / `OrderMassActionReport` 702)** with filters Side / SecurityID / OrdTagID / Asset, plus mass-cancel-on-behalf. | missing | No mass cancel. | high | [#51](https://github.com/pedrosakuma/SbeB3Exchange/issues/51) |
-| GAP-20 | 4.9 | **Throttle** — sliding window of N messages / M ms, per session. Reject violations with `BusinessMessageReject "Throttle limit exceeded"`. | missing | Inbound queue is bounded but throttling per spec is not implemented; rejections do not surface to the client. | medium | [#52](https://github.com/pedrosakuma/SbeB3Exchange/issues/52) |
-| GAP-21 | 4.10 | **Other basic gateway validations** — `<CR>`/`<LF>` check on deskID/senderLocation/enteringTrader/executingTrader; varData length checks on `memo`/`deskID`. | missing | Pre-requisite is GAP-02 (we don't read varData at all today). | medium | depends on GAP-02. |
+| <a id="gap-18"></a>GAP-18 | 4.7 | **Cancel-on-Disconnect (CoD)** — `CancelOnDisconnectType` (4 modes) + `CODTimeoutWindow` in `Establish`. Cancels non-GT working orders on triggering events; spec §4.7.3 enumerates gateway-forced disconnects that also fire CoD if enabled. | missing | No CoD support. | high | [#50](https://github.com/pedrosakuma/SbeB3Exchange/issues/50) |
+| <a id="gap-19"></a>GAP-19 | 4.8 | **Mass Cancel (`OrderMassActionRequest` 701 / `OrderMassActionReport` 702)** with filters Side / SecurityID / OrdTagID / Asset, plus mass-cancel-on-behalf. | missing | No mass cancel. | high | [#51](https://github.com/pedrosakuma/SbeB3Exchange/issues/51) |
+| <a id="gap-20"></a>GAP-20 | 4.9 | **Throttle** — sliding window of N messages / M ms, per session. Reject violations with `BusinessMessageReject "Throttle limit exceeded"`. | missing | Inbound queue is bounded but throttling per spec is not implemented; rejections do not surface to the client. | medium | [#52](https://github.com/pedrosakuma/SbeB3Exchange/issues/52) |
+| <a id="gap-21"></a>GAP-21 | 4.10 | **Other basic gateway validations** — `<CR>`/`<LF>` check on deskID/senderLocation/enteringTrader/executingTrader; varData length checks on `memo`/`deskID`. | missing | Pre-requisite is GAP-02 (we don't read varData at all today). | medium | depends on GAP-02. |
 
 ### Order types / TIF / advanced functionality
 
@@ -142,15 +142,15 @@ These are tracked here for completeness; most are explicit non-goals today.
 
 | # | Spec § | Item | Status | Severity | Issue |
 | --- | --- | --- | --- | --- | --- |
-| GAP-22 | 7.1.1–7.1.6 | Stop / StopLimit / Market-with-leftover-as-Limit (`K`) / RLP (`W`) order types | missing | low (non-goal) | [#53](https://github.com/pedrosakuma/SbeB3Exchange/issues/53) |
-| GAP-23 | 7.1.7–7.1.14 | `GTC` / `GTD` / `MOC` / `MOA` time-in-force | missing | low (non-goal) | [#54](https://github.com/pedrosakuma/SbeB3Exchange/issues/54) |
-| GAP-24 | 7.1.16–7.1.17 | Iceberg / disclosed quantity, MinQty | missing | low (non-goal) | [#55](https://github.com/pedrosakuma/SbeB3Exchange/issues/55) |
-| GAP-25 | 7.1.20 | In-flight modification semantics (priority loss rules) | partial | medium | [#56](https://github.com/pedrosakuma/SbeB3Exchange/issues/56) |
-| GAP-26 | 8.3 | Daily GTC/GTD restatement | missing | low (depends on GAP-23) | [#57](https://github.com/pedrosakuma/SbeB3Exchange/issues/57) |
-| GAP-27 | 15.4 | Self-Trading Prevention | missing | medium | covered by #14 |
-| GAP-28 | 15.5 | Market Protections | missing | low (non-goal) | — |
-| GAP-29 | 15.1 | User-Defined Spreads (UDS) | missing | low | — |
-| GAP-30 | 16.6 | Sweep & Cross | missing | low | — |
+| <a id="gap-22"></a>GAP-22 | 7.1.1–7.1.6 | Stop / StopLimit / Market-with-leftover-as-Limit (`K`) / RLP (`W`) order types | missing | low (non-goal) | [#53](https://github.com/pedrosakuma/SbeB3Exchange/issues/53) |
+| <a id="gap-23"></a>GAP-23 | 7.1.7–7.1.14 | `GTC` / `GTD` / `MOC` / `MOA` time-in-force | missing | low (non-goal) | [#54](https://github.com/pedrosakuma/SbeB3Exchange/issues/54) |
+| <a id="gap-24"></a>GAP-24 | 7.1.16–7.1.17 | Iceberg / disclosed quantity, MinQty | missing | low (non-goal) | [#55](https://github.com/pedrosakuma/SbeB3Exchange/issues/55) |
+| <a id="gap-25"></a>GAP-25 | 7.1.20 | In-flight modification semantics (priority loss rules) | partial | medium | [#56](https://github.com/pedrosakuma/SbeB3Exchange/issues/56) |
+| <a id="gap-26"></a>GAP-26 | 8.3 | Daily GTC/GTD restatement | missing | low (depends on GAP-23) | [#57](https://github.com/pedrosakuma/SbeB3Exchange/issues/57) |
+| <a id="gap-27"></a>GAP-27 | 15.4 | Self-Trading Prevention | missing | medium | covered by #14 |
+| <a id="gap-28"></a>GAP-28 | 15.5 | Market Protections | missing | low (non-goal) | — |
+| <a id="gap-29"></a>GAP-29 | 15.1 | User-Defined Spreads (UDS) | missing | low | — |
+| <a id="gap-30"></a>GAP-30 | 16.6 | Sweep & Cross | missing | low | — |
 
 ## Maintenance notes
 

--- a/docs/B3-ENTRYPOINT-COMPLIANCE.md
+++ b/docs/B3-ENTRYPOINT-COMPLIANCE.md
@@ -94,27 +94,27 @@ termination code. Missing ([GAP-06], [GAP-08]).
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-01 | 4.4 | **Simple Open Framing Header (SOFH)** — 4 bytes (`messageLength` LE + `encodingType=0xEB50`) prepended to every SBE frame; total wire header is **12 bytes**, not 8. | bug | `EntryPointFrameReader` reads only the 8-byte SBE `MessageHeader`. First inbound byte from a real client is interpreted as part of `BlockLength`. | critical | — |
-| GAP-02 | 3.5, 4.6.5 | **Variable-length data trailing the fixed block** (`memo`, `credentials`, `clientIP`, `clientAppName`, `clientAppVersion`). Each is `length(uint8)` + `varData`. Total frame size is `SOFH.messageLength`, not `8 + BlockLength`. | bug | `EntryPointSession.RunReceiveLoopAsync` reads exactly `BlockLength` bytes of body. If the client sends a memo or credentials, those bytes are then consumed as the next message's SBE header → desync, then connection drop. | critical | — |
-| GAP-03 | 4.5.7, 4.10 | **`Terminate` with `terminationCode`** on framing/decoding errors (`16=INVALID_SOFH`, `17=DECODING_ERROR`, `15=UNRECOGNIZED_MESSAGE`, `11=INVALID_SESSIONID`, `13=INVALID_TIMESTAMP`, …). Also enforce SOFH `messageLength ≤ 512` per spec. | missing | On any decode error we silently `Close()` the socket. Spec mandates a `Terminate` with a specific code first. | critical | — |
+| GAP-01 | 4.4 | **Simple Open Framing Header (SOFH)** — 4 bytes (`messageLength` LE + `encodingType=0xEB50`) prepended to every SBE frame; total wire header is **12 bytes**, not 8. | bug | `EntryPointFrameReader` reads only the 8-byte SBE `MessageHeader`. First inbound byte from a real client is interpreted as part of `BlockLength`. | critical | [#39](https://github.com/pedrosakuma/SbeB3Exchange/issues/39) |
+| GAP-02 | 3.5, 4.6.5 | **Variable-length data trailing the fixed block** (`memo`, `credentials`, `clientIP`, `clientAppName`, `clientAppVersion`). Each is `length(uint8)` + `varData`. Total frame size is `SOFH.messageLength`, not `8 + BlockLength`. | bug | `EntryPointSession.RunReceiveLoopAsync` reads exactly `BlockLength` bytes of body. If the client sends a memo or credentials, those bytes are then consumed as the next message's SBE header → desync, then connection drop. | critical | [#40](https://github.com/pedrosakuma/SbeB3Exchange/issues/40) |
+| GAP-03 | 4.5.7, 4.10 | **`Terminate` with `terminationCode`** on framing/decoding errors (`16=INVALID_SOFH`, `17=DECODING_ERROR`, `15=UNRECOGNIZED_MESSAGE`, `11=INVALID_SESSIONID`, `13=INVALID_TIMESTAMP`, …). Also enforce SOFH `messageLength ≤ 512` per spec. | missing | On any decode error we silently `Close()` the socket. Spec mandates a `Terminate` with a specific code first. | critical | [#41](https://github.com/pedrosakuma/SbeB3Exchange/issues/41) |
 
 ### FIXP session lifecycle
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-04 | 4.5.2 | **`Negotiate` / `NegotiateResponse` / `NegotiateReject`** — JSON `credentials` blob (`auth_type`, `username`, `access_key`), `sessionVerID`, daily reset, and the seven reject codes (incl. `ALREADY_NEGOTIATED` carrying `currentSessionVerID`). | missing | The simulator goes straight from TCP `accept` to processing application messages. | high | partial overlap with #16 (which is too generic — mentions "Logon" not Negotiate). |
-| GAP-05 | 4.5.3 | **`Establish` / `EstablishAck` / `EstablishReject`** with `keepAliveInterval`, `nextSeqNo`, `cancelOnDisconnect{Type,TimeoutWindow}` and the eight reject codes. | missing | Same as above — no establishment phase. | high | partial overlap with #16. |
-| GAP-06 | 4.5.4, 4.5.7 | **`Sequence` (heartbeat + reset)** + **`Terminate`** message (with codes from `TerminationCode` enum — see schema lines 384–404). Spec recommends terminating after 3× `keepAliveInterval` of silence. | missing | No heartbeats, no idle teardown of the kind the spec defines. | high | overlap with #9 (heartbeat only — does not cover Terminate codes / Sequence semantics). |
-| GAP-07 | 4.5.5, 4.6.2 | **Inbound `MsgSeqNum` tracking + `NotApplied`** — gap detection emits `NotApplied(fromSeqNo, count)` and updates expected next seq. Outbound seq is per-`SessionID/SessionVerID`, reset daily. | missing | We accept any `MsgSeqNum` in any order. Outbound seq is per-session in-process (see `_msgSeqNum` in `EntryPointSession`) but never reset / persisted across reconnect. | high | — |
-| GAP-08 | 4.5.6 | **`RetransmitRequest` / `Retransmission`** with `RetransmitRejectCode` enum (schema 406–416). Max 1000 messages per request, single in-flight. | missing | No retransmission support — a consumer that loses bytes mid-session has no recovery path. | high | — |
-| GAP-09 | 4.5.1 | **Daily reset** — outbound + inbound seq reset to 1 at the start of each trading day. | missing | Sequence numbers grow unboundedly across the lifetime of the host process. | medium | — |
+| GAP-04 | 4.5.2 | **`Negotiate` / `NegotiateResponse` / `NegotiateReject`** — JSON `credentials` blob (`auth_type`, `username`, `access_key`), `sessionVerID`, daily reset, and the seven reject codes (incl. `ALREADY_NEGOTIATED` carrying `currentSessionVerID`). | missing | The simulator goes straight from TCP `accept` to processing application messages. | high | [#42](https://github.com/pedrosakuma/SbeB3Exchange/issues/42) (refines #16) |
+| GAP-05 | 4.5.3 | **`Establish` / `EstablishAck` / `EstablishReject`** with `keepAliveInterval`, `nextSeqNo`, `cancelOnDisconnect{Type,TimeoutWindow}` and the eight reject codes. | missing | Same as above — no establishment phase. | high | [#43](https://github.com/pedrosakuma/SbeB3Exchange/issues/43) (refines #16) |
+| GAP-06 | 4.5.4, 4.5.7 | **`Sequence` (heartbeat + reset)** + **`Terminate`** message (with codes from `TerminationCode` enum — see schema lines 384–404). Spec recommends terminating after 3× `keepAliveInterval` of silence. | missing | No heartbeats, no idle teardown of the kind the spec defines. | high | [#44](https://github.com/pedrosakuma/SbeB3Exchange/issues/44) (refines #9) |
+| GAP-07 | 4.5.5, 4.6.2 | **Inbound `MsgSeqNum` tracking + `NotApplied`** — gap detection emits `NotApplied(fromSeqNo, count)` and updates expected next seq. Outbound seq is per-`SessionID/SessionVerID`, reset daily. | missing | We accept any `MsgSeqNum` in any order. Outbound seq is per-session in-process (see `_msgSeqNum` in `EntryPointSession`) but never reset / persisted across reconnect. | high | [#42](https://github.com/pedrosakuma/SbeB3Exchange/issues/42) |
+| GAP-08 | 4.5.6 | **`RetransmitRequest` / `Retransmission`** with `RetransmitRejectCode` enum (schema 406–416). Max 1000 messages per request, single in-flight. | missing | No retransmission support — a consumer that loses bytes mid-session has no recovery path. | high | [#43](https://github.com/pedrosakuma/SbeB3Exchange/issues/43) |
+| GAP-09 | 4.5.1 | **Daily reset** — outbound + inbound seq reset to 1 at the start of each trading day. | missing | Sequence numbers grow unboundedly across the lifetime of the host process. | medium | [#44](https://github.com/pedrosakuma/SbeB3Exchange/issues/44) |
 
 ### Application-level header
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-10 | 4.6.3.1 | **Inbound `sessionID` validation** — spec §4.10 mandates `BusinessMessageReject(33003, "Wrong sessionID in businessHeader")` on mismatch. | missing | `InboundMessageDecoder` reads the order body fields starting at offset 20 (after the 20-byte business header) but never reads / validates `sessionID`, `msgSeqNum`, or `sendingTime`. | high | — |
-| GAP-11 | 4.6.4 | **`receivedTime` (tag 35544)** optional field added in schema v3 to ER\_New / ER\_Modify / ER\_Cancel. Carries the gateway-reception timestamp. | missing | `ExecutionReportEncoder` does not emit `receivedTime`. Spec's intent is that latency-tracking clients see ingress vs. egress timestamps. | medium | — |
+| GAP-10 | 4.6.3.1 | **Inbound `sessionID` validation** — spec §4.10 mandates `BusinessMessageReject(33003, "Wrong sessionID in businessHeader")` on mismatch. | missing | `InboundMessageDecoder` reads the order body fields starting at offset 20 (after the 20-byte business header) but never reads / validates `sessionID`, `msgSeqNum`, or `sendingTime`. | high | [#45](https://github.com/pedrosakuma/SbeB3Exchange/issues/45) |
+| GAP-11 | 4.6.4 | **`receivedTime` (tag 35544)** optional field added in schema v3 to ER\_New / ER\_Modify / ER\_Cancel. Carries the gateway-reception timestamp. | missing | `ExecutionReportEncoder` does not emit `receivedTime`. Spec's intent is that latency-tracking clients see ingress vs. egress timestamps. | medium | [#46](https://github.com/pedrosakuma/SbeB3Exchange/issues/46) |
 | GAP-12 | 4.6.3.1 | **`marketSegmentID` for routing** — spec says the gateway uses this header field to route to the matching engine. | deviation | Simulator routes by `SecurityID` (1:1 with channel in our config). Working, but a real B3 client that relies on cross-segment instrument codes will be surprised. | low | documented in "Conscious deviations" — keep here for traceability. |
 | GAP-13 | 4.6.3.2 | **`OutboundBusinessHeader.eventIndicator`** — bit flags (`PossResend`, `LowPriority`). Encoder writes `0` literally; never sets `PossResend` (we have no retransmission anyway → see GAP-08). | partial | OK as long as the simulator never replays. Once retransmission lands, this needs to be set on replayed frames. | low | depends on GAP-08. |
 
@@ -122,18 +122,18 @@ termination code. Missing ([GAP-06], [GAP-08]).
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-14 | 4.6.1 | **`BusinessMessageReject` (template 206)** for application-level rejects (bad sessionID, throttle violations, varData too long, line breaks in deskID/senderLocation/enteringTrader/executingTrader). | missing | Today every error path emits `ExecutionReport_Reject` (template 204) regardless of the spec class. | high | partial overlap with #11. |
-| GAP-15 | 4.6.1 | **`NewOrderSingle` (102)** and **`OrderCancelReplaceRequest` (104)** — the full templates with iceberg/stop/strategy fields. Spec lists these as the canonical messages; `Simple*` variants are explicitly the low-feature subset. | missing | We only support `SimpleNewOrder` (100) and `SimpleModifyOrder` (101). | medium | — |
-| GAP-16 | 4.6.1 | **`NewOrderCross` (106)**. | missing | No cross-order support. | low | — |
-| GAP-17 | 8.2 | **`OrdRejReason` mapping** — codes `1=UnknownSymbol`, `3=OrderExceedsLimit`, `5=UnknownOrder`, `6=DuplicateOrder`, `11=UnsupportedOrderCharacteristic`, etc. | bug | `EntryPointSession.MapRejectReason` maps every engine `RejectReason` to `0` (generic broker option). | medium | — |
+| GAP-14 | 4.6.1 | **`BusinessMessageReject` (template 206)** for application-level rejects (bad sessionID, throttle violations, varData too long, line breaks in deskID/senderLocation/enteringTrader/executingTrader). | missing | Today every error path emits `ExecutionReport_Reject` (template 204) regardless of the spec class. | high | [#50](https://github.com/pedrosakuma/SbeB3Exchange/issues/50) (refines #11) |
+| GAP-15 | 4.6.1 | **`NewOrderSingle` (102)** and **`OrderCancelReplaceRequest` (104)** — the full templates with iceberg/stop/strategy fields. Spec lists these as the canonical messages; `Simple*` variants are explicitly the low-feature subset. | missing | We only support `SimpleNewOrder` (100) and `SimpleModifyOrder` (101). | medium | [#47](https://github.com/pedrosakuma/SbeB3Exchange/issues/47) |
+| GAP-16 | 4.6.1 | **`NewOrderCross` (106)**. | missing | No cross-order support. | low | [#48](https://github.com/pedrosakuma/SbeB3Exchange/issues/48) |
+| GAP-17 | 8.2 | **`OrdRejReason` mapping** — codes `1=UnknownSymbol`, `3=OrderExceedsLimit`, `5=UnknownOrder`, `6=DuplicateOrder`, `11=UnsupportedOrderCharacteristic`, etc. | bug | `EntryPointSession.MapRejectReason` maps every engine `RejectReason` to `0` (generic broker option). | medium | [#49](https://github.com/pedrosakuma/SbeB3Exchange/issues/49) |
 
 ### Operational / risk features
 
 | # | Spec § | Item | Status | Gap | Severity | Issue |
 | --- | --- | --- | --- | --- | --- | --- |
-| GAP-18 | 4.7 | **Cancel-on-Disconnect (CoD)** — `CancelOnDisconnectType` (4 modes) + `CODTimeoutWindow` in `Establish`. Cancels non-GT working orders on triggering events; spec §4.7.3 enumerates gateway-forced disconnects that also fire CoD if enabled. | missing | No CoD support. | high | — |
-| GAP-19 | 4.8 | **Mass Cancel (`OrderMassActionRequest` 701 / `OrderMassActionReport` 702)** with filters Side / SecurityID / OrdTagID / Asset, plus mass-cancel-on-behalf. | missing | No mass cancel. | high | — |
-| GAP-20 | 4.9 | **Throttle** — sliding window of N messages / M ms, per session. Reject violations with `BusinessMessageReject "Throttle limit exceeded"`. | missing | Inbound queue is bounded but throttling per spec is not implemented; rejections do not surface to the client. | medium | — |
+| GAP-18 | 4.7 | **Cancel-on-Disconnect (CoD)** — `CancelOnDisconnectType` (4 modes) + `CODTimeoutWindow` in `Establish`. Cancels non-GT working orders on triggering events; spec §4.7.3 enumerates gateway-forced disconnects that also fire CoD if enabled. | missing | No CoD support. | high | [#50](https://github.com/pedrosakuma/SbeB3Exchange/issues/50) |
+| GAP-19 | 4.8 | **Mass Cancel (`OrderMassActionRequest` 701 / `OrderMassActionReport` 702)** with filters Side / SecurityID / OrdTagID / Asset, plus mass-cancel-on-behalf. | missing | No mass cancel. | high | [#51](https://github.com/pedrosakuma/SbeB3Exchange/issues/51) |
+| GAP-20 | 4.9 | **Throttle** — sliding window of N messages / M ms, per session. Reject violations with `BusinessMessageReject "Throttle limit exceeded"`. | missing | Inbound queue is bounded but throttling per spec is not implemented; rejections do not surface to the client. | medium | [#52](https://github.com/pedrosakuma/SbeB3Exchange/issues/52) |
 | GAP-21 | 4.10 | **Other basic gateway validations** — `<CR>`/`<LF>` check on deskID/senderLocation/enteringTrader/executingTrader; varData length checks on `memo`/`deskID`. | missing | Pre-requisite is GAP-02 (we don't read varData at all today). | medium | depends on GAP-02. |
 
 ### Order types / TIF / advanced functionality
@@ -142,11 +142,11 @@ These are tracked here for completeness; most are explicit non-goals today.
 
 | # | Spec § | Item | Status | Severity | Issue |
 | --- | --- | --- | --- | --- | --- |
-| GAP-22 | 7.1.1–7.1.6 | Stop / StopLimit / Market-with-leftover-as-Limit (`K`) / RLP (`W`) order types | missing | low (non-goal) | — |
-| GAP-23 | 7.1.7–7.1.14 | `GTC` / `GTD` / `MOC` / `MOA` time-in-force | missing | low (non-goal) | — |
-| GAP-24 | 7.1.16–7.1.17 | Iceberg / disclosed quantity, MinQty | missing | low (non-goal) | — |
-| GAP-25 | 7.1.20 | In-flight modification semantics (priority loss rules) | partial | medium | — |
-| GAP-26 | 8.3 | Daily GTC/GTD restatement | missing | low (depends on GAP-23) | — |
+| GAP-22 | 7.1.1–7.1.6 | Stop / StopLimit / Market-with-leftover-as-Limit (`K`) / RLP (`W`) order types | missing | low (non-goal) | [#53](https://github.com/pedrosakuma/SbeB3Exchange/issues/53) |
+| GAP-23 | 7.1.7–7.1.14 | `GTC` / `GTD` / `MOC` / `MOA` time-in-force | missing | low (non-goal) | [#54](https://github.com/pedrosakuma/SbeB3Exchange/issues/54) |
+| GAP-24 | 7.1.16–7.1.17 | Iceberg / disclosed quantity, MinQty | missing | low (non-goal) | [#55](https://github.com/pedrosakuma/SbeB3Exchange/issues/55) |
+| GAP-25 | 7.1.20 | In-flight modification semantics (priority loss rules) | partial | medium | [#56](https://github.com/pedrosakuma/SbeB3Exchange/issues/56) |
+| GAP-26 | 8.3 | Daily GTC/GTD restatement | missing | low (depends on GAP-23) | [#57](https://github.com/pedrosakuma/SbeB3Exchange/issues/57) |
 | GAP-27 | 15.4 | Self-Trading Prevention | missing | medium | covered by #14 |
 | GAP-28 | 15.5 | Market Protections | missing | low (non-goal) | — |
 | GAP-29 | 15.1 | User-Defined Spreads (UDS) | missing | low | — |


### PR DESCRIPTION
Catalogues all known compliance gaps between `src/B3.Exchange.EntryPoint` and the official B3 Binary EntryPoint Messaging Guidelines 8.4.2.1.

Each row in the gap table has a stable `GAP-NN` anchor so the issues we open next can link back here without repeating spec context.

Highlights:
- 3 critical wire-format gaps (SOFH, varData, Terminate codes) that today prevent any real B3 client from interoperating with the simulator.
- 6 FIXP session-lifecycle gaps (Negotiate/Establish/Sequence/NotApplied/Retransmit/daily-reset).
- 4 application-header / message gaps (sessionID validation, receivedTime, BusinessMessageReject, OrdRejReason mapping).
- Operational features missing per spec: CoD, MassCancel, Throttle.
- Order-type / TIF gaps catalogued for traceability even though most are explicit non-goals (#19).

Conscious deviations (continuous-trading-only, routing by SecurityID, single EnteringFirm) and overlap with existing issues (#9, #11, #14, #16) are documented in the same file.