### PR TITLE
feat(entrypoint): GAP-03 emit Terminate before close on framing/decoding errors

### DIFF
--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -33,6 +33,7 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
     private readonly Func<ulong> _nowNanos;
     private readonly EntryPointSessionOptions _options;
     private readonly Action<EntryPointSession, string>? _onClosed;
+    private readonly SemaphoreSlim _streamWriteLock = new(1, 1);
     private long _msgSeqNum;
     private int _isOpen = 1;
     // Watchdog state (milliseconds since process start, monotonic).
@@ -109,10 +110,10 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
             while (!ct.IsCancellationRequested)
             {
                 await ReadExactlyAsync(_stream, headerBuf, ct).ConfigureAwait(false);
-                if (!EntryPointFrameReader.TryParseInboundHeader(headerBuf, out var info, out var hdrErr))
+                if (!EntryPointFrameReader.TryParseInboundHeader(headerBuf, out var info, out var headerError, out var hdrMsg))
                 {
-                    _sink.OnDecodeError(this, hdrErr ?? "invalid header");
-                    Close("decode-error");
+                    _sink.OnDecodeError(this, hdrMsg ?? headerError.ToString());
+                    await TerminateAndCloseAsync(MapHeaderErrorToTerminationCode(headerError), $"decode-error:{headerError}").ConfigureAwait(false);
                     return;
                 }
                 var bodyBuf = ArrayPool<byte>.Shared.Rent(info.BodyLength);
@@ -124,7 +125,11 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
                     Volatile.Write(ref _lastInboundMs, NowMs());
                     Volatile.Write(ref _probeOutstanding, 0);
                     var body = bodyBuf.AsSpan(0, info.BodyLength);
-                    DispatchInbound(info, body);
+                    if (!await DispatchInboundAsync(info, bodyBuf, info.BodyLength).ConfigureAwait(false))
+                    {
+                        // DispatchInboundAsync already wrote Terminate + closed.
+                        return;
+                    }
                 }
                 finally
                 {
@@ -144,7 +149,56 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         }
     }
 
