### PR TITLE
feat(entrypoint): GAP-02 read and validate trailing varData

### DIFF
--- a/src/B3.Exchange.EntryPoint/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointFrameReader.cs
@@ -99,7 +99,14 @@ public static class EntryPointFrameReader
         ushort SchemaId,
         ushort Version,
         int BodyLength,
-        int MessageLength);
+        int MessageLength,
+        int BlockLength)
+    {
+        /// <summary>Bytes of trailing variable-length data after the SBE
+        /// fixed root block (= <see cref="BodyLength"/> -
+        /// <see cref="BlockLength"/>). Always ≥ 0.</summary>
+        public int VarDataLength => BodyLength - BlockLength;
+    }
 
     /// <summary>
     /// Parses the 12-byte composite header (SOFH + SBE) and validates schema /
@@ -167,20 +174,23 @@ public static class EntryPointFrameReader
             return false;
         }
 
-        // For templates without varData (current set), messageLength must be exactly
-        // SofhSize + SbeHeaderSize + BlockLength. GAP-02 will relax this once
-        // length-prefixed varData segments are honoured.
-        int expectedMessageLength = WireHeaderSize + blockLength;
-        if (messageLength != expectedMessageLength)
+        // Per spec §3.5, application messages may carry length-prefixed
+        // variable-length data segments after the SBE fixed root block.
+        // SOFH messageLength is the source of truth for the total frame
+        // size, so we accept anything ≥ WireHeaderSize + BlockLength and
+        // hand the trailing bytes to varData decoding (GAP-02).
+        int minMessageLength = WireHeaderSize + blockLength;
+        if (messageLength < minMessageLength)
         {
             error = HeaderError.MessageLengthMismatch;
-            message = $"SOFH messageLength={messageLength} != WireHeader({WireHeaderSize})+BlockLength({blockLength})={expectedMessageLength}";
+            message = $"SOFH messageLength={messageLength} < WireHeader({WireHeaderSize})+BlockLength({blockLength})={minMessageLength}";
             return false;
         }
 
         info = new FrameInfo(templateId, schemaId, version,
             BodyLength: messageLength - WireHeaderSize,
-            MessageLength: messageLength);
+            MessageLength: messageLength,
+            BlockLength: blockLength);
         return true;
     }
 

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -147,8 +147,23 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
     private void DispatchInbound(EntryPointFrameReader.FrameInfo info, ReadOnlySpan<byte> body)
     {
         ulong now = _nowNanos();
-        _logger.LogTrace("session {ConnectionId} inbound frame templateId={TemplateId} length={Length}",
-            ConnectionId, info.TemplateId, info.BodyLength);
+        _logger.LogTrace("session {ConnectionId} inbound frame templateId={TemplateId} blockLength={BlockLength} varDataLength={VarDataLength}",
+            ConnectionId, info.TemplateId, info.BlockLength, info.VarDataLength);
+
+        // Per spec §3.5, varData segments follow the fixed root block. We
+        // validate them here (length-prefixed, declared per-template caps
+        // from §4.10) before handing the fixed block to the typed
+        // decoders. A failure here is a decoding error — see #41 for the
+        // session-vs-business reject mapping.
+        var fixedBlock = body.Slice(0, info.BlockLength);
+        var varData = body.Slice(info.BlockLength);
+        var spec = EntryPointVarData.ExpectedFor(info.TemplateId, info.Version);
+        if (!EntryPointVarData.TryValidate(varData, spec, out var varErr))
+        {
+            _sink.OnDecodeError(this, varErr ?? "decode error: varData");
+            return;
+        }
+
         switch (info.TemplateId)
         {
             case EntryPointFrameReader.TidSequence:
@@ -156,17 +171,17 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
                 // recorded by the receive loop; nothing else to do.
                 return;
             case EntryPointFrameReader.TidSimpleNewOrder:
-                if (InboundMessageDecoder.TryDecodeNewOrder(body, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
+                if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                     _sink.EnqueueNewOrder(no, this, noClOrd);
                 else _sink.OnDecodeError(this, noErr ?? "decode error: SimpleNewOrder");
                 break;
             case EntryPointFrameReader.TidSimpleModifyOrder:
-                if (InboundMessageDecoder.TryDecodeReplace(body, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr))
+                if (InboundMessageDecoder.TryDecodeReplace(fixedBlock, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr))
                     _sink.EnqueueReplace(rp, this, rpClOrd, rpOrigClOrd);
                 else _sink.OnDecodeError(this, rpErr ?? "decode error: SimpleModifyOrder");
                 break;
             case EntryPointFrameReader.TidOrderCancelRequest:
-                if (InboundMessageDecoder.TryDecodeCancel(body, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
+                if (InboundMessageDecoder.TryDecodeCancel(fixedBlock, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
                     _sink.EnqueueCancel(cn, this, cnClOrd, cnOrigClOrd);
                 else _sink.OnDecodeError(this, cnErr ?? "decode error: OrderCancelRequest");
                 break;

--- a/src/B3.Exchange.EntryPoint/EntryPointVarData.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointVarData.cs
@@ -1,0 +1,105 @@
+namespace B3.Exchange.EntryPoint;
+
+/// <summary>
+/// Walks and validates the length-prefixed variable-length data segments
+/// that follow the SBE fixed root block in EntryPoint application
+/// messages (spec §3.5 / §4.10).
+///
+/// Each segment is encoded as <c>length(uint8)</c> + <c>varData(N bytes)</c>.
+/// The set, order and per-segment maximum length depend on the template;
+/// see <see cref="ExpectedFor(ushort, ushort)"/>.
+/// </summary>
+public static class EntryPointVarData
+{
+    /// <summary>One varData field declaration: spec name and the maximum
+    /// payload length in bytes (the <c>length</c> primitive's
+    /// <c>maxValue</c> attribute in the SBE schema).</summary>
+    public readonly record struct Field(string Name, byte MaxLength);
+
+    private static readonly Field Memo = new("memo", 40);
+    private static readonly Field DeskID = new("deskID", 20);
+
+    private static readonly Field[] SimpleNewOrderFields = [Memo];
+    private static readonly Field[] SimpleModifyOrderFields = [Memo];
+    private static readonly Field[] OrderCancelFields = [DeskID, Memo];
+    private static readonly Field[] None = [];
+
+    /// <summary>
+    /// Returns the ordered varData specification for a template (the
+    /// fields the gateway expects after the fixed block, top-to-bottom in
+    /// the SBE schema). Unknown templates and session-level frames return
+    /// an empty array.
+    /// </summary>
+    public static ReadOnlySpan<Field> ExpectedFor(ushort templateId, ushort version) => (templateId, version) switch
+    {
+        (EntryPointFrameReader.TidSimpleNewOrder, 2) => SimpleNewOrderFields,
+        (EntryPointFrameReader.TidSimpleModifyOrder, 2) => SimpleModifyOrderFields,
+        (EntryPointFrameReader.TidOrderCancelRequest, 0) => OrderCancelFields,
+        _ => None,
+    };
+
+    /// <summary>
+    /// Validates that <paramref name="varData"/> is a well-formed
+    /// concatenation of length-prefixed segments matching
+    /// <paramref name="spec"/>. Each segment is allowed to be empty
+    /// (length=0) and must not exceed its declared
+    /// <see cref="Field.MaxLength"/>. The cumulative length of all
+    /// segments (including their 1-byte length prefixes) must equal
+    /// <paramref name="varData"/>.Length exactly.
+    /// </summary>
+    public static bool TryValidate(ReadOnlySpan<byte> varData, ReadOnlySpan<Field> spec, out string? error)
+    {
+        error = null;
+        int offset = 0;
+        for (int i = 0; i < spec.Length; i++)
+        {
+            if (offset >= varData.Length)
+            {
+                // Per spec, varData fields are optional: a field may be omitted
+                // by truncating the trailer, but if present they must appear in
+                // order. If we're past the buffer, remaining fields are simply
+                // not present — that is OK as long as the buffer ended
+                // exactly.
+                if (offset == varData.Length) return true;
+                error = $"varData truncated at field '{spec[i].Name}' (offset {offset} > {varData.Length})";
+                return false;
+            }
+            byte len = varData[offset];
+            if (len > spec[i].MaxLength)
+            {
+                error = $"varData field '{spec[i].Name}' length {len} exceeds max {spec[i].MaxLength}";
+                return false;
+            }
+            int next = offset + 1 + len;
+            if (next > varData.Length)
+            {
+                error = $"varData field '{spec[i].Name}' length {len} overruns buffer (offset {offset + 1} + {len} > {varData.Length})";
+                return false;
+            }
+            offset = next;
+        }
+        if (offset != varData.Length)
+        {
+            error = $"varData has {varData.Length - offset} trailing byte(s) after declared fields";
+            return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Iterates the next segment in <paramref name="remaining"/>: reads
+    /// the 1-byte length, slices the payload, and advances
+    /// <paramref name="remaining"/>. Returns <c>false</c> if no more
+    /// data, or if the length prefix overruns the buffer.
+    /// </summary>
+    public static bool TryReadNext(ref ReadOnlySpan<byte> remaining, out ReadOnlySpan<byte> segment)
+    {
+        segment = default;
+        if (remaining.IsEmpty) return false;
+        byte len = remaining[0];
+        if (1 + len > remaining.Length) return false;
+        segment = remaining.Slice(1, len);
+        remaining = remaining.Slice(1 + len);
+        return true;
+    }
+}

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointFrameReaderTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointFrameReaderTests.cs
@@ -21,7 +21,24 @@ public class EntryPointFrameReaderTests
         Assert.True(ok, err);
         Assert.Equal(EntryPointFrameReader.TidSimpleNewOrder, info.TemplateId);
         Assert.Equal(82, info.BodyLength);
+        Assert.Equal(82, info.BlockLength);
+        Assert.Equal(0, info.VarDataLength);
         Assert.Equal(Wire + 82, info.MessageLength);
+    }
+
+    [Fact]
+    public void TryParse_AcceptsTrailingVarDataLength()
+    {
+        // GAP-02: messageLength may exceed WireHeader + BlockLength to carry varData.
+        Span<byte> buf = stackalloc byte[Wire];
+        EntryPointFrameReader.WriteHeader(buf,
+            messageLength: (ushort)(Wire + 82 + 5),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        Assert.True(EntryPointFrameReader.TryParseInboundHeader(buf, out var info, out _));
+        Assert.Equal(82, info.BlockLength);
+        Assert.Equal(82 + 5, info.BodyLength);
+        Assert.Equal(5, info.VarDataLength);
     }
 
     [Fact]
@@ -85,12 +102,12 @@ public class EntryPointFrameReaderTests
     }
 
     [Fact]
-    public void TryParse_RejectsMessageLengthInconsistentWithBlock()
+    public void TryParse_RejectsMessageLengthBelowMinimum()
     {
         Span<byte> buf = stackalloc byte[Wire];
-        // Claim one byte more than header+block.
+        // Claim one byte LESS than header+block (under GAP-02 we accept >=).
         EntryPointFrameReader.WriteHeader(buf,
-            messageLength: (ushort)(Wire + 82 + 1),
+            messageLength: (ushort)(Wire + 82 - 1),
             blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
 
         Assert.False(EntryPointFrameReader.TryParseInboundHeader(buf, out _, out var err, out _));

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointVarDataTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointVarDataTests.cs
@@ -1,0 +1,132 @@
+using B3.Exchange.EntryPoint;
+
+namespace B3.Exchange.EntryPoint.Tests;
+
+public class EntryPointVarDataTests
+{
+    private static readonly EntryPointVarData.Field MemoField = new("memo", 40);
+    private static readonly EntryPointVarData.Field DeskIdField = new("deskID", 20);
+
+    [Fact]
+    public void TryValidate_AcceptsEmpty_WhenNoFieldsExpected()
+    {
+        var ok = EntryPointVarData.TryValidate([], [], out var err);
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void TryValidate_AcceptsEmpty_WhenFieldsAreOptional()
+    {
+        // varData buffer is empty: all declared fields are simply absent.
+        var ok = EntryPointVarData.TryValidate([], new[] { MemoField }, out var err);
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void TryValidate_AcceptsEmptyButPresentSegment()
+    {
+        // Memo field present but length=0.
+        var ok = EntryPointVarData.TryValidate(new byte[] { 0 }, new[] { MemoField }, out var err);
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void TryValidate_AcceptsMaxLengthSegment()
+    {
+        var buf = new byte[1 + MemoField.MaxLength];
+        buf[0] = MemoField.MaxLength;
+        var ok = EntryPointVarData.TryValidate(buf, new[] { MemoField }, out var err);
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void TryValidate_RejectsLengthAboveMax()
+    {
+        var buf = new byte[1 + MemoField.MaxLength + 1];
+        buf[0] = (byte)(MemoField.MaxLength + 1);
+        var ok = EntryPointVarData.TryValidate(buf, new[] { MemoField }, out var err);
+        Assert.False(ok);
+        Assert.Contains("exceeds max", err);
+    }
+
+    [Fact]
+    public void TryValidate_RejectsLengthOverrun()
+    {
+        // Length prefix says 5, but only 2 bytes follow.
+        var buf = new byte[] { 5, 0xAA, 0xBB };
+        var ok = EntryPointVarData.TryValidate(buf, new[] { MemoField }, out var err);
+        Assert.False(ok);
+        Assert.Contains("overruns", err);
+    }
+
+    [Fact]
+    public void TryValidate_RejectsTrailingBytes()
+    {
+        // Memo field with length=0, then an extra spurious byte.
+        var buf = new byte[] { 0, 0x11 };
+        var ok = EntryPointVarData.TryValidate(buf, new[] { MemoField }, out var err);
+        Assert.False(ok);
+        Assert.Contains("trailing", err);
+    }
+
+    [Fact]
+    public void TryValidate_AcceptsTwoSegmentsInOrder()
+    {
+        // OrderCancelRequest: deskID then memo.
+        var buf = new byte[] { 3, (byte)'A', (byte)'B', (byte)'C', 2, (byte)'h', (byte)'i' };
+        var ok = EntryPointVarData.TryValidate(buf, new[] { DeskIdField, MemoField }, out var err);
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void ExpectedFor_KnownTemplates_ReturnsExpectedFields()
+    {
+        Assert.Equal("memo",
+            EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidSimpleNewOrder, 2)[0].Name);
+        Assert.Equal("memo",
+            EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidSimpleModifyOrder, 2)[0].Name);
+
+        var cancel = EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidOrderCancelRequest, 0);
+        Assert.Equal(2, cancel.Length);
+        Assert.Equal("deskID", cancel[0].Name);
+        Assert.Equal("memo", cancel[1].Name);
+    }
+
+    [Fact]
+    public void ExpectedFor_UnknownTemplate_ReturnsEmpty()
+    {
+        Assert.Equal(0, EntryPointVarData.ExpectedFor(9999, 0).Length);
+    }
+
+    [Fact]
+    public void TryReadNext_IteratesAllSegments()
+    {
+        var buf = new byte[] { 3, (byte)'A', (byte)'B', (byte)'C', 0, 1, (byte)'X' };
+        ReadOnlySpan<byte> remaining = buf;
+
+        Assert.True(EntryPointVarData.TryReadNext(ref remaining, out var s1));
+        Assert.Equal(3, s1.Length);
+        Assert.Equal((byte)'A', s1[0]);
+
+        Assert.True(EntryPointVarData.TryReadNext(ref remaining, out var s2));
+        Assert.Equal(0, s2.Length);
+
+        Assert.True(EntryPointVarData.TryReadNext(ref remaining, out var s3));
+        Assert.Equal(1, s3.Length);
+        Assert.Equal((byte)'X', s3[0]);
+
+        Assert.False(EntryPointVarData.TryReadNext(ref remaining, out _));
+    }
+
+    [Fact]
+    public void TryReadNext_RejectsOverrun()
+    {
+        ReadOnlySpan<byte> remaining = new byte[] { 5, 0xAA };
+        Assert.False(EntryPointVarData.TryReadNext(ref remaining, out _));
+    }
+}


### PR DESCRIPTION
Closes #40

After SOFH (#39) gives us the authoritative `messageLength`, the receive loop now reads the full body and walks any trailing length-prefixed (`uint8`) varData segments per spec §3.5 / §4.10.

## Per-template varData (caps from the SBE schema)
| Template | Fields |
|---|---|
| SimpleNewOrder (100 v2) | memo (≤40) |
| SimpleModifyOrder (101 v2) | memo (≤40) |
| OrderCancelRequest (105 v0) | deskID (≤20), memo (≤40) |

## Highlights
- `FrameInfo` gains `BlockLength` (and computed `VarDataLength`); `messageLength` may now exceed `WireHeader + BlockLength` to carry varData. Below-minimum still rejected.
- New `EntryPointVarData` exposes per-template spec (`ExpectedFor`) and a `TryValidate` walker that enforces: length prefix, `maxValue` cap, no overrun, no trailing bytes; optional trailing fields may be absent.
- `EntryPointSession` slices fixedBlock vs varData and validates before dispatch. Failures route through `OnDecodeError` — the BusinessMessageReject vs Terminate mapping lands with #41 (GAP-03).
- Tests cover: missing varData, empty-but-present, max-length, over-cap, overrun, trailing bytes, two-field ordering, all known template specs, plus a header round-trip with trailing varData.

## Verification
- `dotnet build -c Release`: ✅
- `dotnet test  -c Release`: ✅ (39 EntryPoint tests, all suites pass)
- `dotnet format --verify-no-changes`: ✅