### PR TITLE
GAP-05: FIXP Establish handshake + strict app-message gating

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -58,6 +58,16 @@ public static class EntryPointFrameReader
     public const ushort TidSequence = 9;
     /// <summary>Session: Negotiate (FIXP, inbound only). See spec §4.5.2.</summary>
     public const ushort TidNegotiate = 1;
+    /// <summary>Session: Establish (FIXP, inbound only). See spec §4.5.3.</summary>
+    public const ushort TidEstablish = 4;
+    /// <summary>Outbound only: NegotiateResponse (template id 2).</summary>
+    public const ushort TidNegotiateResponse = 2;
+    /// <summary>Outbound only: NegotiateReject (template id 3).</summary>
+    public const ushort TidNegotiateReject = 3;
+    /// <summary>Outbound only: EstablishAck (template id 5).</summary>
+    public const ushort TidEstablishAck = 5;
+    /// <summary>Outbound only: EstablishReject (template id 6).</summary>
+    public const ushort TidEstablishReject = 6;
 
     /// <summary>Outbound: ExecutionReport_New (V2).</summary>
     public const ushort TidExecutionReportNew = 200;
@@ -78,6 +88,7 @@ public static class EntryPointFrameReader
         (TidOrderCancelRequest, 0) => 76,        // OrderCancelRequest.MESSAGE_SIZE (V6 base)
         (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.
         (TidNegotiate, 0) => 28,                 // NegotiateData.BLOCK_LENGTH (V6 schema, root version 0)
+        (TidEstablish, 0) => 42,                 // EstablishData.BLOCK_LENGTH
         _ => -1
     };
 

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -26,6 +26,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly Action<FixpSession, string>? _onSessionClosed;
     private readonly NegotiationValidator? _negotiationValidator;
     private readonly SessionClaimRegistry? _sessionClaims;
+    private readonly EstablishValidator? _establishValidator;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
@@ -53,7 +54,8 @@ public sealed class EntryPointListener : IAsyncDisposable
         FixpSessionOptions? sessionOptions = null,
         Action<FixpSession, string>? onSessionClosed = null,
         NegotiationValidator? negotiationValidator = null,
-        SessionClaimRegistry? sessionClaims = null)
+        SessionClaimRegistry? sessionClaims = null,
+        EstablishValidator? establishValidator = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(registry);
@@ -68,6 +70,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         _onSessionClosed = onSessionClosed;
         _negotiationValidator = negotiationValidator;
         _sessionClaims = sessionClaims;
+        _establishValidator = establishValidator;
         if ((_negotiationValidator is null) ^ (_sessionClaims is null))
         {
             throw new ArgumentException(
@@ -132,7 +135,8 @@ public sealed class EntryPointListener : IAsyncDisposable
                     stream, _sink, _loggerFactory.CreateLogger<FixpSession>(),
                     options: _sessionOptions, onClosed: onClosed,
                     negotiationValidator: _negotiationValidator,
-                    sessionClaims: _sessionClaims);
+                    sessionClaims: _sessionClaims,
+                    establishValidator: _establishValidator);
                 _registry.Register(session);
                 lock (_lock) _sessions.Add(session);
                 session.Start();

--- a/src/B3.Exchange.Gateway/EntryPointVarData.cs
+++ b/src/B3.Exchange.Gateway/EntryPointVarData.cs
@@ -18,10 +18,18 @@ public static class EntryPointVarData
 
     private static readonly Field Memo = new("memo", 40);
     private static readonly Field DeskID = new("deskID", 20);
+    private static readonly Field NegotiateCredentials = new("credentials", 128);
+    private static readonly Field NegotiateClientIp = new("clientIP", 30);
+    private static readonly Field NegotiateClientAppName = new("clientAppName", 30);
+    private static readonly Field NegotiateClientAppVersion = new("clientAppVersion", 30);
+    private static readonly Field EstablishCredentials = new("credentials", 128);
 
     private static readonly Field[] SimpleNewOrderFields = [Memo];
     private static readonly Field[] SimpleModifyOrderFields = [Memo];
     private static readonly Field[] OrderCancelFields = [DeskID, Memo];
+    private static readonly Field[] NegotiateFields =
+        [NegotiateCredentials, NegotiateClientIp, NegotiateClientAppName, NegotiateClientAppVersion];
+    private static readonly Field[] EstablishFields = [EstablishCredentials];
     private static readonly Field[] None = [];
 
     /// <summary>
@@ -35,6 +43,8 @@ public static class EntryPointVarData
         (EntryPointFrameReader.TidSimpleNewOrder, 2) => SimpleNewOrderFields,
         (EntryPointFrameReader.TidSimpleModifyOrder, 2) => SimpleModifyOrderFields,
         (EntryPointFrameReader.TidOrderCancelRequest, 0) => OrderCancelFields,
+        (EntryPointFrameReader.TidNegotiate, 0) => NegotiateFields,
+        (EntryPointFrameReader.TidEstablish, 0) => EstablishFields,
         _ => None,
     };
 

--- a/src/B3.Exchange.Gateway/EstablishDecoder.cs
+++ b/src/B3.Exchange.Gateway/EstablishDecoder.cs
@@ -1,0 +1,54 @@
+using System.Buffers.Binary;
+using System.Runtime.InteropServices;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Decoded FIXP <c>Establish</c> root block (spec §4.5.3).
+/// </summary>
+public readonly record struct EstablishRequest(
+    uint SessionId,
+    ulong SessionVerId,
+    ulong TimestampNanos,
+    ulong KeepAliveIntervalMillis,
+    uint NextSeqNo,
+    ushort CancelOnDisconnectType,
+    ulong CodTimeoutWindowMillis);
+
+/// <summary>
+/// Byte-level decoder for the FIXP <c>Establish</c> message
+/// (templateId=4, BLOCK_LENGTH=42). The optional <c>credentials</c>
+/// varData segment is validated upstream by
+/// <see cref="EntryPointVarData.TryValidate"/> and intentionally not
+/// re-parsed here — Negotiate already authenticated the session.
+/// </summary>
+internal static class EstablishDecoder
+{
+    public const ushort TemplateId = FixpSbe.EstablishData.MESSAGE_ID;
+    public const int BlockLength = FixpSbe.EstablishData.BLOCK_LENGTH;
+
+    public static bool TryDecode(ReadOnlySpan<byte> fixedBlock, out EstablishRequest request, out string? error)
+    {
+        request = default;
+        error = null;
+        if (fixedBlock.Length < BlockLength)
+        {
+            error = $"Establish: block length {fixedBlock.Length} < {BlockLength}";
+            return false;
+        }
+        ref readonly var data = ref MemoryMarshal.AsRef<FixpSbe.EstablishData>(fixedBlock);
+        request = new EstablishRequest(
+            SessionId: (uint)data.SessionID,
+            SessionVerId: (ulong)data.SessionVerID,
+            TimestampNanos: data.Timestamp.Time,
+            // KeepAliveInterval and CodTimeoutWindow are uint64
+            // (DeltaInMillis). Read raw from the field positions to
+            // avoid depending on the generated wrapper struct shape.
+            KeepAliveIntervalMillis: BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(20, 8)),
+            NextSeqNo: BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(28, 4)),
+            CancelOnDisconnectType: BinaryPrimitives.ReadUInt16LittleEndian(fixedBlock.Slice(32, 2)),
+            CodTimeoutWindowMillis: BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(34, 8)));
+        return true;
+    }
+}

