### PR TITLE
feat(entrypoint): GAP-01 add SOFH composite header

### DIFF
--- a/src/B3.Exchange.EntryPoint/BusinessMessageRejectEncoder.cs
+++ b/src/B3.Exchange.EntryPoint/BusinessMessageRejectEncoder.cs
@@ -23,7 +23,7 @@ namespace B3.Exchange.EntryPoint;
 /// </summary>
 internal static class BusinessMessageRejectEncoder
 {
-    private const int HeaderSize = 8;
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
     private const int BusinessHeaderSize = 18;
     public const int BusinessRejectBlock = 36;
     private const ulong UTCTimestampNullValue = ulong.MaxValue;
@@ -81,7 +81,8 @@ internal static class BusinessMessageRejectEncoder
         if (dst.Length < total)
             throw new ArgumentException("buffer too small for BusinessMessageReject", nameof(dst));
 
-        EntryPointFrameReader.WriteHeader(dst, BusinessRejectBlock,
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: BusinessRejectBlock,
             EntryPointFrameReader.TidBusinessMessageReject, version: 0);
 
         var body = dst.Slice(HeaderSize, BusinessRejectBlock);

--- a/src/B3.Exchange.EntryPoint/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointFrameReader.cs
@@ -1,17 +1,44 @@
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using B3.Entrypoint.Fixp.Sbe.V6;
 
 namespace B3.Exchange.EntryPoint;
 
 /// <summary>
-/// Wire-format constants and parsers for the stripped-down EntryPoint protocol:
-/// every TCP frame is the SBE 8-byte <see cref="MessageHeader"/> followed by
-/// exactly <c>BlockLength</c> bytes (no FIXP envelope, no repeating groups).
-/// Total frame size = 8 + BlockLength bytes.
+/// Wire-format constants and parsers for the B3 EntryPoint protocol.
+///
+/// Per spec §4.4, every TCP frame starts with a 12-byte composite header:
+///   • 4-byte SOFH (Simple Open Framing Header):
+///       <c>messageLength</c> (uint16 LE) — total frame length including SOFH itself
+///       <c>encodingType</c> (uint16 LE)  — must be <see cref="SofhEncodingType"/> (0xEB50)
+///   • 8-byte SBE <see cref="MessageHeader"/>: BlockLength / TemplateId / SchemaId / Version.
+/// The SBE body (and any trailing variable-length data) follows immediately after.
+///
+/// For the templates this gateway currently understands (no varData yet), the
+/// frame size is exactly <c>SOFH(4) + SBE(8) + BlockLength</c>; once GAP-02
+/// lands, additional length-prefixed varData segments follow the fixed block
+/// and SOFH <c>messageLength</c> is the only authoritative source of total
+/// frame length.
 /// </summary>
 public static class EntryPointFrameReader
 {
     public const ushort SchemaId = 1;
+
+    /// <summary>SOFH framing header size in bytes (uint16 length + uint16 encoding type).</summary>
+    public const int SofhSize = 4;
+
+    /// <summary>SBE message header size in bytes.</summary>
+    public const int SbeHeaderSize = 8;
+
+    /// <summary>Combined wire-header size: SOFH (4) + SBE header (8).</summary>
+    public const int WireHeaderSize = SofhSize + SbeHeaderSize;
+
+    /// <summary>SOFH <c>encodingType</c> for SBE 1.0 little-endian (per spec §4.4).</summary>
+    public const ushort SofhEncodingType = 0xEB50;
+
+    /// <summary>Spec §4.4 cap on inbound <c>messageLength</c> (bytes). Frames
+    /// claiming a larger length are rejected with <c>INVALID_SOFH</c>.</summary>
+    public const int MaxInboundMessageLength = 512;
 
     /// <summary>Outbound (session-level): Terminate (V0). Used as a
     /// "SessionReject" — see <see cref="SessionRejectEncoder"/>.</summary>
@@ -51,56 +78,148 @@ public static class EntryPointFrameReader
         _ => -1
     };
 
-    public readonly record struct FrameInfo(ushort TemplateId, ushort SchemaId, ushort Version, int BodyLength);
+    /// <summary>
+    /// Diagnostic error categories surfaced by header parsing. Mapped by
+    /// callers to the corresponding <c>TerminationCode</c> on the wire.
+    /// </summary>
+    public enum HeaderError
+    {
+        None = 0,
+        ShortHeader,
+        InvalidSofhEncodingType,
+        InvalidSofhMessageLength,   // 0, &lt; 12, or &gt; <see cref="MaxInboundMessageLength"/>
+        UnsupportedSchema,
+        UnsupportedTemplate,
+        BlockLengthMismatch,        // BlockLength != expected for known template
+        MessageLengthMismatch,      // SOFH messageLength inconsistent with SBE header + body
+    }
+
+    public readonly record struct FrameInfo(
+        ushort TemplateId,
+        ushort SchemaId,
+        ushort Version,
+        int BodyLength,
+        int MessageLength);
 
     /// <summary>
-    /// Parses the 8-byte SBE header and validates schema/template/blockLength.
-    /// Returns false if the header is unsupported (caller should drop the
-    /// connection — the protocol has no skip semantics for unknown frames).
+    /// Parses the 12-byte composite header (SOFH + SBE) and validates schema /
+    /// template / blockLength / messageLength. Returns false on any
+    /// well-formedness or compatibility error; <paramref name="error"/>
+    /// carries a category caller can map to a <c>TerminationCode</c>.
     /// </summary>
-    public static bool TryParseInboundHeader(ReadOnlySpan<byte> header, out FrameInfo info, out string? error)
+    public static bool TryParseInboundHeader(ReadOnlySpan<byte> header,
+        out FrameInfo info, out HeaderError error, out string? message)
     {
         info = default;
-        error = null;
-        if (header.Length < MessageHeader.MESSAGE_SIZE)
+        error = HeaderError.None;
+        message = null;
+        if (header.Length < WireHeaderSize)
         {
-            error = "header too short";
+            error = HeaderError.ShortHeader;
+            message = $"header too short: {header.Length} < {WireHeaderSize}";
             return false;
         }
-        if (!MessageHeader.TryReadHeader(header, out var blockLength, out var templateId, out var schemaId, out var version))
+
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(header.Slice(2, 2));
+
+        if (encodingType != SofhEncodingType)
         {
-            error = "header parse failed";
+            error = HeaderError.InvalidSofhEncodingType;
+            message = $"unexpected SOFH encodingType=0x{encodingType:X4} (expected 0x{SofhEncodingType:X4})";
             return false;
         }
+
+        if (messageLength < WireHeaderSize || messageLength > MaxInboundMessageLength)
+        {
+            error = HeaderError.InvalidSofhMessageLength;
+            message = $"SOFH messageLength={messageLength} out of range [{WireHeaderSize}..{MaxInboundMessageLength}]";
+            return false;
+        }
+
+        if (!MessageHeader.TryReadHeader(header.Slice(SofhSize, SbeHeaderSize),
+                out var blockLength, out var templateId, out var schemaId, out var version))
+        {
+            error = HeaderError.ShortHeader;
+            message = "SBE header parse failed";
+            return false;
+        }
+
         if (schemaId != SchemaId)
         {
-            error = $"unexpected SchemaId={schemaId}";
+            error = HeaderError.UnsupportedSchema;
+            message = $"unexpected SchemaId={schemaId}";
             return false;
         }
+
         int expected = ExpectedInboundBlockLength(templateId, version);
         if (expected < 0)
         {
-            error = $"unsupported template={templateId} version={version}";
+            error = HeaderError.UnsupportedTemplate;
+            message = $"unsupported template={templateId} version={version}";
             return false;
         }
+
         if (blockLength != expected)
         {
-            error = $"BlockLength={blockLength} mismatch (expected {expected}) for template={templateId}";
+            error = HeaderError.BlockLengthMismatch;
+            message = $"BlockLength={blockLength} mismatch (expected {expected}) for template={templateId}";
             return false;
         }
-        info = new FrameInfo(templateId, schemaId, version, blockLength);
+
+        // For templates without varData (current set), messageLength must be exactly
+        // SofhSize + SbeHeaderSize + BlockLength. GAP-02 will relax this once
+        // length-prefixed varData segments are honoured.
+        int expectedMessageLength = WireHeaderSize + blockLength;
+        if (messageLength != expectedMessageLength)
+        {
+            error = HeaderError.MessageLengthMismatch;
+            message = $"SOFH messageLength={messageLength} != WireHeader({WireHeaderSize})+BlockLength({blockLength})={expectedMessageLength}";
+            return false;
+        }
+
+        info = new FrameInfo(templateId, schemaId, version,
+            BodyLength: messageLength - WireHeaderSize,
+            MessageLength: messageLength);
         return true;
     }
 
-    /// <summary>Writes the 8-byte SBE header for an outbound message.</summary>
-    public static void WriteHeader(Span<byte> dst, ushort blockLength, ushort templateId, ushort version)
+    /// <summary>
+    /// Backwards-compatible parsing overload that hides the structured
+    /// <see cref="HeaderError"/> and surfaces only a free-form message
+    /// (matches the pre-SOFH signature; useful for callers that do not
+    /// yet route diagnostics back through the FIXP <c>Terminate</c> path).
+    /// </summary>
+    public static bool TryParseInboundHeader(ReadOnlySpan<byte> header, out FrameInfo info, out string? error)
     {
-        if (dst.Length < MessageHeader.MESSAGE_SIZE)
-            throw new ArgumentException("buffer too small for SBE header", nameof(dst));
-        ref var hdr = ref MemoryMarshal.AsRef<MessageHeader>(dst);
+        bool ok = TryParseInboundHeader(header, out info, out _, out var msg);
+        error = msg;
+        return ok;
+    }
+
+    /// <summary>
+    /// Writes the full 12-byte composite header (SOFH + SBE) into
+    /// <paramref name="dst"/> and returns <see cref="WireHeaderSize"/>.
+    /// <paramref name="messageLength"/> is the total frame length the SOFH
+    /// advertises (header + body + any trailing varData).
+    /// </summary>
+    public static int WriteHeader(Span<byte> dst, ushort messageLength,
+        ushort blockLength, ushort templateId, ushort version)
+    {
+        if (dst.Length < WireHeaderSize)
+            throw new ArgumentException("buffer too small for SOFH+SBE header", nameof(dst));
+        if (messageLength < WireHeaderSize)
+            throw new ArgumentOutOfRangeException(nameof(messageLength),
+                $"messageLength must be >= {WireHeaderSize} (got {messageLength})");
+
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(0, 2), messageLength);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(2, 2), SofhEncodingType);
+
+        ref var hdr = ref MemoryMarshal.AsRef<MessageHeader>(dst.Slice(SofhSize, SbeHeaderSize));
         hdr.BlockLength = blockLength;
         hdr.TemplateId = templateId;
         hdr.SchemaId = SchemaId;
         hdr.Version = version;
