### PR TITLE
Issue #69 (part 1/3): FIXP Suspended state on transport drop

### DIFF
--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -46,6 +46,7 @@ public sealed class FixpSession : IAsyncDisposable
     private uint _claimedSessionId;
     private long _msgSeqNum;
     private int _isOpen = 1;
+    private int _isAttached = 1;
     // Watchdog state (milliseconds since process start, monotonic).
     private long _lastInboundMs;
     // Set true while we are waiting on the grace window after sending a probe;
@@ -89,6 +90,15 @@ public sealed class FixpSession : IAsyncDisposable
     /// <c>SessionRegistry</c> backed by authentication.</summary>
     public ContractsSessionId Identity { get; }
     public bool IsOpen => Volatile.Read(ref _isOpen) == 1 && _transport.IsOpen;
+
+    /// <summary>
+    /// True while the session has a live <see cref="TcpTransport"/> attached.
+    /// Set to false on transport-driven disconnect (issue #69). The session
+    /// itself remains in the registry — see <see cref="State"/>; only re-attach
+    /// (issue #69b) brings this back to true. Distinct from
+    /// <see cref="IsOpen"/>, which also goes false on terminal Close.
+    /// </summary>
+    public bool IsAttached => Volatile.Read(ref _isAttached) == 1;
 
     /// <summary>
     /// Current FIXP lifecycle state. Mutated only via <see cref="ApplyTransition"/>,
@@ -147,13 +157,14 @@ public sealed class FixpSession : IAsyncDisposable
             throw new ArgumentException(
                 "sessionClaims is required when negotiationValidator is supplied",
                 nameof(sessionClaims));
-        // The transport's onClose callback funnels back through our Close so
-        // session-level book-keeping (sink notification, onClosed delegate)
-        // runs even when teardown originates from a transport-side IO error.
+        // The transport's onClose callback funnels back through our
+        // OnTransportClosed handler so transport-driven teardown can be
+        // demoted to a Suspend (preserving the FIXP session) when we are
+        // in Established state per spec §4.5 (issue #69).
         _transport = new TcpTransport(connectionId, stream,
             transportLogger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TcpTransport>.Instance,
             sendQueueCapacity,
-            onClose: reason => Close(reason));
+            onClose: reason => OnTransportClosed(reason));
         Volatile.Write(ref _lastInboundMs, NowMs());
     }
 
@@ -214,7 +225,10 @@ public sealed class FixpSession : IAsyncDisposable
         }
         finally
         {
-            Close("recv-eof");
+            // Transport-side EOF: defer to the central handler so the
+            // Established → Suspended demotion (issue #69) is observed
+            // identically to a transport-callback-driven teardown.
+            OnTransportClosed("recv-eof");
         }
     }
 
@@ -908,6 +922,74 @@ public sealed class FixpSession : IAsyncDisposable
     public void Close() => Close("close");
 
     /// <summary>
