### PR TITLE
Phase 1 #64 (2/2): split EntryPointSession into FixpSession + TcpTransport

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -329,7 +329,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         // as normal, but no ER_Trade is sent (there is nobody listening).
         //
         // After this sweep, the dispatcher holds no strong reference to
-        // `reply`, so the EntryPointSession (and its NetworkStream / Socket)
+        // `reply`, so the FixpSession (and its NetworkStream / Socket)
         // becomes eligible for GC once the listener has also dropped it
         // from its live-sessions list.
         if (_orderOwners.Count == 0) return;

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -44,7 +44,7 @@ public sealed class ChannelMetrics
 
 /// <summary>
 /// Provider of per-session send-queue depth gauges. The host wires an
-/// implementation that snapshots the active <c>EntryPointSession</c>
+/// implementation that snapshots the active <c>FixpSession</c>
 /// queues at scrape time. The "channel" label is currently fixed to
 /// <c>"all"</c> because a session's send queue is shared across every
 /// channel that may route ExecutionReports back to it; per-channel

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -7,7 +7,7 @@ namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// TCP accept loop. Each accepted socket is wrapped in a
-/// <see cref="NetworkStream"/> + <see cref="EntryPointSession"/>. The caller
+/// <see cref="NetworkStream"/> + <see cref="FixpSession"/>. The caller
 /// supplies a factory to assign per-connection identity (ConnectionId,
 /// EnteringFirm, SessionId), so the listener doesn't need to know about
 /// authentication or firm-mapping policy.
@@ -21,13 +21,13 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger<EntryPointListener> _logger;
     private readonly Func<EndPoint?, AcceptedConnection> _identityFactory;
-    private readonly EntryPointSessionOptions _sessionOptions;
-    private readonly Action<EntryPointSession, string>? _onSessionClosed;
+    private readonly FixpSessionOptions _sessionOptions;
+    private readonly Action<FixpSession, string>? _onSessionClosed;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
     private long _nextConnectionId;
-    private readonly List<EntryPointSession> _sessions = new();
+    private readonly List<FixpSession> _sessions = new();
     private readonly object _lock = new();
 
     public IPEndPoint? LocalEndpoint => (IPEndPoint?)_listener?.LocalEndpoint;
@@ -35,10 +35,10 @@ public sealed class EntryPointListener : IAsyncDisposable
     /// <summary>
     /// Snapshot of currently active sessions for diagnostics / metrics.
     /// Closed sessions remain in the list until <see cref="DisposeAsync"/>
-    /// runs; callers should filter on <see cref="EntryPointSession.IsOpen"/>
+    /// runs; callers should filter on <see cref="FixpSession.IsOpen"/>
     /// if they only want live ones.
     /// </summary>
-    public IReadOnlyList<EntryPointSession> ActiveSessions
+    public IReadOnlyList<FixpSession> ActiveSessions
     {
         get { lock (_lock) return _sessions.ToArray(); }
     }
@@ -46,8 +46,8 @@ public sealed class EntryPointListener : IAsyncDisposable
     public EntryPointListener(IPEndPoint endpoint, IInboundCommandSink sink,
         ILoggerFactory loggerFactory,
         Func<EndPoint?, AcceptedConnection>? identityFactory = null,
-        EntryPointSessionOptions? sessionOptions = null,
-        Action<EntryPointSession, string>? onSessionClosed = null)
+        FixpSessionOptions? sessionOptions = null,
+        Action<FixpSession, string>? onSessionClosed = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
         _endpoint = endpoint;
@@ -55,7 +55,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<EntryPointListener>();
         _identityFactory = identityFactory ?? DefaultIdentityFactory;
-        _sessionOptions = sessionOptions ?? EntryPointSessionOptions.Default;
+        _sessionOptions = sessionOptions ?? FixpSessionOptions.Default;
         _sessionOptions.Validate();
         _onSessionClosed = onSessionClosed;
     }
