### PR TITLE
Phase 2 #68: explicit FixpStateMachine enum + transition matrix

### DIFF
--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -56,6 +56,28 @@ public sealed class FixpSession : IAsyncDisposable
     public bool IsOpen => Volatile.Read(ref _isOpen) == 1 && _transport.IsOpen;
 
     /// <summary>
+    /// Current FIXP lifecycle state. Mutated only via <see cref="ApplyTransition"/>,
+    /// which routes through <see cref="FixpStateMachine.Apply"/>. Starts at
+    /// <see cref="FixpState.Idle"/> immediately after the TCP transport is
+    /// accepted (before any FIXP <c>Negotiate</c>).
+    /// </summary>
+    public FixpState State { get; private set; } = FixpState.Idle;
+
+    /// <summary>
+    /// Single entry point for state transitions. Looks up the next state and
+    /// recommended action via <see cref="FixpStateMachine.Apply"/>, applies
+    /// the new state, and returns the action so the dispatch loop can act
+    /// on it (write a response frame, terminate, etc.). Idempotent against
+    /// <see cref="FixpState.Terminated"/>.
+    /// </summary>
+    internal FixpAction ApplyTransition(FixpEvent ev)
+    {
+        var t = FixpStateMachine.Apply(State, ev);
+        State = t.NewState;
+        return t.Action;
+    }
+
+    /// <summary>
     /// Approximate number of pre-encoded ExecutionReport frames sitting
     /// in the outbound queue, for /metrics scraping.
     /// </summary>

--- a/src/B3.Exchange.Gateway/FixpStateMachine.cs
+++ b/src/B3.Exchange.Gateway/FixpStateMachine.cs
@@ -8,7 +8,8 @@ namespace B3.Exchange.Gateway;
 /// See <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §5 for the full diagram and
 /// acceptance matrix. The single source of truth for transitions is
 /// <see cref="FixpStateMachine.Apply"/>; <c>FixpSession.State</c> must only
-/// ever be mutated through that method.
+/// ever be mutated by feeding events through that function (in practice via
+/// <c>FixpSession.ApplyTransition</c>, which assigns the returned new state).
 /// </para>
 /// </summary>
 public enum FixpState
@@ -51,8 +52,11 @@ public enum FixpEvent
     Negotiate,
     Establish,
     /// <summary>
-    /// Any FIX/SBE application message (NewOrder, Cancel, ExecutionReport,
-    /// etc.). Only legal in <see cref="FixpState.Established"/>.
+    /// Any inbound application-level FIX/SBE business message (e.g.,
+    /// <c>NewOrderSingle</c>, <c>OrderCancelRequest</c>). Outbound messages
+    /// (e.g., <c>ExecutionReport</c>) do not flow through this enum since
+    /// the gateway is the sender, not the receiver, of those frames. Only
+    /// legal in <see cref="FixpState.Established"/>.
     /// </summary>
     ApplicationMessage,
     /// <summary>FIXP <c>Sequence</c> (heartbeat/seq carrier).</summary>

--- a/src/B3.Exchange.Gateway/FixpStateMachine.cs
+++ b/src/B3.Exchange.Gateway/FixpStateMachine.cs
@@ -123,40 +123,40 @@ public static class FixpStateMachine
     public static FixpTransition Apply(FixpState state, FixpEvent ev) => (state, ev) switch
     {
         // ── Idle ──────────────────────────────────────────────────────────
-        (FixpState.Idle, FixpEvent.Negotiate)          => new(FixpState.Negotiated, FixpAction.Accept),
-        (FixpState.Idle, FixpEvent.Establish)          => new(FixpState.Idle, FixpAction.NotApplied),
+        (FixpState.Idle, FixpEvent.Negotiate) => new(FixpState.Negotiated, FixpAction.Accept),
+        (FixpState.Idle, FixpEvent.Establish) => new(FixpState.Idle, FixpAction.NotApplied),
         (FixpState.Idle, FixpEvent.ApplicationMessage) => new(FixpState.Terminated, FixpAction.RejectAndTerminateUnnegotiated),
-        (FixpState.Idle, FixpEvent.Sequence)           => new(FixpState.Idle, FixpAction.DropSilently),
-        (FixpState.Idle, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
-        (FixpState.Idle, FixpEvent.RetransmitRequest)  => new(FixpState.Idle, FixpAction.DropSilently),
-        (FixpState.Idle, FixpEvent.Detach)             => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Idle, FixpEvent.Sequence) => new(FixpState.Idle, FixpAction.DropSilently),
+        (FixpState.Idle, FixpEvent.Terminate) => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Idle, FixpEvent.RetransmitRequest) => new(FixpState.Idle, FixpAction.DropSilently),
+        (FixpState.Idle, FixpEvent.Detach) => new(FixpState.Terminated, FixpAction.Accept),
 
         // ── Negotiated ────────────────────────────────────────────────────
