### PR TITLE
Fix #83 reviewer findings (refs #42)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -26,11 +26,15 @@
     { "id": "FIRM01", "name": "Alpha Corretora", "enteringFirmCode": 100 },
     { "id": "FIRM02", "name": "Beta Corretora",  "enteringFirmCode": 200 }
   ],
-  // Per-(firm, session) credentials. The Negotiate handshake (#42) will
-  // resolve a session by the wire-format uint32 sessionID and validate the
-  // peer's access_key against accessKey (when auth.devMode is false).
-  // Pre-#42 the host picks the lowest sessionId as the
-  // default tenant for every accept.
+  // Per-(firm, session) credentials. The Negotiate handshake (#42) resolves
+  // a session by the wire-format uint32 sessionID and validates the peer's
+  // access_key against accessKey (when auth.devMode is false).
+  // The host also picks one session as a fallback "default tenant" used to
+  // stamp the EnteringFirm field on TCP accept (before Negotiate completes);
+  // the choice is the lexicographically-first sessionId string. With the
+  // numeric sessionIds enforced below this matches numeric order as long as
+  // every sessionId has the same digit count — keep them aligned to avoid
+  // surprises (e.g. "2" sorts before "10101" lexicographically).
   // sessionId MUST parse as a decimal uint32 (FIXP wire SessionID is uint32).
   "sessions": [
     { "sessionId": "10101", "firmId": "FIRM01", "accessKey": "dev-key-1" },

--- a/src/B3.Exchange.Gateway/FirmRegistry.cs
+++ b/src/B3.Exchange.Gateway/FirmRegistry.cs
@@ -58,6 +58,14 @@ public sealed class FirmRegistry
             if (wireId == 0)
                 throw new InvalidOperationException(
                     $"SessionCredential.SessionId '{s.SessionId}' must be > 0 (zero is the FIXP null value)");
+            // Reject leading zeros so the (string sessionId) → (uint32) map is
+            // truly bijective. NumberStyles.None blocks signs/whitespace but
+            // still accepts "001" → 1, which would let two distinct
+            // SessionCredential.SessionId values collide in wireMap.Add below.
+            if (s.SessionId.Length > 1 && s.SessionId[0] == '0')
+                throw new InvalidOperationException(
+                    $"SessionCredential.SessionId '{s.SessionId}' must not have leading zeros " +
+                    "(canonical decimal required so the wire-uint32 mapping is bijective)");
             if (!firmMap.ContainsKey(s.FirmId))
                 throw new InvalidOperationException(
                     $"session '{s.SessionId}' references unknown firm '{s.FirmId}' " +

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -362,9 +362,22 @@ public sealed class FixpSession : IAsyncDisposable
         // No validator configured → legacy single-tenant mode: accept the
         // peer's claim wholesale (Phase 1 behavior). Stamp identity
         // fields so subsequent app messages carry the peer's values.
+        // We still consult the state machine: a second Negotiate on an
+        // already-negotiated connection MUST be rejected with
+        // ALREADY_NEGOTIATED per spec §4.5.3.1, even in legacy mode.
         if (_validator is null || _claims is null)
         {
-            _ = ApplyTransition(FixpEvent.Negotiate);
+            var action = ApplyTransition(FixpEvent.Negotiate);
+            if (action != FixpAction.Accept)
+            {
+                var rejectFrame = new byte[NegotiateRejectEncoder.Total];
+                NegotiateRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                    req.TimestampNanos, enteringFirm: null,
+                    B3.Entrypoint.Fixp.Sbe.V6.NegotiationRejectCode.ALREADY_NEGOTIATED,
+                    currentSessionVerId: SessionVerId == 0UL ? null : SessionVerId);
+                return NegotiateStep.Rejected(rejectFrame,
+                    $"negotiate-reject (legacy, ALREADY_NEGOTIATED, action={action})");
+            }
             SessionId = req.SessionId;
             EnteringFirm = req.EnteringFirm;
             SessionVerId = req.SessionVerId;

--- a/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
@@ -30,6 +30,14 @@ public class FirmRegistryTests
     }
 
     [Fact]
+    public void Leading_zero_session_id_throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new FirmRegistry(new[] { Firm("F1") }, new[] { Cred("01", "F1") }));
+        Assert.Contains("leading zero", ex.Message);
+    }
+
+    [Fact]
     public void FindFirm_returns_null_when_unknown()
     {
         var r = new FirmRegistry(new[] { Firm("F1") }, Array.Empty<SessionCredential>());


### PR DESCRIPTION
Three real findings from the post-merge Copilot review on #83:

1. **`FirmRegistry`** — `uint.TryParse(NumberStyles.None)` still accepts leading zeros. "01" and "1" would collide in the wire-index dictionary. Now rejected explicitly so the (string sessionId) → (uint32) map is truly bijective.
2. **`config/exchange-simulator.json`** — comment said the default tenant is the "lowest sessionId"; actually it's the lexicographically-first string. Comment updated + warning about mixed-length numeric ids.
3. **`FixpSession` legacy passthrough** — a second `Negotiate` on an already-negotiated connection was silently re-accepted because the `FixpAction` returned by `ApplyTransition` was discarded. Now emits `ALREADY_NEGOTIATED + Terminate` per spec §4.5.3.1 even in legacy mode.

+1 unit test for the leading-zero rejection. `dotnet test` 304/304, `dotnet format` clean.