### PR TITLE
FirmRegistry + per-session credentials from config (#67)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -5,11 +5,38 @@
   //   UMDF channel. instruments file partitions instruments across channels.
   "tcp": {
     "listen": "0.0.0.0:9876",
+    // DEPRECATED — pre-#67 single-tenant fallback. Used only when
+    // firms[]/sessions[] are empty. New deployments should declare
+    // firms[] and sessions[] explicitly (see below).
     "enteringFirm": 1,
     "heartbeatIntervalMs": 30000,
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000
   },
+  // Authentication. devMode=true bypasses access-key validation during
+  // FIXP Negotiate (#42) — useful for local dev / tests. Production
+  // deployments should set this to false and provide non-empty
+  // accessKey values per session.
+  "auth": {
+    "devMode": true
+  },
+  // Participants (corretoras). One entry per firm; enteringFirmCode is
+  // stamped on outbound SBE headers as EnteringFirm.
+  "firms": [
+    { "id": "FIRM01", "name": "Alpha Corretora", "enteringFirmCode": 100 },
+    { "id": "FIRM02", "name": "Beta Corretora",  "enteringFirmCode": 200 }
+  ],
+  // Per-(firm, session) credentials. The Negotiate handshake (#42) will
+  // resolve a session by sessionId here and validate the peer's
+  // access_key against accessKey (when auth.devMode is false).
+  // Pre-#42 the host picks the lexicographically-first session as the
+  // default tenant for every accept.
+  "sessions": [
+    { "sessionId": "FIRM01-SESS-01", "firmId": "FIRM01", "accessKey": "dev-key-1" },
+    { "sessionId": "FIRM01-SESS-02", "firmId": "FIRM01", "accessKey": "dev-key-2" },
+    { "sessionId": "FIRM02-SESS-01", "firmId": "FIRM02", "accessKey": "dev-key-3" },
+    { "sessionId": "FIRM02-SESS-02", "firmId": "FIRM02", "accessKey": "dev-key-4" }
+  ],
   // Optional Kestrel-hosted operability endpoint. Remove this block to
   // disable HTTP entirely. Exposes:
   //   GET /health/live   liveness (dispatcher heartbeats fresher than livenessStaleMs)

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -73,6 +73,15 @@ Exposes:
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000
   },
