### PR TITLE
GAP-04: FIXP Negotiate handshake

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -27,15 +27,16 @@
     { "id": "FIRM02", "name": "Beta Corretora",  "enteringFirmCode": 200 }
   ],
   // Per-(firm, session) credentials. The Negotiate handshake (#42) will
-  // resolve a session by sessionId here and validate the peer's
-  // access_key against accessKey (when auth.devMode is false).
-  // Pre-#42 the host picks the lexicographically-first session as the
+  // resolve a session by the wire-format uint32 sessionID and validate the
+  // peer's access_key against accessKey (when auth.devMode is false).
+  // Pre-#42 the host picks the lowest sessionId as the
   // default tenant for every accept.
+  // sessionId MUST parse as a decimal uint32 (FIXP wire SessionID is uint32).
   "sessions": [
-    { "sessionId": "FIRM01-SESS-01", "firmId": "FIRM01", "accessKey": "dev-key-1" },
-    { "sessionId": "FIRM01-SESS-02", "firmId": "FIRM01", "accessKey": "dev-key-2" },
-    { "sessionId": "FIRM02-SESS-01", "firmId": "FIRM02", "accessKey": "dev-key-3" },
-    { "sessionId": "FIRM02-SESS-02", "firmId": "FIRM02", "accessKey": "dev-key-4" }
+    { "sessionId": "10101", "firmId": "FIRM01", "accessKey": "dev-key-1" },
+    { "sessionId": "10102", "firmId": "FIRM01", "accessKey": "dev-key-2" },
+    { "sessionId": "20201", "firmId": "FIRM02", "accessKey": "dev-key-3" },
+    { "sessionId": "20202", "firmId": "FIRM02", "accessKey": "dev-key-4" }
   ],
   // Optional Kestrel-hosted operability endpoint. Remove this block to
   // disable HTTP entirely. Exposes:

--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -56,6 +56,8 @@ public static class EntryPointFrameReader
     public const ushort TidOrderCancelRequest = 105;
     /// <summary>Session: Sequence (FIXP, also used as heartbeat). Bidirectional.</summary>
     public const ushort TidSequence = 9;
+    /// <summary>Session: Negotiate (FIXP, inbound only). See spec §4.5.2.</summary>
+    public const ushort TidNegotiate = 1;
 
     /// <summary>Outbound: ExecutionReport_New (V2).</summary>
     public const ushort TidExecutionReportNew = 200;
@@ -75,6 +77,7 @@ public static class EntryPointFrameReader
         (TidSimpleModifyOrder, 2) => 98,         // SimpleModifyOrderV2.MESSAGE_SIZE
         (TidOrderCancelRequest, 0) => 76,        // OrderCancelRequest.MESSAGE_SIZE (V6 base)
         (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.
+        (TidNegotiate, 0) => 28,                 // NegotiateData.BLOCK_LENGTH (V6 schema, root version 0)
         _ => -1
     };
 

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -24,6 +24,8 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly Func<EndPoint?, AcceptedConnection> _identityFactory;
     private readonly FixpSessionOptions _sessionOptions;
     private readonly Action<FixpSession, string>? _onSessionClosed;
+    private readonly NegotiationValidator? _negotiationValidator;
+    private readonly SessionClaimRegistry? _sessionClaims;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
@@ -49,7 +51,9 @@ public sealed class EntryPointListener : IAsyncDisposable
         ILoggerFactory loggerFactory,
         Func<EndPoint?, AcceptedConnection>? identityFactory = null,
         FixpSessionOptions? sessionOptions = null,
-        Action<FixpSession, string>? onSessionClosed = null)
+        Action<FixpSession, string>? onSessionClosed = null,
+        NegotiationValidator? negotiationValidator = null,
+        SessionClaimRegistry? sessionClaims = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(registry);
@@ -62,6 +66,13 @@ public sealed class EntryPointListener : IAsyncDisposable
         _sessionOptions = sessionOptions ?? FixpSessionOptions.Default;
         _sessionOptions.Validate();
         _onSessionClosed = onSessionClosed;
+        _negotiationValidator = negotiationValidator;
+        _sessionClaims = sessionClaims;
+        if ((_negotiationValidator is null) ^ (_sessionClaims is null))
+        {
+            throw new ArgumentException(
+                "negotiationValidator and sessionClaims must be supplied together (both null = legacy passthrough mode).");
+        }
     }
 
     // Convenience overload for callers (e.g., tests) that don't need an
@@ -119,7 +130,9 @@ public sealed class EntryPointListener : IAsyncDisposable
 
                 var session = new FixpSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
                     stream, _sink, _loggerFactory.CreateLogger<FixpSession>(),
-                    options: _sessionOptions, onClosed: onClosed);
+                    options: _sessionOptions, onClosed: onClosed,
+                    negotiationValidator: _negotiationValidator,
+                    sessionClaims: _sessionClaims);
                 _registry.Register(session);
                 lock (_lock) _sessions.Add(session);
                 session.Start();

--- a/src/B3.Exchange.Gateway/FirmRegistry.cs
+++ b/src/B3.Exchange.Gateway/FirmRegistry.cs
@@ -17,6 +17,7 @@ public sealed class FirmRegistry
 {
     private readonly IReadOnlyDictionary<string, Firm> _firms;
     private readonly IReadOnlyDictionary<string, SessionCredential> _credentials;
+    private readonly IReadOnlyDictionary<uint, SessionCredential> _credentialsByWire;
 
     /// <summary>All firms keyed by <see cref="Firm.Id"/>.</summary>
     public IReadOnlyDictionary<string, Firm> Firms => _firms;
@@ -40,11 +41,23 @@ public sealed class FirmRegistry
         }
 
         var credMap = new Dictionary<string, SessionCredential>(StringComparer.Ordinal);
+        var wireMap = new Dictionary<uint, SessionCredential>();
         foreach (var s in sessions)
         {
             ArgumentNullException.ThrowIfNull(s);
             if (string.IsNullOrWhiteSpace(s.SessionId))
                 throw new InvalidOperationException("SessionCredential.SessionId must be non-empty");
+            // FIXP wire SessionID is uint32; require config sessionId to
+            // parse as a decimal uint32 so credential lookup at Negotiate
+            // time is unambiguous (see B3-ENTRYPOINT-ARCHITECTURE.md §4.2).
+            if (!uint.TryParse(s.SessionId, System.Globalization.NumberStyles.None,
+                    System.Globalization.CultureInfo.InvariantCulture, out var wireId))
+                throw new InvalidOperationException(
+                    $"SessionCredential.SessionId '{s.SessionId}' must parse as a decimal uint32 " +
+                    "(FIXP wire SessionID is uint32 per spec §4.5.2)");
+            if (wireId == 0)
+                throw new InvalidOperationException(
+                    $"SessionCredential.SessionId '{s.SessionId}' must be > 0 (zero is the FIXP null value)");
             if (!firmMap.ContainsKey(s.FirmId))
                 throw new InvalidOperationException(
                     $"session '{s.SessionId}' references unknown firm '{s.FirmId}' " +
@@ -52,10 +65,15 @@ public sealed class FirmRegistry
             s.Policy.Validate();
             if (!credMap.TryAdd(s.SessionId, s))
                 throw new InvalidOperationException($"duplicate session id: '{s.SessionId}'");
+            // wire index uniqueness is implied by string uniqueness + the
+            // canonical-decimal rule above (no leading zeros / signs allowed
+            // by NumberStyles.None, so the parse is bijective).
+            wireMap.Add(wireId, s);
         }
 
         _firms = firmMap;
         _credentials = credMap;
+        _credentialsByWire = wireMap;
     }
 
     /// <summary>
@@ -68,6 +86,14 @@ public sealed class FirmRegistry
         ArgumentNullException.ThrowIfNull(sessionId);
         return _credentials.TryGetValue(sessionId, out var c) ? c : null;
     }
+
+    /// <summary>
+    /// Resolves a <see cref="SessionCredential"/> by the wire-format
+    /// uint32 SessionID (the encoding used by FIXP <c>Negotiate</c>).
+    /// Returns <c>null</c> when unknown.
+    /// </summary>
+    public SessionCredential? FindSessionByWire(uint sessionId)
+        => _credentialsByWire.TryGetValue(sessionId, out var c) ? c : null;
 
     /// <summary>
     /// Resolves a <see cref="Firm"/> by FirmId. Returns <c>null</c> when

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -34,6 +34,15 @@ public sealed class FixpSession : IAsyncDisposable
     private readonly Func<ulong> _nowNanos;
     private readonly FixpSessionOptions _options;
     private readonly Action<FixpSession, string>? _onClosed;
+    private readonly NegotiationValidator? _validator;
+    private readonly SessionClaimRegistry? _claims;
+    /// <summary>The wire SessionID currently claimed in <see cref="_claims"/>,
+    /// or 0 if no claim is held. Tracked so <see cref="Close"/> can
+    /// release the claim using the value from the moment the claim was
+    /// taken (the public <see cref="SessionId"/> may be re-stamped on a
+    /// subsequent rejected Negotiate that fails after we've already
+    /// claimed).</summary>
+    private uint _claimedSessionId;
     private long _msgSeqNum;
     private int _isOpen = 1;
     // Watchdog state (milliseconds since process start, monotonic).