-    private void DispatchInbound(EntryPointFrameReader.FrameInfo info, ReadOnlySpan<byte> body)
+    /// <summary>
+    /// Maps a header-parse <see cref="EntryPointFrameReader.HeaderError"/>
+    /// to the FIXP <c>TerminationCode</c> the gateway must send before
+    /// dropping the connection (spec §4.5.7 / §4.10).
+    /// </summary>
+    internal static byte MapHeaderErrorToTerminationCode(EntryPointFrameReader.HeaderError error) => error switch
+    {
+        EntryPointFrameReader.HeaderError.InvalidSofhEncodingType => SessionRejectEncoder.TerminationCode.InvalidSofh,
+        EntryPointFrameReader.HeaderError.InvalidSofhMessageLength => SessionRejectEncoder.TerminationCode.InvalidSofh,
+        EntryPointFrameReader.HeaderError.UnsupportedTemplate => SessionRejectEncoder.TerminationCode.UnrecognizedMessage,
+        EntryPointFrameReader.HeaderError.UnsupportedSchema => SessionRejectEncoder.TerminationCode.UnrecognizedMessage,
+        EntryPointFrameReader.HeaderError.BlockLengthMismatch => SessionRejectEncoder.TerminationCode.DecodingError,
+        EntryPointFrameReader.HeaderError.MessageLengthMismatch => SessionRejectEncoder.TerminationCode.DecodingError,
+        EntryPointFrameReader.HeaderError.ShortHeader => SessionRejectEncoder.TerminationCode.DecodingError,
+        _ => SessionRejectEncoder.TerminationCode.Unspecified,
+    };
+
+    /// <summary>
+    /// Sends a Terminate frame with <paramref name="terminationCode"/>
+    /// directly to the underlying stream (bypassing the send queue, which
+    /// might be racing with an in-flight write or about to be cancelled),
+    /// and closes the session. Acquires <see cref="_streamWriteLock"/> so
+    /// it does not collide with the regular send loop.
+    /// </summary>
+    private async Task TerminateAndCloseAsync(byte terminationCode, string reason)
+    {
+        if (!IsOpen) { Close(reason); return; }
+        var frame = new byte[SessionRejectEncoder.TerminateTotal];
+        SessionRejectEncoder.EncodeTerminate(frame, SessionId, 0, terminationCode);
+        try
+        {
+            await _streamWriteLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await _stream.WriteAsync(frame).ConfigureAwait(false);
+                Volatile.Write(ref _lastOutboundMs, NowMs());
+            }
+            finally
+            {
+                _streamWriteLock.Release();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "entrypoint session {ConnectionId} failed to write Terminate({Code})", ConnectionId, terminationCode);
+        }
+        Close(reason);
+    }
+
+    private async Task<bool> DispatchInboundAsync(EntryPointFrameReader.FrameInfo info, byte[] bodyBuf, int bodyLength)
     {
         ulong now = _nowNanos();
         _logger.LogTrace("session {ConnectionId} inbound frame templateId={TemplateId} blockLength={BlockLength} varDataLength={VarDataLength}",
@@ -153,15 +207,16 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         // Per spec §3.5, varData segments follow the fixed root block. We
         // validate them here (length-prefixed, declared per-template caps
         // from §4.10) before handing the fixed block to the typed
-        // decoders. A failure here is a decoding error — see #41 for the
-        // session-vs-business reject mapping.
-        var fixedBlock = body.Slice(0, info.BlockLength);
-        var varData = body.Slice(info.BlockLength);
+        // decoders. A varData failure is always DECODING_ERROR per §4.10.
+        var fullBody = new ReadOnlyMemory<byte>(bodyBuf, 0, bodyLength);
+        var fixedBlock = fullBody.Slice(0, info.BlockLength).Span;
+        var varData = fullBody.Slice(info.BlockLength).Span;
         var spec = EntryPointVarData.ExpectedFor(info.TemplateId, info.Version);
         if (!EntryPointVarData.TryValidate(varData, spec, out var varErr))
         {
             _sink.OnDecodeError(this, varErr ?? "decode error: varData");
-            return;
+            await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:varData").ConfigureAwait(false);
+            return false;
         }
 
         switch (info.TemplateId)
@@ -169,25 +224,40 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
             case EntryPointFrameReader.TidSequence:
                 // Session-layer heartbeat / sequence sync. Liveness already
                 // recorded by the receive loop; nothing else to do.
-                return;
+                return true;
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
+                {
                     _sink.EnqueueNewOrder(no, this, noClOrd);
-                else _sink.OnDecodeError(this, noErr ?? "decode error: SimpleNewOrder");
-                break;
+                    return true;
+                }
+                _sink.OnDecodeError(this, noErr ?? "decode error: SimpleNewOrder");
+                await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:SimpleNewOrder").ConfigureAwait(false);
+                return false;
             case EntryPointFrameReader.TidSimpleModifyOrder:
                 if (InboundMessageDecoder.TryDecodeReplace(fixedBlock, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr))
+                {
                     _sink.EnqueueReplace(rp, this, rpClOrd, rpOrigClOrd);
-                else _sink.OnDecodeError(this, rpErr ?? "decode error: SimpleModifyOrder");
-                break;
+                    return true;
+                }
+                _sink.OnDecodeError(this, rpErr ?? "decode error: SimpleModifyOrder");
+                await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:SimpleModifyOrder").ConfigureAwait(false);
+                return false;
             case EntryPointFrameReader.TidOrderCancelRequest:
                 if (InboundMessageDecoder.TryDecodeCancel(fixedBlock, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
+                {
                     _sink.EnqueueCancel(cn, this, cnClOrd, cnOrigClOrd);
-                else _sink.OnDecodeError(this, cnErr ?? "decode error: OrderCancelRequest");
-                break;
+                    return true;
+                }
+                _sink.OnDecodeError(this, cnErr ?? "decode error: OrderCancelRequest");
+                await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:OrderCancelRequest").ConfigureAwait(false);
+                return false;
             default:
+                // Unreachable: TryParseInboundHeader has already screened out
+                // unknown templates and returned UnsupportedTemplate.
                 _sink.OnDecodeError(this, $"unsupported templateId={info.TemplateId}");
-                break;
+                await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.UnrecognizedMessage, "decode-error:unsupported").ConfigureAwait(false);
+                return false;
         }
     }
 
@@ -199,7 +269,15 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
             {
                 try
                 {
-                    await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                    await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
+                    try
+                    {
+                        await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        _streamWriteLock.Release();
+                    }
                     Volatile.Write(ref _lastOutboundMs, NowMs());
                 }
                 catch (IOException ex)

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointTerminateOnErrorTests.cs
@@ -1,0 +1,147 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.EntryPoint;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.EntryPoint.Tests;
+
+/// <summary>
+/// GAP-03 (#41): the gateway must send a FIXP <c>Terminate</c> with the
+/// appropriate <c>TerminationCode</c> before closing the TCP connection
+/// on framing/decoding errors (spec §4.5.7 / §4.10).
+/// </summary>
+public class EntryPointTerminateOnErrorTests
+{
+    private sealed class NoOpEngineSink : IEntryPointEngineSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(IEntryPointResponseChannel reply, string error) { }
+        public void OnSessionClosed(IEntryPointResponseChannel reply) { }
+    }
+
+    private static async Task<(EntryPointListener listener, TcpClient client)> ConnectAsync()
+    {
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            NullLoggerFactory.Instance);
+        listener.Start();
+        var client = new TcpClient();
+        await client.ConnectAsync(listener.LocalEndpoint!.Address, listener.LocalEndpoint!.Port);
+        return (listener, client);
+    }
+
+    private static async Task<byte> SendBadFrameExpectingTerminateAsync(byte[] frame)
+    {
+        var (listener, client) = await ConnectAsync();
+        await using (listener)
+        using (client)
+        {
+            await client.GetStream().WriteAsync(frame);
+            return await ReadTerminationCodeAsync(client);
+        }
+    }
+
+    private static async Task<byte> ReadTerminationCodeAsync(TcpClient client)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var buf = new byte[SessionRejectEncoder.TerminateTotal];
+        int read = 0;
+        var ns = client.GetStream();
+        while (read < buf.Length)
+        {
+            int n = await ns.ReadAsync(buf.AsMemory(read), cts.Token);
+            if (n <= 0) throw new EndOfStreamException("connection closed before Terminate received");
+            read += n;
+        }
+        // Validate it is a Terminate frame and return the terminationCode byte.
+        ushort msgLen = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2));
+        Assert.Equal(SessionRejectEncoder.TerminateTotal, msgLen);
+        ushort encoding = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(2, 2));
+        Assert.Equal(EntryPointFrameReader.SofhEncodingType, encoding);
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        Assert.Equal(EntryPointFrameReader.TidTerminate, tid);
+        // body offset = WireHeaderSize, terminationCode at body[12]
+        return buf[EntryPointFrameReader.WireHeaderSize + 12];
+    }
+
+    [Fact]
+    public async Task BadSofhEncodingType_SendsInvalidSofhTerminate()
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame,
+            messageLength: (ushort)frame.Length,
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        // Corrupt encodingType.
+        BinaryPrimitives.WriteUInt16LittleEndian(frame.AsSpan(2, 2), 0x1234);
+
+        byte code = await SendBadFrameExpectingTerminateAsync(frame);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.InvalidSofh, code);
+    }
+
+    [Fact]
+    public async Task MessageLengthOverCap_SendsInvalidSofhTerminate()
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame,
+            messageLength: (ushort)(EntryPointFrameReader.MaxInboundMessageLength + 1),
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        byte code = await SendBadFrameExpectingTerminateAsync(frame);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.InvalidSofh, code);
+    }
+
+    [Fact]
+    public async Task UnknownTemplate_SendsUnrecognizedMessageTerminate()
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame,
+            messageLength: (ushort)frame.Length,
+            blockLength: 82, templateId: 9999, version: 2);
+
+        byte code = await SendBadFrameExpectingTerminateAsync(frame);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.UnrecognizedMessage, code);
+    }
+
+    [Fact]
+    public async Task BlockLengthMismatch_SendsDecodingErrorTerminate()
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 80];
+        EntryPointFrameReader.WriteHeader(frame,
+            messageLength: (ushort)frame.Length,
+            blockLength: 80, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        byte code = await SendBadFrameExpectingTerminateAsync(frame);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.DecodingError, code);
+    }
+
+    [Fact]
+    public async Task VarDataOverflow_SendsDecodingErrorTerminate()
+    {
+        // SimpleNewOrder with valid header but a memo varData field whose
+        // declared length exceeds the schema cap (40). Frame is sized so
+        // SOFH messageLength matches.
+        const int blockLen = 82;
+        const int badMemoLen = 200; // > MemoEncoding maxValue (40)
+        int total = EntryPointFrameReader.WireHeaderSize + blockLen + 1 + badMemoLen;
+        var frame = new byte[total];
+        EntryPointFrameReader.WriteHeader(frame,
+            messageLength: (ushort)total,
+            blockLength: blockLen, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        // Fill fixed block with a valid-enough body so per-field decode would
+        // succeed if it ran (Side='1', OrdType='2', TIF='0').
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize, blockLen);
+        body[56] = (byte)'1'; // Side
+        body[57] = (byte)'2'; // OrdType
+        body[58] = (byte)'0'; // TIF
+        // varData: length prefix 200, payload bytes follow.
+        frame[EntryPointFrameReader.WireHeaderSize + blockLen] = badMemoLen;
+
+        byte code = await SendBadFrameExpectingTerminateAsync(frame);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.DecodingError, code);
+    }
+}