+        return WireHeaderSize;
     }
 }

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -22,7 +22,7 @@ namespace B3.Exchange.EntryPoint;
 /// </summary>
 public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDisposable
 {
-    private const int InboundHeaderSize = 8;
+    private const int InboundHeaderSize = EntryPointFrameReader.WireHeaderSize;
     private const int DefaultSendQueueCapacity = 1024;
 
     private readonly Stream _stream;

--- a/src/B3.Exchange.EntryPoint/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.EntryPoint/ExecutionReportEncoder.cs
@@ -19,7 +19,7 @@ namespace B3.Exchange.EntryPoint;
 /// </summary>
 internal static class ExecutionReportEncoder
 {
-    private const int HeaderSize = 8;            // SBE MessageHeader
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;            // SOFH(4) + SBE(8)
     private const int BusinessHeaderSize = 18;
     private const ulong UTCTimestampNullValue = ulong.MaxValue;
     private const long PriceNullMantissa = long.MinValue;
@@ -80,7 +80,8 @@ internal static class ExecutionReportEncoder
         long orderQty, long? priceMantissa)
     {
         if (dst.Length < ExecReportNewTotal) throw new ArgumentException("buffer too small for ER_New", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, ExecReportNewBlock, EntryPointFrameReader.TidExecutionReportNew, version: 2);
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportNewTotal,
+            ExecReportNewBlock, EntryPointFrameReader.TidExecutionReportNew, version: 2);
         var body = dst.Slice(HeaderSize, ExecReportNewBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -112,7 +113,8 @@ internal static class ExecutionReportEncoder
         long leavesQty, long cumQty, long orderQty, long priceMantissa)
     {
         if (dst.Length < ExecReportModifyTotal) throw new ArgumentException("buffer too small for ER_Modify", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, ExecReportModifyBlock, EntryPointFrameReader.TidExecutionReportModify, version: 2);
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportModifyTotal,
+            ExecReportModifyBlock, EntryPointFrameReader.TidExecutionReportModify, version: 2);
         var body = dst.Slice(HeaderSize, ExecReportModifyBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -146,7 +148,8 @@ internal static class ExecutionReportEncoder
         long cumQty, long orderQty, long? priceMantissa)
     {
         if (dst.Length < ExecReportCancelTotal) throw new ArgumentException("buffer too small for ER_Cancel", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, ExecReportCancelBlock, EntryPointFrameReader.TidExecutionReportCancel, version: 2);
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportCancelTotal,
+            ExecReportCancelBlock, EntryPointFrameReader.TidExecutionReportCancel, version: 2);
         var body = dst.Slice(HeaderSize, ExecReportCancelBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -181,7 +184,8 @@ internal static class ExecutionReportEncoder
         bool aggressor, uint tradeId, uint contraBroker, ushort tradeDate, long orderQty)
     {
         if (dst.Length < ExecReportTradeTotal) throw new ArgumentException("buffer too small for ER_Trade", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, ExecReportTradeBlock, EntryPointFrameReader.TidExecutionReportTrade, version: 2);
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportTradeTotal,
+            ExecReportTradeBlock, EntryPointFrameReader.TidExecutionReportTrade, version: 2);
         var body = dst.Slice(HeaderSize, ExecReportTradeBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -215,7 +219,8 @@ internal static class ExecutionReportEncoder
         byte rejectReason, ulong transactTimeNanos)
     {
         if (dst.Length < ExecReportRejectTotal) throw new ArgumentException("buffer too small for ER_Reject", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, ExecReportRejectBlock, EntryPointFrameReader.TidExecutionReportReject, version: 2);
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportRejectTotal,
+            ExecReportRejectBlock, EntryPointFrameReader.TidExecutionReportReject, version: 2);
         var body = dst.Slice(HeaderSize, ExecReportRejectBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);

--- a/src/B3.Exchange.EntryPoint/SessionFrameEncoder.cs
+++ b/src/B3.Exchange.EntryPoint/SessionFrameEncoder.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.EntryPoint;
 /// </summary>
 internal static class SessionFrameEncoder
 {
-    private const int HeaderSize = 8;
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
     public const int SequenceBlock = 4;
     public const int SequenceTotal = HeaderSize + SequenceBlock;
 
@@ -24,7 +24,8 @@ internal static class SessionFrameEncoder
     {
         if (dst.Length < SequenceTotal)
             throw new ArgumentException("buffer too small for Sequence frame", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, blockLength: SequenceBlock,
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)SequenceTotal,
+            blockLength: SequenceBlock,
             templateId: EntryPointFrameReader.TidSequence, version: 0);
         MemoryMarshal.Write(dst.Slice(HeaderSize, 4), in nextSeqNo);
         return SequenceTotal;

--- a/src/B3.Exchange.EntryPoint/SessionRejectEncoder.cs
+++ b/src/B3.Exchange.EntryPoint/SessionRejectEncoder.cs
@@ -18,7 +18,7 @@ namespace B3.Exchange.EntryPoint;
 /// </summary>
 internal static class SessionRejectEncoder
 {
-    private const int HeaderSize = 8;
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
     public const int TerminateBlock = 13;
     public const int TerminateTotal = HeaderSize + TerminateBlock;
 
@@ -38,7 +38,8 @@ internal static class SessionRejectEncoder
     {
         if (dst.Length < TerminateTotal)
             throw new ArgumentException("buffer too small for Terminate", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, TerminateBlock, EntryPointFrameReader.TidTerminate, version: 0);
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)TerminateTotal,
+            blockLength: TerminateBlock, EntryPointFrameReader.TidTerminate, version: 0);
         var body = dst.Slice(HeaderSize, TerminateBlock);
         body.Clear();
         MemoryMarshal.Write(body.Slice(0, 4), in sessionId);

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -81,7 +81,7 @@ public sealed class EntryPointClient : IAsyncDisposable
         _ => -1,
     };
 
-    private const int HeaderSize = 8;
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
 
     private readonly TcpClient _tcp;
     private readonly NetworkStream _stream;
@@ -172,6 +172,7 @@ public sealed class EntryPointClient : IAsyncDisposable
         if (frame.Length < HeaderSize + NewOrderBlockLen)
             throw new ArgumentException("buffer too small for SimpleNewOrderV2", nameof(frame));
         EntryPointFrameReader.WriteHeader(frame.Slice(0, HeaderSize),
+            messageLength: (ushort)(HeaderSize + NewOrderBlockLen),
             blockLength: NewOrderBlockLen,
             templateId: EntryPointFrameReader.TidSimpleNewOrder,
             version: 2);
@@ -202,6 +203,7 @@ public sealed class EntryPointClient : IAsyncDisposable
         if (frame.Length < HeaderSize + CancelBlockLen)
             throw new ArgumentException("buffer too small for OrderCancelRequest", nameof(frame));
         EntryPointFrameReader.WriteHeader(frame.Slice(0, HeaderSize),
+            messageLength: (ushort)(HeaderSize + CancelBlockLen),
             blockLength: CancelBlockLen,
             templateId: EntryPointFrameReader.TidOrderCancelRequest,
             version: 0);
@@ -312,10 +314,26 @@ public sealed class EntryPointClient : IAsyncDisposable
             while (!ct.IsCancellationRequested)
             {
                 await ReadExactAsync(_stream, headerBuf, ct).ConfigureAwait(false);
-                ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
-                ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
-                ushort schemaId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(4, 2));
-                ushort version = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(6, 2));
+                ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+                ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+                if (encodingType != EntryPointFrameReader.SofhEncodingType)
+                {
+                    _logWarn?.Invoke($"unexpected SOFH encodingType=0x{encodingType:X4}, dropping connection");
+                    Close($"unexpected SOFH encodingType=0x{encodingType:X4}");
+                    return;
+                }
+                if (messageLength < EntryPointFrameReader.WireHeaderSize ||
+                    messageLength > EntryPointFrameReader.MaxInboundMessageLength)
+                {
+                    _logWarn?.Invoke($"unreasonable SOFH messageLength={messageLength}, dropping connection");
+                    Close($"unreasonable SOFH messageLength={messageLength}");
+                    return;
+                }
+                var sbe = headerBuf.AsSpan(EntryPointFrameReader.SofhSize, EntryPointFrameReader.SbeHeaderSize);
+                ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(sbe.Slice(0, 2));
+                ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbe.Slice(2, 2));
+                ushort schemaId = BinaryPrimitives.ReadUInt16LittleEndian(sbe.Slice(4, 2));
+                ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbe.Slice(6, 2));
                 if (schemaId != EntryPointFrameReader.SchemaId)
                 {
                     _logWarn?.Invoke($"unexpected schemaId={schemaId}, dropping connection");
@@ -335,11 +353,20 @@ public sealed class EntryPointClient : IAsyncDisposable
                     Close($"unreasonable blockLength={blockLength}");
                     return;
                 }