-        (FixpState.Negotiated, FixpEvent.Negotiate)          => new(FixpState.Negotiated, FixpAction.NegotiateRejectAlreadyNegotiated),
-        (FixpState.Negotiated, FixpEvent.Establish)          => new(FixpState.Established, FixpAction.Accept),
+        (FixpState.Negotiated, FixpEvent.Negotiate) => new(FixpState.Negotiated, FixpAction.NegotiateRejectAlreadyNegotiated),
+        (FixpState.Negotiated, FixpEvent.Establish) => new(FixpState.Established, FixpAction.Accept),
         (FixpState.Negotiated, FixpEvent.ApplicationMessage) => new(FixpState.Terminated, FixpAction.RejectAndTerminateUnestablished),
-        (FixpState.Negotiated, FixpEvent.Sequence)           => new(FixpState.Negotiated, FixpAction.NotApplied),
-        (FixpState.Negotiated, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
-        (FixpState.Negotiated, FixpEvent.RetransmitRequest)  => new(FixpState.Negotiated, FixpAction.DropSilently),
-        (FixpState.Negotiated, FixpEvent.Detach)             => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Negotiated, FixpEvent.Sequence) => new(FixpState.Negotiated, FixpAction.NotApplied),
+        (FixpState.Negotiated, FixpEvent.Terminate) => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Negotiated, FixpEvent.RetransmitRequest) => new(FixpState.Negotiated, FixpAction.DropSilently),
+        (FixpState.Negotiated, FixpEvent.Detach) => new(FixpState.Terminated, FixpAction.Accept),
 
         // ── Established ───────────────────────────────────────────────────
-        (FixpState.Established, FixpEvent.Negotiate)          => new(FixpState.Established, FixpAction.NegotiateReject),
-        (FixpState.Established, FixpEvent.Establish)          => new(FixpState.Established, FixpAction.EstablishReject),
+        (FixpState.Established, FixpEvent.Negotiate) => new(FixpState.Established, FixpAction.NegotiateReject),
+        (FixpState.Established, FixpEvent.Establish) => new(FixpState.Established, FixpAction.EstablishReject),
         (FixpState.Established, FixpEvent.ApplicationMessage) => new(FixpState.Established, FixpAction.Accept),
-        (FixpState.Established, FixpEvent.Sequence)           => new(FixpState.Established, FixpAction.Accept),
-        (FixpState.Established, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
-        (FixpState.Established, FixpEvent.RetransmitRequest)  => new(FixpState.Established, FixpAction.Replay),
-        (FixpState.Established, FixpEvent.Detach)             => new(FixpState.Suspended, FixpAction.Accept),
+        (FixpState.Established, FixpEvent.Sequence) => new(FixpState.Established, FixpAction.Accept),
+        (FixpState.Established, FixpEvent.Terminate) => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Established, FixpEvent.RetransmitRequest) => new(FixpState.Established, FixpAction.Replay),
+        (FixpState.Established, FixpEvent.Detach) => new(FixpState.Suspended, FixpAction.Accept),
 
         // ── Suspended (transport detached; session lifecycle alive) ───────
