### PR TITLE
Phase 1 #65 (2/2): decouple ChannelDispatcher from B3.Exchange.EntryPoint

### DIFF
--- a/src/B3.Exchange.Core/B3.Exchange.Core.csproj
+++ b/src/B3.Exchange.Core/B3.Exchange.Core.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
-    <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
     <ProjectReference Include="..\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
   </ItemGroup>

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -1,4 +1,3 @@
-using B3.Exchange.EntryPoint;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 
@@ -8,7 +7,7 @@ namespace B3.Exchange.Core;
 /// One per UMDF channel. Owns:
 ///  - A <see cref="MatchingEngine"/> (single-threaded by construction).
 ///  - A bounded inbound queue of decoded EntryPoint commands tagged with the
-///    originating <see cref="IEntryPointResponseChannel"/>.
+///    originating <see cref="IGatewayResponseChannel"/>.
 ///  - An order-id → reply-channel map so that PASSIVE-side execution reports
 ///    (e.g. a resting order is filled by a counterparty's aggressor) get
 ///    routed back to the correct TCP session.
@@ -17,12 +16,12 @@ namespace B3.Exchange.Core;
 ///    flushed as one packet (with a packet-header + monotonic
 ///    <c>SequenceNumber</c>) to the <see cref="IUmdfPacketSink"/>.
 ///
-/// Implements both <see cref="IEntryPointEngineSink"/> (commands in) and
+/// Implements both <see cref="IInboundCommandSink"/> (commands in) and
 /// <see cref="IMatchingEventSink"/> (engine events out). The dispatch loop
 /// guarantees that the engine and the event-sink callbacks always run on the
 /// dedicated dispatch thread — there is no cross-thread call into the engine.
 /// </summary>
-public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatchingEventSink, IAsyncDisposable
+public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEventSink, IAsyncDisposable
 {
     private const int DefaultInboundCapacity = 4096;
     private const int MaxPacketBytes = 1400;
@@ -59,7 +58,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     private readonly Dictionary<(uint Firm, ulong ClOrdId), long> _clOrdIdIndex = new();
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
-    private IEntryPointResponseChannel? _currentReply;
+    private IGatewayResponseChannel? _currentReply;
     private ulong _currentClOrdId;
     private ulong _currentOrigClOrdId;
 
@@ -260,7 +259,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
         }
     }
 
-    private bool TryResolveByClOrdId(IEntryPointResponseChannel reply, ulong origClOrdId, out long orderId)
+    private bool TryResolveByClOrdId(IGatewayResponseChannel reply, ulong origClOrdId, out long orderId)
     {
         if (origClOrdId != 0 && _clOrdIdIndex.TryGetValue((reply.EnteringFirm, origClOrdId), out orderId))
             return true;
@@ -320,7 +319,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     /// quiescent dispatcher".</summary>
     internal void TestSetSequenceNumber(uint value) => SequenceNumber = value;
 
-    private void ReleaseOwnerOnDispatchThread(IEntryPointResponseChannel reply)
+    private void ReleaseOwnerOnDispatchThread(IGatewayResponseChannel reply)
     {
         // Sweep the orderId → reply map and drop every entry whose reply is
         // the disconnected session. The orders themselves stay in the book
@@ -366,27 +365,27 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
 
     private void Commit(int written) => _packetWritten += written;
 
-    // ====== IEntryPointEngineSink ======
+    // ====== IInboundCommandSink ======
 
-    public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue)
+    public void EnqueueNewOrder(in NewOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue)
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, reply, clOrdIdValue, 0, cmd, null, null)))
             LogQueueFull(ChannelNumber, WorkKind.New);
     }
 
-    public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
+    public void EnqueueCancel(in CancelOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, reply, clOrdIdValue, origClOrdIdValue, null, cmd, null)))
             LogQueueFull(ChannelNumber, WorkKind.Cancel);
     }
 
-    public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
+    public void EnqueueReplace(in ReplaceOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, reply, clOrdIdValue, origClOrdIdValue, null, null, cmd)))
             LogQueueFull(ChannelNumber, WorkKind.Replace);
     }
 
-    public void OnDecodeError(IEntryPointResponseChannel reply, string error)
+    public void OnDecodeError(IGatewayResponseChannel reply, string error)
     {
         _logger.LogWarning("channel {ChannelNumber} inbound decode error: {Error}", ChannelNumber, error);
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.DecodeError, reply, 0, 0, null, null, null)))
@@ -416,7 +415,7 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
     public bool EnqueueSnapshotTick()
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.SnapshotRotation, null, 0, 0, null, null, null));
 