+    /// Routes a transport-side teardown (network IO error, EOF, or
+    /// transport-initiated close) into either a session-preserving
+    /// <see cref="Suspend"/> (when we are <see cref="FixpState.Established"/>
+    /// per spec §4.5 / issue #69) or a full <see cref="Close"/>. Idempotent
+    /// — multiple callers (transport callback, receive-loop finally, watchdog)
+    /// converge here without repeating side effects.
+    /// </summary>
+    private void OnTransportClosed(string reason)
+    {
+        if (Volatile.Read(ref _isOpen) == 0) return;
+        // Re-entrancy guard: Suspend() itself calls _transport.Close(...),
+        // which will fire this callback a second time. Once we have detached
+        // (or are about to detach), defer to whichever branch already took
+        // ownership rather than escalating to a full Close.
+        if (Volatile.Read(ref _isAttached) == 0) return;
+        if (State == FixpState.Established)
+        {
+            Suspend(reason);
+            return;
+        }
+        Close(reason);
+    }
+
+    /// <summary>
+    /// Demote an <see cref="FixpState.Established"/> session to
+    /// <see cref="FixpState.Suspended"/> after the underlying TCP transport
+    /// has dropped (spec §4.5, issue #69). The session remains registered in
+    /// the <see cref="SessionRegistry"/> and retains its claim so that a
+    /// subsequent <c>Establish</c> on a brand-new transport (issue #69b) can
+    /// re-attach without re-Negotiate. The dispatch / watchdog loops are
+    /// stopped via <c>_cts.Cancel()</c>; a future re-attach will start fresh
+    /// loops bound to the new transport.
+    /// </summary>
+    public void Suspend(string reason)
+    {
+        // Atomically flip the attachment flag; second caller is a no-op.
+        if (Interlocked.Exchange(ref _isAttached, 0) == 0) return;
+        _logger.LogInformation("fixp session {ConnectionId} suspending (reason={Reason})",
+            ConnectionId, reason);
+        var action = ApplyTransition(FixpEvent.Detach);
+        if (action != FixpAction.Accept || State != FixpState.Suspended)
+        {
+            // State machine refused the demotion (e.g. we were already past
+            // Established when the transport died). Fall back to Close so we
+            // don't leave a half-broken session registered.
+            _logger.LogInformation(
+                "fixp session {ConnectionId} suspend declined (state={State} action={Action}); closing instead",
+                ConnectionId, State, action);
+            Close(reason);
+            return;
+        }
+        // Tear down the dead transport + cancel loops. Claim/registration are
+        // intentionally retained for re-attach. We do NOT call
+        // _sink.OnSessionClosed nor _onClosed because, from the engine's
+        // and the listener's perspective, the FIXP session is still alive.
+        try { _cts.Cancel(); } catch { }
+        try { _transport.Close(reason); } catch { }
+        // Dispose the dead NetworkStream/socket explicitly. Otherwise the
+        // suspended session keeps the underlying file descriptor open until
+        // re-attach (issue #69b) swaps in a new transport, or until GC
+        // finalizes the stream — under repeated client reconnects this would
+        // leak FDs. The stream owns its socket (NetworkStream(sock,
+        // ownsSocket:true) in EntryPointListener), so disposing it closes
+        // the socket too. Re-attach will install a fresh stream.
+        try { _transport.Stream.Dispose(); } catch { }
+    }
+
+    /// <summary>
     /// Closes the session with a diagnostic reason. The reason is forwarded to
     /// the optional <c>onClosed</c> callback supplied at construction so the
     /// listener (or tests) can log it. <see cref="Close()"/> is the
