### PR TITLE
Phase 1 #63: B3.Exchange.Contracts assembly

### DIFF
--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/B3.EntryPoint.Sbe/B3.EntryPoint.Sbe.csproj" />
     <Project Path="src/B3.Umdf.Sbe/B3.Umdf.Sbe.csproj" />
     <Project Path="src/B3.Umdf.WireEncoder/B3.Umdf.WireEncoder.csproj" />
+    <Project Path="src/B3.Exchange.Contracts/B3.Exchange.Contracts.csproj" />
     <Project Path="src/B3.Exchange.Instruments/B3.Exchange.Instruments.csproj" />
     <Project Path="src/B3.Exchange.Matching/B3.Exchange.Matching.csproj" />
     <Project Path="src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj" />

--- a/src/B3.Exchange.Contracts/B3.Exchange.Contracts.csproj
+++ b/src/B3.Exchange.Contracts/B3.Exchange.Contracts.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Exchange.Contracts</RootNamespace>
+    <AssemblyName>B3.Exchange.Contracts</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/src/B3.Exchange.Contracts/Commands/InboundCancelCommand.cs
+++ b/src/B3.Exchange.Contracts/Commands/InboundCancelCommand.cs
@@ -1,0 +1,17 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Gateway → Core: cancel an existing order.
+///
+/// Either <see cref="OrigClOrdID"/> or <see cref="ExplicitOrderId"/>
+/// must be set; if both are present the Core uses the explicit
+/// <see cref="ExplicitOrderId"/>.
+/// </summary>
+public sealed record InboundCancelCommand(
+    SessionId Session,
+    FirmId Firm,
+    string ClOrdID,
+    string? OrigClOrdID,
+    long? ExplicitOrderId,
+    long SecurityId,
+    long ReceivedAtNs);

--- a/src/B3.Exchange.Contracts/Commands/InboundModifyCommand.cs
+++ b/src/B3.Exchange.Contracts/Commands/InboundModifyCommand.cs
@@ -1,0 +1,17 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Gateway → Core: amend ("replace") an existing order. Same lookup
+/// rules as <see cref="InboundCancelCommand"/> for resolving the live
+/// order.
+/// </summary>
+public sealed record InboundModifyCommand(
+    SessionId Session,
+    FirmId Firm,
+    string ClOrdID,
+    string? OrigClOrdID,
+    long? ExplicitOrderId,
+    long SecurityId,
+    long NewPriceMantissa,
+    long NewQuantity,
+    long ReceivedAtNs);

--- a/src/B3.Exchange.Contracts/Commands/InboundOrderCommand.cs
+++ b/src/B3.Exchange.Contracts/Commands/InboundOrderCommand.cs
@@ -1,0 +1,27 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Gateway → Core: a new-order request decoded from the wire and
+/// authenticated against a session.
+///
+/// <para><see cref="Session"/> is the routing key Core stamps onto every
+/// outbound event for this order. <see cref="Firm"/> is carried for
+/// audit / risk and is set by the Gateway from the session's
+/// authenticated firm registration — the wire payload alone does NOT
+/// determine the firm.</para>
+///
+/// <para><see cref="PriceMantissa"/> is the implicit /10000 mantissa
+/// used throughout the simulator (a price of 100.05 is encoded as
+/// <c>1_000_500</c>).</para>
+/// </summary>
+public sealed record InboundOrderCommand(
+    SessionId Session,
+    FirmId Firm,
+    string ClOrdID,
+    long SecurityId,
+    Side Side,
+    OrderType Type,
+    long PriceMantissa,
+    long Quantity,
+    TimeInForce Tif,
+    long ReceivedAtNs);