-    public void OnSessionClosed(IEntryPointResponseChannel reply)
+    public void OnSessionClosed(IGatewayResponseChannel reply)
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.ReleaseOwner, reply, 0, 0, null, null, null));
 
     /// <summary>
@@ -589,11 +588,11 @@ public sealed partial class ChannelDispatcher : IEntryPointEngineSink, IMatching
 
     internal enum WorkKind : byte { New, Cancel, Replace, DecodeError, SnapshotRotation, ReleaseOwner, OperatorSnapshotNow, OperatorBumpVersion }
 
-    internal readonly record struct OrderOwnership(IEntryPointResponseChannel Reply, ulong ClOrdId, uint EnteringFirm);
+    internal readonly record struct OrderOwnership(IGatewayResponseChannel Reply, ulong ClOrdId, uint EnteringFirm);
 
     internal sealed record WorkItem(
         WorkKind Kind,
-        IEntryPointResponseChannel? Reply,
+        IGatewayResponseChannel? Reply,
         ulong ClOrdId,
         ulong OrigClOrdId,
         NewOrderCommand? NewOrder,

--- a/src/B3.Exchange.Core/GatewayInterfaces.cs
+++ b/src/B3.Exchange.Core/GatewayInterfaces.cs
@@ -1,19 +1,20 @@
 using B3.Exchange.Matching;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Core;
 
 /// <summary>
-/// Per-connection writer of outbound ExecutionReports. The matching engine's
-/// integration layer is expected to call these from the engine dispatch thread;
-/// implementations (e.g. <see cref="EntryPointSession"/>) MUST be thread-safe
-/// for the write side and serialise sends through a dedicated send loop.
+/// Per-session writer of outbound ExecutionReports. Owned by the gateway
+/// (TCP/FIXP transport); Core obtains an instance via the session-id
+/// indirection and never holds a transport reference directly.
+/// Implementations MUST be thread-safe for the write side and serialise
+/// sends through a dedicated send loop.
 ///
 /// All <c>Write*</c> methods return <c>true</c> if the report was queued for
 /// sending or <c>false</c> if the channel is closed (peer disconnected) or
 /// backpressure forced a drop. A returned <c>false</c> is informational; the
 /// caller should not retry on the same channel.
 /// </summary>
-public interface IEntryPointResponseChannel
+public interface IGatewayResponseChannel
 {
     /// <summary>Stable per-connection identifier (for diagnostics + ownership maps).</summary>
     long ConnectionId { get; }
@@ -66,29 +67,29 @@ public interface IEntryPointResponseChannel
 
 /// <summary>
 /// Sink for inbound commands decoded from a TCP connection. The
-/// <see cref="EntryPointSession"/> calls these on the receive loop thread.
+/// <see cref="IGatewayResponseChannel"/> calls these on the receive loop thread.
 ///
 /// IMPORTANT: implementations MUST hand off to a per-channel dispatch queue
 /// (the matching engine is single-threaded per channel — invoking it inline
 /// from multiple sessions corrupts internal state). The integration layer
 /// (next milestone) owns this hand-off.
 /// </summary>
-public interface IEntryPointEngineSink
+public interface IInboundCommandSink
 {
-    void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue);
-    void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue);
-    void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue);
+    void EnqueueNewOrder(in NewOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue);
+    void EnqueueCancel(in CancelOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue);
+    void EnqueueReplace(in ReplaceOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue);
 
     /// <summary>Called when a frame fails decoding (unsupported template,
     /// invalid block length, malformed body). The integration layer may close
     /// the connection or emit a generic reject.</summary>
-    void OnDecodeError(IEntryPointResponseChannel reply, string error);
+    void OnDecodeError(IGatewayResponseChannel reply, string error);
 
     /// <summary>
     /// Called once when a session's transport closes (peer disconnect, IO
     /// error, host shutdown). The integration layer MUST drop any cached
     /// references to <paramref name="reply"/> so the disconnected
-    /// <see cref="EntryPointSession"/> can be garbage-collected.
+    /// <see cref="IGatewayResponseChannel"/> can be garbage-collected.
     ///
     /// The session's resting orders stay on the book — they ARE the book —
     /// but any reply-channel back-references (e.g. orderId → reply maps used
@@ -96,5 +97,5 @@ public interface IEntryPointEngineSink
     /// integration layer treats further passive fills on those orders as
     /// "unowned" (no ER emitted) until / unless a fresh session takes over.
     /// </summary>