+                int bodyLength = messageLength - EntryPointFrameReader.WireHeaderSize;
+                if (bodyLength < blockLength || bodyLength > MaxAcceptedBlockLength)
+                {
+                    _logWarn?.Invoke($"SOFH messageLength inconsistent with body (msgLen={messageLength}, block={blockLength}), dropping");
+                    Close($"messageLength inconsistent");
+                    return;
+                }
                 // Rent the body buffer to avoid per-frame heap allocations under load.
-                var body = ArrayPool<byte>.Shared.Rent(blockLength);
+                // Body may include trailing varData beyond BlockLength once GAP-02 lands;
+                // we read the full bodyLength here so the cursor stays aligned.
+                var body = ArrayPool<byte>.Shared.Rent(bodyLength);
                 try
                 {
-                    await ReadExactAsync(_stream, body.AsMemory(0, blockLength), ct).ConfigureAwait(false);
+                    await ReadExactAsync(_stream, body.AsMemory(0, bodyLength), ct).ConfigureAwait(false);
                     Dispatch(templateId, version, body, blockLength);
                 }
                 finally

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointFrameReaderTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointFrameReaderTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using B3.Exchange.EntryPoint;
 
@@ -5,43 +6,130 @@ namespace B3.Exchange.EntryPoint.Tests;
 
 public class EntryPointFrameReaderTests
 {
+    private const int Wire = EntryPointFrameReader.WireHeaderSize;
+
     [Fact]
     public void TryParse_AcceptsValidSimpleNewOrderHeader()
     {
-        Span<byte> buf = stackalloc byte[8];
-        EntryPointFrameReader.WriteHeader(buf, blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 82),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
 
         var ok = EntryPointFrameReader.TryParseInboundHeader(buf, out var info, out var err);
 
         Assert.True(ok, err);
         Assert.Equal(EntryPointFrameReader.TidSimpleNewOrder, info.TemplateId);
         Assert.Equal(82, info.BodyLength);
+        Assert.Equal(Wire + 82, info.MessageLength);
     }
 
     [Fact]
     public void TryParse_RejectsMismatchedBlockLength()
     {
-        Span<byte> buf = stackalloc byte[8];
-        EntryPointFrameReader.WriteHeader(buf, blockLength: 81, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 81),
+            blockLength: 81, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
         Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out _));
     }
 
     [Fact]
     public void TryParse_RejectsUnknownTemplate()
     {
-        Span<byte> buf = stackalloc byte[8];
-        EntryPointFrameReader.WriteHeader(buf, blockLength: 82, templateId: 9999, version: 2);
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 82),
+            blockLength: 82, templateId: 9999, version: 2);
         Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out _));
     }
 
     [Fact]
     public void TryParse_RejectsWrongSchema()
     {
-        Span<byte> buf = stackalloc byte[8];
-        EntryPointFrameReader.WriteHeader(buf, blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
-        // Patch SchemaId to wrong value
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 82),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        // Patch SchemaId (offset = SOFH(4) + 4) to wrong value.
         ushort badSchema = 999;
-        MemoryMarshal.Write(buf.Slice(4, 2), in badSchema);
+        MemoryMarshal.Write(buf.Slice(EntryPointFrameReader.SofhSize + 4, 2), in badSchema);
         Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out _));