@@ -45,8 +54,22 @@ public sealed class FixpSession : IAsyncDisposable
     private Task? _watchdogTask;
 
     public long ConnectionId { get; }
-    public uint EnteringFirm { get; }
-    public uint SessionId { get; }
+    /// <summary>
+    /// Numeric firm code (B3 EnteringFirm). Initially set from
+    /// <c>identityFactory</c> at accept time as a placeholder; rewritten
+    /// to the resolved <see cref="Firm.EnteringFirmCode"/> after a
+    /// successful FIXP <c>Negotiate</c> handshake (#42).
+    /// </summary>
+    public uint EnteringFirm { get; private set; }
+    /// <summary>
+    /// FIXP wire SessionID (uint32). Set from <c>identityFactory</c> at
+    /// accept time as a placeholder; rewritten to the value claimed by
+    /// the peer after a successful Negotiate.
+    /// </summary>
+    public uint SessionId { get; private set; }
+    /// <summary>FIXP <c>sessionVerID</c> recorded on the most recent
+    /// successful Negotiate. Zero before the handshake has completed.</summary>
+    public ulong SessionVerId { get; private set; }
     /// <summary>Stable, transport-neutral identity of this session as seen
     /// by Core / Contracts. Routing key the Gateway uses to resolve
     /// outbound ExecutionReports back to this <see cref="FixpSession"/>.
@@ -89,7 +112,9 @@ public sealed class FixpSession : IAsyncDisposable
         int sendQueueCapacity = DefaultSendQueueCapacity,
         FixpSessionOptions? options = null,
         Action<FixpSession, string>? onClosed = null,
-        ILogger<TcpTransport>? transportLogger = null)
+        ILogger<TcpTransport>? transportLogger = null,
+        NegotiationValidator? negotiationValidator = null,
+        SessionClaimRegistry? sessionClaims = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ConnectionId = connectionId;
@@ -102,6 +127,12 @@ public sealed class FixpSession : IAsyncDisposable
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
         _onClosed = onClosed;
+        _validator = negotiationValidator;
+        _claims = sessionClaims;
+        if (negotiationValidator is not null && sessionClaims is null)
+            throw new ArgumentException(
+                "sessionClaims is required when negotiationValidator is supplied",
+                nameof(sessionClaims));
         // The transport's onClose callback funnels back through our Close so
         // session-level book-keeping (sink notification, onClosed delegate)
         // runs even when teardown originates from a transport-side IO error.
@@ -238,6 +269,11 @@ public sealed class FixpSession : IAsyncDisposable
                 // Session-layer heartbeat / sequence sync. Liveness already
                 // recorded by the receive loop; nothing else to do.
                 return true;
+            case EntryPointFrameReader.TidNegotiate:
+                {
+                    var step = ProcessNegotiate(fixedBlock, varData);
+                    return await ExecuteNegotiateStepAsync(step).ConfigureAwait(false);
+                }
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                 {
@@ -272,6 +308,168 @@ public sealed class FixpSession : IAsyncDisposable
                 await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.UnrecognizedMessage, "decode-error:unsupported").ConfigureAwait(false);
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Outcome of synchronously processing an inbound Negotiate frame.
+    /// Buffered byte arrays are produced inside <see cref="ProcessNegotiate"/>
+    /// so the async writer in <see cref="ExecuteNegotiateStepAsync"/> can
+    /// send them after spans have gone out of scope.
+    /// </summary>
+    private readonly struct NegotiateStep
+    {
+        public readonly bool IsAccepted;
+        public readonly bool DecodeError;
+        public readonly string? DecodeErrorMessage;
+        public readonly byte[]? ResponseFrame;
+        public readonly byte[]? RejectFrame;
+        public readonly string LogReason;
+
+        private NegotiateStep(bool accepted, bool decodeErr, string? decodeMsg,
+            byte[]? response, byte[]? reject, string logReason)
+        {
+            IsAccepted = accepted;
+            DecodeError = decodeErr;
+            DecodeErrorMessage = decodeMsg;
+            ResponseFrame = response;
+            RejectFrame = reject;
+            LogReason = logReason;
+        }
+
+        public static NegotiateStep Accepted(byte[] response, string reason)
+            => new(true, false, null, response, null, reason);
+        public static NegotiateStep Rejected(byte[] reject, string reason)
+            => new(false, false, null, null, reject, reason);
+        public static NegotiateStep Decode(string message)
+            => new(false, true, message, null, null, message);
+    }
+
+    /// <summary>
+    /// Synchronous Negotiate processing: SBE decode, JSON credentials
+    /// parse, validator dispatch, claim acquisition, state transition,
+    /// session-state mutation. Produces a <see cref="NegotiateStep"/>
+    /// describing what the async wrapper should send (and whether to
+    /// close the connection afterwards).
+    /// </summary>
+    private NegotiateStep ProcessNegotiate(ReadOnlySpan<byte> fixedBlock, ReadOnlySpan<byte> varData)
+    {
+        if (!NegotiateDecoder.TryDecode(fixedBlock, varData,
+                out var req, out var credentialsBytes, out var decodeErr))
+        {
+            return NegotiateStep.Decode(decodeErr ?? "decode error: Negotiate");
+        }
+
+        // No validator configured → legacy single-tenant mode: accept the
+        // peer's claim wholesale (Phase 1 behavior). Stamp identity
+        // fields so subsequent app messages carry the peer's values.
+        if (_validator is null || _claims is null)
+        {
+            _ = ApplyTransition(FixpEvent.Negotiate);
+            SessionId = req.SessionId;
+            EnteringFirm = req.EnteringFirm;
+            SessionVerId = req.SessionVerId;
+            var frame = new byte[NegotiateResponseEncoder.Total];
+            NegotiateResponseEncoder.Encode(frame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos, req.EnteringFirm,
+                semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+            return NegotiateStep.Accepted(frame, $"negotiate-accept (legacy, sid={req.SessionId})");
+        }
+
+        if (!NegotiateCredentials.TryParse(credentialsBytes, out var creds, out var jsonErr))
+        {
+            // Credentials parse failure is a Credentials reject per spec
+            // §4.5.2, NOT a decoding error (the SBE wire shape was fine).
+            var rejectFrame = new byte[NegotiateRejectEncoder.Total];
+            NegotiateRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos, enteringFirm: null,
+                B3.Entrypoint.Fixp.Sbe.V6.NegotiationRejectCode.CREDENTIALS,
+                currentSessionVerId: null);
+            return NegotiateStep.Rejected(rejectFrame,
+                $"negotiate-reject (Credentials: {jsonErr})");
+        }
+
+        var outcome = _validator.Validate(in req, in creds, State);
+
+        if (!outcome.IsAccepted)
+        {
+            var rejectFrame = new byte[NegotiateRejectEncoder.Total];
+            NegotiateRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos, enteringFirm: null,
+                outcome.RejectCode,
+                outcome.CurrentSessionVerId == 0UL ? null : outcome.CurrentSessionVerId);
+            return NegotiateStep.Rejected(rejectFrame,
+                $"negotiate-reject ({outcome.RejectCode}: {outcome.RejectReason})");
+        }
+
+        // Atomic claim. If another live transport already holds this
+        // sessionID (or the version is stale by the time we commit), we
+        // must reject — spec §4.5.2.
+        var claim = _claims.TryClaim(req.SessionId, req.SessionVerId, this);
+        if (claim != SessionClaimRegistry.ClaimResult.Accepted)
+        {
+            var code = claim switch
+            {
+                SessionClaimRegistry.ClaimResult.DuplicateConnection
+                    => B3.Entrypoint.Fixp.Sbe.V6.NegotiationRejectCode.DUPLICATE_SESSION_CONNECTION,
+                _ => B3.Entrypoint.Fixp.Sbe.V6.NegotiationRejectCode.INVALID_SESSIONVERID,
+            };
+            var rejectFrame = new byte[NegotiateRejectEncoder.Total];
+            NegotiateRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos, enteringFirm: null, code,
+                claim == SessionClaimRegistry.ClaimResult.StaleVersion
+                    ? _claims.CurrentSessionVerId(req.SessionId) : null);
+            return NegotiateStep.Rejected(rejectFrame,
+                $"negotiate-reject ({code}: claim {claim})");
+        }
+
+        _claimedSessionId = req.SessionId;
+        _ = ApplyTransition(FixpEvent.Negotiate);
+        SessionId = req.SessionId;
+        EnteringFirm = outcome.Firm!.EnteringFirmCode;
+        SessionVerId = req.SessionVerId;
+
+        var responseFrame = new byte[NegotiateResponseEncoder.Total];
+        NegotiateResponseEncoder.Encode(responseFrame, req.SessionId, req.SessionVerId,
+            req.TimestampNanos, outcome.Firm.EnteringFirmCode,
+            semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+        return NegotiateStep.Accepted(responseFrame,
+            $"negotiate-accept (sid={req.SessionId} firm={outcome.Firm.Id})");
+    }
+
+    private async Task<bool> ExecuteNegotiateStepAsync(NegotiateStep step)
+    {
+        if (step.DecodeError)
+        {
+            _sink.OnDecodeError(Identity, step.DecodeErrorMessage ?? "decode error: Negotiate");
+            await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError,
+                "decode-error:Negotiate").ConfigureAwait(false);
+            return false;
+        }
+        if (step.IsAccepted)
+        {
+            _logger.LogInformation("session {ConnectionId} {Reason}", ConnectionId, step.LogReason);
+            if (!_transport.TryEnqueueFrame(step.ResponseFrame!))
+            {
+                _logger.LogWarning("session {ConnectionId} could not enqueue NegotiateResponse — closing",
+                    ConnectionId);
+                Close("send-queue-full:NegotiateResponse");
+                return false;
+            }
+            return true;
+        }
+        // Reject path: send NegotiateReject, then Terminate, then close.
+        _logger.LogInformation("session {ConnectionId} {Reason}", ConnectionId, step.LogReason);
+        try
+        {
+            await _transport.SendDirectAsync(step.RejectFrame!).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "session {ConnectionId} failed to write NegotiateReject", ConnectionId);
+        }
+        await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.Unspecified,
+            step.LogReason).ConfigureAwait(false);
+        return false;
     }
 
     /// <summary>