-    void OnSessionClosed(IEntryPointResponseChannel reply);
+    void OnSessionClosed(IGatewayResponseChannel reply);
 }

--- a/src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj
+++ b/src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="..\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.EntryPoint/EntryPointListener.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointListener.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Sockets;
+using B3.Exchange.Core;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Exchange.EntryPoint;
@@ -16,7 +17,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     public readonly record struct AcceptedConnection(long ConnectionId, uint EnteringFirm, uint SessionId);
 
     private readonly IPEndPoint _endpoint;
-    private readonly IEntryPointEngineSink _sink;
+    private readonly IInboundCommandSink _sink;
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<EntryPointListener> _logger;
     private readonly Func<EndPoint?, AcceptedConnection> _identityFactory;
@@ -42,7 +43,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         get { lock (_lock) return _sessions.ToArray(); }
     }
 
-    public EntryPointListener(IPEndPoint endpoint, IEntryPointEngineSink sink,
+    public EntryPointListener(IPEndPoint endpoint, IInboundCommandSink sink,
         ILoggerFactory loggerFactory,
         Func<EndPoint?, AcceptedConnection>? identityFactory = null,
         EntryPointSessionOptions? sessionOptions = null,

--- a/src/B3.Exchange.EntryPoint/EntryPointSession.cs
+++ b/src/B3.Exchange.EntryPoint/EntryPointSession.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Threading.Channels;
+using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 
@@ -8,7 +9,7 @@ namespace B3.Exchange.EntryPoint;
 /// <summary>
 /// Stream-based per-connection session. Hosts:
 ///  - a receive loop that reads SBE-framed inbound messages and dispatches
-///    decoded commands to <see cref="IEntryPointEngineSink"/>;
+///    decoded commands to <see cref="IInboundCommandSink"/>;
 ///  - a send loop that drains a bounded <see cref="Channel{T}"/> of
 ///    pre-encoded outbound frames and writes them to the stream.
 ///
@@ -20,13 +21,13 @@ namespace B3.Exchange.EntryPoint;
 /// is closed (<c>FullMode = DropWrite</c> + explicit close). This drops the
 /// connection rather than ballooning memory under a stuck peer.
 /// </summary>
-public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDisposable
+public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposable
 {
     private const int InboundHeaderSize = EntryPointFrameReader.WireHeaderSize;
     private const int DefaultSendQueueCapacity = 1024;
 
     private readonly Stream _stream;
-    private readonly IEntryPointEngineSink _sink;
+    private readonly IInboundCommandSink _sink;
     private readonly ILogger<EntryPointSession> _logger;
     private readonly Channel<byte[]> _sendQueue;
     private readonly CancellationTokenSource _cts = new();
@@ -60,7 +61,7 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
     public int SendQueueDepth => _sendQueue.Reader.Count;
 
     public EntryPointSession(long connectionId, uint enteringFirm, uint sessionId,
-        Stream stream, IEntryPointEngineSink sink, ILogger<EntryPointSession> logger,
+        Stream stream, IInboundCommandSink sink, ILogger<EntryPointSession> logger,
         Func<ulong>? nowNanos = null,
         int sendQueueCapacity = DefaultSendQueueCapacity,
         EntryPointSessionOptions? options = null,
@@ -522,7 +523,7 @@ public sealed class EntryPointSession : IEntryPointResponseChannel, IAsyncDispos
         _sendQueue.Writer.TryComplete();
         try { _cts.Cancel(); } catch { }
         // Notify the engine sink so it releases any cached references to this
-        // session (see IEntryPointEngineSink.OnSessionClosed). Without this the
+        // session (see IInboundCommandSink.OnSessionClosed). Without this the
         // ChannelDispatcher's order-owners map keeps the session rooted for
         // the lifetime of every resting order it placed → unbounded memory.
         try { _sink.OnSessionClosed(this); } catch { }

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Logging;
 namespace B3.Exchange.Host;
 
 /// <summary>
-/// <see cref="IEntryPointEngineSink"/> that fans inbound commands from one
+/// <see cref="IInboundCommandSink"/> that fans inbound commands from one
 /// TCP session out to the right <see cref="ChannelDispatcher"/> based on the
 /// command's <c>SecurityId</c>. A single session may submit orders for any
 /// instrument across any channel; the host owns the SecurityId → Channel
@@ -15,7 +15,7 @@ namespace B3.Exchange.Host;
 /// On unknown SecurityId the router synthesizes a reject ER directly to the
 /// session (no engine is involved).
 /// </summary>
-public sealed class HostRouter : IEntryPointEngineSink
+public sealed class HostRouter : IInboundCommandSink
 {
     private readonly IReadOnlyDictionary<long, ChannelDispatcher> _bySecId;
     private readonly IReadOnlyList<ChannelDispatcher> _allDispatchers;
@@ -34,7 +34,7 @@ public sealed class HostRouter : IEntryPointEngineSink
         _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
     }
 
-    public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue)
+    public void EnqueueNewOrder(in NewOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue)
     {
         if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
             disp.EnqueueNewOrder(cmd, reply, clOrdIdValue);
@@ -42,7 +42,7 @@ public sealed class HostRouter : IEntryPointEngineSink
             RejectUnknownInstrument(cmd.SecurityId, reply, clOrdIdValue);
     }
 
-    public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
+    public void EnqueueCancel(in CancelOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
             disp.EnqueueCancel(cmd, reply, clOrdIdValue, origClOrdIdValue);
@@ -50,7 +50,7 @@ public sealed class HostRouter : IEntryPointEngineSink
             RejectUnknownInstrument(cmd.SecurityId, reply, clOrdIdValue);
     }
 
-    public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
+    public void EnqueueReplace(in ReplaceOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
             disp.EnqueueReplace(cmd, reply, clOrdIdValue, origClOrdIdValue);
@@ -58,7 +58,7 @@ public sealed class HostRouter : IEntryPointEngineSink
             RejectUnknownInstrument(cmd.SecurityId, reply, clOrdIdValue);
     }
 
-    public void OnDecodeError(IEntryPointResponseChannel reply, string error)
+    public void OnDecodeError(IGatewayResponseChannel reply, string error)
     {
         // Logging hook only. The EntryPointSession itself emits the
         // appropriate SessionReject (Terminate) or BusinessMessageReject
@@ -67,7 +67,7 @@ public sealed class HostRouter : IEntryPointEngineSink
         _logger.LogWarning("inbound decode error from connection {ConnectionId}: {Error}", reply.ConnectionId, error);
     }
 
-    public void OnSessionClosed(IEntryPointResponseChannel reply)
+    public void OnSessionClosed(IGatewayResponseChannel reply)
     {
         // A single session may have placed orders on any channel, so fan the
         // notification out to ALL dispatchers. Each one enqueues a release
@@ -78,7 +78,7 @@ public sealed class HostRouter : IEntryPointEngineSink
             disp.OnSessionClosed(reply);
     }
 
-    private void RejectUnknownInstrument(long secId, IEntryPointResponseChannel reply, ulong clOrdIdValue)
+    private void RejectUnknownInstrument(long secId, IGatewayResponseChannel reply, ulong clOrdIdValue)
     {
         _logger.LogWarning("rejecting clOrdId={ClOrdId} from connection {ConnectionId}: unknown securityId={SecurityId}",
             clOrdIdValue, reply.ConnectionId, secId);

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -33,7 +33,7 @@ public class ChannelDispatcherTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Packets.Add(packet.ToArray());
     }
 
-    private sealed class RecordingReply : IEntryPointResponseChannel
+    private sealed class RecordingReply : IGatewayResponseChannel
     {
         public long ConnectionId => 1;
         public uint EnteringFirm => 7;
@@ -220,7 +220,7 @@ public class ChannelDispatcherTests
         // Session A drops. After processing OnSessionClosed on the dispatcher
         // thread, only B's owner entry must remain. Orders themselves stay on
         // the book (the engine never sees a Cancel).
-        ((IEntryPointEngineSink)disp).OnSessionClosed(sessionA);
+        ((IInboundCommandSink)disp).OnSessionClosed(sessionA);
         DrainInbound(disp);
 
         Assert.Equal(1, OrderOwnerCount(disp));
@@ -275,9 +275,9 @@ public class ChannelDispatcherTests
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
     private static void NotifyClosedAndForget(ChannelDispatcher disp, WeakReference weak)
     {
-        var target = (IEntryPointResponseChannel?)weak.Target;
+        var target = (IGatewayResponseChannel?)weak.Target;
         if (target is null) return;
-        ((IEntryPointEngineSink)disp).OnSessionClosed(target);
+        ((IInboundCommandSink)disp).OnSessionClosed(target);
         target = null;
         DrainInbound(disp);
     }

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -332,7 +332,7 @@ public class ChannelDispatcherSnapshotTests
     }
 }
 
-internal sealed class ChannelDispatcherTests_RecordingReply : B3.Exchange.EntryPoint.IEntryPointResponseChannel
+internal sealed class ChannelDispatcherTests_RecordingReply : B3.Exchange.Core.IGatewayResponseChannel
 {
     public long ConnectionId => 1;
     public uint EnteringFirm => 7;

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointHeartbeatTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Core;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.EntryPoint;
@@ -13,13 +14,13 @@ namespace B3.Exchange.EntryPoint.Tests;
 /// </summary>
 public class EntryPointHeartbeatTests
 {
-    private sealed class NoOpEngineSink : IEntryPointEngineSink
+    private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void OnDecodeError(IEntryPointResponseChannel reply, string error) { }
-        public void OnSessionClosed(IEntryPointResponseChannel reply) { }
+        public void EnqueueNewOrder(in NewOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(IGatewayResponseChannel reply, string error) { }
+        public void OnSessionClosed(IGatewayResponseChannel reply) { }
     }
 
     private static byte[] BuildSequenceFrame(uint nextSeq)

--- a/tests/B3.Exchange.EntryPoint.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.EntryPoint.Tests/EntryPointTerminateOnErrorTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Core;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
@@ -14,13 +15,13 @@ namespace B3.Exchange.EntryPoint.Tests;
 /// </summary>
 public class EntryPointTerminateOnErrorTests
 {
-    private sealed class NoOpEngineSink : IEntryPointEngineSink
+    private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, IEntryPointResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void OnDecodeError(IEntryPointResponseChannel reply, string error) { }
-        public void OnSessionClosed(IEntryPointResponseChannel reply) { }
+        public void EnqueueNewOrder(in NewOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, IGatewayResponseChannel reply, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(IGatewayResponseChannel reply, string error) { }
+        public void OnSessionClosed(IGatewayResponseChannel reply) { }
     }
 
     private static async Task<(EntryPointListener listener, TcpClient client)> ConnectAsync()

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -15,7 +15,7 @@ public class HostRouterTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Calls.Add(channelNumber);
     }
 
-    private sealed class RecordingReply : IEntryPointResponseChannel
+    private sealed class RecordingReply : IGatewayResponseChannel
     {
         public long ConnectionId => 1;
         public uint EnteringFirm => 1;


### PR DESCRIPTION
Closes #65.

Follow-up to PR #76 (the rename). Removes `B3.Exchange.Core`'s project reference to `B3.Exchange.EntryPoint` by relocating the gateway-facing interfaces into Core and flipping the project-reference arrow.

## Diff shape (12 files, +67 / -63)

`git mv src/B3.Exchange.EntryPoint/IEntryPointEngineSink.cs src/B3.Exchange.Core/GatewayInterfaces.cs` followed by:

| Old (in EntryPoint)              | New (in Core)              |
| -------------------------------- | -------------------------- |
| `IEntryPointResponseChannel`     | `IGatewayResponseChannel`  |
| `IEntryPointEngineSink`          | `IInboundCommandSink`      |
| namespace `B3.Exchange.EntryPoint` | namespace `B3.Exchange.Core` |

- `B3.Exchange.Core.csproj`: drops `<ProjectReference Include="…/B3.Exchange.EntryPoint.csproj" />`.
- `B3.Exchange.EntryPoint.csproj`: adds reference to `B3.Exchange.Core`.
- All consumers (`EntryPointSession`, `EntryPointListener`, `ChannelDispatcher`, `HostRouter`, `HttpServer`, every test fake) updated to the new names; adds `using B3.Exchange.Core;` where needed.

## Acceptance criteria — verified

- ✅ `B3.Exchange.Core.csproj` has **no** ProjectReference to `B3.Exchange.EntryPoint` or `B3.EntryPoint.Sbe`.
- ✅ Build clean under `TreatWarningsAsErrors=true`.
- ✅ `dotnet format --verify-no-changes` reports no diffs.
- ✅ All 205 tests pass (including E2E smoke, snapshot and HostRouter suites).

## Scoping note

The interfaces still expose Matching event records (`OrderAcceptedEvent`, `TradeEvent`, …). Switching to the neutral `B3.Exchange.Contracts.ICoreInbound` / `IGatewayInbound` surface (and the wire-event ↔ `ExecutionEvent` translation that requires) lands with the Gateway carve in #64 — where the new translation layer naturally belongs. Doing it in this PR would have required enriching `ExecutionEvent` and rewriting most of `EntryPointSession`'s ER paths in the same change, which would obscure the structural decoupling this PR is about.