+    }
+
+    [Fact]
+    public void TryParse_RejectsBadEncodingType()
+    {
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 82),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        // Corrupt encodingType.
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.Slice(2, 2), 0x1234);
+
+        Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out var err, out var msg));
+        Assert.Equal(EntryPointFrameReader.HeaderError.InvalidSofhEncodingType, err);
+        Assert.NotNull(msg);
+    }
+
+    [Fact]
+    public void TryParse_RejectsMessageLengthOverCap()
+    {
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(EntryPointFrameReader.MaxInboundMessageLength + 1),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out var err, out _));
+        Assert.Equal(EntryPointFrameReader.HeaderError.InvalidSofhMessageLength, err);
+    }
+
+    [Fact]
+    public void TryParse_RejectsMessageLengthInconsistentWithBlock()
+    {
+        Span<byte> buf = stackalloc byte[Wire];
+        // Claim one byte more than header+block.
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 82 + 1),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out var err, out _));
+        Assert.Equal(EntryPointFrameReader.HeaderError.MessageLengthMismatch, err);
+    }
+
+    [Fact]
+    public void WriteHeader_WritesSofhAndSbeBytes()
+    {
+        Span<byte> buf = stackalloc byte[Wire];
+        int n = EntryPointFrameReader.WriteHeader(buf,
+            messageLength: 0x1234,
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        Assert.Equal(Wire, n);
+        Assert.Equal((ushort)0x1234, BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(0, 2)));
+        Assert.Equal(EntryPointFrameReader.SofhEncodingType, BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(2, 2)));
+        Assert.Equal((ushort)82, BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(4, 2)));
+        Assert.Equal(EntryPointFrameReader.TidSimpleNewOrder, BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(6, 2)));
+        Assert.Equal(EntryPointFrameReader.SchemaId, BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(8, 2)));
+        Assert.Equal((ushort)2, BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(10, 2)));
+    }
+
+    [Fact]
+    public void WriteHeader_RoundTripsThroughTryParse()
+    {
+        // Acceptance #4: bytes written by WriteHeader must be parsed back to identical fields.
+        Span<byte> buf = stackalloc byte[Wire];
+        ushort msgLen = (ushort)(Wire + 82);
+        int n = EntryPointFrameReader.WriteHeader(buf,
+            messageLength: msgLen,
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        Assert.Equal(Wire, n);
+        Assert.True(EntryPointFrameReader.TryParseInboundHeader(buf, out var info, out var err));
+        Assert.Null(err);
+        Assert.Equal(msgLen, info.MessageLength);
+        Assert.Equal(82, info.BodyLength);
+        Assert.Equal(EntryPointFrameReader.TidSimpleNewOrder, info.TemplateId);
+        Assert.Equal((ushort)2, info.Version);
     }
 }

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
@@ -24,9 +24,11 @@ public class EntryPointHeartbeatTests
 
     private static byte[] BuildSequenceFrame(uint nextSeq)
     {
-        var f = new byte[12];
-        EntryPointFrameReader.WriteHeader(f, blockLength: 4, templateId: EntryPointFrameReader.TidSequence, version: 0);
-        BitConverter.GetBytes(nextSeq).CopyTo(f, 8);
+        const int total = EntryPointFrameReader.WireHeaderSize + 4;
+        var f = new byte[total];
+        EntryPointFrameReader.WriteHeader(f, messageLength: (ushort)total,
+            blockLength: 4, templateId: EntryPointFrameReader.TidSequence, version: 0);
+        BitConverter.GetBytes(nextSeq).CopyTo(f, EntryPointFrameReader.WireHeaderSize);
         return f;
     }
 
