### PR TITLE
Phase 1 #65 (1/2): rename B3.Exchange.Integration → B3.Exchange.Core

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,7 +81,7 @@ Layered projects under `src/` (build order roughly bottom-up):
 5. `B3.Exchange.EntryPoint` — TCP listener, framed SBE inbound decoder,
    ExecutionReport encoder. Each TCP session implements
    `IEntryPointResponseChannel`.
-6. `B3.Exchange.Integration` — `ChannelDispatcher`: bounded inbound queue +
+6. `B3.Exchange.Core` — `ChannelDispatcher`: bounded inbound queue +
    single dispatch thread per channel. Pumps decoded commands into the engine,
    buffers emitted UMDF events for the duration of one command, then flushes
    them as a single packet (≤1400 bytes, `PacketHeader` + N inc messages) to

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ a 24/7 simulated venue against any UMDF consumer.
 - **`B3.Exchange.Instruments`** — JSON instrument loader.
 - **`B3.Exchange.EntryPoint`** — TCP listener, framed SBE inbound decoder,
   ExecutionReport encoder.
-- **`B3.Exchange.Integration`** — per-channel `ChannelDispatcher`: bounded
+- **`B3.Exchange.Core`** — per-channel `ChannelDispatcher`: bounded
   inbound queue, single dispatch thread, packs MBO/Trade frames into 1400-byte
   UMDF packets, publishes via `IUmdfPacketSink`.
 - **`B3.Exchange.Host`** — JSON-configured single-binary host wiring

--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -7,7 +7,7 @@
     <Project Path="src/B3.Exchange.Instruments/B3.Exchange.Instruments.csproj" />
     <Project Path="src/B3.Exchange.Matching/B3.Exchange.Matching.csproj" />
     <Project Path="src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj" />
-    <Project Path="src/B3.Exchange.Integration/B3.Exchange.Integration.csproj" />
+    <Project Path="src/B3.Exchange.Core/B3.Exchange.Core.csproj" />
     <Project Path="src/B3.Exchange.Host/B3.Exchange.Host.csproj" />
     <Project Path="src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj" />
   </Folder>
@@ -16,7 +16,7 @@
     <Project Path="tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Matching.Tests/B3.Exchange.Matching.Tests.csproj" />
     <Project Path="tests/B3.Exchange.EntryPoint.Tests/B3.Exchange.EntryPoint.Tests.csproj" />
-    <Project Path="tests/B3.Exchange.Integration.Tests/B3.Exchange.Integration.Tests.csproj" />
+    <Project Path="tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj" />
     <Project Path="tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj" />
   </Folder>

--- a/docs/B3-ENTRYPOINT-ARCHITECTURE.md
+++ b/docs/B3-ENTRYPOINT-ARCHITECTURE.md
@@ -153,7 +153,7 @@ src/
       CredentialValidator.cs         ← #43 (GAP-05)
     GatewayHost.cs                   ← wires listener → sessions → ICoreInbound
 
-  B3.Exchange.Core/                  ← RENAMED from B3.Exchange.Integration
+  B3.Exchange.Core/                  ← RENAMED from B3.Exchange.Core
     HostRouter.cs
     ChannelDispatcher.cs             ← no longer holds IEntryPointResponseChannel
     InstrumentDefinitionPublisher.cs
@@ -569,7 +569,7 @@ testing of later phases.
 - Create `B3.Exchange.Gateway`; move all of `B3.Exchange.EntryPoint`
   into it; rename old `EntryPointSession` to `LegacyTcpSession` and
   carve out `TcpTransport` + `FixpSession` skeletons.
-- Rename `B3.Exchange.Integration` → `B3.Exchange.Core`. Strip all
+- Rename `B3.Exchange.Core` → `B3.Exchange.Core`. Strip all
   references to `IEntryPointResponseChannel` from `ChannelDispatcher`;
   replace with `IGatewayInbound` from contracts.
 - Wire both via `B3.Exchange.Host` using in-process implementations of

--- a/src/B3.Exchange.Core/B3.Exchange.Core.csproj
+++ b/src/B3.Exchange.Core/B3.Exchange.Core.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootNamespace>B3.Exchange.Integration</RootNamespace>
-    <AssemblyName>B3.Exchange.Integration</AssemblyName>
+    <RootNamespace>B3.Exchange.Core</RootNamespace>
+    <AssemblyName>B3.Exchange.Core</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="B3.Exchange.Integration.Tests" />
+    <InternalsVisibleTo Include="B3.Exchange.Core.Tests" />
     <InternalsVisibleTo Include="B3.Exchange.Host.Tests" />
   </ItemGroup>
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -2,7 +2,7 @@ using B3.Exchange.EntryPoint;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// One per UMDF channel. Owns:

--- a/src/B3.Exchange.Core/IReadinessProbe.cs
+++ b/src/B3.Exchange.Core/IReadinessProbe.cs
@@ -1,4 +1,4 @@
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Single readiness signal. Composes additively: the host's overall

--- a/src/B3.Exchange.Core/ISnapshotBookSource.cs
+++ b/src/B3.Exchange.Core/ISnapshotBookSource.cs
@@ -1,6 +1,6 @@
 using B3.Exchange.Matching;
 
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Minimal read-only view that <see cref="SnapshotRotator"/> needs over a