@@ -494,6 +692,13 @@ public sealed class FixpSession : IAsyncDisposable
         // callback in IO-error paths). Either way, ensure it's down so the
         // send loop wakes up and exits.
         _transport.Close(reason);
+        // Release the FIXP session claim (if any) so the same sessionID
+        // can be re-negotiated by a future transport.
+        if (_claimedSessionId != 0 && _claims is not null)
+        {
+            try { _claims.Release(_claimedSessionId, this); } catch { }
+            _claimedSessionId = 0;
+        }
         // Notify the engine sink so it releases any cached references to this
         // session (see IInboundCommandSink.OnSessionClosed). Without this the
         // ChannelDispatcher's order-owners map keeps the session rooted for

--- a/src/B3.Exchange.Gateway/NegotiateCredentials.cs
+++ b/src/B3.Exchange.Gateway/NegotiateCredentials.cs
@@ -1,0 +1,116 @@
+using System.Buffers.Text;
+using System.Text;
+using System.Text.Json;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Parsed FIXP <c>credentials</c> blob. Per spec §4.5.2 the field is a
+/// JSON document with three required string properties:
+/// <code>{ "auth_type": "basic", "username": "...", "access_key": "..." }</code>
+/// Only <c>auth_type == "basic"</c> is supported today; anything else
+/// must produce a <c>NegotiateReject(Credentials)</c>.
+/// </summary>
+public readonly record struct NegotiateCredentials(string AuthType, string Username, string AccessKey)
+{
+    /// <summary>Maximum size (bytes) the SBE schema reserves for the
+    /// <c>credentials</c> varData segment in <c>Negotiate</c>.</summary>
+    public const int MaxByteLength = 128;
+
+    /// <summary>
+    /// Strict JSON parser. Returns <c>false</c> on any structural or
+    /// semantic problem (truncated bytes, wrong root type, missing /
+    /// non-string / empty required field, embedded NUL byte, additional
+    /// unrecognised properties ignored).
+    /// </summary>
+    /// <remarks>
+    /// We deliberately use <see cref="Utf8JsonReader"/> directly (no
+    /// allocations beyond the three returned strings) and only accept
+    /// strict ASCII for the credential strings to avoid Unicode tricks
+    /// (homoglyph attacks against the username comparator). Property
+    /// matching is case-sensitive per the spec sample.
+    /// </remarks>
+    public static bool TryParse(ReadOnlySpan<byte> json, out NegotiateCredentials parsed, out string? error)
+    {
+        parsed = default;
+        error = null;
+
+        if (json.IsEmpty)
+        {
+            error = "credentials: empty";
+            return false;
+        }
+        if (json.Length > MaxByteLength)
+        {
+            error = $"credentials: length {json.Length} exceeds max {MaxByteLength}";
+            return false;
+        }
+
+        try
+        {
+            var reader = new Utf8JsonReader(json,
+                new JsonReaderOptions { CommentHandling = JsonCommentHandling.Disallow });
+            if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+            {
+                error = "credentials: not a JSON object";
+                return false;
+            }
+            string? authType = null, username = null, accessKey = null;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndObject) break;
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                {
+                    error = "credentials: unexpected token";
+                    return false;
+                }
+                var name = reader.GetString();
+                if (!reader.Read())
+                {
+                    error = "credentials: truncated";
+                    return false;
+                }
+                if (reader.TokenType != JsonTokenType.String)
+                {
+                    // Skip non-string values (forward-compatibility).
+                    reader.Skip();
+                    continue;
+                }
+                var value = reader.GetString();
+                switch (name)
+                {
+                    case "auth_type": authType = value; break;
+                    case "username": username = value; break;
+                    case "access_key": accessKey = value; break;
+                }
+            }
+            if (string.IsNullOrEmpty(authType) || string.IsNullOrEmpty(username) || accessKey is null)
+            {
+                error = "credentials: missing required field (auth_type/username/access_key)";
+                return false;
+            }
+            if (!IsAsciiPrintable(authType) || !IsAsciiPrintable(username) || !IsAsciiPrintable(accessKey))
+            {
+                error = "credentials: non-printable-ASCII byte in field";
+                return false;
+            }
+            parsed = new NegotiateCredentials(authType, username, accessKey);
+            return true;
+        }
+        catch (JsonException ex)
+        {
+            error = "credentials: " + ex.Message;
+            return false;
+        }
+    }
+
+    private static bool IsAsciiPrintable(string s)
+    {
+        for (int i = 0; i < s.Length; i++)
+        {
+            char c = s[i];
+            if (c < 0x20 || c > 0x7E) return false;
+        }
+        return true;
+    }
+}

--- a/src/B3.Exchange.Gateway/NegotiateDecoder.cs
+++ b/src/B3.Exchange.Gateway/NegotiateDecoder.cs
@@ -1,0 +1,97 @@
+using System.Runtime.InteropServices;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Byte-level decoder for the FIXP <c>Negotiate</c> message
+/// (templateId=1, BLOCK_LENGTH=28). Splits the buffer into the fixed
+/// root block (returned as <see cref="NegotiateRequest"/>) and the four
+/// length-prefixed varData segments
+/// (<c>credentials</c>, <c>clientIP</c>, <c>clientAppName</c>, <c>clientAppVersion</c>).
+///
+/// <para>Validation of the JSON payload of <c>credentials</c> is the
+/// responsibility of <see cref="NegotiateCredentials.TryParse"/>; this
+/// decoder only verifies the SBE wire shape.</para>
+/// </summary>
+internal static class NegotiateDecoder
+{
+    /// <summary>FIXP Negotiate template id.</summary>
+    public const ushort TemplateId = FixpSbe.NegotiateData.MESSAGE_ID;
+    public const int BlockLength = FixpSbe.NegotiateData.BLOCK_LENGTH;
+
+    /// <summary>Per-spec maximum varData segment lengths (matches the
+    /// SBE schema).</summary>
+    public const int MaxCredentialsLength = 128;
+    public const int MaxClientIpLength = 30;
+    public const int MaxClientAppNameLength = 30;
+    public const int MaxClientAppVersionLength = 30;
+
+    public static bool TryDecode(
+        ReadOnlySpan<byte> fixedBlock,
+        ReadOnlySpan<byte> varData,
+        out NegotiateRequest request,
+        out ReadOnlySpan<byte> credentials,
+        out string? error)
+    {
+        request = default;
+        credentials = default;
+        error = null;
+
+        if (fixedBlock.Length < BlockLength)
+        {
+            error = $"Negotiate: block length {fixedBlock.Length} < {BlockLength}";
+            return false;
+        }
+
+        ref readonly var data = ref MemoryMarshal.AsRef<FixpSbe.NegotiateData>(fixedBlock);
+        request = new NegotiateRequest(
+            SessionId: (uint)data.SessionID,
+            SessionVerId: (ulong)data.SessionVerID,
+            TimestampNanos: data.Timestamp.Time,
+            EnteringFirm: (uint)data.EnteringFirm,
+            OnBehalfFirm: data.OnbehalfFirm);
+
+        // varData segments: each is length(uint8) + bytes. Per spec the
+        // four segments appear in a fixed order; trailing segments may
+        // be omitted but if present must obey the maximum lengths.
+        // Local copy so we can pass ref-into ref-struct helpers.
+        var remaining = varData;
+        if (!TryReadSegment(ref remaining, MaxCredentialsLength, "credentials", out credentials, out error))
+            return false;
+        if (!TryReadSegment(ref remaining, MaxClientIpLength, "clientIP", out _, out error))
+            return false;
+        if (!TryReadSegment(ref remaining, MaxClientAppNameLength, "clientAppName", out _, out error))
+            return false;
+        if (!TryReadSegment(ref remaining, MaxClientAppVersionLength, "clientAppVersion", out _, out error))
+            return false;
+        if (remaining.Length != 0)
+        {
+            error = $"Negotiate: {remaining.Length} unexpected trailing varData byte(s)";
+            return false;
+        }
+        return true;
+    }
+
+    private static bool TryReadSegment(scoped ref ReadOnlySpan<byte> remaining, int maxLength,
+        string fieldName, out ReadOnlySpan<byte> segment, out string? error)
+    {
+        segment = default;
+        error = null;
+        if (remaining.Length == 0) return true; // segment omitted (allowed)
+        byte len = remaining[0];
+        if (len > maxLength)
+        {
+            error = $"Negotiate: {fieldName} length {len} exceeds max {maxLength}";
+            return false;
+        }
+        if (remaining.Length < 1 + len)
+        {
+            error = $"Negotiate: {fieldName} truncated (declared {len}, available {remaining.Length - 1})";
+            return false;
+        }
+        segment = remaining.Slice(1, len);
+        remaining = remaining.Slice(1 + len);
+        return true;
+    }
+}