@@ -76,10 +78,11 @@ public class EntryPointHeartbeatTests
         }
         catch (OperationCanceledException) { }
         catch (IOException) { }
-        // We should have received exactly one Sequence probe (12 bytes) before EOF.
-        Assert.Equal(12, total);
-        // Header sanity: templateId == 9 at offset 2.
-        ushort tid = BitConverter.ToUInt16(buf, 2);
+        // We should have received exactly one Sequence probe (SOFH+SBE+4 bytes) before EOF.
+        const int expectedFrameLen = EntryPointFrameReader.WireHeaderSize + 4;
+        Assert.Equal(expectedFrameLen, total);
+        // Header sanity: templateId == 9 at offset SOFH+2.
+        ushort tid = BitConverter.ToUInt16(buf, EntryPointFrameReader.SofhSize + 2);
         Assert.Equal((ushort)EntryPointFrameReader.TidSequence, tid);
     }
 
@@ -149,17 +152,18 @@ public class EntryPointHeartbeatTests
         // Keep inbound alive with one Sequence frame so idle never trips —
         // but with idle/grace at 10s the test would not run long enough to
         // notice anyway. Just read whatever the server sends.
-        byte[] buf = new byte[12];
+        const int expectedFrameLen = EntryPointFrameReader.WireHeaderSize + 4;
+        byte[] buf = new byte[expectedFrameLen];
         int total = 0;
         using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-        while (total < 12)