-        (FixpState.Suspended, FixpEvent.Negotiate)          => new(FixpState.Suspended, FixpAction.NegotiateRejectAlreadyNegotiated),
-        (FixpState.Suspended, FixpEvent.Establish)          => new(FixpState.Established, FixpAction.Accept), // re-attach
+        (FixpState.Suspended, FixpEvent.Negotiate) => new(FixpState.Suspended, FixpAction.NegotiateRejectAlreadyNegotiated),
+        (FixpState.Suspended, FixpEvent.Establish) => new(FixpState.Established, FixpAction.Accept), // re-attach
         (FixpState.Suspended, FixpEvent.ApplicationMessage) => new(FixpState.Suspended, FixpAction.DropSilently),
-        (FixpState.Suspended, FixpEvent.Sequence)           => new(FixpState.Suspended, FixpAction.DropSilently),
-        (FixpState.Suspended, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
-        (FixpState.Suspended, FixpEvent.RetransmitRequest)  => new(FixpState.Suspended, FixpAction.DeferredToReestablish),
-        (FixpState.Suspended, FixpEvent.Detach)             => new(FixpState.Suspended, FixpAction.DropSilently),
+        (FixpState.Suspended, FixpEvent.Sequence) => new(FixpState.Suspended, FixpAction.DropSilently),
+        (FixpState.Suspended, FixpEvent.Terminate) => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Suspended, FixpEvent.RetransmitRequest) => new(FixpState.Suspended, FixpAction.DeferredToReestablish),
+        (FixpState.Suspended, FixpEvent.Detach) => new(FixpState.Suspended, FixpAction.DropSilently),
 
         // ── Terminated (terminal) ─────────────────────────────────────────
         (FixpState.Terminated, _) => new(FixpState.Terminated, FixpAction.Terminal),