--- a/src/B3.Exchange.Gateway/NegotiateHandshakeEncoders.cs
+++ b/src/B3.Exchange.Gateway/NegotiateHandshakeEncoders.cs
@@ -1,0 +1,90 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Byte-level encoder for the FIXP <c>NegotiateResponse</c> message
+/// (templateId=2, schemaId=1, version=6, BlockLength=28). Sent in
+/// response to an accepted client <c>Negotiate</c> per spec §4.5.3.
+///
+/// Layout (V6) — pinned to <see cref="FixpSbe.NegotiateResponseData"/>:
+///   header(8) | sessionID(uint32 @0) | sessionVerID(uint64 @4)
+///           | requestTimestamp(uint64 @12) | enteringFirm(uint32 @20)
+///           | semanticVersion(Version @24, 4 bytes: major,minor,patch,build)
+/// Total wire size = 8 + 28 = 36 bytes.
+/// </summary>
+internal static class NegotiateResponseEncoder
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+    public const int Block = FixpSbe.NegotiateResponseData.BLOCK_LENGTH;
+    public const int Total = HeaderSize + Block;
+    public const ushort TemplateId = FixpSbe.NegotiateResponseData.MESSAGE_ID;
+    public const ushort SchemaVersion = 6;
+
+    public static int Encode(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        ulong requestTimestampNanos, uint enteringFirm,
+        byte semVerMajor, byte semVerMinor, byte semVerPatch, byte semVerBuild = 0)
+    {
+        if (dst.Length < Total)
+            throw new ArgumentException("buffer too small for NegotiateResponse", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)Total,
+            blockLength: Block, TemplateId, version: SchemaVersion);
+        var body = dst.Slice(HeaderSize, Block);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(12, 8), requestTimestampNanos);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(20, 4), enteringFirm);
+        body[24] = semVerMajor;
+        body[25] = semVerMinor;
+        body[26] = semVerPatch;
+        body[27] = semVerBuild;
+        return Total;
+    }
+}
+
+/// <summary>
+/// Byte-level encoder for the FIXP <c>NegotiateReject</c> message
+/// (templateId=3, schemaId=1, version=0, BlockLength=36). Per spec
+/// §4.5.3.1, the rejecting side then sends a <c>Terminate</c> and closes.
+///
+/// Layout (V0) — pinned to <see cref="FixpSbe.NegotiateRejectData"/>:
+///   header(8) | sessionID(uint32 @0) | sessionVerID(uint64 @4)
+///           | requestTimestamp(uint64 @12) | enteringFirm(uint32 optional @20)
+///           | negotiationRejectCode(uint8 @24)
+///           | (3 bytes implicit padding)
+///           | currentSessionVerID(uint64 optional @28)
+/// Total wire size = 8 + 36 = 44 bytes.
+/// </summary>
+internal static class NegotiateRejectEncoder
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+    public const int Block = FixpSbe.NegotiateRejectData.BLOCK_LENGTH;
+    public const int Total = HeaderSize + Block;
+    public const ushort TemplateId = FixpSbe.NegotiateRejectData.MESSAGE_ID;
+    public const ushort SchemaVersion = 0;
+
+    public static int Encode(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        ulong requestTimestampNanos, uint? enteringFirm,
+        FixpSbe.NegotiationRejectCode rejectCode, ulong? currentSessionVerId)
+    {
+        if (dst.Length < Total)
+            throw new ArgumentException("buffer too small for NegotiateReject", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)Total,
+            blockLength: Block, TemplateId, version: SchemaVersion);
+        var body = dst.Slice(HeaderSize, Block);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(12, 8), requestTimestampNanos);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(20, 4),
+            enteringFirm ?? FixpSbe.NegotiateRejectData.EnteringFirmNullValue);
+        body[24] = (byte)rejectCode;
+        // bytes 25,26,27 are implicit padding (zeroed by Clear()).
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(28, 8),
+            currentSessionVerId ?? FixpSbe.NegotiateRejectData.CurrentSessionVerIDNullValue);
+        return Total;
+    }
+}

--- a/src/B3.Exchange.Gateway/NegotiationValidator.cs
+++ b/src/B3.Exchange.Gateway/NegotiationValidator.cs
@@ -1,0 +1,190 @@
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Decoded fixed-block fields of a FIXP <c>Negotiate</c> message (V6
+/// schema, MESSAGE_ID = 1, BLOCK_LENGTH = 28). The credentials varData
+/// segment is parsed separately into <see cref="NegotiateCredentials"/>.
+/// </summary>
+public readonly record struct NegotiateRequest(
+    uint SessionId,
+    ulong SessionVerId,
+    ulong TimestampNanos,
+    uint EnteringFirm,
+    uint? OnBehalfFirm);
+
+/// <summary>
+/// Result of <see cref="NegotiationValidator.Validate"/>. Either the
+/// peer was accepted (carrying the resolved <see cref="Firm"/> and
+/// <see cref="SessionCredential"/> for the dispatch loop to install on
+/// the <see cref="FixpSession"/>) or it was rejected with one of the
+/// FIXP <c>NegotiationRejectCode</c> values.
+/// </summary>
+public readonly struct NegotiationOutcome
+{
+    public bool IsAccepted { get; }
+    public FixpSbe.NegotiationRejectCode RejectCode { get; }
+    public string? RejectReason { get; }
+    /// <summary>For <c>ALREADY_NEGOTIATED</c>: the current session
+    /// version that must be echoed in the reject frame per §4.5.3.1.
+    /// Zero when not applicable.</summary>
+    public ulong CurrentSessionVerId { get; }
+    public SessionCredential? Credential { get; }
+    public Firm? Firm { get; }
+
+    private NegotiationOutcome(bool ok, FixpSbe.NegotiationRejectCode code, string? reason,
+        ulong currentSessionVerId, SessionCredential? cred, Firm? firm)
+    {
+        IsAccepted = ok;
+        RejectCode = code;
+        RejectReason = reason;
+        CurrentSessionVerId = currentSessionVerId;
+        Credential = cred;
+        Firm = firm;
+    }
+
+    public static NegotiationOutcome Accept(SessionCredential credential, Firm firm)
+        => new(true, FixpSbe.NegotiationRejectCode.UNSPECIFIED, null, 0UL, credential, firm);
+
+    public static NegotiationOutcome Reject(FixpSbe.NegotiationRejectCode code, string reason,
+        ulong currentSessionVerId = 0UL)
+        => new(false, code, reason, currentSessionVerId, null, null);
+}
+
+/// <summary>
+/// Pure (no IO, no socket) validator that maps an inbound
+/// <see cref="NegotiateRequest"/> + parsed <see cref="NegotiateCredentials"/>
+/// to a <see cref="NegotiationOutcome"/>. Encapsulates every spec rule
+/// from §4.5.2/§4.5.3:
+/// <list type="bullet">
+///   <item>Auth type <c>basic</c> only.</item>
+///   <item><c>username</c> must equal the wire <c>sessionID</c> (decimal
+///   string).</item>
+///   <item>Session must exist in <see cref="FirmRegistry"/>.</item>
+///   <item><c>enteringFirm</c> must match the credential's owning
+///   firm's <c>EnteringFirmCode</c>.</item>
+///   <item><c>access_key</c> must match (when the credential declares
+///   one) — bypassed only when <c>devMode</c> is true.</item>
+///   <item><c>sessionVerID</c> must be non-zero and strictly greater
+///   than the last seen value (claim registry).</item>
+///   <item>No other transport may currently hold a claim on the same
+///   <c>sessionID</c> (DUPLICATE_SESSION_CONNECTION).</item>
+///   <item>Caller passes <c>currentSessionState</c> = <see cref="FixpState.Negotiated"/>
+///   or <see cref="FixpState.Established"/> if the same TCP connection
+///   already negotiated — surfaces as ALREADY_NEGOTIATED.</item>
+/// </list>
+///
+/// <para>The validator does <em>not</em> mutate the claim registry; the
+/// caller's dispatch loop calls <see cref="SessionClaimRegistry.TryClaim"/>
+/// after deciding to apply the lifecycle transition. This keeps the
+/// validator pure and testable.</para>
+/// </summary>
+public sealed class NegotiationValidator
+{
+    private readonly FirmRegistry _firms;
+    private readonly SessionClaimRegistry _claims;
+    private readonly bool _devMode;
+    private readonly Func<ulong> _nowNanos;
+    /// <summary>Maximum tolerated absolute clock skew (nanoseconds)
+    /// between server and Negotiate <c>timestamp</c>. Zero disables the
+    /// check (used by tests). Default 5 minutes.</summary>
+    public ulong TimestampSkewToleranceNs { get; }
+
+    public NegotiationValidator(FirmRegistry firms, SessionClaimRegistry claims,
+        bool devMode, Func<ulong>? nowNanos = null,
+        ulong timestampSkewToleranceNs = 5UL * 60UL * 1_000_000_000UL)
+    {
+        _firms = firms ?? throw new ArgumentNullException(nameof(firms));
+        _claims = claims ?? throw new ArgumentNullException(nameof(claims));
+        _devMode = devMode;
+        _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
+        TimestampSkewToleranceNs = timestampSkewToleranceNs;
+    }
+
+    /// <param name="currentSessionState">The session's lifecycle state
+    /// at the moment Negotiate arrives. <see cref="FixpState.Idle"/> for
+    /// a fresh handshake; anything else triggers
+    /// <c>ALREADY_NEGOTIATED</c> with the recorded session version.</param>
+    public NegotiationOutcome Validate(in NegotiateRequest req,
+        in NegotiateCredentials credentials, FixpState currentSessionState)
+    {
+        if (currentSessionState != FixpState.Idle)
+        {
+            // §4.5.3.1: the reject MUST echo the currently-active
+            // sessionVerID so the client can recover its session state.
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.ALREADY_NEGOTIATED,
+                $"already in state {currentSessionState}",
+                _claims.CurrentSessionVerId(req.SessionId));
+        }
+
+        // Cheap structural checks first.
+        if (req.SessionId == 0)
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.INVALID_SESSIONID, "sessionID is zero (null value)");
+
+        if (TimestampSkewToleranceNs > 0 && req.TimestampNanos != 0)
+        {
+            var now = _nowNanos();
+            var diff = req.TimestampNanos > now ? req.TimestampNanos - now : now - req.TimestampNanos;
+            if (diff > TimestampSkewToleranceNs)
+                return NegotiationOutcome.Reject(
+                    FixpSbe.NegotiationRejectCode.INVALID_TIMESTAMP,
+                    $"timestamp skew {diff}ns exceeds {TimestampSkewToleranceNs}ns");
+        }
+
+        if (!string.Equals(credentials.AuthType, "basic", StringComparison.Ordinal))
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.CREDENTIALS,
+                $"auth_type='{credentials.AuthType}' not supported (only 'basic')");
+
+        // §4.5.2: username MUST equal the wire SessionID expressed as a
+        // decimal string. We canonicalise on the server side so the
+        // comparison is unambiguous regardless of zero-padding the
+        // client may apply.
+        var sessionIdString = req.SessionId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        if (!string.Equals(credentials.Username, sessionIdString, StringComparison.Ordinal))
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.CREDENTIALS,
+                $"username '{credentials.Username}' does not match sessionID {req.SessionId}");
+
+        var cred = _firms.FindSessionByWire(req.SessionId);
+        if (cred is null)
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.CREDENTIALS,
+                $"unknown sessionID {req.SessionId}");
+
+        var firm = _firms.FindFirm(cred.FirmId)
+            ?? throw new InvalidOperationException(
+                $"BUG: session '{cred.SessionId}' references firm '{cred.FirmId}' missing from registry");
+
+        if (req.EnteringFirm != firm.EnteringFirmCode)
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.INVALID_FIRM,
+                $"enteringFirm {req.EnteringFirm} does not match registered firm code {firm.EnteringFirmCode}");
+
+        if (!_devMode && !string.IsNullOrEmpty(cred.AccessKey) &&
+            !string.Equals(credentials.AccessKey, cred.AccessKey, StringComparison.Ordinal))
+        {
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.CREDENTIALS, "access_key mismatch");
+        }
+
+        // sessionVerID monotonicity is enforced by the claim registry at
+        // commit time (TryClaim). We surface a specific reject here when
+        // we can detect the failure cheaply, so callers don't have to
+        // race-then-retry.
+        if (req.SessionVerId == 0UL)
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.INVALID_SESSIONVERID,
+                "sessionVerID is zero (null value)");
+        var lastSeen = _claims.CurrentSessionVerId(req.SessionId);
+        if (lastSeen != 0UL && req.SessionVerId <= lastSeen)
+            return NegotiationOutcome.Reject(
+                FixpSbe.NegotiationRejectCode.INVALID_SESSIONVERID,
+                $"sessionVerID {req.SessionVerId} is not strictly greater than last-seen {lastSeen}");
+
+        return NegotiationOutcome.Accept(cred, firm);
+    }
+}