+        while (total < expectedFrameLen)
         {
-            int n = await ns.ReadAsync(buf.AsMemory(total, 12 - total), readCts.Token);
+            int n = await ns.ReadAsync(buf.AsMemory(total, expectedFrameLen - total), readCts.Token);
             if (n == 0) break;
             total += n;
         }
-        Assert.Equal(12, total);
-        Assert.Equal((ushort)EntryPointFrameReader.TidSequence, BitConverter.ToUInt16(buf, 2));
-        Assert.Equal((ushort)4, BitConverter.ToUInt16(buf, 0)); // BlockLength
+        Assert.Equal(expectedFrameLen, total);
+        Assert.Equal((ushort)EntryPointFrameReader.TidSequence, BitConverter.ToUInt16(buf, EntryPointFrameReader.SofhSize + 2));
+        Assert.Equal((ushort)4, BitConverter.ToUInt16(buf, EntryPointFrameReader.SofhSize)); // BlockLength
     }
 }

--- a/tests/B3.Exchange.EntryPoint.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/ExecutionReportEncoderTests.cs
@@ -19,14 +19,14 @@ public class ExecutionReportEncoderTests
             orderQty: 10, priceMantissa: 12_3450L);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportNewTotal, n);
-        // Header: BlockLength=144 @0, TemplateId=200 @2, SchemaId=1 @4, Version=2 @6
-        var hdr = buf.AsSpan(0, 8);
+        // SBE header at offset SOFH(4)..SOFH+8: BlockLength=144, TemplateId=200, SchemaId=1, Version=2
+        var hdr = buf.AsSpan(EntryPointFrameReader.SofhSize, EntryPointFrameReader.SbeHeaderSize);
         Assert.Equal((ushort)ExecutionReportEncoder.ExecReportNewBlock, MemoryMarshal.Read<ushort>(hdr.Slice(0, 2)));
         Assert.Equal((ushort)EntryPointFrameReader.TidExecutionReportNew, MemoryMarshal.Read<ushort>(hdr.Slice(2, 2)));
         Assert.Equal((ushort)1, MemoryMarshal.Read<ushort>(hdr.Slice(4, 2)));
         Assert.Equal((ushort)2, MemoryMarshal.Read<ushort>(hdr.Slice(6, 2)));
 
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal((uint)42, MemoryMarshal.Read<uint>(body.Slice(0, 4)));        // SessionId
         Assert.Equal((uint)1, MemoryMarshal.Read<uint>(body.Slice(4, 4)));         // MsgSeqNum
         Assert.Equal(1_000_000_000UL, MemoryMarshal.Read<ulong>(body.Slice(8, 8)));// SendingTime
@@ -61,7 +61,7 @@ public class ExecutionReportEncoderTests
             tradeDate: 19000, orderQty: 5);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportTradeTotal, n);
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal((byte)'2', body[18]);          // Side=Sell
         Assert.Equal((byte)'2', body[19]);          // OrdStatus=Filled (leaves==0)
         Assert.Equal(5L, MemoryMarshal.Read<long>(body.Slice(48, 8)));   // LastQty
@@ -89,7 +89,7 @@ public class ExecutionReportEncoderTests
             cumQty: 0, orderQty: 100, priceMantissa: 12_3450L);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportCancelTotal, n);
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal((byte)'4', body[19]);                                          // OrdStatus=Canceled
         Assert.Equal(11UL, MemoryMarshal.Read<ulong>(body.Slice(20, 8)));           // ClOrdID
         Assert.Equal(0L, MemoryMarshal.Read<long>(body.Slice(44, 8)));              // CumQty (overlap)
@@ -110,7 +110,7 @@ public class ExecutionReportEncoderTests
             rejectReason: 5, transactTimeNanos: 0UL);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportRejectTotal, n);
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal(7UL, MemoryMarshal.Read<ulong>(body.Slice(20, 8)));            // ClOrdID
         Assert.Equal(333L, MemoryMarshal.Read<long>(body.Slice(36, 8)));            // SecurityID
         Assert.Equal((byte)5, body[44]);                                            // OrdRejReason