--- a/src/B3.Exchange.Gateway/EstablishHandshakeEncoders.cs
+++ b/src/B3.Exchange.Gateway/EstablishHandshakeEncoders.cs
@@ -1,0 +1,90 @@
+using System.Buffers.Binary;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Byte-level encoder for the FIXP <c>EstablishAck</c> message
+/// (templateId=5, schemaId=1, version=6, BlockLength=40). Sent in
+/// response to an accepted client <c>Establish</c> per spec §4.5.3.
+///
+/// Layout (V6) — pinned to <see cref="FixpSbe.EstablishAckData"/>:
+///   header(8) | sessionID(uint32 @0) | sessionVerID(uint64 @4)
+///           | requestTimestamp(uint64 @12) | keepAliveInterval(uint64 @20)
+///           | nextSeqNo(uint32 @28) | lastIncomingSeqNo(uint32 @32)
+///           | semanticVersion(Version @36, 4 bytes)
+/// Total wire size = 8 + 40 = 48 bytes.
+/// </summary>
+internal static class EstablishAckEncoder
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+    public const int Block = FixpSbe.EstablishAckData.BLOCK_LENGTH;
+    public const int Total = HeaderSize + Block;
+    public const ushort TemplateId = FixpSbe.EstablishAckData.MESSAGE_ID;
+    public const ushort SchemaVersion = 6;
+
+    public static int Encode(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        ulong requestTimestampNanos, ulong keepAliveIntervalMillis,
+        uint nextSeqNo, uint lastIncomingSeqNo,
+        byte semVerMajor, byte semVerMinor, byte semVerPatch, byte semVerBuild = 0)
+    {
+        if (dst.Length < Total)
+            throw new ArgumentException("buffer too small for EstablishAck", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)Total,
+            blockLength: Block, TemplateId, version: SchemaVersion);
+        var body = dst.Slice(HeaderSize, Block);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(12, 8), requestTimestampNanos);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), keepAliveIntervalMillis);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(28, 4), nextSeqNo);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(32, 4), lastIncomingSeqNo);
+        body[36] = semVerMajor;
+        body[37] = semVerMinor;
+        body[38] = semVerPatch;
+        body[39] = semVerBuild;
+        return Total;
+    }
+}
+
+/// <summary>
+/// Byte-level encoder for the FIXP <c>EstablishReject</c> message
+/// (templateId=6, schemaId=1, version=0, BlockLength=26). Per spec
+/// §4.5.3.1, the rejecting side then sends a <c>Terminate</c> and closes.
+///
+/// Layout (V0) — pinned to <see cref="FixpSbe.EstablishRejectData"/>:
+///   header(8) | sessionID(uint32 @0) | sessionVerID(uint64 @4)
+///           | requestTimestamp(uint64 @12)
+///           | establishmentRejectCode(uint8 @20) | (1 byte padding)
+///           | lastIncomingSeqNo(uint32 optional @22)
+/// Total wire size = 8 + 26 = 34 bytes.
+/// </summary>
+internal static class EstablishRejectEncoder
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+    public const int Block = FixpSbe.EstablishRejectData.BLOCK_LENGTH;
+    public const int Total = HeaderSize + Block;
+    public const ushort TemplateId = FixpSbe.EstablishRejectData.MESSAGE_ID;
+    public const ushort SchemaVersion = 0;
+
+    public static int Encode(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        ulong requestTimestampNanos, FixpSbe.EstablishRejectCode rejectCode,
+        uint? lastIncomingSeqNo)
+    {
+        if (dst.Length < Total)
+            throw new ArgumentException("buffer too small for EstablishReject", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)Total,
+            blockLength: Block, TemplateId, version: SchemaVersion);
+        var body = dst.Slice(HeaderSize, Block);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(12, 8), requestTimestampNanos);
+        body[20] = (byte)rejectCode;
+        // body[21] is implicit padding (zeroed by Clear()).
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(22, 4),
+            lastIncomingSeqNo ?? FixpSbe.EstablishRejectData.LastIncomingSeqNoNullValue);
+        return Total;
+    }
+}