--- a/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
+++ b/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
@@ -1,0 +1,106 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Process-wide ledger of <em>active</em> FIXP session claims plus the
+/// last-seen <c>sessionVerID</c> for each known session. Backs the
+/// <c>DuplicateSessionConnection</c> and <c>InvalidSessionVerID</c>
+/// reject paths in <see cref="NegotiationValidator"/>.
+///
+/// <para>Distinct from <see cref="SessionRegistry"/> (which maps the
+/// transport-neutral <c>Contracts.SessionId</c> to a live
+/// <see cref="FixpSession"/>): this registry deals in FIXP wire
+/// <c>uint32</c> session IDs and is concerned with handshake-time
+/// invariants only.</para>
+///
+/// <para>Thread-safety: backed by a single lock; contention is bounded
+/// by Negotiate frequency (handshake-only, very low rate).</para>
+/// </summary>
+public sealed class SessionClaimRegistry
+{
+    private readonly object _lock = new();
+    private readonly Dictionary<uint, ulong> _lastSessionVerId = new();
+    private readonly Dictionary<uint, object> _activeClaims = new();
+
+    /// <summary>Number of currently-claimed sessionIDs.</summary>
+    public int ActiveCount
+    {
+        get { lock (_lock) return _activeClaims.Count; }
+    }
+
+    /// <summary>
+    /// The highest <c>sessionVerID</c> ever seen for the given session,
+    /// or 0 if the session has never been negotiated. Exposed for the
+    /// <c>NegotiateReject(AlreadyNegotiated)</c> path which must echo
+    /// the current session version per spec §4.5.3.1.
+    /// </summary>
+    public ulong CurrentSessionVerId(uint sessionId)
+    {
+        lock (_lock) return _lastSessionVerId.TryGetValue(sessionId, out var v) ? v : 0UL;
+    }
+
+    /// <summary>Outcome of <see cref="TryClaim"/>.</summary>
+    public enum ClaimResult
+    {
+        /// <summary>Claim accepted; sessionVerID recorded as latest.</summary>
+        Accepted,
+        /// <summary>Another live transport already owns this session; the
+        /// new request must be rejected with
+        /// <c>DUPLICATE_SESSION_CONNECTION</c>.</summary>
+        DuplicateConnection,
+        /// <summary>The proposed sessionVerID is &lt;= the highest seen
+        /// for this session (spec §4.5.2 monotonicity rule). Reject with
+        /// <c>INVALID_SESSIONVERID</c>.</summary>
+        StaleVersion,
+        /// <summary>sessionVerID is zero (FIXP null value). Reject with
+        /// <c>INVALID_SESSIONVERID</c>.</summary>
+        ZeroVersion,
+    }
+
+    /// <summary>
+    /// Atomically validate <paramref name="sessionVerId"/> against the
+    /// monotonic-per-process rule and (on success) register
+    /// <paramref name="claimToken"/> as the live owner of
+    /// <paramref name="sessionId"/>.
+    /// </summary>
+    /// <param name="claimToken">An opaque identity (typically the
+    /// <see cref="FixpSession"/>) used to scope <see cref="Release"/>
+    /// so a stale teardown of an already-replaced claim is a no-op.</param>
+    public ClaimResult TryClaim(uint sessionId, ulong sessionVerId, object claimToken)
+    {
+        ArgumentNullException.ThrowIfNull(claimToken);
+        if (sessionVerId == 0UL) return ClaimResult.ZeroVersion;
+
+        lock (_lock)
+        {
+            if (_activeClaims.ContainsKey(sessionId))
+                return ClaimResult.DuplicateConnection;
+            if (_lastSessionVerId.TryGetValue(sessionId, out var last) && sessionVerId <= last)
+                return ClaimResult.StaleVersion;
+
+            _activeClaims[sessionId] = claimToken;
+            _lastSessionVerId[sessionId] = sessionVerId;
+            return ClaimResult.Accepted;
+        }
+    }
+
+    /// <summary>
+    /// Releases the claim for <paramref name="sessionId"/> if (and only
+    /// if) it is currently held by <paramref name="claimToken"/>. Safe to
+    /// call from any thread; safe to call multiple times. Does not
+    /// reset the recorded last-seen sessionVerID — that persists for
+    /// the life of the process so reconnects can be checked for
+    /// monotonicity.
+    /// </summary>
+    public void Release(uint sessionId, object claimToken)
+    {
+        ArgumentNullException.ThrowIfNull(claimToken);
+        lock (_lock)
+        {
+            if (_activeClaims.TryGetValue(sessionId, out var owner) &&
+                ReferenceEquals(owner, claimToken))
+            {
+                _activeClaims.Remove(sessionId);
+            }
+        }
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -206,15 +206,19 @@ public sealed class ExchangeHost : IAsyncDisposable
             IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,
             TestRequestGraceMs = _config.Tcp.TestRequestGraceMs,
         };
+        // Phase 2 (#42): real Negotiate handshake. The validator is pure
+        // (no IO); the claim ledger lives for the host process lifetime
+        // so duplicate-connection detection works across reconnects.
+        var sessionClaims = new SessionClaimRegistry();
+        var negotiationValidator = new NegotiationValidator(firmRegistry, sessionClaims, devMode: _config.Auth.DevMode);
         _listener = new EntryPointListener(listenEp, _router, sessionRegistry, _loggerFactory,
             identityFactory: remote =>
             {
                 var connectionId = Random.Shared.NextInt64() & 0x7FFFFFFFFFFFFFFFL;
-                // Pre-#42 (Negotiate): we do not yet know which session the
-                // peer will claim, so we stamp the default session's firm
-                // code on every accept. #42 will move firm/session
-                // resolution into the Negotiate handler and consult
-                // FirmRegistry by sessionID claimed by the peer.
+                // Pre-Negotiate placeholder: firm/session are stamped from
+                // a default and rewritten by FixpSession on a successful
+                // Negotiate. SessionId here is just a unique pre-handshake
+                // tag for log correlation.
                 var enteringFirm = defaultSession.firmCode;
                 return new EntryPointListener.AcceptedConnection(
                     ConnectionId: connectionId,
@@ -222,7 +226,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                     SessionId: (uint)(connectionId & 0xFFFFFFFFu));
             },
             sessionOptions: sessionOptions,
-            onSessionClosed: (s, reason) => _logger.LogInformation("session {ConnectionId} closed: {Reason}", s.ConnectionId, reason));
+            onSessionClosed: (s, reason) => _logger.LogInformation("session {ConnectionId} closed: {Reason}", s.ConnectionId, reason),
+            negotiationValidator: negotiationValidator,
+            sessionClaims: sessionClaims);
         _listener.Start();
         _logger.LogInformation("entrypoint listening on {Endpoint}", _listener.LocalEndpoint);
 