@@ -127,7 +127,7 @@ public class ExecutionReportEncoderTests
             leavesQty: 50, cumQty: 25, orderQty: 75, priceMantissa: 99_0000L);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportModifyTotal, n);
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal((byte)'5', body[19]);                                          // OrdStatus=Replaced
         Assert.Equal(50L, MemoryMarshal.Read<long>(body.Slice(44, 8)));             // LeavesQty (overlap)
         Assert.Equal(25L, MemoryMarshal.Read<long>(body.Slice(72, 8)));             // CumQty

--- a/tests/B3.Exchange.EntryPoint.Tests/RejectEncoderTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/RejectEncoderTests.cs
@@ -16,17 +16,21 @@ public class RejectEncoderTests
             terminationCode: SessionRejectEncoder.TerminationCode.DecodingError);
 
         Assert.Equal(SessionRejectEncoder.TerminateTotal, n);
-        Assert.Equal(21, n);
+        Assert.Equal(EntryPointFrameReader.WireHeaderSize + 13, n);
 
-        // SBE header
-        var hdr = buf.AsSpan(0, 8);
+        // SOFH (offset 0..4)
+        Assert.Equal((ushort)n, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2)));
+        Assert.Equal(EntryPointFrameReader.SofhEncodingType, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(2, 2)));
+
+        // SBE header (offset SOFH+0 .. SOFH+8)
+        var hdr = buf.AsSpan(EntryPointFrameReader.SofhSize, EntryPointFrameReader.SbeHeaderSize);
         Assert.Equal((ushort)SessionRejectEncoder.TerminateBlock, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(0, 2)));
         Assert.Equal(EntryPointFrameReader.TidTerminate, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(2, 2)));
         Assert.Equal((ushort)EntryPointFrameReader.SchemaId, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(4, 2)));
         Assert.Equal((ushort)0, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(6, 2)));
 
         // Body
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal(0xDEADBEEFu, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
         Assert.Equal(0x0102030405060708UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)));
         Assert.Equal((byte)SessionRejectEncoder.TerminationCode.DecodingError, body[12]);
@@ -46,15 +50,19 @@ public class RejectEncoderTests
 
         Assert.Equal(BusinessMessageRejectEncoder.TotalSize(12), n);
 
-        // Header: BlockLength=36, TemplateId=206, SchemaId=1, Version=0
-        var hdr = buf.AsSpan(0, 8);
+        // SOFH
+        Assert.Equal((ushort)n, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2)));
+        Assert.Equal(EntryPointFrameReader.SofhEncodingType, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(2, 2)));
+
+        // SBE header: BlockLength=36, TemplateId=206, SchemaId=1, Version=0
+        var hdr = buf.AsSpan(EntryPointFrameReader.SofhSize, EntryPointFrameReader.SbeHeaderSize);
         Assert.Equal((ushort)BusinessMessageRejectEncoder.BusinessRejectBlock, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(0, 2)));
         Assert.Equal(EntryPointFrameReader.TidBusinessMessageReject, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(2, 2)));
         Assert.Equal((ushort)EntryPointFrameReader.SchemaId, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(4, 2)));
         Assert.Equal((ushort)0, BinaryPrimitives.ReadUInt16LittleEndian(hdr.Slice(6, 2)));
 
         // OutboundBusinessHeader
-        var body = buf.AsSpan(8);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
         Assert.Equal(99u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(4, 4)));
         Assert.Equal(1_700_000_000_000_000_000UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(8, 8)));
@@ -69,7 +77,7 @@ public class RejectEncoderTests
             BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(32, 4)));                   // BusinessRejectReason
 
         // VarData: memo (length 0) then text ("invalid Side", 11 ASCII bytes)
-        var trailer = buf.AsSpan(8 + BusinessMessageRejectEncoder.BusinessRejectBlock);
+        var trailer = buf.AsSpan(EntryPointFrameReader.WireHeaderSize + BusinessMessageRejectEncoder.BusinessRejectBlock);
         Assert.Equal((byte)0, trailer[0]);          // memo length
         Assert.Equal((byte)12, trailer[1]);         // text length
         var text = System.Text.Encoding.ASCII.GetString(trailer.Slice(2, 12));
@@ -85,8 +93,8 @@ public class RejectEncoderTests
             refMsgType: 0, refSeqNum: 0u, businessRejectRefId: 0UL,
             businessRejectReason: BusinessMessageRejectEncoder.Reason.Other,
             text: null);
-        Assert.Equal(8 + BusinessMessageRejectEncoder.BusinessRejectBlock + 2, n);
-        var trailer = buf.AsSpan(8 + BusinessMessageRejectEncoder.BusinessRejectBlock);
+        Assert.Equal(EntryPointFrameReader.WireHeaderSize + BusinessMessageRejectEncoder.BusinessRejectBlock + 2, n);
+        var trailer = buf.AsSpan(EntryPointFrameReader.WireHeaderSize + BusinessMessageRejectEncoder.BusinessRejectBlock);
         Assert.Equal((byte)0, trailer[0]);
         Assert.Equal((byte)0, trailer[1]);
     }
@@ -102,7 +110,7 @@ public class RejectEncoderTests
             businessRejectReason: BusinessMessageRejectEncoder.Reason.Other,
             text: longText);
         Assert.Equal(BusinessMessageRejectEncoder.TotalSize(BusinessMessageRejectEncoder.MaxTextLength), n);