--- a/src/B3.Exchange.Contracts/Enums.cs
+++ b/src/B3.Exchange.Contracts/Enums.cs
@@ -1,0 +1,55 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>Side of an order. Wire-neutral mirror of FIX tag 54.</summary>
+public enum Side : byte
+{
+    Buy = 1,
+    Sell = 2,
+}
+
+/// <summary>Order type. Wire-neutral mirror of FIX tag 40.</summary>
+public enum OrderType : byte
+{
+    Market = 1,
+    Limit = 2,
+}
+
+/// <summary>Time-in-force. Wire-neutral mirror of FIX tag 59.</summary>
+public enum TimeInForce : byte
+{
+    Day = 0,
+    IOC = 3,
+    FOK = 4,
+}
+
+/// <summary>
+/// Type of execution event reported by Core. Mirrors FIX
+/// <c>ExecType</c> (tag 150) values used by the EntryPoint protocol.
+/// </summary>
+public enum ExecType : byte
+{
+    New = 0,
+    PartialFill = 1,
+    Fill = 2,
+    Cancelled = 4,
+    Replaced = 5,
+    Rejected = 8,
+    Expired = 12,
+}
+
+/// <summary>
+/// Reason for a Core-side reject. Maps 1:1 to FIX
+/// <c>OrdRejReason</c> (tag 103) wire codes per spec §3 — keeps Core
+/// independent of the EntryPoint encoder while preserving the wire
+/// numbering for downstream mapping.
+/// </summary>
+public enum OrdRejReason : byte
+{
+    BrokerExchangeOption = 0,
+    UnknownSymbol = 1,
+    OrderExceedsLimit = 3,
+    UnknownOrder = 5,
+    DuplicateOrder = 6,
+    UnsupportedOrderCharacteristic = 11,
+    Other = 99,
+}

--- a/src/B3.Exchange.Contracts/Events/BusinessRejectEvent.cs
+++ b/src/B3.Exchange.Contracts/Events/BusinessRejectEvent.cs
@@ -1,0 +1,19 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Core → Gateway: business-level reject (BMR / FIX 35=j). Used when the
+/// inbound message is parseable but cannot be processed by Core (e.g.
+/// session not authorised to trade an instrument). Distinct from
+/// <see cref="RejectEvent"/>, which is order-flow specific.
+///
+/// <para><b>Stub</b>: the spec field set is tracked under issue #50
+/// (GAP-14). Today only the minimum needed to route the message back to
+/// the originating session is captured; <see cref="RefSeqNum"/> /
+/// <see cref="RefMsgType"/> / business reject reason will be added when
+/// #50 lands.</para>
+/// </summary>
+public sealed record BusinessRejectEvent(
+    SessionId Session,
+    string? RefBusinessRejectRefId,
+    string Text,
+    long EmittedAtNs);

--- a/src/B3.Exchange.Contracts/Events/ExecutionEvent.cs
+++ b/src/B3.Exchange.Contracts/Events/ExecutionEvent.cs
@@ -1,0 +1,26 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Core → Gateway: an execution lifecycle event for an order
+/// (acknowledgement, fill, partial fill, cancel, replace).
+///
+/// <para><see cref="Session"/> is the originator's <see cref="SessionId"/>
+/// — the Gateway uses it to find the live <c>FixpSession</c> (or the
+/// retransmission ring of a Suspended one). Core does NOT track which
+/// transport produced the order; it simply echoes back the
+/// <see cref="SessionId"/> stamped on the inbound command.</para>
+///
+/// <para><see cref="LastPx"/> is in the same /10000 mantissa as
+/// <see cref="InboundOrderCommand.PriceMantissa"/>.</para>
+/// </summary>
+public sealed record ExecutionEvent(
+    SessionId Session,
+    long OrderId,
+    long TradeId,
+    string ClOrdID,
+    ExecType ExecType,
+    long LastQty,
+    long LastPx,
+    long LeavesQty,
+    long CumQty,
+    long EmittedAtNs);