+  "auth": { "devMode": true },
+  "firms": [
+    { "id": "FIRM01", "name": "Alpha", "enteringFirmCode": 100 },
+    { "id": "FIRM02", "name": "Beta",  "enteringFirmCode": 200 }
+  ],
+  "sessions": [
+    { "sessionId": "FIRM01-SESS-01", "firmId": "FIRM01", "accessKey": "dev-1" },
+    { "sessionId": "FIRM02-SESS-01", "firmId": "FIRM02", "accessKey": "dev-2" }
+  ],
   "http": { "listen": "0.0.0.0:8080", "livenessStaleMs": 5000 },
   "channels": [
     {
@@ -102,8 +111,22 @@ Exposes:
 ```
 
 * `tcp.listen` — bind address for the EntryPoint TCP server.
-* `tcp.enteringFirm` — uint stamped on every accepted order (single-firm
-  default; per-session firm assignment is not yet implemented).
+* `tcp.enteringFirm` — **DEPRECATED** (pre-#67 single-tenant fallback).
+  Used only when `firms[]`/`sessions[]` are empty. New configs should
+  declare firms and sessions explicitly (see below).
+* `auth.devMode` — when `true`, the FIXP `Negotiate` handler (#42) skips
+  `accessKey` validation. Useful for local dev / tests. Mixing
+  `devMode=true` with non-empty per-session `accessKey` values produces a
+  startup warning.
+* `firms[]` — one entry per participant (corretora). Each firm exposes
+  an `enteringFirmCode` (uint) that is stamped on outbound SBE headers.
+  See `docs/B3-ENTRYPOINT-ARCHITECTURE.md` §4.1.
+* `sessions[]` — per-`(firm, session)` credentials. The Negotiate
+  handshake (#42) resolves a session by `sessionId` and validates the
+  peer's `access_key` against `accessKey` (when `auth.devMode=false`).
+  Pre-#42 the host picks the lexicographically-first `sessionId` as the
+  default tenant for every accept. Optional `policy{}` block overrides
+  per-session throttling and keep-alive timings.
 * `tcp.heartbeatIntervalMs` — server emits a `Sequence` (templateId=9, used
   as heartbeat by B3) when no other outbound traffic has been sent within
   this window. Default `30000`.

--- a/src/B3.Exchange.Gateway/Firm.cs
+++ b/src/B3.Exchange.Gateway/Firm.cs
@@ -1,0 +1,73 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Static identity for a participant (corretora / brokerage). Loaded once
+/// at startup from <c>HostConfig.firms[]</c>; immutable for the life of the
+/// process. See <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §4.1.
+/// </summary>
+/// <param name="Id">Stable string identifier (e.g. <c>"FIRM01"</c>).</param>
+/// <param name="Name">Human-readable name; used for diagnostics only.</param>
+/// <param name="EnteringFirmCode">
+/// Numeric code stamped on outbound SBE headers as <c>EnteringFirm</c>. Must
+/// match what the upstream B3 systems expect for this corretora.
+/// </param>
+public sealed record Firm(string Id, string Name, uint EnteringFirmCode);
+
+/// <summary>
+/// Per-session policy knobs. Loaded with the parent
+/// <see cref="SessionCredential"/>; immutable. Defaults match today's
+/// global TCP defaults for backwards-compatibility.
+/// </summary>
+public sealed record SessionPolicy(
+    int ThrottleMessagesPerSecond = 0,
+    int KeepAliveIntervalMs = 30_000,
+    int IdleTimeoutMs = 30_000,
+    int TestRequestGraceMs = 5_000,
+    int RetransmitBufferSize = 10_000)
+{
+    public static SessionPolicy Default { get; } = new();
+
+    public void Validate()
+    {
+        if (KeepAliveIntervalMs <= 0)
+            throw new InvalidOperationException("SessionPolicy.KeepAliveIntervalMs must be > 0");
+        if (IdleTimeoutMs <= 0)
+            throw new InvalidOperationException("SessionPolicy.IdleTimeoutMs must be > 0");
+        if (TestRequestGraceMs <= 0)
+            throw new InvalidOperationException("SessionPolicy.TestRequestGraceMs must be > 0");
+        if (RetransmitBufferSize <= 0)
+            throw new InvalidOperationException("SessionPolicy.RetransmitBufferSize must be > 0");
+        if (ThrottleMessagesPerSecond < 0)
+            throw new InvalidOperationException("SessionPolicy.ThrottleMessagesPerSecond must be >= 0 (0 disables)");
+    }
+}
+
+/// <summary>
+/// Per-session credential record. One per <c>(firmId, sessionId)</c> pair.
+/// Loaded once at startup from <c>HostConfig.sessions[]</c>; immutable.
+/// See <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §4.2.
+///
+/// <para>Phase 2 #67 introduces this type as part of the multi-firm /
+/// multi-session model. The <c>FixpSession</c> Negotiate handler (#42)
+/// resolves a credential by matching <c>Negotiate.sessionID</c> against
+/// <see cref="SessionId"/> here and validating <c>credentials.access_key</c>
+/// against <see cref="AccessKey"/> (when <c>auth.devMode</c> is false).</para>
+/// </summary>
+/// <param name="SessionId">Stable string identifier matching FIXP <c>sessionID</c>.</param>
+/// <param name="FirmId">Owning firm — must resolve via <see cref="FirmRegistry"/>.</param>
+/// <param name="AccessKey">
+/// Plain shared secret (dev). Production hashing is deferred per
+/// architecture §7. Empty string disables credential validation for this
+/// session even outside dev mode (use only for tests).
+/// </param>
+/// <param name="AllowedSourceCidrs">
+/// Optional whitelist of CIDR ranges. <c>null</c> or empty disables
+/// source-IP filtering. Future enforcement; today informational only.
+/// </param>
+/// <param name="Policy">Per-session throttle / keep-alive overrides.</param>
+public sealed record SessionCredential(
+    string SessionId,
+    string FirmId,
+    string AccessKey,
+    IReadOnlyList<string>? AllowedSourceCidrs,
+    SessionPolicy Policy);

--- a/src/B3.Exchange.Gateway/FirmRegistry.cs
+++ b/src/B3.Exchange.Gateway/FirmRegistry.cs
@@ -1,0 +1,93 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Immutable, startup-loaded registry of <see cref="Firm"/> records and
+/// their associated <see cref="SessionCredential"/>s. Authoritative for
+/// "is this firm/session known and what is its policy?"
+///
+/// <para>See <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §4.6 and §8 for the
+/// configuration schema. Validation is performed at construction time;
+/// startup fails fast on any inconsistency (unknown <c>firmId</c>,
+/// duplicate <c>sessionId</c>, etc.).</para>
+///
+/// <para>Thread-safety: read-only after construction; safe for concurrent
+/// lookups from any thread.</para>
+/// </summary>
+public sealed class FirmRegistry
+{
+    private readonly IReadOnlyDictionary<string, Firm> _firms;
+    private readonly IReadOnlyDictionary<string, SessionCredential> _credentials;
+
+    /// <summary>All firms keyed by <see cref="Firm.Id"/>.</summary>
+    public IReadOnlyDictionary<string, Firm> Firms => _firms;
+
+    /// <summary>All session credentials keyed by <see cref="SessionCredential.SessionId"/>.</summary>
+    public IReadOnlyDictionary<string, SessionCredential> Credentials => _credentials;
+
+    public FirmRegistry(IEnumerable<Firm> firms, IEnumerable<SessionCredential> sessions)
+    {
+        ArgumentNullException.ThrowIfNull(firms);
+        ArgumentNullException.ThrowIfNull(sessions);
+
+        var firmMap = new Dictionary<string, Firm>(StringComparer.Ordinal);
+        foreach (var f in firms)
+        {
+            ArgumentNullException.ThrowIfNull(f);
+            if (string.IsNullOrWhiteSpace(f.Id))
+                throw new InvalidOperationException("Firm.Id must be non-empty");
+            if (!firmMap.TryAdd(f.Id, f))
+                throw new InvalidOperationException($"duplicate firm id: '{f.Id}'");
+        }
+
+        var credMap = new Dictionary<string, SessionCredential>(StringComparer.Ordinal);
+        foreach (var s in sessions)
+        {
+            ArgumentNullException.ThrowIfNull(s);
+            if (string.IsNullOrWhiteSpace(s.SessionId))
+                throw new InvalidOperationException("SessionCredential.SessionId must be non-empty");
+            if (!firmMap.ContainsKey(s.FirmId))
+                throw new InvalidOperationException(
+                    $"session '{s.SessionId}' references unknown firm '{s.FirmId}' " +
+                    $"(known firms: {string.Join(", ", firmMap.Keys)})");
+            s.Policy.Validate();
+            if (!credMap.TryAdd(s.SessionId, s))
+                throw new InvalidOperationException($"duplicate session id: '{s.SessionId}'");
+        }
+
+        _firms = firmMap;
+        _credentials = credMap;
+    }
+
+    /// <summary>
+    /// Resolves a <see cref="SessionCredential"/> by FIXP sessionID. Returns
+    /// <c>null</c> when unknown — callers should respond with
+    /// <c>NegotiateReject(Credentials)</c> in that case.
+    /// </summary>
+    public SessionCredential? FindSession(string sessionId)
+    {
+        ArgumentNullException.ThrowIfNull(sessionId);
+        return _credentials.TryGetValue(sessionId, out var c) ? c : null;
+    }
+
+    /// <summary>
+    /// Resolves a <see cref="Firm"/> by FirmId. Returns <c>null</c> when
+    /// unknown.
+    /// </summary>
+    public Firm? FindFirm(string firmId)
+    {
+        ArgumentNullException.ThrowIfNull(firmId);
+        return _firms.TryGetValue(firmId, out var f) ? f : null;
+    }
+
+    /// <summary>
+    /// Convenience: returns the <see cref="Firm"/> that owns the given
+    /// session, or <c>null</c> if either lookup fails. Used by FixpSession
+    /// after Negotiate to stamp outbound ER frames with the right
+    /// <c>EnteringFirmCode</c>.
+    /// </summary>
+    public Firm? FirmOf(string sessionId)
+    {
+        var c = FindSession(sessionId);
+        return c is null ? null : FindFirm(c.FirmId);
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -58,6 +58,12 @@ public sealed class ExchangeHost : IAsyncDisposable
     public MetricsRegistry Metrics => _metrics;
     public IReadOnlyList<ChannelDispatcher> Dispatchers => _dispatchers;
 
+    /// <summary>Firm + session credentials parsed from <c>HostConfig</c>.
+    /// Built lazily on first access (or on <see cref="StartAsync"/>); empty
+    /// when <c>firms[]</c>/<c>sessions[]</c> are not configured.</summary>
+    public FirmRegistry FirmRegistry => _firmRegistry ??= BuildFirmRegistry();
+    private FirmRegistry? _firmRegistry;
+
     /// <summary>Snapshot of the InstrumentDef publishers, primarily for tests.</summary>
     public IReadOnlyList<InstrumentDefinitionPublisher> InstrumentDefinitionPublishers => _instrumentDefPublishers;
 
@@ -81,6 +87,9 @@ public sealed class ExchangeHost : IAsyncDisposable
         _logger.LogInformation("exchange host starting with {ChannelCount} channels", _config.Channels.Count);
         var sessionRegistry = new SessionRegistry();
         var gatewayRouter = new GatewayRouter(sessionRegistry, _loggerFactory.CreateLogger<GatewayRouter>());
+
+        var firmRegistry = FirmRegistry;
+        var defaultSession = ResolveDefaultSession(firmRegistry);
         var routing = new Dictionary<long, ChannelDispatcher>();
         foreach (var ch in _config.Channels)
         {
@@ -201,9 +210,15 @@ public sealed class ExchangeHost : IAsyncDisposable
             identityFactory: remote =>
             {
                 var connectionId = Random.Shared.NextInt64() & 0x7FFFFFFFFFFFFFFFL;
+                // Pre-#42 (Negotiate): we do not yet know which session the
+                // peer will claim, so we stamp the default session's firm
+                // code on every accept. #42 will move firm/session
+                // resolution into the Negotiate handler and consult
+                // FirmRegistry by sessionID claimed by the peer.
+                var enteringFirm = defaultSession.firmCode;
                 return new EntryPointListener.AcceptedConnection(
                     ConnectionId: connectionId,
-                    EnteringFirm: _config.Tcp.EnteringFirm,
+                    EnteringFirm: enteringFirm,
                     SessionId: (uint)(connectionId & 0xFFFFFFFFu));
             },
             sessionOptions: sessionOptions,
@@ -240,6 +255,73 @@ public sealed class ExchangeHost : IAsyncDisposable
                     QueueDepth: s.SendQueueDepth);
             }
         }
+    }
+
+    private FirmRegistry BuildFirmRegistry()
+    {
+        var firms = _config.Firms.Select(fc =>
+        {
+            if (string.IsNullOrWhiteSpace(fc.Id))
+                throw new InvalidOperationException("HostConfig.firms[].id must be non-empty");
+            if (fc.EnteringFirmCode == 0)
+                throw new InvalidOperationException(
+                    $"HostConfig.firms['{fc.Id}'].enteringFirmCode must be > 0");
+            return new Firm(fc.Id, string.IsNullOrWhiteSpace(fc.Name) ? fc.Id : fc.Name, fc.EnteringFirmCode);
+        });
+
+        var sessions = _config.Sessions.Select(sc =>
+        {
+            var policy = sc.Policy is null
+                ? SessionPolicy.Default
+                : new SessionPolicy(
+                    ThrottleMessagesPerSecond: sc.Policy.ThrottleMessagesPerSecond,
+                    KeepAliveIntervalMs: sc.Policy.KeepAliveIntervalMs,
+                    IdleTimeoutMs: sc.Policy.IdleTimeoutMs,
+                    TestRequestGraceMs: sc.Policy.TestRequestGraceMs,
+                    RetransmitBufferSize: sc.Policy.RetransmitBufferSize);
+            return new SessionCredential(
+                SessionId: sc.SessionId,
+                FirmId: sc.FirmId,
+                AccessKey: sc.AccessKey ?? "",
+                AllowedSourceCidrs: sc.AllowedSourceCidrs,
+                Policy: policy);
+        });
+
+        var registry = new FirmRegistry(firms, sessions);
+
+        if (_config.Auth.DevMode &&
+            registry.Credentials.Values.Any(c => !string.IsNullOrEmpty(c.AccessKey)))
+        {
+            _logger.LogWarning(
+                "auth.devMode=true but {Count} session(s) declare a non-empty accessKey; access keys will be ignored",
+                registry.Credentials.Values.Count(c => !string.IsNullOrEmpty(c.AccessKey)));
+        }
+
+        return registry;
+    }
+
+    private (string sessionId, uint firmCode) ResolveDefaultSession(FirmRegistry registry)
+    {
+        if (registry.Credentials.Count > 0)
+        {
+            // Stable: pick the lexicographically-first session id so the
+            // selection is deterministic regardless of YAML/JSON ordering
+            // quirks. #42 will replace this with peer-claimed sessionID.
+            var sid = registry.Credentials.Keys.OrderBy(k => k, StringComparer.Ordinal).First();
+            var firm = registry.FirmOf(sid)
+                ?? throw new InvalidOperationException($"BUG: session '{sid}' has no resolved firm");
+            _logger.LogInformation(
+                "pre-#42 default session: '{SessionId}' firm '{FirmId}' enteringFirmCode={EnteringFirmCode}",
+                sid, firm.Id, firm.EnteringFirmCode);
+            return (sid, firm.EnteringFirmCode);
+        }
+
+        // Backwards compatibility: pre-#67 single-tenant config.
+        _logger.LogWarning(
+            "HostConfig.firms[]/sessions[] is empty; falling back to deprecated tcp.enteringFirm={EnteringFirm}. " +
+            "Update your config to declare firms[] and sessions[] per docs/B3-ENTRYPOINT-ARCHITECTURE.md §8.",
+            _config.Tcp.EnteringFirm);
+        return ("legacy", _config.Tcp.EnteringFirm);
     }
 
     private static IPEndPoint ParseEndpoint(string s)

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -11,6 +11,9 @@ namespace B3.Exchange.Host;
 public sealed class HostConfig
 {
     [JsonPropertyName("tcp")] public TcpConfig Tcp { get; set; } = new();
+    [JsonPropertyName("auth")] public AuthConfig Auth { get; set; } = new();
+    [JsonPropertyName("firms")] public List<FirmConfig> Firms { get; set; } = new();
+    [JsonPropertyName("sessions")] public List<SessionConfig> Sessions { get; set; } = new();
     [JsonPropertyName("http")] public HttpConfig? Http { get; set; }
     [JsonPropertyName("channels")] public List<ChannelConfig> Channels { get; set; } = new();
 }
@@ -18,6 +21,12 @@ public sealed class HostConfig
 public sealed class TcpConfig
 {
     [JsonPropertyName("listen")] public string Listen { get; set; } = "0.0.0.0:9876";
+    /// <summary>
+    /// DEPRECATED — pre-#67 single-tenant fallback. Used only when
+    /// <c>firms[]</c> / <c>sessions[]</c> are empty so existing configs
+    /// keep working. New configs should declare firms and sessions
+    /// explicitly per <c>docs/B3-ENTRYPOINT-ARCHITECTURE.md</c> §8.
+    /// </summary>
     [JsonPropertyName("enteringFirm")] public uint EnteringFirm { get; set; } = 1;
     /// <summary>Server-side heartbeat (Sequence) interval in milliseconds.
     /// A heartbeat is only emitted when no other outbound traffic has been
@@ -29,6 +38,44 @@ public sealed class TcpConfig
     /// <summary>Additional grace window after the probe before the session is
     /// closed for inactivity. Default: 5 s.</summary>
     [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
+}
+
+/// <summary>
+/// Authentication mode. <c>devMode=true</c> bypasses access-key validation
+/// during Negotiate (#42) — useful for local development / tests. Mixing
+/// devMode with non-empty <c>sessions[].accessKey</c> values produces a
+/// startup warning.
+/// </summary>
+public sealed class AuthConfig
+{
+    [JsonPropertyName("devMode")] public bool DevMode { get; set; }
+}
+
+/// <summary>One firm (corretora). See architecture §4.1.</summary>
+public sealed class FirmConfig
+{
+    [JsonPropertyName("id")] public string Id { get; set; } = "";
+    [JsonPropertyName("name")] public string Name { get; set; } = "";
+    [JsonPropertyName("enteringFirmCode")] public uint EnteringFirmCode { get; set; }
+}
+
+/// <summary>One session credential. See architecture §4.2.</summary>
+public sealed class SessionConfig
+{
+    [JsonPropertyName("sessionId")] public string SessionId { get; set; } = "";
+    [JsonPropertyName("firmId")] public string FirmId { get; set; } = "";
+    [JsonPropertyName("accessKey")] public string AccessKey { get; set; } = "";
+    [JsonPropertyName("allowedSourceCidrs")] public List<string>? AllowedSourceCidrs { get; set; }
+    [JsonPropertyName("policy")] public SessionPolicyConfig? Policy { get; set; }
+}
+
+public sealed class SessionPolicyConfig
+{
+    [JsonPropertyName("throttleMessagesPerSecond")] public int ThrottleMessagesPerSecond { get; set; }
+    [JsonPropertyName("keepAliveIntervalMs")] public int KeepAliveIntervalMs { get; set; } = 30_000;
+    [JsonPropertyName("idleTimeoutMs")] public int IdleTimeoutMs { get; set; } = 30_000;
+    [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
+    [JsonPropertyName("retransmitBufferSize")] public int RetransmitBufferSize { get; set; } = 10_000;
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
@@ -1,0 +1,132 @@
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class FirmRegistryTests
+{
+    private static Firm Firm(string id, uint code = 1) => new(id, id, code);
+
+    private static SessionCredential Cred(string sid, string firmId, string ak = "")
+        => new(sid, firmId, ak, AllowedSourceCidrs: null, Policy: SessionPolicy.Default);
+
+    [Fact]
+    public void Construction_succeeds_with_valid_firms_and_sessions()
+    {
+        var r = new FirmRegistry(
+            new[] { Firm("F1", 100), Firm("F2", 200) },
+            new[] { Cred("S1", "F1"), Cred("S2", "F2") });
+
+        Assert.Equal(2, r.Firms.Count);
+        Assert.Equal(2, r.Credentials.Count);
+        Assert.Equal(100u, r.FindFirm("F1")!.EnteringFirmCode);
+        Assert.Equal("F1", r.FindSession("S1")!.FirmId);
+    }
+
+    [Fact]
+    public void FindSession_returns_null_when_unknown()
+    {
+        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "F1") });
+        Assert.Null(r.FindSession("missing"));
+    }
+
+    [Fact]
+    public void FindFirm_returns_null_when_unknown()
+    {
+        var r = new FirmRegistry(new[] { Firm("F1") }, Array.Empty<SessionCredential>());
+        Assert.Null(r.FindFirm("missing"));
+    }
+
+    [Fact]
+    public void FirmOf_resolves_firm_by_session_id()
+    {
+        var r = new FirmRegistry(new[] { Firm("F1", 42) }, new[] { Cred("S1", "F1") });
+        Assert.Equal(42u, r.FirmOf("S1")!.EnteringFirmCode);
+    }
+
+    [Fact]
+    public void FirmOf_returns_null_for_unknown_session()
+    {
+        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "F1") });
+        Assert.Null(r.FirmOf("ghost"));
+    }
+
+    [Fact]
+    public void Duplicate_firm_id_throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1"), Firm("F1") }, Array.Empty<SessionCredential>()));
+        Assert.Contains("duplicate firm id", ex.Message);
+    }
+
+    [Fact]
+    public void Duplicate_session_id_throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "F1"), Cred("S1", "F1") }));
+        Assert.Contains("duplicate session id", ex.Message);
+    }
+
+    [Fact]
+    public void Session_referencing_unknown_firm_throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "GHOST") }));
+        Assert.Contains("unknown firm 'GHOST'", ex.Message);
+    }
+
+    [Fact]
+    public void Empty_firm_id_throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("") }, Array.Empty<SessionCredential>()));
+    }
+
+    [Fact]
+    public void Empty_session_id_throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("", "F1") }));
+    }
+
+    [Fact]
+    public void Invalid_policy_propagates_validation_error()
+    {
+        var bad = new SessionCredential("S1", "F1", "", null,
+            new SessionPolicy(KeepAliveIntervalMs: 0));
+        Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { bad }));
+    }
+
+    [Fact]
+    public void Empty_registry_is_valid()
+    {
+        var r = new FirmRegistry(Array.Empty<Firm>(), Array.Empty<SessionCredential>());
+        Assert.Empty(r.Firms);
+        Assert.Empty(r.Credentials);
+    }
+
+    [Fact]
+    public void SessionPolicy_default_validates()
+    {
+        SessionPolicy.Default.Validate();
+    }
+
+    [Theory]
+    [InlineData(0, 30_000, 5_000, 10_000)]   // KeepAlive
+    [InlineData(30_000, 0, 5_000, 10_000)]   // IdleTimeout
+    [InlineData(30_000, 30_000, 0, 10_000)]  // TestRequestGrace
+    [InlineData(30_000, 30_000, 5_000, 0)]   // RetransmitBuffer
+    public void SessionPolicy_rejects_zero_or_negative_durations(
+        int keepAlive, int idle, int grace, int retxBuf)
+    {
+        var p = new SessionPolicy(0, keepAlive, idle, grace, retxBuf);
+        Assert.Throws<InvalidOperationException>(p.Validate);
+    }
+
+    [Fact]
+    public void SessionPolicy_rejects_negative_throttle()
+    {
+        var p = new SessionPolicy(ThrottleMessagesPerSecond: -1);
+        Assert.Throws<InvalidOperationException>(p.Validate);
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/HostConfigFirmRegistryTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostConfigFirmRegistryTests.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using B3.Exchange.Host;
+
+namespace B3.Exchange.Host.Tests;
+
+public class HostConfigFirmRegistryTests
+{
+    private static string WriteTempJson(string contents)
+    {
+        var path = Path.Combine(Path.GetTempPath(),
+            $"host-config-{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, contents, Encoding.UTF8);
+        return path;
+    }
+
+    [Fact]
+    public void Load_parses_firms_sessions_and_auth()
+    {
+        var json = """
+        {
+          "tcp": { "listen": "127.0.0.1:0" },
+          "auth": { "devMode": true },
+          "firms": [
+            { "id": "FIRM01", "name": "Alpha Corretora", "enteringFirmCode": 100 },
+            { "id": "FIRM02", "name": "Beta Corretora", "enteringFirmCode": 200 }
+          ],
+          "sessions": [
+            { "sessionId": "SESS-A", "firmId": "FIRM01", "accessKey": "k1" },
+            { "sessionId": "SESS-B", "firmId": "FIRM02", "accessKey": "k2",
+              "policy": { "throttleMessagesPerSecond": 50, "keepAliveIntervalMs": 15000,
+                          "idleTimeoutMs": 20000, "testRequestGraceMs": 3000,
+                          "retransmitBufferSize": 5000 } }
+          ],
+          "channels": [
+            { "channelNumber": 1, "instrumentsFile": "instruments.json",
+              "umdf": { "group": "239.0.0.1", "port": 30001 } }
+          ]
+        }
+        """;
+        var path = WriteTempJson(json);
+        try
+        {
+            var cfg = HostConfigLoader.Load(path);
+            Assert.True(cfg.Auth.DevMode);
+            Assert.Equal(2, cfg.Firms.Count);
+            Assert.Equal(100u, cfg.Firms[0].EnteringFirmCode);
+            Assert.Equal(2, cfg.Sessions.Count);
+            Assert.Equal("FIRM02", cfg.Sessions[1].FirmId);
+            Assert.NotNull(cfg.Sessions[1].Policy);
+            Assert.Equal(50, cfg.Sessions[1].Policy!.ThrottleMessagesPerSecond);
+            Assert.Equal(15000, cfg.Sessions[1].Policy!.KeepAliveIntervalMs);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void Load_back_compat_uses_legacy_enteringFirm_when_no_firms()
+    {
+        var json = """
+        {
+          "tcp": { "listen": "127.0.0.1:0", "enteringFirm": 7 },
+          "channels": [
+            { "channelNumber": 1, "instrumentsFile": "instruments.json",
+              "umdf": { "group": "239.0.0.1", "port": 30001 } }
+          ]
+        }
+        """;
+        var path = WriteTempJson(json);
+        try
+        {
+            var cfg = HostConfigLoader.Load(path);
+            Assert.Empty(cfg.Firms);
+            Assert.Empty(cfg.Sessions);
+            Assert.Equal(7u, cfg.Tcp.EnteringFirm);
+            Assert.False(cfg.Auth.DevMode);
+        }
+        finally { File.Delete(path); }
+    }
+}


### PR DESCRIPTION
Closes #67. Refs epic #60.

## What

Introduces a config-driven multi-firm / multi-session identity model in the Gateway:

- **`Firm`**, **`SessionCredential`**, **`SessionPolicy`** records (Gateway, immutable).
- **`FirmRegistry`** loaded once at startup; validates uniqueness, firmId resolution, policy bounds. Read-only after construction.
- **`HostConfig`** gains `firms[]`, `sessions[]`, `auth` blocks (per architecture §4.1–4.2 & §8). `tcp.enteringFirm` marked DEPRECATED but still honored as fallback when the registries are empty.
- **`ExchangeHost`** builds the registry and resolves a default session for the listener identity factory, with a deprecation warning when falling back.

## Scope notes

- Pre-#42 (Negotiate) the host can't yet resolve which session a peer claims, so every accept is stamped with the lexicographically-first session's firm code. This preserves today's single-tenant runtime behavior while making the registries real and validated.
- The acceptance bullet about *two parallel TCP sessions producing ER frames with distinct EnteringFirmCode* is **deferred to #42**, where the Negotiate handler will resolve firm/session per peer-claimed sessionID. Filed as a follow-up E2E test there.
- Persistent FixpSession across disconnects belongs to #69 (Suspended state).

## Tests (+20)

- `FirmRegistryTests` — lookups, duplicate detection, missing-firm rejection, policy validation, default policy round-trip.
- `HostConfigFirmRegistryTests` — JSON parse for new schema + back-compat path.

All 261 tests green; format clean.