--- a/src/B3.Exchange.Gateway/EstablishValidator.cs
+++ b/src/B3.Exchange.Gateway/EstablishValidator.cs
@@ -1,0 +1,141 @@
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Outcome of validating an inbound FIXP <c>Establish</c> request
+/// against the session's current state and identity. On <see cref="IsAccepted"/>
+/// the dispatch loop should commit the negotiated keepAlive interval and
+/// transition to <see cref="FixpState.Established"/>. On reject the
+/// caller emits an <c>EstablishReject(<see cref="RejectCode"/>)</c>
+/// followed by a <c>Terminate</c>.
+/// </summary>
+public readonly struct EstablishOutcome
+{
+    public bool IsAccepted { get; }
+    public FixpSbe.EstablishRejectCode RejectCode { get; }
+    public string? RejectReason { get; }
+    /// <summary>For <c>INVALID_NEXTSEQNO</c>: the server's last accepted
+    /// inbound application <c>MsgSeqNum</c> (per spec §4.5.3.1, the
+    /// peer should resume from <c>lastIncomingSeqNo + 1</c>).</summary>
+    public uint? LastIncomingSeqNo { get; }
+
+    private EstablishOutcome(bool ok, FixpSbe.EstablishRejectCode code, string? reason, uint? lastSeq)
+    {
+        IsAccepted = ok;
+        RejectCode = code;
+        RejectReason = reason;
+        LastIncomingSeqNo = lastSeq;
+    }
+
+    public static EstablishOutcome Accept()
+        => new(true, FixpSbe.EstablishRejectCode.UNSPECIFIED, null, null);
+
+    public static EstablishOutcome Reject(FixpSbe.EstablishRejectCode code, string reason,
+        uint? lastIncomingSeqNo = null)
+        => new(false, code, reason, lastIncomingSeqNo);
+}
+
+/// <summary>
+/// Pure (no IO, no socket) validator for the FIXP <c>Establish</c>
+/// handshake. Encapsulates every spec rule from §4.5.3 so the
+/// <see cref="FixpSession"/> dispatch loop can stay a thin orchestration
+/// layer.
+///
+/// <para>Rule order is significant — the implementation walks rules
+/// cheapest-first so a malformed request is rejected with the most
+/// informative reject code. The <em>state</em> rule comes first because
+/// it must be honored even if other fields are corrupt
+/// (e.g. <c>UNNEGOTIATED</c> wins over <c>INVALID_KEEPALIVE_INTERVAL</c>
+/// before the peer has any business sending Establish).</para>
+/// </summary>
+public sealed class EstablishValidator
+{
+    private readonly Func<ulong> _nowNanos;
+    /// <summary>Maximum tolerated absolute clock skew (nanoseconds)
+    /// between server and Establish <c>timestamp</c>. Zero disables the
+    /// check (used by tests). Default 5 minutes.</summary>
+    public ulong TimestampSkewToleranceNs { get; }
+
+    /// <summary>Inclusive lower bound for <c>keepAliveInterval</c> (ms).
+    /// Issue #43 acceptance criterion specifies <c>[1, 60000]</c>; the
+    /// SBE schema field description says <c>1000–60000</c>. We follow
+    /// the issue.</summary>
+    public const ulong MinKeepAliveIntervalMs = 1;
+    /// <summary>Inclusive upper bound for <c>keepAliveInterval</c> (ms).</summary>
+    public const ulong MaxKeepAliveIntervalMs = 60_000;
+
+    public EstablishValidator(Func<ulong>? nowNanos = null,
+        ulong timestampSkewToleranceNs = 5UL * 60UL * 1_000_000_000UL)
+    {
+        _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
+        TimestampSkewToleranceNs = timestampSkewToleranceNs;
+    }
+
+    /// <param name="negotiatedSessionId">The wire-format SessionID
+    /// claimed during the preceding <c>Negotiate</c>. The Establish
+    /// frame must carry the same id, otherwise <c>INVALID_SESSIONID</c>.</param>
+    /// <param name="negotiatedSessionVerId">The <c>sessionVerID</c>
+    /// recorded at Negotiate time; mismatch ⇒ <c>INVALID_SESSIONVERID</c>.</param>
+    /// <param name="lastIncomingSeqNo">Highest inbound application
+    /// <c>MsgSeqNum</c> previously accepted on this session
+    /// (0 for a fresh session). Used by <c>INVALID_NEXTSEQNO</c>.</param>
+    public EstablishOutcome Validate(in EstablishRequest req,
+        FixpState currentSessionState,
+        uint negotiatedSessionId, ulong negotiatedSessionVerId,
+        uint lastIncomingSeqNo)
+    {
+        // §4.5.3 strict-gating: order matters. State first because the
+        // peer is forbidden from sending Establish before Negotiate.
+        if (currentSessionState == FixpState.Idle)
+            return EstablishOutcome.Reject(
+                FixpSbe.EstablishRejectCode.UNNEGOTIATED,
+                "Establish received before Negotiate");
+        if (currentSessionState == FixpState.Established)
+            return EstablishOutcome.Reject(
+                FixpSbe.EstablishRejectCode.ALREADY_ESTABLISHED,
+                "Establish received after session already established");
+
+        // Identity must match Negotiate. Spec keeps these as separate
+        // codes so the client can correlate which field disagrees.
+        if (req.SessionId != negotiatedSessionId)
+            return EstablishOutcome.Reject(
+                FixpSbe.EstablishRejectCode.INVALID_SESSIONID,
+                $"sessionID {req.SessionId} does not match negotiated {negotiatedSessionId}");
+        if (req.SessionVerId != negotiatedSessionVerId)
+            return EstablishOutcome.Reject(
+                FixpSbe.EstablishRejectCode.INVALID_SESSIONVERID,
+                $"sessionVerID {req.SessionVerId} does not match negotiated {negotiatedSessionVerId}");
+
+        if (TimestampSkewToleranceNs > 0 && req.TimestampNanos != 0)
+        {
+            var now = _nowNanos();
+            var diff = req.TimestampNanos > now ? req.TimestampNanos - now : now - req.TimestampNanos;
+            if (diff > TimestampSkewToleranceNs)
+                return EstablishOutcome.Reject(
+                    FixpSbe.EstablishRejectCode.INVALID_TIMESTAMP,
+                    $"timestamp skew {diff}ns exceeds {TimestampSkewToleranceNs}ns");
+        }
+
+        if (req.KeepAliveIntervalMillis < MinKeepAliveIntervalMs ||
+            req.KeepAliveIntervalMillis > MaxKeepAliveIntervalMs)
+        {
+            return EstablishOutcome.Reject(
+                FixpSbe.EstablishRejectCode.INVALID_KEEPALIVE_INTERVAL,
+                $"keepAliveInterval {req.KeepAliveIntervalMillis}ms is outside " +
+                $"[{MinKeepAliveIntervalMs},{MaxKeepAliveIntervalMs}]");
+        }
+
+        // We do not yet enforce strict in-order MsgSeqNum on inbound
+        // application messages — that is #GAP-07. For now reject only
+        // the obviously-invalid sentinel value of 0 so we don't claim
+        // semantics we don't implement.
+        if (req.NextSeqNo == 0)
+            return EstablishOutcome.Reject(
+                FixpSbe.EstablishRejectCode.INVALID_NEXTSEQNO,
+                "nextSeqNo is zero (must be >= 1)",
+                lastIncomingSeqNo: lastIncomingSeqNo);
+
+        return EstablishOutcome.Accept();
+    }
+}

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -35,6 +35,7 @@ public sealed class FixpSession : IAsyncDisposable
     private readonly FixpSessionOptions _options;
     private readonly Action<FixpSession, string>? _onClosed;
     private readonly NegotiationValidator? _validator;
+    private readonly EstablishValidator? _establishValidator;
     private readonly SessionClaimRegistry? _claims;
     /// <summary>The wire SessionID currently claimed in <see cref="_claims"/>,
     /// or 0 if no claim is held. Tracked so <see cref="Close"/> can
@@ -70,6 +71,17 @@ public sealed class FixpSession : IAsyncDisposable
     /// <summary>FIXP <c>sessionVerID</c> recorded on the most recent
     /// successful Negotiate. Zero before the handshake has completed.</summary>
     public ulong SessionVerId { get; private set; }