--- a/src/B3.Exchange.Gateway/FixpStateMachine.cs
+++ b/src/B3.Exchange.Gateway/FixpStateMachine.cs
@@ -1,0 +1,166 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// FIXP per-session lifecycle state. The session starts in <see cref="Idle"/>
+/// when a TCP connection is accepted, transitions through Negotiate /
+/// Establish, and ends in <see cref="Terminated"/> when the session ends.
+/// <para>
+/// See <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §5 for the full diagram and
+/// acceptance matrix. The single source of truth for transitions is
+/// <see cref="FixpStateMachine.Apply"/>; <c>FixpSession.State</c> must only
+/// ever be mutated through that method.
+/// </para>
+/// </summary>
+public enum FixpState
+{
+    /// <summary>
+    /// TCP transport is open; no <c>Negotiate</c> received yet. Application
+    /// frames in this state must be rejected with <c>Terminate(Unnegotiated)</c>.
+    /// </summary>
+    Idle,
+    /// <summary>
+    /// <c>Negotiate</c> accepted. Awaiting <c>Establish</c>. Application
+    /// frames in this state must be rejected with <c>Terminate(Unestablished)</c>.
+    /// </summary>
+    Negotiated,
+    /// <summary>
+    /// Fully established session. Application messages flow normally; keep-
+    /// alive (<c>Sequence</c>) and retransmission requests are accepted.
+    /// </summary>
+    Established,
+    /// <summary>
+    /// Transport is detached but the session lifecycle is still alive (retx
+    /// buffer held). A subsequent <c>Establish</c> with the same
+    /// <c>sessionVerID</c> re-attaches and returns to <see cref="Established"/>.
+    /// </summary>
+    Suspended,
+    /// <summary>
+    /// Terminal state. No further events are processed; the session is reaped
+    /// from the registry once its dispatch loop drains.
+    /// </summary>
+    Terminated,
+}
+
+/// <summary>
+/// Inputs to <see cref="FixpStateMachine.Apply"/>. Combines inbound message
+/// kinds (decoded by the transport layer) and out-of-band lifecycle events
+/// (<see cref="Detach"/> for TCP loss).
+/// </summary>
+public enum FixpEvent
+{
+    Negotiate,
+    Establish,
+    /// <summary>
+    /// Any FIX/SBE application message (NewOrder, Cancel, ExecutionReport,
+    /// etc.). Only legal in <see cref="FixpState.Established"/>.
+    /// </summary>
+    ApplicationMessage,
+    /// <summary>FIXP <c>Sequence</c> (heartbeat/seq carrier).</summary>
+    Sequence,
+    /// <summary>Inbound or outbound <c>Terminate</c>.</summary>
+    Terminate,
+    /// <summary>FIXP <c>RetransmitRequest</c>.</summary>
+    RetransmitRequest,
+    /// <summary>
+    /// Out-of-band: TCP transport detached (socket closed, not from a
+    /// <c>Terminate</c> exchange). Maps Established → Suspended; in pre-
+    /// established states the session is reaped.
+    /// </summary>
+    Detach,
+}
+
+/// <summary>
+/// Outcome describing both the new state and the action the dispatch loop
+/// must take in response. The state machine itself is pure; the FixpSession
+/// dispatch loop is responsible for performing the action (writing the
+/// response frame, closing the transport, etc.).
+/// </summary>
+public enum FixpAction
+{
+    /// <summary>Frame accepted; nothing to send beyond normal application
+    /// processing.</summary>
+    Accept,
+    /// <summary>Reject with <c>NegotiateReject(AlreadyNegotiated)</c>.</summary>
+    NegotiateRejectAlreadyNegotiated,
+    /// <summary>Reject with <c>NegotiateReject</c> (generic — duplicate
+    /// negotiate after Establish).</summary>
+    NegotiateReject,
+    /// <summary>Reject with <c>EstablishReject</c> (duplicate establish).</summary>
+    EstablishReject,
+    /// <summary>FIXP <c>NotApplied</c> response (sequence-tracking message
+    /// arrived in a state where seq tracking is not active).</summary>
+    NotApplied,
+    /// <summary>Application message in <see cref="FixpState.Idle"/> — must
+    /// reject + send <c>Terminate(Unnegotiated)</c>.</summary>
+    RejectAndTerminateUnnegotiated,
+    /// <summary>Application message in <see cref="FixpState.Negotiated"/> —
+    /// must reject + send <c>Terminate(Unestablished)</c>.</summary>
+    RejectAndTerminateUnestablished,
+    /// <summary>Discard frame silently (e.g., RetransmitRequest in
+    /// <see cref="FixpState.Idle"/>).</summary>
+    DropSilently,
+    /// <summary>Replay missing messages from the retx buffer (RetransmitRequest
+    /// in <see cref="FixpState.Established"/>).</summary>
+    Replay,
+    /// <summary>Defer handling until the session is re-established (RetransmitRequest
+    /// in <see cref="FixpState.Suspended"/>).</summary>
+    DeferredToReestablish,
+    /// <summary>Terminal state was already reached; ignore the event.</summary>
+    Terminal,
+}
+
+/// <summary>Pure transition result.</summary>
+public readonly record struct FixpTransition(FixpState NewState, FixpAction Action);
+
+/// <summary>
+/// Pure (state, event) → (state', action) function table. No I/O, no
+/// allocation, no logging — this is the single source of truth for the FIXP
+/// session lifecycle. See <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §5 for
+/// the matrix this implements.
+/// </summary>
+public static class FixpStateMachine
+{
+    public static FixpTransition Apply(FixpState state, FixpEvent ev) => (state, ev) switch
+    {
+        // ── Idle ──────────────────────────────────────────────────────────
+        (FixpState.Idle, FixpEvent.Negotiate)          => new(FixpState.Negotiated, FixpAction.Accept),
+        (FixpState.Idle, FixpEvent.Establish)          => new(FixpState.Idle, FixpAction.NotApplied),
+        (FixpState.Idle, FixpEvent.ApplicationMessage) => new(FixpState.Terminated, FixpAction.RejectAndTerminateUnnegotiated),
+        (FixpState.Idle, FixpEvent.Sequence)           => new(FixpState.Idle, FixpAction.DropSilently),
+        (FixpState.Idle, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Idle, FixpEvent.RetransmitRequest)  => new(FixpState.Idle, FixpAction.DropSilently),
+        (FixpState.Idle, FixpEvent.Detach)             => new(FixpState.Terminated, FixpAction.Accept),
+
+        // ── Negotiated ────────────────────────────────────────────────────
+        (FixpState.Negotiated, FixpEvent.Negotiate)          => new(FixpState.Negotiated, FixpAction.NegotiateRejectAlreadyNegotiated),
+        (FixpState.Negotiated, FixpEvent.Establish)          => new(FixpState.Established, FixpAction.Accept),
+        (FixpState.Negotiated, FixpEvent.ApplicationMessage) => new(FixpState.Terminated, FixpAction.RejectAndTerminateUnestablished),
+        (FixpState.Negotiated, FixpEvent.Sequence)           => new(FixpState.Negotiated, FixpAction.NotApplied),
+        (FixpState.Negotiated, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Negotiated, FixpEvent.RetransmitRequest)  => new(FixpState.Negotiated, FixpAction.DropSilently),
+        (FixpState.Negotiated, FixpEvent.Detach)             => new(FixpState.Terminated, FixpAction.Accept),
+
+        // ── Established ───────────────────────────────────────────────────
+        (FixpState.Established, FixpEvent.Negotiate)          => new(FixpState.Established, FixpAction.NegotiateReject),
+        (FixpState.Established, FixpEvent.Establish)          => new(FixpState.Established, FixpAction.EstablishReject),
+        (FixpState.Established, FixpEvent.ApplicationMessage) => new(FixpState.Established, FixpAction.Accept),
+        (FixpState.Established, FixpEvent.Sequence)           => new(FixpState.Established, FixpAction.Accept),
+        (FixpState.Established, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Established, FixpEvent.RetransmitRequest)  => new(FixpState.Established, FixpAction.Replay),
+        (FixpState.Established, FixpEvent.Detach)             => new(FixpState.Suspended, FixpAction.Accept),
+
+        // ── Suspended (transport detached; session lifecycle alive) ───────
+        (FixpState.Suspended, FixpEvent.Negotiate)          => new(FixpState.Suspended, FixpAction.NegotiateRejectAlreadyNegotiated),
+        (FixpState.Suspended, FixpEvent.Establish)          => new(FixpState.Established, FixpAction.Accept), // re-attach
+        (FixpState.Suspended, FixpEvent.ApplicationMessage) => new(FixpState.Suspended, FixpAction.DropSilently),
+        (FixpState.Suspended, FixpEvent.Sequence)           => new(FixpState.Suspended, FixpAction.DropSilently),
+        (FixpState.Suspended, FixpEvent.Terminate)          => new(FixpState.Terminated, FixpAction.Accept),
+        (FixpState.Suspended, FixpEvent.RetransmitRequest)  => new(FixpState.Suspended, FixpAction.DeferredToReestablish),
+        (FixpState.Suspended, FixpEvent.Detach)             => new(FixpState.Suspended, FixpAction.DropSilently),
+
+        // ── Terminated (terminal) ─────────────────────────────────────────
+        (FixpState.Terminated, _) => new(FixpState.Terminated, FixpAction.Terminal),
+
+        _ => throw new InvalidOperationException($"Unhandled FIXP transition ({state}, {ev})"),
+    };
+}