@@ -92,16 +92,16 @@ public sealed class EntryPointListener : IAsyncDisposable
                 var stream = new NetworkStream(sock, ownsSocket: true);
 
                 // Wrap onClosed to remove session from _sessions (so the
-                // disconnected EntryPointSession + its NetworkStream/Socket
+                // disconnected FixpSession + its NetworkStream/Socket
                 // become GC-eligible) before invoking the external callback.
-                Action<EntryPointSession, string> onClosed = (s, reason) =>
+                Action<FixpSession, string> onClosed = (s, reason) =>
                 {
                     lock (_lock) _sessions.Remove(s);
                     _onSessionClosed?.Invoke(s, reason);
                 };
 
-                var session = new EntryPointSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
-                    stream, _sink, _loggerFactory.CreateLogger<EntryPointSession>(),
+                var session = new FixpSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
+                    stream, _sink, _loggerFactory.CreateLogger<FixpSession>(),
                     options: _sessionOptions, onClosed: onClosed);
                 lock (_lock) _sessions.Add(session);
                 session.Start();
@@ -120,7 +120,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         try { _cts.Cancel(); } catch { }
         try { _listener?.Stop(); } catch { }
         if (_acceptTask != null) { try { await _acceptTask.ConfigureAwait(false); } catch { } }
-        EntryPointSession[] toClose;
+        FixpSession[] toClose;
         lock (_lock) { toClose = _sessions.ToArray(); _sessions.Clear(); }
         foreach (var s in toClose) await s.DisposeAsync().ConfigureAwait(false);
         _cts.Dispose();

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -1,5 +1,4 @@
 using System.Buffers;
-using System.Threading.Channels;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
@@ -7,94 +6,89 @@ using Microsoft.Extensions.Logging;
 namespace B3.Exchange.Gateway;
 
 /// <summary>
-/// Stream-based per-connection session. Hosts:
-///  - a receive loop that reads SBE-framed inbound messages and dispatches
-///    decoded commands to <see cref="IInboundCommandSink"/>;
-///  - a send loop that drains a bounded <see cref="Channel{T}"/> of
-///    pre-encoded outbound frames and writes them to the stream.
+/// Per-connection FIXP session: owns session identity (<see cref="SessionId"/>,
+/// <see cref="EnteringFirm"/>), the inbound decode loop, the FIXP-style
+/// liveness watchdog, and the implementation of
+/// <see cref="IGatewayResponseChannel"/> that encodes outbound
+/// ExecutionReports. Hands the actual byte-level send/receive of frames
+/// to a composed <see cref="TcpTransport"/>.
 ///
-/// Stream-based (rather than Socket-bound) so it can be exercised in tests
-/// with <c>MemoryStream</c> or duplex pipes — see
-/// <see cref="EntryPointListener"/> for the production accept loop.
+/// <para>The class is the destination for the
+/// <see cref="IInboundCommandSink"/> dispatch — Core never holds a
+/// transport reference. Future Phase-2 work (FIXP state machine,
+/// authentication, retransmission) will plug into this same surface.</para>
 ///
-/// Send-side backpressure: the channel is bounded; on overflow the channel
-/// is closed (<c>FullMode = DropWrite</c> + explicit close). This drops the
-/// connection rather than ballooning memory under a stuck peer.
+/// <para>Stream-based (rather than Socket-bound) so it can be exercised
+/// in tests with <c>MemoryStream</c> or duplex pipes — see
+/// <see cref="EntryPointListener"/> for the production accept loop.</para>
 /// </summary>