+
+    /// <summary>Negotiated <c>keepAliveInterval</c> (ms) committed by the
+    /// most recent successful Establish. Zero before Establish completes.
+    /// Set inside the dispatch thread; read by the watchdog.</summary>
+    public long KeepAliveIntervalMs { get; private set; }
+
+    /// <summary>Highest inbound application <c>MsgSeqNum</c> accepted on
+    /// this session. Zero until the first inbound application message is
+    /// processed. Used to populate <c>EstablishAck.lastIncomingSeqNo</c>
+    /// and to compute <c>EstablishReject.lastIncomingSeqNo</c>.</summary>
+    public uint LastIncomingSeqNo { get; private set; }
     /// <summary>Stable, transport-neutral identity of this session as seen
     /// by Core / Contracts. Routing key the Gateway uses to resolve
     /// outbound ExecutionReports back to this <see cref="FixpSession"/>.
@@ -114,7 +126,8 @@ public sealed class FixpSession : IAsyncDisposable
         Action<FixpSession, string>? onClosed = null,
         ILogger<TcpTransport>? transportLogger = null,
         NegotiationValidator? negotiationValidator = null,
-        SessionClaimRegistry? sessionClaims = null)
+        SessionClaimRegistry? sessionClaims = null,
+        EstablishValidator? establishValidator = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ConnectionId = connectionId;
@@ -128,6 +141,7 @@ public sealed class FixpSession : IAsyncDisposable
         _options.Validate();
         _onClosed = onClosed;
         _validator = negotiationValidator;