--- a/tests/B3.Exchange.Gateway.Tests/FixpStateMachineTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpStateMachineTests.cs
@@ -1,0 +1,279 @@
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Acceptance-matrix coverage for <see cref="FixpStateMachine"/>. One test
+/// per (state, event) cell from <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §5.
+/// </summary>
+public class FixpStateMachineTests
+{
+    // ── Idle row ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Idle_Negotiate_Accepted_TransitionsToNegotiated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.Negotiate);
+        Assert.Equal(FixpState.Negotiated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Idle_Establish_NotApplied_StaysIdle()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.Establish);
+        Assert.Equal(FixpState.Idle, t.NewState);
+        Assert.Equal(FixpAction.NotApplied, t.Action);
+    }
+
+    [Fact]
+    public void Idle_ApplicationMessage_RejectsAndTerminatesUnnegotiated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.ApplicationMessage);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.RejectAndTerminateUnnegotiated, t.Action);
+    }
+
+    [Fact]
+    public void Idle_Sequence_DroppedSilently()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.Sequence);
+        Assert.Equal(FixpState.Idle, t.NewState);
+        Assert.Equal(FixpAction.DropSilently, t.Action);
+    }
+
+    [Fact]
+    public void Idle_Terminate_Accepted_GoesTerminated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.Terminate);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Idle_RetransmitRequest_DroppedSilently()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.RetransmitRequest);
+        Assert.Equal(FixpState.Idle, t.NewState);
+        Assert.Equal(FixpAction.DropSilently, t.Action);
+    }
+
+    [Fact]
+    public void Idle_Detach_GoesTerminated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Idle, FixpEvent.Detach);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    // ── Negotiated row ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Negotiated_Negotiate_RejectsAlreadyNegotiated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.Negotiate);
+        Assert.Equal(FixpState.Negotiated, t.NewState);
+        Assert.Equal(FixpAction.NegotiateRejectAlreadyNegotiated, t.Action);
+    }
+
+    [Fact]
+    public void Negotiated_Establish_Accepted_TransitionsToEstablished()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.Establish);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Negotiated_ApplicationMessage_RejectsAndTerminatesUnestablished()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.ApplicationMessage);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.RejectAndTerminateUnestablished, t.Action);
+    }
+
+    [Fact]
+    public void Negotiated_Sequence_NotApplied()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.Sequence);
+        Assert.Equal(FixpState.Negotiated, t.NewState);
+        Assert.Equal(FixpAction.NotApplied, t.Action);
+    }
+
+    [Fact]
+    public void Negotiated_Terminate_GoesTerminated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.Terminate);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Negotiated_RetransmitRequest_DroppedSilently()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.RetransmitRequest);
+        Assert.Equal(FixpState.Negotiated, t.NewState);
+        Assert.Equal(FixpAction.DropSilently, t.Action);
+    }
+
+    [Fact]
+    public void Negotiated_Detach_GoesTerminated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Negotiated, FixpEvent.Detach);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    // ── Established row ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Established_Negotiate_Rejects()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.Negotiate);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.NegotiateReject, t.Action);
+    }
+
+    [Fact]
+    public void Established_Establish_Rejects()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.Establish);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.EstablishReject, t.Action);
+    }
+
+    [Fact]
+    public void Established_ApplicationMessage_Accepted()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.ApplicationMessage);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Established_Sequence_Accepted()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.Sequence);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Established_Terminate_GoesTerminated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.Terminate);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Established_RetransmitRequest_TriggersReplay()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.RetransmitRequest);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.Replay, t.Action);
+    }
+
+    [Fact]
+    public void Established_Detach_GoesSuspended()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Established, FixpEvent.Detach);
+        Assert.Equal(FixpState.Suspended, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    // ── Suspended row ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Suspended_Negotiate_RejectsAlreadyNegotiated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.Negotiate);
+        Assert.Equal(FixpState.Suspended, t.NewState);
+        Assert.Equal(FixpAction.NegotiateRejectAlreadyNegotiated, t.Action);
+    }
+
+    [Fact]
+    public void Suspended_Establish_ReAttachesToEstablished()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.Establish);
+        Assert.Equal(FixpState.Established, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Suspended_ApplicationMessage_DroppedSilently()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.ApplicationMessage);
+        Assert.Equal(FixpState.Suspended, t.NewState);
+        Assert.Equal(FixpAction.DropSilently, t.Action);
+    }
+
+    [Fact]
+    public void Suspended_Sequence_DroppedSilently()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.Sequence);
+        Assert.Equal(FixpState.Suspended, t.NewState);
+        Assert.Equal(FixpAction.DropSilently, t.Action);
+    }
+
+    [Fact]
+    public void Suspended_Terminate_GoesTerminated()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.Terminate);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Accept, t.Action);
+    }
+
+    [Fact]
+    public void Suspended_RetransmitRequest_DeferredToReestablish()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.RetransmitRequest);
+        Assert.Equal(FixpState.Suspended, t.NewState);
+        Assert.Equal(FixpAction.DeferredToReestablish, t.Action);
+    }
+
+    [Fact]
+    public void Suspended_Detach_StaysSuspended()
+    {
+        var t = FixpStateMachine.Apply(FixpState.Suspended, FixpEvent.Detach);
+        Assert.Equal(FixpState.Suspended, t.NewState);
+        Assert.Equal(FixpAction.DropSilently, t.Action);
+    }
+
+    // ── Terminated (terminal) ─────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(FixpEvent.Negotiate)]
+    [InlineData(FixpEvent.Establish)]
+    [InlineData(FixpEvent.ApplicationMessage)]
+    [InlineData(FixpEvent.Sequence)]
+    [InlineData(FixpEvent.Terminate)]
+    [InlineData(FixpEvent.RetransmitRequest)]
+    [InlineData(FixpEvent.Detach)]
+    public void Terminated_AnyEvent_StaysTerminated(FixpEvent ev)
+    {
+        var t = FixpStateMachine.Apply(FixpState.Terminated, ev);
+        Assert.Equal(FixpState.Terminated, t.NewState);
+        Assert.Equal(FixpAction.Terminal, t.Action);
+    }
+
+    // ── Matrix completeness guard ─────────────────────────────────────────
+
+    /// <summary>
+    /// Sanity check: every (state, event) combination must be handled by
+    /// <see cref="FixpStateMachine.Apply"/>. Catches accidental matrix
+    /// holes if a future enum value is added without a row update.
+    /// </summary>
+    [Fact]
+    public void EveryStateEventCombination_IsCovered()
+    {
+        foreach (FixpState s in Enum.GetValues<FixpState>())
+            foreach (FixpEvent e in Enum.GetValues<FixpEvent>())
+            {
+                // Should not throw.
+                var t = FixpStateMachine.Apply(s, e);
+                _ = t.NewState;
+                _ = t.Action;
+            }
+    }
+}