-public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposable
+public sealed class FixpSession : IGatewayResponseChannel, IAsyncDisposable
 {
     private const int InboundHeaderSize = EntryPointFrameReader.WireHeaderSize;
     private const int DefaultSendQueueCapacity = 1024;
 
-    private readonly Stream _stream;
+    private readonly TcpTransport _transport;
     private readonly IInboundCommandSink _sink;
-    private readonly ILogger<EntryPointSession> _logger;
-    private readonly Channel<byte[]> _sendQueue;
+    private readonly ILogger<FixpSession> _logger;
     private readonly CancellationTokenSource _cts = new();
     private readonly Func<ulong> _nowNanos;
-    private readonly EntryPointSessionOptions _options;
-    private readonly Action<EntryPointSession, string>? _onClosed;
-    private readonly SemaphoreSlim _streamWriteLock = new(1, 1);
+    private readonly FixpSessionOptions _options;
+    private readonly Action<FixpSession, string>? _onClosed;
     private long _msgSeqNum;
     private int _isOpen = 1;
     // Watchdog state (milliseconds since process start, monotonic).
     private long _lastInboundMs;
-    private long _lastOutboundMs;
     // Set true while we are waiting on the grace window after sending a probe;
     // cleared as soon as any inbound frame arrives. Prevents flooding probes.
     private int _probeOutstanding;
     private Task? _recvTask;
-    private Task? _sendTask;
     private Task? _watchdogTask;
 
     public long ConnectionId { get; }
     public uint EnteringFirm { get; }
     public uint SessionId { get; }
-    public bool IsOpen => Volatile.Read(ref _isOpen) == 1;
+    public bool IsOpen => Volatile.Read(ref _isOpen) == 1 && _transport.IsOpen;
 
     /// <summary>
-    /// Approximate number of pre-encoded ExecutionReport frames sitting in
-    /// the outbound queue, for /metrics scraping. Reads
-    /// <see cref="System.Threading.Channels.ChannelReader{T}.Count"/>,
-    /// which is O(1) on a bounded channel.
+    /// Approximate number of pre-encoded ExecutionReport frames sitting
+    /// in the outbound queue, for /metrics scraping.
     /// </summary>
-    public int SendQueueDepth => _sendQueue.Reader.Count;
+    public int SendQueueDepth => _transport.SendQueueDepth;
 
-    public EntryPointSession(long connectionId, uint enteringFirm, uint sessionId,
-        Stream stream, IInboundCommandSink sink, ILogger<EntryPointSession> logger,
+    public FixpSession(long connectionId, uint enteringFirm, uint sessionId,
+        Stream stream, IInboundCommandSink sink, ILogger<FixpSession> logger,
         Func<ulong>? nowNanos = null,
         int sendQueueCapacity = DefaultSendQueueCapacity,
-        EntryPointSessionOptions? options = null,
-        Action<EntryPointSession, string>? onClosed = null)
+        FixpSessionOptions? options = null,
+        Action<FixpSession, string>? onClosed = null,
+        ILogger<TcpTransport>? transportLogger = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ConnectionId = connectionId;
         EnteringFirm = enteringFirm;
         SessionId = sessionId;
-        _stream = stream;
         _sink = sink;
         _logger = logger;
         _nowNanos = nowNanos ?? DefaultNowNanos;
-        _options = options ?? EntryPointSessionOptions.Default;
+        _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
         _onClosed = onClosed;
-        _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(sendQueueCapacity)
-        {
-            SingleReader = true,
-            SingleWriter = false,
-            FullMode = BoundedChannelFullMode.DropWrite,
-        });
-        long now = NowMs();
-        Volatile.Write(ref _lastInboundMs, now);
-        Volatile.Write(ref _lastOutboundMs, now);
+        // The transport's onClose callback funnels back through our Close so
+        // session-level book-keeping (sink notification, onClosed delegate)
+        // runs even when teardown originates from a transport-side IO error.
+        _transport = new TcpTransport(connectionId, stream,
+            transportLogger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TcpTransport>.Instance,
+            sendQueueCapacity,
+            onClose: reason => Close(reason));
+        Volatile.Write(ref _lastInboundMs, NowMs());
     }
 
     public void Start()
     {
-        _logger.LogInformation("entrypoint session opened: connectionId={ConnectionId} sessionId={SessionId} firm={EnteringFirm}",
+        _logger.LogInformation("fixp session opened: connectionId={ConnectionId} sessionId={SessionId} firm={EnteringFirm}",
             ConnectionId, SessionId, EnteringFirm);
+        _transport.StartSendLoop(_cts.Token);
         _recvTask = Task.Run(() => RunReceiveLoopAsync(_cts.Token));
-        _sendTask = Task.Run(() => RunSendLoopAsync(_cts.Token));
         _watchdogTask = Task.Run(() => RunWatchdogLoopAsync(_cts.Token));
     }
 
@@ -105,12 +99,13 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
 
     private async Task RunReceiveLoopAsync(CancellationToken ct)
     {
+        var stream = _transport.Stream;
         var headerBuf = new byte[InboundHeaderSize];
         try
         {
             while (!ct.IsCancellationRequested)
             {
-                await ReadExactlyAsync(_stream, headerBuf, ct).ConfigureAwait(false);
+                await ReadExactlyAsync(stream, headerBuf, ct).ConfigureAwait(false);
                 if (!EntryPointFrameReader.TryParseInboundHeader(headerBuf, out var info, out var headerError, out var hdrMsg))
                 {
                     _sink.OnDecodeError(this, hdrMsg ?? headerError.ToString());
@@ -120,12 +115,11 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
                 var bodyBuf = ArrayPool<byte>.Shared.Rent(info.BodyLength);
                 try
                 {
-                    await ReadExactlyAsync(_stream, bodyBuf.AsMemory(0, info.BodyLength), ct).ConfigureAwait(false);
+                    await ReadExactlyAsync(stream, bodyBuf.AsMemory(0, info.BodyLength), ct).ConfigureAwait(false);
                     // Any well-framed inbound frame counts as liveness, including
                     // session-layer Sequence (heartbeat) frames.
                     Volatile.Write(ref _lastInboundMs, NowMs());
                     Volatile.Write(ref _probeOutstanding, 0);
-                    var body = bodyBuf.AsSpan(0, info.BodyLength);
                     if (!await DispatchInboundAsync(info, bodyBuf, info.BodyLength).ConfigureAwait(false))
                     {
                         // DispatchInboundAsync already wrote Terminate + closed.
@@ -142,7 +136,7 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
         catch (EndOfStreamException) { }
         catch (IOException ex)
         {
-            _logger.LogWarning(ex, "entrypoint session {ConnectionId} receive IO error", ConnectionId);
+            _logger.LogWarning(ex, "fixp session {ConnectionId} receive IO error", ConnectionId);
         }
         finally
         {
@@ -169,10 +163,8 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
 
     /// <summary>
     /// Sends a Terminate frame with <paramref name="terminationCode"/>
-    /// directly to the underlying stream (bypassing the send queue, which
-    /// might be racing with an in-flight write or about to be cancelled),
-    /// and closes the session. Acquires <see cref="_streamWriteLock"/> so
-    /// it does not collide with the regular send loop.
+    /// directly to the underlying stream (bypassing the send queue), and
+    /// closes the session.
     /// </summary>
     private async Task TerminateAndCloseAsync(byte terminationCode, string reason)
     {
@@ -181,20 +173,11 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
         SessionRejectEncoder.EncodeTerminate(frame, SessionId, 0, terminationCode);
         try
         {
-            await _streamWriteLock.WaitAsync().ConfigureAwait(false);
-            try
-            {
-                await _stream.WriteAsync(frame).ConfigureAwait(false);
-                Volatile.Write(ref _lastOutboundMs, NowMs());
-            }
-            finally
-            {
-                _streamWriteLock.Release();
-            }
+            await _transport.SendDirectAsync(frame).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "entrypoint session {ConnectionId} failed to write Terminate({Code})", ConnectionId, terminationCode);
+            _logger.LogWarning(ex, "fixp session {ConnectionId} failed to write Terminate({Code})", ConnectionId, terminationCode);
         }
         Close(reason);
     }
@@ -262,47 +245,11 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
         }
     }
 
-    private async Task RunSendLoopAsync(CancellationToken ct)
-    {
-        try
-        {
-            await foreach (var frame in _sendQueue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
-            {
-                try
-                {
-                    await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
-                    try
-                    {
-                        await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        _streamWriteLock.Release();
-                    }
-                    Volatile.Write(ref _lastOutboundMs, NowMs());
-                }
-                catch (IOException ex)
-                {
-                    _logger.LogWarning(ex, "entrypoint session {ConnectionId} send IO error; closing", ConnectionId);
-                    Close("send-io-error");
-                    return;
-                }
-                // Frames enqueued here are plain `new byte[]` (see TryEnqueueExact),
-                // never pool-owned, so we do not return them to ArrayPool.
-            }
-        }
-        catch (OperationCanceledException) { }
-        finally
-        {
-            Close("send-loop-exit");
-        }
-    }
-
     /// <summary>
     /// Periodic watchdog that drives the FIXP-style heartbeat + idle-timeout
     /// policy. Runs on its own task; never touches the socket directly —
-    /// instead it enqueues <c>Sequence</c> frames into the same bounded
-    /// channel the send loop drains, so all writes remain serialised.
+    /// instead it enqueues <c>Sequence</c> frames into the transport's
+    /// bounded channel, so all writes remain serialised.
     /// </summary>
     private async Task RunWatchdogLoopAsync(CancellationToken ct)
     {
@@ -319,12 +266,13 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
 
                 long now = NowMs();
                 long sinceIn = now - Volatile.Read(ref _lastInboundMs);
-                long sinceOut = now - Volatile.Read(ref _lastOutboundMs);
+                long sinceOut = now - _transport.LastOutboundTickMs;
 
                 // Idle teardown: if a probe is outstanding and grace elapsed
                 // without any inbound, close. The grace clock starts from the
-                // moment the probe was sent (i.e. _lastOutboundMs was bumped),
-                // so we measure the additional silence beyond idleTimeoutMs.
+                // moment the probe was sent (i.e. last outbound tick was
+                // bumped), so we measure the additional silence beyond
+                // idleTimeoutMs.
                 if (sinceIn >= (long)_options.IdleTimeoutMs + _options.TestRequestGraceMs &&
                     Volatile.Read(ref _probeOutstanding) == 1)
                 {
@@ -368,7 +316,7 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
         if (!IsOpen) return;
         var frame = new byte[SessionFrameEncoder.SequenceTotal];
         SessionFrameEncoder.EncodeSequence(frame, NextMsgSeqNum());
-        TryEnqueue(frame);
+        _transport.TryEnqueueFrame(frame);
     }
 
     private static async Task ReadExactlyAsync(Stream s, byte[] buf, CancellationToken ct)
@@ -383,14 +331,6 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
             if (n == 0) throw new EndOfStreamException();
             total += n;
         }
-    }
-
-    private bool TryEnqueue(byte[] frame)
-    {
-        if (!IsOpen) return false;
-        if (_sendQueue.Writer.TryWrite(frame)) return true;
-        Close("send-queue-full");
-        return false;
     }
 
     private uint NextMsgSeqNum() => (uint)Interlocked.Increment(ref _msgSeqNum);
@@ -473,7 +413,7 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
         var exact = new byte[written];
         Buffer.BlockCopy(frame, 0, exact, 0, written);
         ArrayPool<byte>.Shared.Return(frame);
-        return TryEnqueue(exact);
+        return _transport.TryEnqueueFrame(exact);
     }
 
     public bool WriteSessionReject(byte terminationCode)
@@ -519,9 +459,12 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
     public void Close(string reason)
     {
         if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
-        _logger.LogInformation("entrypoint session {ConnectionId} closing", ConnectionId);
-        _sendQueue.Writer.TryComplete();
+        _logger.LogInformation("fixp session {ConnectionId} closing", ConnectionId);
         try { _cts.Cancel(); } catch { }
+        // The transport may have already closed (it's the source of the
+        // callback in IO-error paths). Either way, ensure it's down so the
+        // send loop wakes up and exits.
+        _transport.Close(reason);
         // Notify the engine sink so it releases any cached references to this
         // session (see IInboundCommandSink.OnSessionClosed). Without this the
         // ChannelDispatcher's order-owners map keeps the session rooted for
@@ -534,8 +477,8 @@ public sealed class EntryPointSession : IGatewayResponseChannel, IAsyncDisposabl
     {
         Close("dispose");
         try { if (_recvTask != null) await _recvTask.ConfigureAwait(false); } catch { }
-        try { if (_sendTask != null) await _sendTask.ConfigureAwait(false); } catch { }
         try { if (_watchdogTask != null) await _watchdogTask.ConfigureAwait(false); } catch { }
+        await _transport.DisposeAsync().ConfigureAwait(false);
         _cts.Dispose();
     }
 }

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -16,13 +16,13 @@ namespace B3.Exchange.Gateway;
 /// Defaults match the issue (#9) spec: 30 s heartbeat, 30 s idle, 5 s grace.
 /// Tests override with sub-second values to keep the suite fast.
 /// </summary>
-public sealed record EntryPointSessionOptions
+public sealed record FixpSessionOptions
 {
     public int HeartbeatIntervalMs { get; init; } = 30_000;
     public int IdleTimeoutMs { get; init; } = 30_000;
     public int TestRequestGraceMs { get; init; } = 5_000;
 
-    public static EntryPointSessionOptions Default { get; } = new();
+    public static FixpSessionOptions Default { get; } = new();
 
     internal void Validate()
     {

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -5,7 +5,7 @@ namespace B3.Exchange.Gateway;
 
 /// <summary>
 /// Decodes inbound EntryPoint message bodies (no SBE header — the
-/// <see cref="EntryPointSession"/> consumes that first) into matching engine
+/// <see cref="FixpSession"/> consumes that first) into matching engine
 /// command records. Field offsets are pinned to the V2 SBE layout; the
 /// frame-length validation guarantees the body is exactly the right size.
 /// </summary>

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -1,0 +1,179 @@
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Transport-only half of a per-connection FIXP session. Owns the
+/// underlying <see cref="Stream"/> (typically a <see cref="System.Net.Sockets.NetworkStream"/>),
+/// a single send loop draining a bounded outbound queue, and the
+/// write-lock that serialises *all* writes to the stream — including
+/// emergency Terminate sends that bypass the queue.
+///
+/// <para>Knows nothing about FIXP framing, SBE templates, sequence
+/// numbers, or session identity. It pumps opaque, fully-encoded byte
+/// arrays. The owning <see cref="FixpSession"/> drives the receive loop
+/// directly off <see cref="Stream"/> so it can cooperate with the
+/// liveness watchdog without crossing a callback boundary on every
+/// frame.</para>
+///
+/// <para>Backpressure: the send queue is bounded with
+/// <c>FullMode = DropWrite</c>. On overflow the transport closes the
+/// connection rather than ballooning memory under a stuck peer; the
+/// session is notified via the <c>onClose</c> delegate.</para>
+/// </summary>
+public sealed class TcpTransport : IAsyncDisposable
+{
+    private readonly Stream _stream;
+    private readonly ILogger<TcpTransport> _logger;
+    private readonly Channel<byte[]> _sendQueue;
+    private readonly SemaphoreSlim _streamWriteLock = new(1, 1);
+    private readonly long _connectionId;
+    private readonly Action<string>? _onClose;
+    private int _isOpen = 1;
+    private long _lastOutboundTickMs;
+    private Task? _sendTask;
+
+    /// <summary>
+    /// Underlying stream. Exposed for the session-level receive loop —
+    /// the session reads framed bytes directly so it can update liveness
+    /// counters frame-by-frame without an indirection.
+    /// </summary>
+    public Stream Stream => _stream;
+
+    public bool IsOpen => Volatile.Read(ref _isOpen) == 1;
+
+    /// <summary>
+    /// Approximate number of pre-encoded frames sitting in the outbound
+    /// queue. <see cref="ChannelReader{T}.Count"/> is O(1) on a bounded
+    /// channel; safe to scrape from /metrics.
+    /// </summary>
+    public int SendQueueDepth => _sendQueue.Reader.Count;
+
+    /// <summary>
+    /// <see cref="Environment.TickCount64"/> reading captured at the end
+    /// of the last successful stream write (queued send or direct send).
+    /// The <see cref="FixpSession"/> reads this for its idle-timeout
+    /// watchdog.
+    /// </summary>
+    public long LastOutboundTickMs => Volatile.Read(ref _lastOutboundTickMs);
+
+    public TcpTransport(long connectionId, Stream stream, ILogger<TcpTransport> logger,
+        int sendQueueCapacity, Action<string>? onClose = null)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(logger);
+        _connectionId = connectionId;
+        _stream = stream;
+        _logger = logger;
+        _onClose = onClose;
+        _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(sendQueueCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.DropWrite,
+        });
+        Volatile.Write(ref _lastOutboundTickMs, Environment.TickCount64);
+    }
+
+    /// <summary>
+    /// Starts the send loop. Must be called once. The receive loop is
+    /// the session's responsibility (it reads <see cref="Stream"/>
+    /// directly so it can refresh liveness counters frame-by-frame).
+    /// </summary>
+    public void StartSendLoop(CancellationToken ct)
+    {
+        _sendTask = Task.Run(() => RunSendLoopAsync(ct), ct);
+    }
+
+    /// <summary>
+    /// Hands a fully-encoded outbound frame to the send queue. Returns
+    /// <c>false</c> if the transport is closed or the queue overflowed
+    /// (in which case the transport is closed as a side-effect to avoid
+    /// unbounded memory growth under a stuck peer).
+    /// </summary>
+    public bool TryEnqueueFrame(byte[] frame)
+    {
+        if (!IsOpen) return false;
+        if (_sendQueue.Writer.TryWrite(frame)) return true;
+        Close("send-queue-full");
+        return false;
+    }
+
+    /// <summary>
+    /// Writes <paramref name="frame"/> directly to the stream, bypassing
+    /// the send queue. Used by the session to flush a Terminate before
+    /// closing — the queue might be racing with an in-flight write or
+    /// about to be cancelled, so we acquire the write lock and write
+    /// inline. Always single-shot; never retried.
+    /// </summary>
+    public async Task SendDirectAsync(ReadOnlyMemory<byte> frame, CancellationToken ct = default)
+    {
+        if (!IsOpen) return;
+        await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+            Volatile.Write(ref _lastOutboundTickMs, Environment.TickCount64);
+        }
+        finally
+        {
+            _streamWriteLock.Release();
+        }
+    }
+
+    private async Task RunSendLoopAsync(CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var frame in _sendQueue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                try
+                {
+                    await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
+                    try
+                    {
+                        await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        _streamWriteLock.Release();
+                    }
+                    Volatile.Write(ref _lastOutboundTickMs, Environment.TickCount64);
+                }
+                catch (IOException ex)
+                {
+                    _logger.LogWarning(ex, "tcp transport {ConnectionId} send IO error; closing", _connectionId);
+                    Close("send-io-error");
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
+        finally
+        {
+            Close("send-loop-exit");
+        }
+    }
+
+    /// <summary>
+    /// Marks the transport closed and notifies the owning session via
+    /// the <c>onClose</c> callback. Idempotent. Subsequent
+    /// <see cref="TryEnqueueFrame"/> calls return false; the send loop
+    /// exits when the writer completes.
+    /// </summary>
+    public void Close(string reason)
+    {
+        if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
+        _logger.LogInformation("tcp transport {ConnectionId} closing: {Reason}", _connectionId, reason);
+        _sendQueue.Writer.TryComplete();
+        try { _onClose?.Invoke(reason); } catch { }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        Close("dispose");
+        try { if (_sendTask != null) await _sendTask.ConfigureAwait(false); } catch { }
+        _streamWriteLock.Dispose();
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -188,7 +188,7 @@ public sealed class ExchangeHost : IAsyncDisposable
 
         _router = new HostRouter(routing, _loggerFactory.CreateLogger<HostRouter>());
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
-        var sessionOptions = new EntryPointSessionOptions
+        var sessionOptions = new FixpSessionOptions
         {
             HeartbeatIntervalMs = _config.Tcp.HeartbeatIntervalMs,
             IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -60,7 +60,7 @@ public sealed class HostRouter : IInboundCommandSink
 
     public void OnDecodeError(IGatewayResponseChannel reply, string error)
     {
-        // Logging hook only. The EntryPointSession itself emits the
+        // Logging hook only. The FixpSession itself emits the
         // appropriate SessionReject (Terminate) or BusinessMessageReject
         // and decides whether to close the connection — the router has no
         // additional context to add here.

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -38,7 +38,7 @@ public class EntryPointHeartbeatTests
     {
         var closures = new List<string>();
         var sem = new SemaphoreSlim(0, 1);
-        var options = new EntryPointSessionOptions
+        var options = new FixpSessionOptions
         {
             HeartbeatIntervalMs = 10_000, // not relevant for this test
             IdleTimeoutMs = 200,
@@ -91,7 +91,7 @@ public class EntryPointHeartbeatTests
     public async Task ActivelyHeartbeatingSession_StaysAlive()
     {
         var closures = new List<string>();
-        var options = new EntryPointSessionOptions
+        var options = new FixpSessionOptions
         {
             HeartbeatIntervalMs = 10_000, // ignore server-emitted heartbeats here
             IdleTimeoutMs = 200,
@@ -132,7 +132,7 @@ public class EntryPointHeartbeatTests
     [Fact]
     public async Task ServerEmitsHeartbeat_WhenOutboundIdle()
     {
-        var options = new EntryPointSessionOptions
+        var options = new FixpSessionOptions
         {
             HeartbeatIntervalMs = 150,
             IdleTimeoutMs = 10_000,        // disable idle teardown for this test


### PR DESCRIPTION
Closes #64.

Carves the per-connection responsibilities of the old `EntryPointSession` into two collaborating types:

| Concern                                        | Owner             |
| ---------------------------------------------- | ----------------- |
| `Stream`, bounded send queue, send loop        | `TcpTransport`    |
| Stream-write lock (queued + direct sends)      | `TcpTransport`    |
| Inbound recv loop, header + body decode        | `FixpSession`     |
| Liveness watchdog (heartbeat / probe / idle)   | `FixpSession`     |
| `SessionId`, `EnteringFirm`, msgSeqNum         | `FixpSession`     |
| `IGatewayResponseChannel` ER encoders          | `FixpSession`     |
| Terminate + close (uses transport direct send) | `FixpSession`     |

`TcpTransport` knows nothing about FIXP framing, SBE templates, or session identity — it pumps opaque byte arrays. The transport's `onClose` callback funnels back through `FixpSession.Close` so sink notification and the `onClosed` delegate fire even when teardown originates from a transport-side IO error.

`EntryPointSession` and `EntryPointSessionOptions` no longer exist per the issue's acceptance criteria — all references in listener / host / tests / doc comments switch to `FixpSession` / `FixpSessionOptions`.

## Out of scope (later phases)

FIXP state machine, Negotiate/Establish, RetransmitBuffer, auth, multi-firm registry — Phases 2/3.

## Validation

- `dotnet build -c Release`: clean under `TreatWarningsAsErrors=true`.
- `dotnet test --no-build -c Release`: all 205 tests pass unchanged (incl. heartbeat/terminate/E2E suites).
- `dotnet format --verify-no-changes`: no diffs.

## Diff
10 files changed, +263 / -141. Old session file is renamed via `git mv`; the diff against `FixpSession.cs` is reasonably reviewable side-by-side.