+        _establishValidator = establishValidator;
         _claims = sessionClaims;
         if (negotiationValidator is not null && sessionClaims is null)
             throw new ArgumentException(
@@ -255,6 +269,39 @@ public sealed class FixpSession : IAsyncDisposable
         var fullBody = new ReadOnlyMemory<byte>(bodyBuf, 0, bodyLength);
         var fixedBlock = fullBody.Slice(0, info.BlockLength).Span;
         var varData = fullBody.Slice(info.BlockLength).Span;
+
+        // Strict gating (issue #43, spec §4.5.3.1): when the validator is
+        // wired (i.e. we're running in "real" multi-tenant mode), an
+        // application-template message that arrives before Establish has
+        // completed MUST be rejected with Terminate(Unnegotiated) or
+        // Terminate(NotEstablished) BEFORE we even attempt to decode the
+        // payload. We deliberately skip varData validation in that case
+        // so the peer learns the gating reason rather than a misleading
+        // DECODING_ERROR. Legacy mode (no validator) keeps the previous
+        // permissive behavior — covered by Phase 0/1 tests.
+        if (_validator is not null && IsApplicationTemplate(info.TemplateId))
+        {
+            var gate = ApplyTransition(FixpEvent.ApplicationMessage);
+            switch (gate)
+            {
+                case FixpAction.RejectAndTerminateUnnegotiated:
+                    await TerminateAndCloseAsync(
+                        SessionRejectEncoder.TerminationCode.Unnegotiated,
+                        "app-message-before-negotiate").ConfigureAwait(false);
+                    return false;
+                case FixpAction.RejectAndTerminateUnestablished:
+                    await TerminateAndCloseAsync(
+                        SessionRejectEncoder.TerminationCode.NotEstablished,
+                        "app-message-before-establish").ConfigureAwait(false);
+                    return false;
+                case FixpAction.Accept:
+                    break;
+                default:
+                    // DropSilently / Terminal / NotApplied — defensive: drop frame.
+                    return true;
+            }
+        }
+
         var spec = EntryPointVarData.ExpectedFor(info.TemplateId, info.Version);
         if (!EntryPointVarData.TryValidate(varData, spec, out var varErr))
         {
@@ -273,6 +320,11 @@ public sealed class FixpSession : IAsyncDisposable
                 {
                     var step = ProcessNegotiate(fixedBlock, varData);
                     return await ExecuteNegotiateStepAsync(step).ConfigureAwait(false);
+                }
+            case EntryPointFrameReader.TidEstablish:
+                {
+                    var step = ProcessEstablish(fixedBlock);
+                    return await ExecuteEstablishStepAsync(step).ConfigureAwait(false);
                 }
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
@@ -485,6 +537,161 @@ public sealed class FixpSession : IAsyncDisposable
         return false;
     }
 
+    private static bool IsApplicationTemplate(ushort templateId)
+        => templateId == EntryPointFrameReader.TidSimpleNewOrder
+        || templateId == EntryPointFrameReader.TidSimpleModifyOrder
+        || templateId == EntryPointFrameReader.TidOrderCancelRequest;
+
+    /// <summary>
+    /// Outcome of synchronously processing an inbound Establish frame.
+    /// Mirrors <see cref="NegotiateStep"/> so the async writer in
+    /// <see cref="ExecuteEstablishStepAsync"/> can post the buffered
+    /// EstablishAck / EstablishReject without holding spans across an
+    /// <c>await</c>.
+    /// </summary>
+    private readonly struct EstablishStep
+    {
+        public readonly bool IsAccepted;
+        public readonly bool DecodeError;
+        public readonly string? DecodeErrorMessage;
+        public readonly byte[]? AckFrame;
+        public readonly byte[]? RejectFrame;
+        public readonly string LogReason;
+
+        private EstablishStep(bool accepted, bool decodeErr, string? decodeMsg,
+            byte[]? ack, byte[]? reject, string logReason)
+        {
+            IsAccepted = accepted;
+            DecodeError = decodeErr;
+            DecodeErrorMessage = decodeMsg;
+            AckFrame = ack;
+            RejectFrame = reject;
+            LogReason = logReason;
+        }
+
+        public static EstablishStep Accepted(byte[] ack, string reason)
+            => new(true, false, null, ack, null, reason);
+        public static EstablishStep Rejected(byte[] reject, string reason)
+            => new(false, false, null, null, reject, reason);
+        public static EstablishStep Decode(string message)
+            => new(false, true, message, null, null, message);
+    }
+
+    /// <summary>
+    /// Synchronous Establish processing: SBE decode, validator dispatch,
+    /// state transition, session-state mutation. Produces an
+    /// <see cref="EstablishStep"/> describing what the async wrapper should
+    /// send (and whether to close the connection afterwards). On accept
+    /// the negotiated <c>keepAliveInterval</c> is committed to
+    /// <see cref="KeepAliveIntervalMs"/> so the watchdog can react.
+    /// </summary>
+    private EstablishStep ProcessEstablish(ReadOnlySpan<byte> fixedBlock)
+    {
+        if (!EstablishDecoder.TryDecode(fixedBlock, out var req, out var decodeErr))
+            return EstablishStep.Decode(decodeErr ?? "decode error: Establish");
+
+        // Legacy / no-validator mode mirrors Negotiate: accept whatever
+        // the peer asked for, transition to Established, echo an Ack with
+        // the requested keepAliveInterval. Existing Phase-1 tests rely on
+        // this pass-through.
+        if (_establishValidator is null)
+        {
+            var action = ApplyTransition(FixpEvent.Establish);
+            if (action != FixpAction.Accept)
+            {
+                var rejectFrame = new byte[EstablishRejectEncoder.Total];
+                EstablishRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                    req.TimestampNanos,
+                    B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.UNSPECIFIED,
+                    lastIncomingSeqNo: LastIncomingSeqNo == 0 ? null : LastIncomingSeqNo);
+                return EstablishStep.Rejected(rejectFrame,
+                    $"establish-reject (legacy, action={action})");
+            }
+            KeepAliveIntervalMs = (long)req.KeepAliveIntervalMillis;
+            var ackFrame = new byte[EstablishAckEncoder.Total];
+            EstablishAckEncoder.Encode(ackFrame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos, req.KeepAliveIntervalMillis,
+                nextSeqNo: PeekNextMsgSeqNum(), lastIncomingSeqNo: LastIncomingSeqNo,
+                semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+            return EstablishStep.Accepted(ackFrame, $"establish-accept (legacy, sid={req.SessionId})");
+        }
+
+        // Strict mode: validate against current state + negotiated identity
+        // before any transition. The validator is pure and never mutates.
+        var outcome = _establishValidator.Validate(in req, State,
+            negotiatedSessionId: SessionId,
+            negotiatedSessionVerId: SessionVerId,
+            lastIncomingSeqNo: LastIncomingSeqNo);
+        if (!outcome.IsAccepted)
+        {
+            var rejectFrame = new byte[EstablishRejectEncoder.Total];
+            EstablishRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos, outcome.RejectCode,
+                lastIncomingSeqNo: outcome.LastIncomingSeqNo);
+            return EstablishStep.Rejected(rejectFrame,
+                $"establish-reject ({outcome.RejectCode}: {outcome.RejectReason})");
+        }
+
+        // Defensive: validator already screened state, but fold the
+        // result through the state machine so the canonical transition
+        // log records the event.
+        var act = ApplyTransition(FixpEvent.Establish);
+        if (act != FixpAction.Accept)
+        {
+            var rejectFrame = new byte[EstablishRejectEncoder.Total];
+            EstablishRejectEncoder.Encode(rejectFrame, req.SessionId, req.SessionVerId,
+                req.TimestampNanos,
+                B3.Entrypoint.Fixp.Sbe.V6.EstablishRejectCode.UNSPECIFIED,
+                lastIncomingSeqNo: LastIncomingSeqNo == 0 ? null : LastIncomingSeqNo);
+            return EstablishStep.Rejected(rejectFrame,
+                $"establish-reject (state-machine action={act})");
+        }
+
+        KeepAliveIntervalMs = (long)req.KeepAliveIntervalMillis;
+        var ack = new byte[EstablishAckEncoder.Total];
+        EstablishAckEncoder.Encode(ack, req.SessionId, req.SessionVerId,
+            req.TimestampNanos, req.KeepAliveIntervalMillis,
+            nextSeqNo: PeekNextMsgSeqNum(), lastIncomingSeqNo: LastIncomingSeqNo,
+            semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+        return EstablishStep.Accepted(ack, $"establish-accept (sid={req.SessionId})");
+    }
+
+    private async Task<bool> ExecuteEstablishStepAsync(EstablishStep step)
+    {
+        if (step.DecodeError)
+        {
+            _sink.OnDecodeError(Identity, step.DecodeErrorMessage ?? "decode error: Establish");
+            await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError,
+                "decode-error:Establish").ConfigureAwait(false);
+            return false;
+        }
+        if (step.IsAccepted)
+        {
+            _logger.LogInformation("session {ConnectionId} {Reason}", ConnectionId, step.LogReason);
+            if (!_transport.TryEnqueueFrame(step.AckFrame!))
+            {
+                _logger.LogWarning("session {ConnectionId} could not enqueue EstablishAck — closing",
+                    ConnectionId);
+                Close("send-queue-full:EstablishAck");
+                return false;
+            }
+            return true;
+        }
+        // Reject path: send EstablishReject, then Terminate, then close.
+        _logger.LogInformation("session {ConnectionId} {Reason}", ConnectionId, step.LogReason);
+        try
+        {
+            await _transport.SendDirectAsync(step.RejectFrame!).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "session {ConnectionId} failed to write EstablishReject", ConnectionId);
+        }
+        await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.Unspecified,
+            step.LogReason).ConfigureAwait(false);
+        return false;
+    }
+
     /// <summary>
     /// Periodic watchdog that drives the FIXP-style heartbeat + idle-timeout
     /// policy. Runs on its own task; never touches the socket directly —
@@ -555,7 +762,12 @@ public sealed class FixpSession : IAsyncDisposable
     {
         if (!IsOpen) return;
         var frame = new byte[SessionFrameEncoder.SequenceTotal];
-        SessionFrameEncoder.EncodeSequence(frame, NextMsgSeqNum());
+        // FIXP §4.5.5: the Sequence message announces the *next* MsgSeqNum
+        // we intend to send. It does not consume a sequence number itself,
+        // so we must peek instead of incrementing — otherwise the Establish
+        // handshake would observe a phantom gap (e.g. an idle heartbeat
+        // before Establish would push EstablishAck.nextSeqNo off by one).
+        SessionFrameEncoder.EncodeSequence(frame, PeekNextMsgSeqNum());
         _transport.TryEnqueueFrame(frame);
     }
 
@@ -574,6 +786,11 @@ public sealed class FixpSession : IAsyncDisposable
     }
 
     private uint NextMsgSeqNum() => (uint)Interlocked.Increment(ref _msgSeqNum);