### PR DESCRIPTION
Closes #68.

Foundation for Phase 2 lifecycle work. Pure additive change — no behavioural impact on existing flows; subsequent PRs (#42 Negotiate, #43 Establish) will wire inbound message validation against `FixpSession.State`.

## What

- `FixpState` enum: `Idle`, `Negotiated`, `Established`, `Suspended`, `Terminated`.
- `FixpEvent` enum: `Negotiate`, `Establish`, `ApplicationMessage`, `Sequence`, `Terminate`, `RetransmitRequest`, `Detach` (transport-loss event).
- `FixpAction` enum: per-cell recommended response (Accept, NegotiateReject variants, EstablishReject, NotApplied, RejectAndTerminate{Unnegotiated,Unestablished}, DropSilently, Replay, DeferredToReestablish, Terminal).
- `FixpStateMachine.Apply(state, event) → (state', action)`: pure switch covering every cell of the §5 matrix.
- `FixpSession.State` is now `{ get; private set; }`; `internal FixpAction ApplyTransition(FixpEvent ev)` is the only path that mutates it.

## Acceptance

- ✅ `FixpSession.State` is private-set and only assigned inside `ApplyTransition` (which delegates to `FixpStateMachine.Apply`).
- ✅ Acceptance matrix tests cover every cell, plus a completeness sweep that catches future enum holes (`EveryStateEventCombination_IsCovered`).
- ✅ Idle invalid frame → `Terminate(Unnegotiated)` (action `RejectAndTerminateUnnegotiated`).
- ✅ Negotiated invalid frame → `Terminate(Unestablished)` (action `RejectAndTerminateUnestablished`).
- ✅ Build clean under `TreatWarningsAsErrors=true` (241/241 tests passing).

## Verify

```
dotnet build SbeB3Exchange.slnx -c Release
dotnet test  SbeB3Exchange.slnx --no-build -c Release
dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
```