### PR TITLE
Phase 1 #64 (1/2): rename B3.Exchange.EntryPoint → B3.Exchange.Gateway

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ Layered projects under `src/` (build order roughly bottom-up):
    `MatchingEngine` owns one `LimitOrderBook` per `SecurityId`, monotonic
    order/trade-id allocators, and an `RptSeq` incremented on every emitted
    event. **Not thread-safe by design.**
-5. `B3.Exchange.EntryPoint` — TCP listener, framed SBE inbound decoder,
+5. `B3.Exchange.Gateway` — TCP listener, framed SBE inbound decoder,
    ExecutionReport encoder. Each TCP session implements
    `IEntryPointResponseChannel`.
 6. `B3.Exchange.Core` — `ChannelDispatcher`: bounded inbound queue +

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ a 24/7 simulated venue against any UMDF consumer.
   Limit/Market × Day/IOC/FOK, replace (priority preservation rules), cancel,
   FOK pre-check, market-no-liquidity, tick/lot/band validation.
 - **`B3.Exchange.Instruments`** — JSON instrument loader.
-- **`B3.Exchange.EntryPoint`** — TCP listener, framed SBE inbound decoder,
+- **`B3.Exchange.Gateway`** — TCP listener, framed SBE inbound decoder,
   ExecutionReport encoder.
 - **`B3.Exchange.Core`** — per-channel `ChannelDispatcher`: bounded
   inbound queue, single dispatch thread, packs MBO/Trade frames into 1400-byte

--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -6,7 +6,7 @@
     <Project Path="src/B3.Exchange.Contracts/B3.Exchange.Contracts.csproj" />
     <Project Path="src/B3.Exchange.Instruments/B3.Exchange.Instruments.csproj" />
     <Project Path="src/B3.Exchange.Matching/B3.Exchange.Matching.csproj" />
-    <Project Path="src/B3.Exchange.EntryPoint/B3.Exchange.EntryPoint.csproj" />
+    <Project Path="src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj" />
     <Project Path="src/B3.Exchange.Core/B3.Exchange.Core.csproj" />
     <Project Path="src/B3.Exchange.Host/B3.Exchange.Host.csproj" />
     <Project Path="src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj" />
@@ -15,7 +15,7 @@
     <Project Path="tests/B3.Umdf.WireEncoder.Tests/B3.Umdf.WireEncoder.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Matching.Tests/B3.Exchange.Matching.Tests.csproj" />
-    <Project Path="tests/B3.Exchange.EntryPoint.Tests/B3.Exchange.EntryPoint.Tests.csproj" />
+    <Project Path="tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj" />
     <Project Path="tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj" />

--- a/docs/B3-ENTRYPOINT-ARCHITECTURE.md
+++ b/docs/B3-ENTRYPOINT-ARCHITECTURE.md
@@ -135,7 +135,7 @@ src/
     ICoreInbound.cs                  ← Gateway → Core
     IGatewayInbound.cs               ← Core → Gateway
 
-  B3.Exchange.Gateway/               ← NEW (replaces B3.Exchange.EntryPoint)
+  B3.Exchange.Gateway/               ← NEW (replaces B3.Exchange.Gateway)
     TcpListener.cs
     TcpTransport.cs                  ← owns Socket + send queue
     FixpSession.cs                   ← single-thread actor
@@ -566,7 +566,7 @@ testing of later phases.
 
 ### Phase 1 — Component split (the big one)
 - Create `B3.Exchange.Contracts` with DTOs and interfaces (§3.2).
-- Create `B3.Exchange.Gateway`; move all of `B3.Exchange.EntryPoint`
+- Create `B3.Exchange.Gateway`; move all of `B3.Exchange.Gateway`
   into it; rename old `EntryPointSession` to `LegacyTcpSession` and
   carve out `TcpTransport` + `FixpSession` skeletons.
 - Rename `B3.Exchange.Core` → `B3.Exchange.Core`. Strip all