### PR DESCRIPTION
Closes #41

Per spec §4.5.7 / §4.10, the gateway must send a FIXP `Terminate` with the appropriate `TerminationCode` before tearing down the TCP connection on framing/decoding errors. Previously every error path called `Close()` silently.

## Mapping (HeaderError → TerminationCode)
| Error | Code | Name |
|---|---|---|
| InvalidSofhEncodingType / InvalidSofhMessageLength | 16 | INVALID_SOFH |
| UnsupportedTemplate / UnsupportedSchema | 15 | UNRECOGNIZED_MESSAGE |
| BlockLengthMismatch / MessageLengthMismatch / ShortHeader | 17 | DECODING_ERROR |

VarData failures (length cap exceeded, overrun) and per-message decoder failures (bad Side/OrdType/TIF) also emit DECODING_ERROR.

The 512-byte cap on inbound `messageLength` (already enforced in GAP-01 #39) now surfaces as INVALID_SOFH instead of a silent close.

## Implementation note
`TerminateAndCloseAsync` writes the Terminate frame **directly** to the underlying stream — bypassing the bounded send queue, which would be cancelled mid-write by `Close()` — under a new `_streamWriteLock` that the regular send loop also takes. This guarantees one writer at a time and that the goodbye frame actually reaches the wire before the socket is torn down.

## Tests (TCP loopback, real listener)
- BadSofhEncodingType → INVALID_SOFH
- MessageLengthOverCap (513) → INVALID_SOFH
- UnknownTemplate → UNRECOGNIZED_MESSAGE
- BlockLengthMismatch → DECODING_ERROR
- VarDataOverflow → DECODING_ERROR

## Verification
- `dotnet build -c Release`: ✅
- `dotnet test  -c Release`: ✅ (44 EntryPoint tests, all suites pass)
- `dotnet format --verify-no-changes`: ✅

## Phase 0 status
GAP-01 #39 ✅ → GAP-02 #40 ✅ → GAP-03 #41 (this PR). Phase 0 complete after merge.