--- a/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
@@ -14,40 +14,40 @@ public class FirmRegistryTests
     {
         var r = new FirmRegistry(
             new[] { Firm("F1", 100), Firm("F2", 200) },
-            new[] { Cred("S1", "F1"), Cred("S2", "F2") });
+            new[] { Cred("1", "F1"), Cred("2", "F2") });
 
         Assert.Equal(2, r.Firms.Count);
         Assert.Equal(2, r.Credentials.Count);
         Assert.Equal(100u, r.FindFirm("F1")!.EnteringFirmCode);
-        Assert.Equal("F1", r.FindSession("S1")!.FirmId);
+        Assert.Equal("F1", r.FindSession("1")!.FirmId);
     }
 
     [Fact]
     public void FindSession_returns_null_when_unknown()
     {
-        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "F1") });
-        Assert.Null(r.FindSession("missing"));
+        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("1", "F1") });
+        Assert.Null(r.FindSession("99999"));
     }
 
     [Fact]
     public void FindFirm_returns_null_when_unknown()
     {
         var r = new FirmRegistry(new[] { Firm("F1") }, Array.Empty<SessionCredential>());
-        Assert.Null(r.FindFirm("missing"));
+        Assert.Null(r.FindFirm("99999"));
     }
 
     [Fact]
     public void FirmOf_resolves_firm_by_session_id()
     {
-        var r = new FirmRegistry(new[] { Firm("F1", 42) }, new[] { Cred("S1", "F1") });
-        Assert.Equal(42u, r.FirmOf("S1")!.EnteringFirmCode);
+        var r = new FirmRegistry(new[] { Firm("F1", 42) }, new[] { Cred("1", "F1") });
+        Assert.Equal(42u, r.FirmOf("1")!.EnteringFirmCode);
     }
 
     [Fact]
     public void FirmOf_returns_null_for_unknown_session()
     {
-        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "F1") });
-        Assert.Null(r.FirmOf("ghost"));
+        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("1", "F1") });
+        Assert.Null(r.FirmOf("99999"));
     }
 
     [Fact]
@@ -62,7 +62,7 @@ public class FirmRegistryTests
     public void Duplicate_session_id_throws()
     {
         var ex = Assert.Throws<InvalidOperationException>(() =>
-            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "F1"), Cred("S1", "F1") }));
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("1", "F1"), Cred("1", "F1") }));
         Assert.Contains("duplicate session id", ex.Message);
     }
 
@@ -70,7 +70,7 @@ public class FirmRegistryTests
     public void Session_referencing_unknown_firm_throws()
     {
         var ex = Assert.Throws<InvalidOperationException>(() =>
-            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("S1", "GHOST") }));
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("1", "GHOST") }));
         Assert.Contains("unknown firm 'GHOST'", ex.Message);
     }
 
@@ -89,9 +89,42 @@ public class FirmRegistryTests
     }
 
     [Fact]