--- a/src/B3.Exchange.Contracts/Events/RejectEvent.cs
+++ b/src/B3.Exchange.Contracts/Events/RejectEvent.cs
@@ -1,0 +1,13 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Core → Gateway: order-level reject (e.g. unknown instrument,
+/// invalid price). The Gateway translates this into an
+/// <c>ExecutionReport(8)</c> with <c>ExecType=Rejected</c> on the wire.
+/// </summary>
+public sealed record RejectEvent(
+    SessionId Session,
+    string ClOrdID,
+    OrdRejReason Reason,
+    string? Text,
+    long EmittedAtNs);

--- a/src/B3.Exchange.Contracts/FirmId.cs
+++ b/src/B3.Exchange.Contracts/FirmId.cs
@@ -1,0 +1,12 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Identifier of the firm (broker / "corretora") that owns a session.
+/// Determined at authentication time and carried through every command
+/// and event so Core, audit and post-trade can attribute every action to
+/// the responsible market participant.
+/// </summary>
+public readonly record struct FirmId(string Value)
+{
+    public override string ToString() => Value;
+}

--- a/src/B3.Exchange.Contracts/ICoreInbound.cs
+++ b/src/B3.Exchange.Contracts/ICoreInbound.cs
@@ -1,0 +1,21 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Inbound surface exposed by Core to the Gateway. Implementations are
+/// expected to be <b>thread-safe at the <see cref="SessionId"/> grain</b>
+/// (today: routed to a single dispatch thread per channel) and to
+/// return immediately after enqueueing — the heavy work happens on the
+/// Core's dispatch thread.
+///
+/// <para>Designed so Core and Gateway can be split into separate
+/// processes later: every parameter is a value object on
+/// <c>B3.Exchange.Contracts</c>.</para>
+/// </summary>
+public interface ICoreInbound
+{
+    void Submit(InboundOrderCommand command);
+
+    void Submit(InboundCancelCommand command);
+
+    void Submit(InboundModifyCommand command);
+}

--- a/src/B3.Exchange.Contracts/IGatewayInbound.cs
+++ b/src/B3.Exchange.Contracts/IGatewayInbound.cs
@@ -1,0 +1,21 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Inbound surface exposed by the Gateway to Core. Core calls these
+/// methods on its own dispatch thread when an order lifecycle event is
+/// emitted; the Gateway is responsible for resolving
+/// <see cref="ExecutionEvent.Session"/> to the live transport (or to a
+/// retransmission ring for a Suspended session) and for translating the
+/// event into the FIXP wire form.
+///
+/// <para>Implementations must not block the calling thread on I/O;
+/// long-running work should be enqueued on a per-session writer.</para>
+/// </summary>
+public interface IGatewayInbound
+{
+    void Deliver(ExecutionEvent evt);
+
+    void Deliver(RejectEvent evt);
+
+    void Deliver(BusinessRejectEvent evt);
+}

--- a/src/B3.Exchange.Contracts/SessionId.cs
+++ b/src/B3.Exchange.Contracts/SessionId.cs
@@ -1,0 +1,19 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Stable, transport-neutral identifier of a logical FIXP session.
+///
+/// Issued by the Gateway after authentication and used as the only routing
+/// key Core knows about: outbound events are stamped with
+/// <see cref="SessionId"/>, and the Gateway resolves the live transport
+/// (or buffers into a <c>Suspended</c> session's retx ring) at delivery
+/// time. Core never holds a reference to a transport, socket, or
+/// <c>FixpSession</c> instance.
+///
+/// Stored as <see cref="string"/> so the assembly stays serialisable
+/// without taking dependencies on numeric session-id schemes.
+/// </summary>
+public readonly record struct SessionId(string Value)
+{
+    public override string ToString() => Value;
+}


### PR DESCRIPTION
Closes #63

Phase 1 step 1 of 4. Pure additive — introduces a transport-neutral
`B3.Exchange.Contracts` assembly that the future Gateway and Core
projects will both depend on (and only on).

## What's in the box
- `SessionId`, `FirmId` — record-struct identifiers.
- Enums `Side`, `OrderType`, `TimeInForce`, `ExecType`, `OrdRejReason` (mirror spec wire numbering; intentionally duplicated from `B3.Exchange.Matching` so Contracts stays dependency-free).
- Inbound commands: `InboundOrderCommand`, `InboundCancelCommand`, `InboundModifyCommand`.
- Outbound events: `ExecutionEvent`, `RejectEvent`, `BusinessRejectEvent` (stub for #50).
- Interfaces: `ICoreInbound`, `IGatewayInbound`.

## Constraints honoured
- Zero project references, zero NuGet packages.
- Builds clean under `TreatWarningsAsErrors=true`.
- No behaviour changes; nothing else in the repo references it yet.
- Wired into `SbeB3Exchange.slnx`.

Follow-ups: #65 (rename Integration→Core), #64 (carve Gateway), #66 (ownership map move).