--- a/docs/B3-ENTRYPOINT-COMPLIANCE.md
+++ b/docs/B3-ENTRYPOINT-COMPLIANCE.md
@@ -1,6 +1,6 @@
 # B3 Binary EntryPoint — Compliance Audit
 
-Audit of how `src/B3.Exchange.EntryPoint` and friends compare to the official
+Audit of how `src/B3.Exchange.Gateway` and friends compare to the official
 B3 spec. This is the canonical "what's missing / what's wrong vs. the wire
 protocol" reference for the simulator — issues that track individual gaps
 should link back to a row in the table below by `#gap-NN`.

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -2,7 +2,7 @@
 
 Stateful B3-style exchange simulator built on top of the matching engine
 in `src/B3.Exchange.Matching` and the EntryPoint TCP server in
-`src/B3.Exchange.EntryPoint`. Publishes synthetic UMDF traffic on multicast
+`src/B3.Exchange.Gateway`. Publishes synthetic UMDF traffic on multicast
 and accepts SBE EntryPoint orders over TCP.
 
 This is **distinct from** the synthetic publisher in

--- a/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
+++ b/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <RootNamespace>B3.Exchange.EntryPoint</RootNamespace>
-    <AssemblyName>B3.Exchange.EntryPoint</AssemblyName>
+    <RootNamespace>B3.Exchange.Gateway</RootNamespace>
+    <AssemblyName>B3.Exchange.Gateway</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <InternalsVisibleTo Include="B3.Exchange.EntryPoint.Tests" />
+    <InternalsVisibleTo Include="B3.Exchange.Gateway.Tests" />
     <InternalsVisibleTo Include="B3.Exchange.SyntheticTrader.Tests" />
     <InternalsVisibleTo Include="B3.Exchange.Host.Tests" />
   </ItemGroup>

--- a/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
@@ -1,7 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Byte-level encoder for the B3 EntryPoint <c>BusinessMessageReject</c>

--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -2,7 +2,7 @@ using System.Buffers.Binary;
 using System.Runtime.InteropServices;
 using B3.Entrypoint.Fixp.Sbe.V6;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Wire-format constants and parsers for the B3 EntryPoint protocol.

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -3,7 +3,7 @@ using System.Net.Sockets;
 using B3.Exchange.Core;
 using Microsoft.Extensions.Logging;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// TCP accept loop. Each accepted socket is wrapped in a

--- a/src/B3.Exchange.Gateway/EntryPointSession.cs
+++ b/src/B3.Exchange.Gateway/EntryPointSession.cs
@@ -4,7 +4,7 @@ using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Stream-based per-connection session. Hosts:

--- a/src/B3.Exchange.Gateway/EntryPointSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/EntryPointSessionOptions.cs
@@ -1,4 +1,4 @@
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Session-level timing knobs for heartbeats and idle-timeout teardown.