+
+    /// <summary>Peek the value <see cref="NextMsgSeqNum"/> would return on
+    /// its next call without consuming a sequence number. Used by FIXP
+    /// <c>Sequence</c> frames, which announce but do not consume.</summary>
+    private uint PeekNextMsgSeqNum() => (uint)(Volatile.Read(ref _msgSeqNum) + 1);
 
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e)
     {

--- a/src/B3.Exchange.Gateway/SessionRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/SessionRejectEncoder.cs
@@ -29,6 +29,12 @@ internal static class SessionRejectEncoder
     public static class TerminationCode
     {
         public const byte Unspecified = 0;
+        /// <summary>Peer sent an application message before completing
+        /// FIXP <c>Negotiate</c>. Spec §4.5 strict-gating rule.</summary>
+        public const byte Unnegotiated = 2;
+        /// <summary>Peer sent an application message after Negotiate but
+        /// before <c>Establish</c>. Spec §4.5 strict-gating rule.</summary>
+        public const byte NotEstablished = 3;
         public const byte UnrecognizedMessage = 15;
         public const byte InvalidSofh = 16;
         public const byte DecodingError = 17;

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -211,6 +211,14 @@ public sealed class ExchangeHost : IAsyncDisposable
         // so duplicate-connection detection works across reconnects.
         var sessionClaims = new SessionClaimRegistry();
         var negotiationValidator = new NegotiationValidator(firmRegistry, sessionClaims, devMode: _config.Auth.DevMode);
+        // Phase 2 (#43): Establish handshake validator. Pure (no IO);
+        // tolerates ±5 minutes of clock skew on Establish.timestamp.
+        var establishValidator = new EstablishValidator();
+        // Legacy passthrough mode (RequireFixpHandshake=false) leaves both
+        // session-layer validators unwired so app messages flow without a
+        // prior Negotiate/Establish — used by the synthetic trader and
+        // pre-#42 integration tests until they learn the handshake.
+        bool requireHandshake = _config.Auth.RequireFixpHandshake;
         _listener = new EntryPointListener(listenEp, _router, sessionRegistry, _loggerFactory,
             identityFactory: remote =>
             {
@@ -227,8 +235,9 @@ public sealed class ExchangeHost : IAsyncDisposable
             },
             sessionOptions: sessionOptions,
             onSessionClosed: (s, reason) => _logger.LogInformation("session {ConnectionId} closed: {Reason}", s.ConnectionId, reason),
-            negotiationValidator: negotiationValidator,
-            sessionClaims: sessionClaims);
+            negotiationValidator: requireHandshake ? negotiationValidator : null,
+            sessionClaims: requireHandshake ? sessionClaims : null,
+            establishValidator: requireHandshake ? establishValidator : null);
         _listener.Start();
         _logger.LogInformation("entrypoint listening on {Endpoint}", _listener.LocalEndpoint);
 

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -49,6 +49,17 @@ public sealed class TcpConfig
 public sealed class AuthConfig
 {
     [JsonPropertyName("devMode")] public bool DevMode { get; set; }
+
+    /// <summary>
+    /// When true (default), the host wires the FIXP <c>Negotiate</c> and
+    /// <c>Establish</c> validators so application messages received on a
+    /// session before the handshake completes are rejected per spec
+    /// §4.5.3.1 (<c>Terminate(Unnegotiated)</c> /
+    /// <c>Terminate(NotEstablished)</c>). Set to <c>false</c> to run in
+    /// legacy permissive mode used by integration tests / synthetic
+    /// trader flows that do not yet implement the handshake.
+    /// </summary>
+    [JsonPropertyName("requireFixpHandshake")] public bool RequireFixpHandshake { get; set; } = true;
 }
 
 /// <summary>One firm (corretora). See architecture §4.1.</summary>

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
@@ -1,0 +1,92 @@
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Gateway;
+using Microsoft.Extensions.Logging.Abstractions;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #43 — strict app-message gating: a SimpleNewOrder/Modify/Cancel
+/// frame received before <c>Negotiate</c>+<c>Establish</c> have completed
+/// must be answered with <c>Terminate(Unnegotiated)</c> /
+/// <c>Terminate(NotEstablished)</c>, not silently accepted.
+/// </summary>
+public class EntryPointStrictGatingTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static EntryPointListener BuildListenerWithValidators()
+    {
+        var firms = new FirmRegistry(
+            new[] { new Firm(Id: "F1", Name: "Firm 1", EnteringFirmCode: 42u) },
+            new[] { new SessionCredential(SessionId: "1", FirmId: "F1", AccessKey: "key", AllowedSourceCidrs: null, Policy: SessionPolicy.Default) });
+        var claims = new SessionClaimRegistry();
+        var negotiationValidator = new NegotiationValidator(firms, claims, devMode: false,
+            timestampSkewToleranceNs: 0);
+        var establishValidator = new EstablishValidator(timestampSkewToleranceNs: 0);
+        return new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            new SessionRegistry(),
+            NullLoggerFactory.Instance,
+            negotiationValidator: negotiationValidator,
+            sessionClaims: claims,
+            establishValidator: establishValidator);
+    }
+
+    private static byte[] BuildBareNewOrderFrame()
+    {
+        // Minimal valid SimpleNewOrder header (block content does not need to
+        // be valid because gating fires BEFORE decode).
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame,
+            messageLength: (ushort)frame.Length,
+            blockLength: 82,
+            templateId: EntryPointFrameReader.TidSimpleNewOrder,
+            version: 2);
+        return frame;
+    }
+
+    private static async Task<byte> ReadTerminationCodeAsync(TcpClient client)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var buf = new byte[SessionRejectEncoder.TerminateTotal];
+        int read = 0;
+        var ns = client.GetStream();
+        while (read < buf.Length)
+        {
+            int n = await ns.ReadAsync(buf.AsMemory(read), cts.Token);
+            if (n <= 0) throw new EndOfStreamException("connection closed before Terminate");
+            read += n;
+        }
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        Assert.Equal(EntryPointFrameReader.TidTerminate, tid);
+        return buf[EntryPointFrameReader.WireHeaderSize + 12];
+    }
+
+    [Fact]
+    public async Task NewOrder_before_negotiate_yields_terminate_unnegotiated()
+    {
+        var listener = BuildListenerWithValidators();
+        listener.Start();
+        await using (listener)
+        using (var client = new TcpClient())
+        {
+            await client.ConnectAsync(listener.LocalEndpoint!.Address, listener.LocalEndpoint!.Port);
+            await client.GetStream().WriteAsync(BuildBareNewOrderFrame());
+            byte code = await ReadTerminationCodeAsync(client);
+            Assert.Equal(SessionRejectEncoder.TerminationCode.Unnegotiated, code);
+        }
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/EstablishDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishDecoderTests.cs
@@ -1,0 +1,48 @@
+using System.Buffers.Binary;
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class EstablishDecoderTests
+{
+    private static byte[] BuildBlock(uint sid, ulong ver, ulong ts, ulong keepAlive,
+        uint nextSeq, ushort cod, ulong codTimeout)
+    {
+        var buf = new byte[EstablishDecoder.BlockLength];
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(0, 4), sid);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(4, 8), ver);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(12, 8), ts);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(20, 8), keepAlive);
+        BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(28, 4), nextSeq);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(32, 2), cod);
+        BinaryPrimitives.WriteUInt64LittleEndian(buf.AsSpan(34, 8), codTimeout);
+        return buf;
+    }
+
+    [Fact]
+    public void Decode_roundtrips_all_fields()
+    {
+        var block = BuildBlock(0xDEAD_BEEFu, 0x1122_3344_5566_7788UL,
+            0xAABB_CCDD_EEFF_0011UL, keepAlive: 5_000UL, nextSeq: 1, cod: 1,
+            codTimeout: 30_000UL);
+        Assert.True(EstablishDecoder.TryDecode(block, out var req, out var err));
+        Assert.Null(err);
+        Assert.Equal(0xDEAD_BEEFu, req.SessionId);
+        Assert.Equal(0x1122_3344_5566_7788UL, req.SessionVerId);
+        Assert.Equal(0xAABB_CCDD_EEFF_0011UL, req.TimestampNanos);
+        Assert.Equal(5_000UL, req.KeepAliveIntervalMillis);
+        Assert.Equal(1u, req.NextSeqNo);
+        Assert.Equal((ushort)1, req.CancelOnDisconnectType);
+        Assert.Equal(30_000UL, req.CodTimeoutWindowMillis);
+    }
+
+    [Fact]
+    public void Decode_truncated_block_rejects()
+    {
+        var block = new byte[EstablishDecoder.BlockLength - 1];
+        Assert.False(EstablishDecoder.TryDecode(block, out _, out var err));
+        Assert.NotNull(err);
+        Assert.Contains("Establish", err);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/EstablishHandshakeEncodersTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishHandshakeEncodersTests.cs
@@ -1,0 +1,76 @@
+using System.Buffers.Binary;
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class EstablishHandshakeEncodersTests
+{
+    [Fact]
+    public void Ack_layout_matches_spec()
+    {
+        var buf = new byte[EstablishAckEncoder.Total];
+        int n = EstablishAckEncoder.Encode(buf,
+            sessionId: 12345, sessionVerId: 9,
+            requestTimestampNanos: 0x1122334455667788UL,
+            keepAliveIntervalMillis: 5_000UL,
+            nextSeqNo: 1, lastIncomingSeqNo: 0,
+            semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+        Assert.Equal(EstablishAckEncoder.Total, n);
+
+        Assert.Equal(EstablishAckEncoder.Total, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2)));
+        Assert.Equal(EntryPointFrameReader.SofhEncodingType, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(2, 2)));
+        Assert.Equal(EstablishAckEncoder.Block, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(4, 2)));
+        Assert.Equal(EstablishAckEncoder.TemplateId, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(6, 2)));
+        Assert.Equal(EntryPointFrameReader.SchemaId, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(8, 2)));
+        Assert.Equal(EstablishAckEncoder.SchemaVersion, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(10, 2)));
+
+        var body = buf.AsSpan(12); // header is 8 bytes (SOFH + SBE header)
+        Assert.Equal(12345u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
+        Assert.Equal(9UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)));
+        Assert.Equal(0x1122334455667788UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)));
+        Assert.Equal(5_000UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(20, 8)));
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(28, 4)));
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(32, 4)));
+        Assert.Equal(8, body[36]);
+        Assert.Equal(4, body[37]);
+        Assert.Equal(2, body[38]);
+        Assert.Equal(0, body[39]);
+    }
+
+    [Fact]
+    public void Reject_layout_with_lastIncomingSeqNo()
+    {
+        var buf = new byte[EstablishRejectEncoder.Total];
+        int n = EstablishRejectEncoder.Encode(buf,
+            sessionId: 7, sessionVerId: 1,
+            requestTimestampNanos: 0xCAFEBABE_DEADBEEFUL,
+            rejectCode: FixpSbe.EstablishRejectCode.INVALID_NEXTSEQNO,
+            lastIncomingSeqNo: 42u);
+        Assert.Equal(EstablishRejectEncoder.Total, n);
+
+        Assert.Equal(EstablishRejectEncoder.TemplateId, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(6, 2)));
+        Assert.Equal(EstablishRejectEncoder.SchemaVersion, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(10, 2)));
+
+        var body = buf.AsSpan(12);
+        Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
+        Assert.Equal(1UL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)));
+        Assert.Equal(0xCAFEBABE_DEADBEEFUL, BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)));
+        Assert.Equal((byte)FixpSbe.EstablishRejectCode.INVALID_NEXTSEQNO, body[20]);
+        Assert.Equal(0, body[21]); // padding
+        Assert.Equal(42u, BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(22, 4)));
+    }
+
+    [Fact]
+    public void Reject_omits_lastIncomingSeqNo_via_null_sentinel()
+    {
+        var buf = new byte[EstablishRejectEncoder.Total];
+        EstablishRejectEncoder.Encode(buf,
+            sessionId: 7, sessionVerId: 1, requestTimestampNanos: 0,
+            rejectCode: FixpSbe.EstablishRejectCode.UNNEGOTIATED,
+            lastIncomingSeqNo: null);
+        var body = buf.AsSpan(12);
+        Assert.Equal(FixpSbe.EstablishRejectData.LastIncomingSeqNoNullValue,
+            BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(22, 4)));
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/EstablishValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishValidatorTests.cs
@@ -1,0 +1,95 @@
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class EstablishValidatorTests
+{
+    private static EstablishRequest Req(uint sid = 100, ulong ver = 1, ulong ts = 0,
+        ulong keep = 5_000UL, uint nextSeq = 1)
+        => new(sid, ver, ts, keep, nextSeq, CancelOnDisconnectType: 0, CodTimeoutWindowMillis: 0);
+
+    [Fact]
+    public void Accepts_valid_request_in_negotiated_state()
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var o = v.Validate(Req(sid: 100, ver: 1), FixpState.Negotiated, 100, 1, 0);
+        Assert.True(o.IsAccepted);
+    }
+
+    [Fact]
+    public void Rejects_when_idle_with_unnegotiated()
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var o = v.Validate(Req(), FixpState.Idle, 100, 1, 0);
+        Assert.False(o.IsAccepted);
+        Assert.Equal(FixpSbe.EstablishRejectCode.UNNEGOTIATED, o.RejectCode);
+    }
+
+    [Fact]
+    public void Rejects_when_already_established()
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var o = v.Validate(Req(), FixpState.Established, 100, 1, 0);
+        Assert.False(o.IsAccepted);
+        Assert.Equal(FixpSbe.EstablishRejectCode.ALREADY_ESTABLISHED, o.RejectCode);
+    }
+
+    [Fact]
+    public void Rejects_session_id_mismatch()
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var o = v.Validate(Req(sid: 999), FixpState.Negotiated, 100, 1, 0);
+        Assert.Equal(FixpSbe.EstablishRejectCode.INVALID_SESSIONID, o.RejectCode);
+    }
+
+    [Fact]
+    public void Rejects_session_ver_mismatch()
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var o = v.Validate(Req(sid: 100, ver: 2), FixpState.Negotiated, 100, 1, 0);
+        Assert.Equal(FixpSbe.EstablishRejectCode.INVALID_SESSIONVERID, o.RejectCode);
+    }
+
+    [Fact]
+    public void Rejects_timestamp_skew_beyond_tolerance()
+    {
+        ulong now = 1_000_000_000UL;
+        var v = new EstablishValidator(nowNanos: () => now,
+            timestampSkewToleranceNs: 1_000UL);
+        var req = Req(sid: 100, ver: 1, ts: now + 10_000UL);
+        var o = v.Validate(req, FixpState.Negotiated, 100, 1, 0);
+        Assert.Equal(FixpSbe.EstablishRejectCode.INVALID_TIMESTAMP, o.RejectCode);
+    }
+
+    [Theory]
+    [InlineData(0UL)]
+    [InlineData(60_001UL)]
+    public void Rejects_keepalive_out_of_range(ulong keep)
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var req = Req(sid: 100, ver: 1, keep: keep);
+        var o = v.Validate(req, FixpState.Negotiated, 100, 1, 0);
+        Assert.Equal(FixpSbe.EstablishRejectCode.INVALID_KEEPALIVE_INTERVAL, o.RejectCode);
+    }
+
+    [Fact]
+    public void Rejects_nextseqno_zero_with_last_incoming_echoed()
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var req = Req(sid: 100, ver: 1, nextSeq: 0);
+        var o = v.Validate(req, FixpState.Negotiated, 100, 1, lastIncomingSeqNo: 7);
+        Assert.Equal(FixpSbe.EstablishRejectCode.INVALID_NEXTSEQNO, o.RejectCode);
+        Assert.Equal(7u, o.LastIncomingSeqNo);
+    }
+
+    [Fact]
+    public void State_check_takes_precedence_over_field_validation()
+    {
+        // Bad keepAlive AND idle state: state-machine reason wins.
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var req = Req(sid: 100, ver: 1, keep: 99_999UL);
+        var o = v.Validate(req, FixpState.Idle, 100, 1, 0);
+        Assert.Equal(FixpSbe.EstablishRejectCode.UNNEGOTIATED, o.RejectCode);
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -41,6 +41,7 @@ public class ExchangeHostE2ETests
         var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
             Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
             Channels =
             {

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
@@ -45,6 +45,7 @@ public class ExchangeHostSnapshotE2ETests
         var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
             Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
             Channels =
             {
@@ -140,6 +141,7 @@ public class ExchangeHostSnapshotE2ETests
         var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
             Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
             Channels =
             {

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -17,6 +17,7 @@ public class HttpServerTests
         var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
             Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
             Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = livenessStaleMs },
             Channels =

--- a/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
+++ b/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
@@ -81,6 +81,7 @@ public class SoakSmokeTests
         var sink = new MonotonicSink();
         var hostCfg = new HostConfig
         {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
             Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 1 },
             Channels =
             {

--- a/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
@@ -44,6 +44,7 @@ public class SyntheticTraderHostIntegrationTests
         var sink = new RecordingPacketSink();
         var hostCfg = new HostConfig
         {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
             Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
             Channels =
             {


### PR DESCRIPTION
Implements the issue #43 acceptance criteria for §4.5.3 of the EntryPoint spec.

## What

- `EstablishDecoder` for the V0 root block (BLOCK_LENGTH=42). Optional credentials varData is validated by the central `EntryPointVarData` registry but not re-parsed (Negotiate already authenticated).
- `EstablishAckEncoder` (V6 BLOCK=40) and `EstablishRejectEncoder` (V0 BLOCK=26) with optional `lastIncomingSeqNo` sentinel.
- `EstablishValidator` (pure, no IO): walks
  `UNNEGOTIATED → ALREADY_ESTABLISHED → INVALID_SESSIONID →
  INVALID_SESSIONVERID → INVALID_TIMESTAMP →
  INVALID_KEEPALIVE_INTERVAL → INVALID_NEXTSEQNO`. KeepAlive range is `[1, 60000] ms` per the issue's acceptance criterion.
- `FixpSession`: `ProcessEstablish` / `ExecuteEstablishStepAsync` mirroring the Negotiate flow; commits the negotiated keepAliveInterval to a new public `KeepAliveIntervalMs` property; emits Terminate after EstablishReject.
- **Strict app-message gating** (the second half of issue #43): when validators are wired, `SimpleNewOrder/Modify/Cancel` arriving before the handshake completes is rejected with `Terminate(Unnegotiated=2)` or `Terminate(NotEstablished=3)` BEFORE varData decoding — otherwise a malformed pre-handshake app message would surface as `DECODING_ERROR` instead of the spec code.
- `HostConfig.Auth.RequireFixpHandshake` (default `true`) toggles the validators on/off so the existing legacy integration tests can opt out of strict mode until they learn the handshake.

## Latent bugs fixed alongside

- `EntryPointVarData.ExpectedFor` was missing `TidNegotiate` entirely. The real receive loop would have rejected a real Negotiate frame with 'trailing bytes'; the existing tests passed only because they exercised the decoder directly. Added both Negotiate and Establish entries.
- The FIXP `Sequence` heartbeat now **peeks** `MsgSeqNum` instead of consuming, so an idle heartbeat between Negotiate and Establish doesn't push `EstablishAck.nextSeqNo` off-by-one.

## Out of scope (deferred)

- §5.3 reconnect / replay scenario — requires persistent session state across transports.
- Strict in-order `nextSeqNo` enforcement is tracked under #GAP-07; this PR only rejects `nextSeqNo == 0`.

## Tests

- `EstablishDecoderTests` — round-trip + truncation.
- `EstablishHandshakeEncodersTests` — Ack + Reject byte layout (with/without `lastIncomingSeqNo`).
- `EstablishValidatorTests` — every reject path.
- `EntryPointStrictGatingTests` — end-to-end TCP: NewOrder before Negotiate yields `Terminate(Unnegotiated)`.

Refs #43.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>