@@ -916,6 +998,7 @@ public sealed class FixpSession : IAsyncDisposable
     public void Close(string reason)
     {
         if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
+        Volatile.Write(ref _isAttached, 0);
         _logger.LogInformation("fixp session {ConnectionId} closing", ConnectionId);
         try { _cts.Cancel(); } catch { }
         // The transport may have already closed (it's the source of the

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #69 (part 1 — "Suspended state plumbing"): when the underlying
+/// TCP transport drops while the FIXP session is <see cref="FixpState.Established"/>,
+/// the session must transition to <see cref="FixpState.Suspended"/> instead
+/// of being torn down. The session must remain alive (so a future Establish
+/// on a new transport — issue #69b — can re-attach) and its claim must NOT
+/// be released. The legacy code path (transport drop while still
+/// <see cref="FixpState.Idle"/>) must continue to fully close the session.
+/// </summary>
+public class FixpSessionSuspendTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public int SessionClosedCalls;
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
+    }
+
+    /// <summary>
+    /// Bring up a connected (server-side, client-side) <see cref="NetworkStream"/>
+    /// pair via a loopback TCP listener so we can drive the FIXP session with
+    /// real socket semantics — including <c>EOF</c> when the client side
+    /// closes — without needing the full handshake encoders.
+    /// </summary>
+    private static async Task<(TcpListener tcp, NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        return (tcp, new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    [Fact]
+    public async Task TransportDrop_WhileEstablished_DemotesToSuspended_NotClose()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new NoOpEngineSink();
+            int onClosedCalls = 0;
+            var session = new FixpSession(
+                connectionId: 42, enteringFirm: 7, sessionId: 100,
+                stream: serverStream, sink: sink,
+                logger: NullLogger<FixpSession>.Instance,
+                onClosed: (_, _) => Interlocked.Increment(ref onClosedCalls));
+            session.Start();
+
+            // Drive state to Established without going through the full
+            // handshake (test seam — ApplyTransition is internal). The
+            // sequence Idle→Negotiated→Established matches what a real
+            // Negotiate + Establish exchange would produce.
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+            Assert.Equal(FixpState.Established, session.State);
+
+            // Drop the client side: the receive loop will hit EOF and our
+            // OnTransportClosed handler should demote rather than close.
+            client.Close();
+
+            // Wait for the receive loop to observe EOF and run its finally.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+            while (session.IsAttached && DateTime.UtcNow < deadline)
+                await Task.Delay(20);
+
+            Assert.False(session.IsAttached);
+            Assert.Equal(FixpState.Suspended, session.State);
+            // No Close-side hooks fired — the session is preserved.
+            Assert.Equal(0, Volatile.Read(ref onClosedCalls));
+            Assert.Equal(0, Volatile.Read(ref sink.SessionClosedCalls));
+            // IsOpen is false because the transport is down, so any stray
+            // Write*-style call early-returns instead of throwing.
+            Assert.False(session.IsOpen);
+
+            // Clean up the suspended session for the test.
+            session.Close("test-cleanup");
+        }
+        finally
+        {
+            client.Dispose();
+            serverStream.Dispose();
+            tcp.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task TransportDrop_WhileIdle_StillFullyCloses()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new NoOpEngineSink();
+            int onClosedCalls = 0;
+            var session = new FixpSession(
+                connectionId: 43, enteringFirm: 7, sessionId: 101,
+                stream: serverStream, sink: sink,
+                logger: NullLogger<FixpSession>.Instance,
+                onClosed: (_, _) => Interlocked.Increment(ref onClosedCalls));
+            session.Start();
+
+            client.Close();
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+            // Wait for IsOpen to flip false AND onClosed callback to fire.
+            // IsOpen becomes false the instant Close() flips _isOpen, but
+            // _onClosed is invoked a few statements later — poll on the
+            // callback counter to avoid a benign race.
+            while ((session.IsOpen || Volatile.Read(ref onClosedCalls) == 0)
+                && DateTime.UtcNow < deadline)
+                await Task.Delay(20);
+
+            Assert.False(session.IsOpen);
+            Assert.False(session.IsAttached);
+            // State machine has no Idle→<Detach>→Suspended transition; the
+            // legacy Close path runs instead, so onClosed + sink hooks fire.
+            Assert.NotEqual(FixpState.Suspended, session.State);
+            Assert.Equal(1, Volatile.Read(ref onClosedCalls));
+            Assert.Equal(1, Volatile.Read(ref sink.SessionClosedCalls));
+        }
+        finally
+        {
+            client.Dispose();
+            serverStream.Dispose();
+            tcp.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Scope (narrow — part 1 of 3)

When the TCP transport drops while the FIXP session is in **Established** state, demote it to **Suspended** instead of running the full Close path. The session, claim, and registry entry are retained so a future Establish on a new transport can re-attach.

This is sub-PR 1 of 3 splitting #69:

- **#69a (this PR)**: Established → Suspended demotion + transport teardown.
- **#69b (next)**: Re-attach via Establish on a new TCP connection.
- **#69c (=#46)**: Retransmission buffer + replay with EventIndicator.PossResend=1.

## Implementation

- New `FixpSession.IsAttached` / `_isAttached` attachment flag.
- New `OnTransportClosed(reason)` router replaces direct `Close()` calls from the receive-loop finally and the transport onClose callback. Re-entrancy-safe via the `_isAttached` guard (Suspend's own `_transport.Close` re-fires onClose; the guard prevents escalation).
- `Suspend(reason)`: atomic detach, `ApplyTransition(Detach)`, `_cts.Cancel`, close transport, **dispose** the dead NetworkStream/socket. Does NOT release claim, fire `OnSessionClosed`, or invoke `onClosed`.
- `Close()` defensively writes `_isAttached=0`.

## Why dispose the stream?

`TcpTransport.Close` only marks the transport closed; it does not own the stream. Without explicit `Stream.Dispose()` in Suspend, the suspended session would keep the underlying FD open until reattach swaps in a new transport — a code-review pass flagged this as an FD leak risk under repeated client reconnects. Fixed by disposing the stream at suspend time (it owns its socket via `NetworkStream(sock, ownsSocket: true)`).

## Tests

- `TransportDrop_WhileEstablished_DemotesToSuspended_NotClose`: real TCP loopback pair, drops client mid-Established, asserts `Suspended` state and that `OnSessionClosed`/`onClosed` never fire.
- `TransportDrop_WhileIdle_StillFullyCloses`: same setup pre-Establish, asserts the legacy Close path runs (state machine has no Idle+Detach transition, so the demotion declines and falls back to Close).

## Known limitation (acceptable for sub-PR)

Suspended sessions sit in the registry indefinitely without a reaper. This is the entire point of the sub-PR — re-attach (#69b) and Phase-4 CoD timer will reclaim them. Documented for awareness.

Refs #69 (part 1; reattach in #69b, replay in #46).