--- a/src/B3.Exchange.Gateway/EntryPointVarData.cs
+++ b/src/B3.Exchange.Gateway/EntryPointVarData.cs
@@ -1,4 +1,4 @@
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Walks and validates the length-prefixed variable-length data segments

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Per-template byte-level encoders for the outbound ExecutionReports we

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -1,7 +1,7 @@
 using System.Runtime.InteropServices;
 using B3.Exchange.Matching;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Decodes inbound EntryPoint message bodies (no SBE header — the

--- a/src/B3.Exchange.Gateway/SessionFrameEncoder.cs
+++ b/src/B3.Exchange.Gateway/SessionFrameEncoder.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Byte-level encoders for FIXP session-layer frames (currently just

--- a/src/B3.Exchange.Gateway/SessionRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/SessionRejectEncoder.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace B3.Exchange.EntryPoint;
+namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Byte-level encoder for the B3 EntryPoint <c>Terminate</c> message

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
-    <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
   </ItemGroup>
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -1,5 +1,5 @@
 using System.Net;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -1,4 +1,4 @@
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
+++ b/src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
-    <ProjectReference Include="..\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -2,7 +2,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Threading.Channels;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 
 namespace B3.Exchange.SyntheticTrader;
 
@@ -68,7 +68,7 @@ public sealed class EntryPointClient : IAsyncDisposable
     private const int MaxAcceptedBlockLength = 1024;
 
     // Per-template expected block lengths (mirroring ExecutionReportEncoder
-    // constants in B3.Exchange.EntryPoint, which is internal). Used as a
+    // constants in B3.Exchange.Gateway, which is internal). Used as a
     // tighter, schema-aware validation before allocating the body buffer.
     // Returns -1 for unknown template IDs (caller falls back to MaxAcceptedBlockLength).
     private static int ExpectedBlockLength(ushort templateId) => templateId switch

--- a/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
+++ b/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
   </ItemGroup>

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -1,5 +1,5 @@
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;

--- a/tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj
+++ b/tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
   </ItemGroup>
 

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointFrameReaderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointFrameReaderTests.cs
@@ -1,8 +1,8 @@
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 public class EntryPointFrameReaderTests
 {

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -1,11 +1,11 @@
 using B3.Exchange.Core;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 /// <summary>
 /// Integration coverage for issue #9: server-side heartbeat + idle timeout.

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
@@ -2,11 +2,11 @@ using B3.Exchange.Core;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 /// <summary>
 /// GAP-03 (#41): the gateway must send a FIXP <c>Terminate</c> with the

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointVarDataTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointVarDataTests.cs
@@ -1,6 +1,6 @@
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 public class EntryPointVarDataTests
 {

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -1,8 +1,8 @@
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 public class ExecutionReportEncoderTests
 {

--- a/tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs
@@ -1,8 +1,8 @@
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 public class InboundMessageDecoderTests
 {

--- a/tests/B3.Exchange.Gateway.Tests/RejectEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/RejectEncoderTests.cs
@@ -1,8 +1,8 @@
 using System.Buffers.Binary;
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 
-namespace B3.Exchange.EntryPoint.Tests;
+namespace B3.Exchange.Gateway.Tests;
 
 public class RejectEncoderTests
 {

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -2,7 +2,7 @@ using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Umdf.WireEncoder;
 

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
@@ -1,7 +1,7 @@
 using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Umdf.WireEncoder;
 

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -1,4 +1,4 @@
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Host;
 using B3.Exchange.Core;
 using B3.Exchange.Instruments;

--- a/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
+++ b/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
@@ -1,6 +1,6 @@
 using System.Buffers.Binary;
 using System.Net;
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Exchange.SyntheticTrader;

--- a/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
@@ -15,7 +15,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.EntryPoint\B3.Exchange.EntryPoint.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
   </ItemGroup>
 

--- a/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
@@ -1,4 +1,4 @@
-using B3.Exchange.EntryPoint;
+using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 
 namespace B3.Exchange.SyntheticTrader.Tests;


### PR DESCRIPTION
Refs #64. Mechanical rename, **zero behaviour change**.

- `src/B3.Exchange.EntryPoint`            → `src/B3.Exchange.Gateway`
- `tests/B3.Exchange.EntryPoint.Tests`    → `tests/B3.Exchange.Gateway.Tests`
- csproj `RootNamespace`/`AssemblyName`, `InternalsVisibleTo`, slnx entries
- All `using B3.Exchange.EntryPoint;` references in src + tests
- Doc/README mentions

`B3.EntryPoint.Sbe` (vendored SBE bindings for the protocol) is intentionally NOT renamed — the protocol is called *EntryPoint*. Only the exchange-side gateway implementation moves namespace.

Type names (`EntryPointSession`, `EntryPointListener`, `EntryPointFrameReader`, …) keep their `EntryPoint*` prefix for now. The follow-up PR splits `EntryPointSession` into `FixpSession` + `TcpTransport` (closes #64).

## Validation
- `dotnet build -c Release`: clean under `TreatWarningsAsErrors`.
- `dotnet test --no-build -c Release`: all 205 tests pass.
- `dotnet format --verify-no-changes`: no diffs.