--- a/src/B3.Exchange.Core/IUmdfPacketSink.cs
+++ b/src/B3.Exchange.Core/IUmdfPacketSink.cs
@@ -1,4 +1,4 @@
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Sink for fully-formed UMDF incremental packets ready for the wire.

--- a/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
+++ b/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
@@ -1,7 +1,7 @@
 using B3.Exchange.Instruments;
 using B3.Umdf.WireEncoder;
 
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Periodically emits <c>SecurityDefinition_12</c> ("SecurityDefinition_d"

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
 using System.Text;
 
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Per-channel atomic counters and gauges. All mutating methods are

--- a/src/B3.Exchange.Core/MulticastUdpPacketSink.cs
+++ b/src/B3.Exchange.Core/MulticastUdpPacketSink.cs
@@ -2,7 +2,7 @@ using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
 
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Production <see cref="IUmdfPacketSink"/> backed by a UDP multicast socket.

--- a/src/B3.Exchange.Core/SnapshotRotator.cs
+++ b/src/B3.Exchange.Core/SnapshotRotator.cs
@@ -1,7 +1,7 @@
 using B3.Exchange.Matching;
 using B3.Umdf.WireEncoder;
 
-namespace B3.Exchange.Integration;
+namespace B3.Exchange.Core;
 
 /// <summary>
 /// Per-UMDF-channel snapshot publisher. Each invocation of

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
-    <ProjectReference Include="..\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -1,7 +1,7 @@
 using System.Net;
 using B3.Exchange.EntryPoint;
 using B3.Exchange.Instruments;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -1,5 +1,5 @@
 using B3.Exchange.EntryPoint;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;

--- a/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
+++ b/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
   </ItemGroup>
 

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -1,12 +1,12 @@
 using System.Runtime.InteropServices;
 using B3.Exchange.EntryPoint;
 using B3.Exchange.Instruments;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Umdf.WireEncoder;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace B3.Exchange.Integration.Tests;
+namespace B3.Exchange.Core.Tests;
 
 public class ChannelDispatcherTests
 {

--- a/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
@@ -1,10 +1,10 @@
 using System.Runtime.InteropServices;
 using B3.Exchange.Instruments;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.WireEncoder;
 
-namespace B3.Exchange.Integration.Tests;
+namespace B3.Exchange.Core.Tests;
 
 /// <summary>
 /// Verifies that <see cref="InstrumentDefinitionPublisher"/> emits one

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -1,6 +1,6 @@
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 
-namespace B3.Exchange.Integration.Tests;
+namespace B3.Exchange.Core.Tests;
 
 public class MetricsRegistryTests
 {

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -1,12 +1,12 @@
 using System.Runtime.InteropServices;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.WireEncoder;
 using Side = B3.Exchange.Matching.Side;
 
-namespace B3.Exchange.Integration.Tests;
+namespace B3.Exchange.Core.Tests;
 
 /// <summary>
 /// Unit tests for <see cref="SnapshotRotator"/> using a hand-rolled

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
   </ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -3,7 +3,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using B3.Exchange.EntryPoint;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Umdf.WireEncoder;
 
 namespace B3.Exchange.Host.Tests;

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
@@ -2,7 +2,7 @@ using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using B3.Exchange.EntryPoint;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Umdf.WireEncoder;
 
 namespace B3.Exchange.Host.Tests;

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -1,6 +1,6 @@
 using B3.Exchange.EntryPoint;
 using B3.Exchange.Host;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Exchange.Instruments;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -1,5 +1,5 @@
 using System.Net.Http;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 
 namespace B3.Exchange.Host.Tests;
 

--- a/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
+++ b/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
@@ -1,7 +1,7 @@
 using System.Buffers.Binary;
 using System.Net;
 using B3.Exchange.EntryPoint;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Exchange.SyntheticTrader;
 

--- a/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.Integration\B3.Exchange.Integration.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
   </ItemGroup>

--- a/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
@@ -1,5 +1,5 @@
 using B3.Exchange.Host;
-using B3.Exchange.Integration;
+using B3.Exchange.Core;
 
 namespace B3.Exchange.SyntheticTrader.Tests;
 


### PR DESCRIPTION
Refs #65 (does not close yet — see follow-up PR for the actual decoupling).

Mechanical rename only, **zero behaviour change**:

- `src/B3.Exchange.Integration`            → `src/B3.Exchange.Core`
- `tests/B3.Exchange.Integration.Tests`    → `tests/B3.Exchange.Core.Tests`
- csproj `RootNamespace` / `AssemblyName` / `InternalsVisibleTo`
- `SbeB3Exchange.slnx` entries
- All `using B3.Exchange.Integration;` references in src + tests
- Doc/README mentions

## Why split?

#65 bundles a rename and a meaty decoupling (`ChannelDispatcher` no longer touching `IEntryPointResponseChannel`, implementing `ICoreInbound`/`IGatewayInbound` from #63). Landing the rename first keeps the diff reviewable and the follow-up focused on the architectural change.

## Validation

- `dotnet build -c Release`: clean under `TreatWarningsAsErrors=true`.
- `dotnet test -c Release --no-build`: 205 tests pass.
- `dotnet format --verify-no-changes`: no diffs.

Follow-up PR will close #65 by carving the EntryPoint dependency out of `ChannelDispatcher`.