+    public void Non_uint32_session_id_throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("FIRM01-SESS-01", "F1") }));
+        Assert.Contains("uint32", ex.Message);
+    }
+
+    [Fact]
+    public void Zero_session_id_throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("0", "F1") }));
+    }
+
+    [Fact]
+    public void FindSessionByWire_resolves_credential()
+    {
+        var r = new FirmRegistry(new[] { Firm("F1", 100) },
+            new[] { Cred("4242", "F1", "secret") });
+        var c = r.FindSessionByWire(4242u);
+        Assert.NotNull(c);
+        Assert.Equal("F1", c!.FirmId);
+        Assert.Equal("secret", c.AccessKey);
+    }
+
+    [Fact]
+    public void FindSessionByWire_returns_null_for_unknown()
+    {
+        var r = new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("1", "F1") });
+        Assert.Null(r.FindSessionByWire(999u));
+    }
+
+    [Fact]
     public void Invalid_policy_propagates_validation_error()
     {
-        var bad = new SessionCredential("S1", "F1", "", null,
+        var bad = new SessionCredential("1", "F1", "", null,
             new SessionPolicy(KeepAliveIntervalMs: 0));
         Assert.Throws<InvalidOperationException>(() =>
             new FirmRegistry(new[] { Firm("F1") }, new[] { bad }));

--- a/tests/B3.Exchange.Gateway.Tests/NegotiateCredentialsTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiateCredentialsTests.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class NegotiateCredentialsTests
+{
+    private static ReadOnlySpan<byte> Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    [Fact]
+    public void Parses_valid_basic_credentials()
+    {
+        var json = Utf8("{\"auth_type\":\"basic\",\"username\":\"10101\",\"access_key\":\"secret\"}");
+        Assert.True(NegotiateCredentials.TryParse(json, out var c, out var err));
+        Assert.Null(err);
+        Assert.Equal("basic", c.AuthType);
+        Assert.Equal("10101", c.Username);
+        Assert.Equal("secret", c.AccessKey);
+    }
+
+    [Fact]
+    public void Empty_input_rejected()
+    {
+        Assert.False(NegotiateCredentials.TryParse(default, out _, out var err));
+        Assert.Contains("empty", err);
+    }
+
+    [Fact]
+    public void Oversize_rejected()
+    {
+        var json = Utf8("{\"auth_type\":\"basic\",\"username\":\"u\",\"access_key\":\"" + new string('x', 200) + "\"}");
+        Assert.False(NegotiateCredentials.TryParse(json, out _, out var err));
+        Assert.Contains("max", err);
+    }
+
+    [Fact]
+    public void Non_object_root_rejected()
+    {
+        Assert.False(NegotiateCredentials.TryParse(Utf8("\"basic\""), out _, out var err));
+        Assert.Contains("not a JSON object", err);
+    }
+
+    [Fact]
+    public void Missing_field_rejected()
+    {
+        var json = Utf8("{\"auth_type\":\"basic\",\"username\":\"u\"}");
+        Assert.False(NegotiateCredentials.TryParse(json, out _, out var err));
+        Assert.Contains("missing required field", err);
+    }
+
+    [Fact]
+    public void Non_ascii_rejected()
+    {
+        var json = Utf8("{\"auth_type\":\"basic\",\"username\":\"héllo\",\"access_key\":\"k\"}");
+        Assert.False(NegotiateCredentials.TryParse(json, out _, out var err));
+        Assert.Contains("non-printable-ASCII", err);
+    }
+
+    [Fact]
+    public void Malformed_json_rejected()
+    {
+        Assert.False(NegotiateCredentials.TryParse(Utf8("{\"auth_type\":}"), out _, out var err));
+        Assert.NotNull(err);
+    }
+
+    [Fact]
+    public void Empty_username_rejected_as_missing_required()
+    {
+        var json = Utf8("{\"auth_type\":\"basic\",\"username\":\"\",\"access_key\":\"k\"}");
+        Assert.False(NegotiateCredentials.TryParse(json, out _, out var err));
+        Assert.Contains("missing required field", err);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/NegotiateDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiateDecoderTests.cs
@@ -1,0 +1,108 @@
+using System.Buffers.Binary;
+using System.Text;
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class NegotiateDecoderTests
+{
+    private static byte[] BuildFixedBlock(uint sessionId = 10101, ulong sessionVerId = 7,
+        ulong timestamp = 1000, uint enteringFirm = 42, uint onBehalf = 0)
+    {
+        var b = new byte[NegotiateDecoder.BlockLength];
+        BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(b.AsSpan(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(b.AsSpan(12, 8), timestamp);
+        BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(20, 4), enteringFirm);
+        BinaryPrimitives.WriteUInt32LittleEndian(b.AsSpan(24, 4), onBehalf);
+        return b;
+    }
+
+    private static byte[] Segment(string s)
+    {
+        var bytes = Encoding.UTF8.GetBytes(s);
+        var buf = new byte[1 + bytes.Length];
+        buf[0] = (byte)bytes.Length;
+        bytes.CopyTo(buf, 1);
+        return buf;
+    }
+
+    private static byte[] Concat(params byte[][] parts)
+    {
+        var len = 0;
+        foreach (var p in parts) len += p.Length;
+        var result = new byte[len];
+        var i = 0;
+        foreach (var p in parts) { p.CopyTo(result, i); i += p.Length; }
+        return result;
+    }
+
+    [Fact]
+    public void Decodes_complete_negotiate()
+    {
+        var fixedBlock = BuildFixedBlock();
+        var varData = Concat(
+            Segment("{\"auth_type\":\"basic\",\"username\":\"10101\",\"access_key\":\"k\"}"),
+            Segment("127.0.0.1"),
+            Segment("test-app"),
+            Segment("1.0"));
+        Assert.True(NegotiateDecoder.TryDecode(fixedBlock, varData, out var req, out var creds, out var err));
+        Assert.Null(err);
+        Assert.Equal(10101u, req.SessionId);
+        Assert.Equal(7UL, req.SessionVerId);
+        Assert.Equal(1000UL, req.TimestampNanos);
+        Assert.Equal(42u, req.EnteringFirm);
+        Assert.Equal("10101", System.Text.Json.JsonDocument.Parse(creds.ToArray()).RootElement.GetProperty("username").GetString());
+    }
+
+    [Fact]
+    public void Truncated_block_rejected()
+    {
+        var fixedBlock = new byte[10];
+        Assert.False(NegotiateDecoder.TryDecode(fixedBlock, default, out _, out _, out var err));
+        Assert.Contains("block length", err);
+    }
+
+    [Fact]
+    public void Oversize_credentials_segment_rejected()
+    {
+        var fixedBlock = BuildFixedBlock();
+        // declared length 200 — exceeds max 128.
+        var varData = new byte[1 + 200];
+        varData[0] = 200;
+        Assert.False(NegotiateDecoder.TryDecode(fixedBlock, varData, out _, out _, out var err));
+        Assert.Contains("credentials", err);
+        Assert.Contains("max", err);
+    }
+
+    [Fact]
+    public void Truncated_segment_rejected()
+    {
+        var fixedBlock = BuildFixedBlock();
+        // declared length 10, only 3 bytes available.
+        var varData = new byte[] { 10, 1, 2, 3 };
+        Assert.False(NegotiateDecoder.TryDecode(fixedBlock, varData, out _, out _, out var err));
+        Assert.Contains("truncated", err);
+    }
+
+    [Fact]
+    public void Trailing_garbage_rejected()
+    {
+        var fixedBlock = BuildFixedBlock();
+        var varData = Concat(
+            Segment("{\"auth_type\":\"basic\",\"username\":\"u\",\"access_key\":\"k\"}"),
+            Segment(""), Segment(""), Segment(""),
+            new byte[] { 0xFF, 0xFF });
+        Assert.False(NegotiateDecoder.TryDecode(fixedBlock, varData, out _, out _, out var err));
+        Assert.Contains("trailing", err);
+    }
+
+    [Fact]
+    public void Allows_omitted_trailing_segments()
+    {
+        var fixedBlock = BuildFixedBlock();
+        var varData = Segment("{\"auth_type\":\"basic\",\"username\":\"u\",\"access_key\":\"k\"}");
+        Assert.True(NegotiateDecoder.TryDecode(fixedBlock, varData, out _, out var creds, out _));
+        Assert.NotEqual(0, creds.Length);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/NegotiateHandshakeEncodersTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiateHandshakeEncodersTests.cs
@@ -1,0 +1,87 @@
+using System.Buffers.Binary;
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class NegotiateHandshakeEncodersTests
+{
+    [Fact]
+    public void Response_layout_matches_spec()
+    {
+        var buf = new byte[NegotiateResponseEncoder.Total];
+        int n = NegotiateResponseEncoder.Encode(buf, sessionId: 10101, sessionVerId: 7,
+            requestTimestampNanos: 0x1122334455667788UL, enteringFirm: 42,
+            semVerMajor: 8, semVerMinor: 4, semVerPatch: 2, semVerBuild: 0);
+        Assert.Equal(NegotiateResponseEncoder.Total, n);
+
+        // SOFH (4) + SBE header (8): messageLength @0, encodingType @2,
+        // blockLength @4, templateId @6, schemaId @8, version @10.
+        Assert.Equal(NegotiateResponseEncoder.Total, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2)));
+        Assert.Equal(EntryPointFrameReader.SofhEncodingType, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(2, 2)));
+        Assert.Equal(NegotiateResponseEncoder.Block, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(4, 2)));
+        Assert.Equal(NegotiateResponseEncoder.TemplateId, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(6, 2)));
+        Assert.Equal(EntryPointFrameReader.SchemaId, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(8, 2)));
+        Assert.Equal(6, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(10, 2)));
+
+        // Body @12: sessionID(4) | sessionVerID(8) | requestTimestamp(8)
+        //         | enteringFirm(4) | semVer(maj,min,patch,build)
+        var body = buf.AsSpan(12);
+        Assert.Equal(10101u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
+        Assert.Equal(7UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)));
+        Assert.Equal(0x1122334455667788UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)));
+        Assert.Equal(42u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(20, 4)));
+        Assert.Equal(8, body[24]);
+        Assert.Equal(4, body[25]);
+        Assert.Equal(2, body[26]);
+        Assert.Equal(0, body[27]);
+    }
+
+    [Fact]
+    public void Reject_layout_matches_spec_with_optional_fields()
+    {
+        var buf = new byte[NegotiateRejectEncoder.Total];
+        int n = NegotiateRejectEncoder.Encode(buf, sessionId: 10101, sessionVerId: 3,
+            requestTimestampNanos: 0xDEADBEEFCAFEBABEUL, enteringFirm: 42,
+            FixpSbe.NegotiationRejectCode.CREDENTIALS, currentSessionVerId: 99);
+        Assert.Equal(NegotiateRejectEncoder.Total, n);
+
+        Assert.Equal(NegotiateRejectEncoder.TemplateId, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(6, 2)));
+        Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(10, 2))); // version 0
+
+        var body = buf.AsSpan(12);
+        Assert.Equal(10101u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
+        Assert.Equal(3UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)));
+        Assert.Equal(0xDEADBEEFCAFEBABEUL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)));
+        Assert.Equal(42u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(20, 4)));
+        Assert.Equal((byte)FixpSbe.NegotiationRejectCode.CREDENTIALS, body[24]);
+        Assert.Equal(99UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(28, 8)));
+    }
+
+    [Fact]
+    public void Reject_writes_null_sentinels_when_optionals_omitted()
+    {
+        var buf = new byte[NegotiateRejectEncoder.Total];
+        NegotiateRejectEncoder.Encode(buf, sessionId: 10101, sessionVerId: 3,
+            requestTimestampNanos: 0,
+            enteringFirm: null,
+            FixpSbe.NegotiationRejectCode.UNSPECIFIED,
+            currentSessionVerId: null);
+        var body = buf.AsSpan(12);
+        Assert.Equal(FixpSbe.NegotiateRejectData.EnteringFirmNullValue,
+            BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(20, 4)));
+        Assert.Equal(FixpSbe.NegotiateRejectData.CurrentSessionVerIDNullValue,
+            BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(28, 8)));
+    }
+
+    [Fact]
+    public void Throws_when_buffer_too_small()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            NegotiateResponseEncoder.Encode(new byte[NegotiateResponseEncoder.Total - 1],
+                1, 1, 0, 1, 1, 1, 1));
+        Assert.Throws<ArgumentException>(() =>
+            NegotiateRejectEncoder.Encode(new byte[NegotiateRejectEncoder.Total - 1],
+                1, 1, 0, null, FixpSbe.NegotiationRejectCode.UNSPECIFIED, null));
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
@@ -1,0 +1,145 @@
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class NegotiationValidatorTests
+{
+    private static FirmRegistry BuildRegistry()
+    {
+        var firm = new Firm("BROKER1", "Broker One", EnteringFirmCode: 42);
+        var sess = new SessionCredential("10101", "BROKER1", "secret", null, SessionPolicy.Default);
+        return new FirmRegistry(new[] { firm }, new[] { sess });
+    }
+
+    private static (NegotiationValidator v, SessionClaimRegistry claims) Build(bool devMode = false)
+    {
+        var claims = new SessionClaimRegistry();
+        var v = new NegotiationValidator(BuildRegistry(), claims, devMode,
+            nowNanos: () => 1_000_000_000UL, timestampSkewToleranceNs: 0UL);
+        return (v, claims);
+    }
+
+    private static NegotiateRequest Req(uint sid = 10101, ulong ver = 1, uint firm = 42, ulong ts = 0)
+        => new(SessionId: sid, SessionVerId: ver, TimestampNanos: ts, EnteringFirm: firm, OnBehalfFirm: default);
+
+    private static NegotiateCredentials Cred(string user = "10101", string key = "secret", string auth = "basic")
+        => new(auth, user, key);
+
+    [Fact]
+    public void Accepts_valid_negotiate()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(), Cred(), FixpState.Idle);
+        Assert.True(o.IsAccepted);
+        Assert.Equal(42u, o.Firm!.EnteringFirmCode);
+    }
+
+    [Fact]
+    public void Already_negotiated_when_state_not_idle()
+    {
+        var (v, claims) = Build();
+        claims.TryClaim(10101, 7, new object());
+        var o = v.Validate(Req(), Cred(), FixpState.Negotiated);
+        Assert.False(o.IsAccepted);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.ALREADY_NEGOTIATED, o.RejectCode);
+        Assert.Equal(7UL, o.CurrentSessionVerId);
+    }
+
+    [Fact]
+    public void Zero_session_id_rejected_invalid_sessionid()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(sid: 0), Cred(user: "0"), FixpState.Idle);
+        Assert.False(o.IsAccepted);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_SESSIONID, o.RejectCode);
+    }
+
+    [Fact]
+    public void Wrong_auth_type_rejected()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(), Cred(auth: "oauth"), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.CREDENTIALS, o.RejectCode);
+    }
+
+    [Fact]
+    public void Username_mismatch_rejected()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(), Cred(user: "wrong"), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.CREDENTIALS, o.RejectCode);
+    }
+
+    [Fact]
+    public void Unknown_session_rejected_credentials()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(sid: 99999), Cred(user: "99999"), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.CREDENTIALS, o.RejectCode);
+    }
+
+    [Fact]
+    public void Wrong_firm_rejected_invalid_firm()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(firm: 99), Cred(), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_FIRM, o.RejectCode);
+    }
+
+    [Fact]
+    public void Wrong_access_key_rejected_credentials()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(), Cred(key: "wrong"), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.CREDENTIALS, o.RejectCode);
+    }
+
+    [Fact]
+    public void DevMode_bypasses_access_key()
+    {
+        var (v, _) = Build(devMode: true);
+        var o = v.Validate(Req(), Cred(key: "wrong"), FixpState.Idle);
+        Assert.True(o.IsAccepted);
+    }
+
+    [Fact]
+    public void DevMode_still_enforces_firm()
+    {
+        var (v, _) = Build(devMode: true);
+        var o = v.Validate(Req(firm: 99), Cred(), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_FIRM, o.RejectCode);
+    }
+
+    [Fact]
+    public void Zero_session_ver_id_rejected()
+    {
+        var (v, _) = Build();
+        var o = v.Validate(Req(ver: 0), Cred(), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_SESSIONVERID, o.RejectCode);
+    }
+
+    [Fact]
+    public void Stale_session_ver_id_rejected()
+    {
+        var (v, claims) = Build();
+        claims.TryClaim(10101, 5, new object());
+        // Token released so the active-claim check passes; the
+        // last-seen rule should still trigger.
+        var o = v.Validate(Req(ver: 5), Cred(), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_SESSIONVERID, o.RejectCode);
+    }
+
+    [Fact]
+    public void Timestamp_skew_rejected_when_tolerance_set()
+    {
+        var claims = new SessionClaimRegistry();
+        var v = new NegotiationValidator(BuildRegistry(), claims, devMode: false,
+            nowNanos: () => 1_000_000_000UL,
+            timestampSkewToleranceNs: 100_000_000UL);
+        // far-future timestamp
+        var o = v.Validate(Req(ts: 5_000_000_000UL), Cred(), FixpState.Idle);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_TIMESTAMP, o.RejectCode);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/SessionClaimRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionClaimRegistryTests.cs
@@ -1,0 +1,71 @@
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class SessionClaimRegistryTests
+{
+    [Fact]
+    public void First_claim_accepted_and_records_version()
+    {
+        var r = new SessionClaimRegistry();
+        var token = new object();
+        Assert.Equal(SessionClaimRegistry.ClaimResult.Accepted, r.TryClaim(10101, 5, token));
+        Assert.Equal(5UL, r.CurrentSessionVerId(10101));
+        Assert.Equal(1, r.ActiveCount);
+    }
+
+    [Fact]
+    public void Zero_version_rejected()
+    {
+        var r = new SessionClaimRegistry();
+        Assert.Equal(SessionClaimRegistry.ClaimResult.ZeroVersion, r.TryClaim(10101, 0, new object()));
+    }
+
+    [Fact]
+    public void Duplicate_claim_while_active_rejected()
+    {
+        var r = new SessionClaimRegistry();
+        r.TryClaim(10101, 1, new object());
+        Assert.Equal(SessionClaimRegistry.ClaimResult.DuplicateConnection, r.TryClaim(10101, 2, new object()));
+    }
+
+    [Fact]
+    public void Stale_version_rejected_after_release()
+    {
+        var r = new SessionClaimRegistry();
+        var t1 = new object();
+        r.TryClaim(10101, 5, t1);
+        r.Release(10101, t1);
+        // Same or smaller version after release: reject as stale.
+        Assert.Equal(SessionClaimRegistry.ClaimResult.StaleVersion, r.TryClaim(10101, 5, new object()));
+        Assert.Equal(SessionClaimRegistry.ClaimResult.StaleVersion, r.TryClaim(10101, 1, new object()));
+    }
+
+    [Fact]
+    public void Higher_version_accepted_after_release()
+    {
+        var r = new SessionClaimRegistry();
+        var t1 = new object();
+        r.TryClaim(10101, 5, t1);
+        r.Release(10101, t1);
+        Assert.Equal(SessionClaimRegistry.ClaimResult.Accepted, r.TryClaim(10101, 6, new object()));
+        Assert.Equal(6UL, r.CurrentSessionVerId(10101));
+    }
+
+    [Fact]
+    public void Release_by_non_owner_is_noop()
+    {
+        var r = new SessionClaimRegistry();
+        var owner = new object();
+        r.TryClaim(10101, 1, owner);
+        r.Release(10101, new object());
+        // Owner still holds it.
+        Assert.Equal(SessionClaimRegistry.ClaimResult.DuplicateConnection, r.TryClaim(10101, 2, new object()));
+    }
+
+    [Fact]
+    public void CurrentSessionVerId_unknown_session_returns_zero()
+    {
+        Assert.Equal(0UL, new SessionClaimRegistry().CurrentSessionVerId(99999));
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/HostConfigFirmRegistryTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostConfigFirmRegistryTests.cs
@@ -25,8 +25,8 @@ public class HostConfigFirmRegistryTests
             { "id": "FIRM02", "name": "Beta Corretora", "enteringFirmCode": 200 }
           ],
           "sessions": [
-            { "sessionId": "SESS-A", "firmId": "FIRM01", "accessKey": "k1" },
-            { "sessionId": "SESS-B", "firmId": "FIRM02", "accessKey": "k2",
+            { "sessionId": "101", "firmId": "FIRM01", "accessKey": "k1" },
+            { "sessionId": "102", "firmId": "FIRM02", "accessKey": "k2",
               "policy": { "throttleMessagesPerSecond": 50, "keepAliveIntervalMs": 15000,
                           "idleTimeoutMs": 20000, "testRequestGraceMs": 3000,
                           "retransmitBufferSize": 5000 } }


### PR DESCRIPTION
Refs #42 (partial — strict app-message gating deferred to #43).

Implements the server-side FIXP `Negotiate / NegotiateResponse / NegotiateReject` flow per spec §4.5.2-3 on top of the FixpSession dispatch loop introduced in #67/#68.

## What's in
- `NegotiateCredentials`: strict JSON parser (`auth_type`/`username`/`access_key`, ASCII-printable, 128-byte cap)
- `NegotiateDecoder`: SBE wire decoder for fixed block + 4 varData segments with per-spec max lengths
- `NegotiateHandshakeEncoders`: byte-level Response (V6, 36 bytes) + Reject (V0, 44 bytes) encoders
- `SessionClaimRegistry`: process-wide ledger enforcing duplicate-connection + monotonic `sessionVerID`
- `NegotiationValidator`: pure validator covering every reject code (CREDENTIALS, INVALID_SESSIONID/SESSIONVERID/TIMESTAMP/FIRM, ALREADY_NEGOTIATED, DUPLICATE_SESSION_CONNECTION)
- `FixpSession`: dispatches `TidNegotiate=1`; acquires/releases claim; sync `ProcessNegotiate` + async `ExecuteNegotiateStepAsync` (ReadOnlySpan can't cross await)
- `EntryPointListener` + `ExchangeHost` wiring with `AuthConfig.DevMode`
- `FirmRegistry`: requires sessionId to parse as decimal uint32 (FIXP wire type) and exposes `FindSessionByWire(uint)`

## NOT in scope (deferred to #43)
- Strict gating that rejects application messages until `Established`
- Establish handshake itself

## Tests
+39 unit tests covering credentials parsing, claim registry, validator (every reject path), decoder (truncation/oversize/trailing), and encoder byte layout. Total suite: 303 tests, all green. `dotnet format` clean.