-        var trailer = buf.AsSpan(8 + BusinessMessageRejectEncoder.BusinessRejectBlock);
+        var trailer = buf.AsSpan(EntryPointFrameReader.WireHeaderSize + BusinessMessageRejectEncoder.BusinessRejectBlock);
         Assert.Equal((byte)0, trailer[0]);
         Assert.Equal((byte)BusinessMessageRejectEncoder.MaxTextLength, trailer[1]);
     }

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -289,12 +289,13 @@ public class ExchangeHostE2ETests
 
     private static byte[] BuildOrderCancelRequest(ulong clOrdId, long secId, ulong orderId, ulong origClOrdId, char side)
     {
-        // 8-byte SBE MessageHeader + 76-byte OrderCancelRequest (V6) body.
-        var frame = new byte[8 + 76];
-        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+        // 12-byte composite header (SOFH+SBE) + 76-byte OrderCancelRequest (V6) body.
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 76];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
             blockLength: 76, templateId: EntryPointFrameReader.TidOrderCancelRequest, version: 0);
 
-        var body = frame.AsSpan(8);
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(28, 8), secId);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(36, 8), orderId);
@@ -306,12 +307,13 @@ public class ExchangeHostE2ETests
     private static byte[] BuildSimpleModifyOrder(ulong clOrdId, long secId, char side, long qty,
         long priceMantissa, ulong orderId, ulong origClOrdId)
     {
-        // 8-byte SBE MessageHeader + 98-byte SimpleModifyOrderV2 body.
-        var frame = new byte[8 + 98];
-        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+        // 12-byte composite header + 98-byte SimpleModifyOrderV2 body.
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 98];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
             blockLength: 98, templateId: EntryPointFrameReader.TidSimpleModifyOrder, version: 2);
 
-        var body = frame.AsSpan(8);
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
         body[56] = (byte)side;
@@ -325,12 +327,13 @@ public class ExchangeHostE2ETests
     private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
         char tif, long qty, long priceMantissa)
     {
-        // 8-byte SBE MessageHeader + 82-byte SimpleNewOrderV2 body.
-        var frame = new byte[8 + 82];
-        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+        // 12-byte composite header + 82-byte SimpleNewOrderV2 body.
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
             blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
 
-        var body = frame.AsSpan(8);
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
         body[56] = (byte)side;
@@ -347,12 +350,18 @@ public class ExchangeHostE2ETests
     {
         if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
         using var cts = new CancellationTokenSource(timeout);
-        var headerBuf = new byte[8];
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
         await ReadExactAsync(stream, headerBuf, cts.Token);
-        ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
-        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
-        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(6, 2));
-        var body = new byte[blockLength];
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(0, 2));
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
         await ReadExactAsync(stream, body, cts.Token);
         return new ReadFrame(templateId, version, body);
     }

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
@@ -194,10 +194,11 @@ public class ExchangeHostSnapshotE2ETests
     private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
         char tif, long qty, long priceMantissa)
     {
-        var frame = new byte[8 + 82];
-        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, 8),
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
             blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
-        var body = frame.AsSpan(8);
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
         body[56] = (byte)side;
@@ -214,12 +215,18 @@ public class ExchangeHostSnapshotE2ETests
     {
         if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
         using var cts = new CancellationTokenSource(timeout);
-        var headerBuf = new byte[8];
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
         await ReadExactAsync(stream, headerBuf, cts.Token);
-        ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
-        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
-        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(6, 2));
-        var body = new byte[blockLength];
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(0, 2));
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
         await ReadExactAsync(stream, body, cts.Token);
         return new ReadFrame(templateId, version, body);
     }

--- a/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
@@ -14,7 +14,7 @@ namespace B3.Exchange.SyntheticTrader.Tests;
 /// </summary>
 public class WireFormatCompatTests
 {
-    private const int SbeHeaderSize = 8;
+    private const int SbeHeaderSize = EntryPointFrameReader.WireHeaderSize;
 
     [Fact]
     public void SimpleNewOrder_RoundTripsThroughHostInboundDecoder()


### PR DESCRIPTION
Closes #39

Implements the 4-byte Simple Open Framing Header (SOFH) per B3 EntryPoint spec §4.4 on both inbound and outbound TCP frames. Wire header is now SOFH(4) + SBE(8) = 12 bytes; inbound frames capped at 512 bytes.

## Highlights
- `EntryPointFrameReader` exposes SOFH constants, `MaxInboundMessageLength`, a `HeaderError` enum (consumed by upcoming GAP-03 Terminate mapping), and `FrameInfo.MessageLength`.
- `WriteHeader` signature now takes `messageLength`; all encoders updated.
- `EntryPointSession` reads the 12-byte composite header.
- `SyntheticTrader.EntryPointClient` encodes/decodes SOFH end-to-end (the companion wire client must stay in sync).
- New tests cover: SOFH happy path, invalid encodingType, messageLength mismatch, blockLength mismatch, unknown template, wrong schema, oversize, plus a `WriteHeader → TryParseInboundHeader` byte round-trip.
- E2E host tests (TCP) parse the new composite header — exercises real wire compat.

## Verification
- `dotnet build -c Release` (warnings-as-errors): ✅
- `dotnet test  -c Release`: ✅ all suites
- `dotnet format --verify-no-changes`: ✅

## Phase 0 sequence
GAP-01 → GAP-02 (#40 varData) → GAP-03 (#41 Terminate + 512-byte cap on framing errors)