### PR TITLE
Issue #69b-1: Suspended-session reaper + WaitUntilAsync test helper

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -30,6 +30,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
+    private Task? _reaperTask;
     private long _nextConnectionId;
     private readonly List<FixpSession> _sessions = new();
     private readonly object _lock = new();
@@ -102,6 +103,75 @@ public sealed class EntryPointListener : IAsyncDisposable
         _listener.Start();
         _logger.LogInformation("entrypoint listener bound to {Endpoint}", _listener.LocalEndpoint);
         _acceptTask = Task.Run(() => RunAcceptLoopAsync(_cts.Token));
+        if (_sessionOptions.SuspendedTimeoutMs > 0)
+            _reaperTask = Task.Run(() => RunSuspendedReaperAsync(_cts.Token));
+    }
+
+    /// <summary>
+    /// Periodically scans <see cref="_sessions"/> for FIXP sessions that
+    /// have been in <see cref="FixpState.Suspended"/> longer than
+    /// <see cref="FixpSessionOptions.SuspendedTimeoutMs"/> and fully closes
+    /// them. Without this, every transport drop while Established (issue
+    /// #69a) leaves the session, its claim, and the engine's order-owner
+    /// reference rooted in memory until process exit. The full re-attach
+    /// machinery (#69b-2) will move long-lived suspended sessions back to
+    /// Established before the reaper fires.
+    /// </summary>
+    private async Task RunSuspendedReaperAsync(CancellationToken ct)
+    {
+        // Poll often enough to honor the timeout within ~10% latency, but
+        // never busy-loop and never sleep longer than 30 s in production
+        // configurations. Floor 50 ms keeps the test suite fast when
+        // tests set SuspendedTimeoutMs to e.g. 200 ms.
+        var timeoutMs = _sessionOptions.SuspendedTimeoutMs;
+        var pollMs = Math.Max(50, Math.Min(timeoutMs / 4, 30_000));
+        var poll = TimeSpan.FromMilliseconds(pollMs);
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try { await Task.Delay(poll, ct).ConfigureAwait(false); }
+                catch (OperationCanceledException) { return; }
+                ReapSuspendedOnce(Environment.TickCount64);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "suspended-session reaper terminated unexpectedly");
+        }
+    }
+
+    /// <summary>
+    /// Single pass of the suspended-session reaper: fully closes any
+    /// session whose <see cref="FixpSession.SuspendedSinceMs"/> is older
+    /// than <see cref="FixpSessionOptions.SuspendedTimeoutMs"/>. Exposed
+    /// internally so tests can drive the reaper deterministically without
+    /// waiting for the Timer-based loop.
+    /// </summary>
+    internal void ReapSuspendedOnce(long nowMs)
+    {
+        var timeoutMs = _sessionOptions.SuspendedTimeoutMs;
+        if (timeoutMs <= 0) return;
+        FixpSession[] snapshot;
+        lock (_lock) snapshot = _sessions.ToArray();
+        foreach (var s in snapshot)
+        {
+            var since = s.SuspendedSinceMs;
+            if (since is null) continue;
+            // Defensive: only reap sessions that are still formally
+            // Suspended. A concurrent re-attach (#69b-2) will clear
+            // SuspendedSinceMs before we re-check.
+            if (s.State != FixpState.Suspended) continue;
+            if (nowMs - since.Value < timeoutMs) continue;
+            _logger.LogInformation(
+                "reaping suspended session {ConnectionId} sessionId={SessionId} (suspended for {AgeMs}ms, timeout={TimeoutMs}ms)",
+                s.ConnectionId, s.SessionId, nowMs - since.Value, timeoutMs);
+            try { s.Close("suspended-timeout"); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "reaper failed to close session {ConnectionId}", s.ConnectionId);
+            }
+        }
     }
 
     private async Task RunAcceptLoopAsync(CancellationToken ct)
@@ -155,6 +225,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         try { _cts.Cancel(); } catch { }
         try { _listener?.Stop(); } catch { }
         if (_acceptTask != null) { try { await _acceptTask.ConfigureAwait(false); } catch { } }
+        if (_reaperTask != null) { try { await _reaperTask.ConfigureAwait(false); } catch { } }
         FixpSession[] toClose;
         lock (_lock) { toClose = _sessions.ToArray(); _sessions.Clear(); }
         foreach (var s in toClose) await s.DisposeAsync().ConfigureAwait(false);

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -92,6 +92,25 @@ public sealed class FixpSession : IAsyncDisposable
     public bool IsOpen => Volatile.Read(ref _isOpen) == 1 && _transport.IsOpen;
 
     /// <summary>
+    /// Wall-clock-ish (Environment.TickCount64) timestamp of the moment the
+    /// session entered <see cref="FixpState.Suspended"/>, or <c>null</c> if
+    /// the session is not currently Suspended. Read by the listener's
+    /// suspended-session reaper to decide whether the session has lingered
+    /// past <see cref="FixpSessionOptions.SuspendedTimeoutMs"/>.
+    /// Set on the dispatch thread inside <see cref="Suspend"/>; cleared
+    /// inside <see cref="Close"/>. Reads use <c>Volatile.Read</c>.
+    /// </summary>
+    public long? SuspendedSinceMs
+    {
+        get
+        {
+            var v = Volatile.Read(ref _suspendedSinceMs);
+            return v == 0 ? null : v;
+        }
+    }
+    private long _suspendedSinceMs;
+
+    /// <summary>
     /// True while the session has a live <see cref="TcpTransport"/> attached.
     /// Set to false on transport-driven disconnect (issue #69). The session
     /// itself remains in the registry — see <see cref="State"/>; only re-attach
@@ -987,6 +1006,9 @@ public sealed class FixpSession : IAsyncDisposable
         // ownsSocket:true) in EntryPointListener), so disposing it closes
         // the socket too. Re-attach will install a fresh stream.
         try { _transport.Stream.Dispose(); } catch { }
+        // Stamp the suspension timestamp last, so the reaper only observes
+        // Suspended sessions whose teardown is fully complete.
+        Volatile.Write(ref _suspendedSinceMs, NowMs());
     }
 
     /// <summary>
@@ -999,6 +1021,9 @@ public sealed class FixpSession : IAsyncDisposable
     {
         if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
         Volatile.Write(ref _isAttached, 0);
+        // Clear the suspended-since timestamp so a concurrent reaper poll
+        // doesn't try to re-Close a session that's already terminal.
+        Volatile.Write(ref _suspendedSinceMs, 0);
         _logger.LogInformation("fixp session {ConnectionId} closing", ConnectionId);
         try { _cts.Cancel(); } catch { }
         // The transport may have already closed (it's the source of the

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -12,15 +12,22 @@ namespace B3.Exchange.Gateway;
 ///     TestRequest) and starts a grace timer of
 ///     <see cref="TestRequestGraceMs"/>; if no inbound arrives in that grace
 ///     window the connection is closed.
+///   - <see cref="SuspendedTimeoutMs"/> caps how long a Suspended session
+///     (transport dropped, awaiting re-attach in #69b) remains in the
+///     listener's session list before being fully closed by the reaper.
+///     Set to <c>0</c> to disable the reaper (tests sometimes do this to
+///     assert pure suspension behavior without timeout interference).
 ///
-/// Defaults match the issue (#9) spec: 30 s heartbeat, 30 s idle, 5 s grace.
-/// Tests override with sub-second values to keep the suite fast.
+/// Defaults match the issue (#9) spec: 30 s heartbeat, 30 s idle, 5 s grace,
+/// 5 min suspended-session reap. Tests override with sub-second values to
+/// keep the suite fast.
 /// </summary>
 public sealed record FixpSessionOptions
 {
     public int HeartbeatIntervalMs { get; init; } = 30_000;
     public int IdleTimeoutMs { get; init; } = 30_000;
     public int TestRequestGraceMs { get; init; } = 5_000;
+    public int SuspendedTimeoutMs { get; init; } = 5 * 60_000;
 
     public static FixpSessionOptions Default { get; } = new();
 
@@ -29,5 +36,6 @@ public sealed record FixpSessionOptions
         if (HeartbeatIntervalMs <= 0) throw new ArgumentOutOfRangeException(nameof(HeartbeatIntervalMs));
         if (IdleTimeoutMs <= 0) throw new ArgumentOutOfRangeException(nameof(IdleTimeoutMs));
         if (TestRequestGraceMs <= 0) throw new ArgumentOutOfRangeException(nameof(TestRequestGraceMs));
+        if (SuspendedTimeoutMs < 0) throw new ArgumentOutOfRangeException(nameof(SuspendedTimeoutMs));
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
@@ -1,0 +1,193 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #69b-1: <see cref="EntryPointListener"/> must reap FIXP sessions
+/// that have lingered in <see cref="FixpState.Suspended"/> beyond
+/// <see cref="FixpSessionOptions.SuspendedTimeoutMs"/>. Without this, every
+/// transport drop while Established (#69a) leaks the session, its claim,
+/// and the engine sink reference until process exit. The reaper exists
+/// as a stop-gap; #69b-2 (re-attach) is expected to recover most
+/// suspended sessions before the timeout fires.
+/// </summary>
+public class EntryPointListenerReaperTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public int SessionClosedCalls;
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
+    }
+
+    /// <summary>
+    /// Stand up a listener, accept one client, return the resulting
+    /// <see cref="FixpSession"/> driven to <see cref="FixpState.Suspended"/>
+    /// by closing the client transport while we have already nudged the
+    /// state machine to Established (test seam — <c>ApplyTransition</c>
+    /// is internal so we don't need to wire the full Negotiate+Establish
+    /// handshake just to exercise the reaper).
+    /// </summary>
+    private static async Task<(EntryPointListener listener, NoOpEngineSink sink, TcpClient client, FixpSession session, List<string> closures)>
+        SetupSuspendedSessionAsync(int suspendedTimeoutMs)
+    {
+        var sink = new NoOpEngineSink();
+        var closures = new List<string>();
+        var options = new FixpSessionOptions
+        {
+            HeartbeatIntervalMs = 60_000,
+            IdleTimeoutMs = 60_000,
+            TestRequestGraceMs = 60_000,
+            SuspendedTimeoutMs = suspendedTimeoutMs,
+        };
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            sink,
+            NullLoggerFactory.Instance,
+            sessionOptions: options,
+            onSessionClosed: (_, reason) => { lock (closures) closures.Add(reason); });
+        listener.Start();
+
+        var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, listener.LocalEndpoint!.Port);
+
+        // Wait for the listener's accept loop to register the session.
+        var registered = await TestUtil.WaitUntilAsync(
+            () => listener.ActiveSessions.Count == 1,
+            TimeSpan.FromSeconds(2));
+        Assert.True(registered, "listener never registered the accepted session");
+        var session = listener.ActiveSessions[0];
+
+        // Drive state to Established, then drop client → recv loop EOF →
+        // OnTransportClosed → Suspend.
+        session.ApplyTransition(FixpEvent.Negotiate);
+        session.ApplyTransition(FixpEvent.Establish);
+        Assert.Equal(FixpState.Established, session.State);
+        client.Close();
+        var suspended = await TestUtil.WaitUntilAsync(
+            () => session.State == FixpState.Suspended && session.SuspendedSinceMs is not null,
+            TimeSpan.FromSeconds(2));
+        Assert.True(suspended, $"session never became Suspended (state={session.State})");
+        return (listener, sink, client, session, closures);
+    }
+
+    [Fact]
+    public async Task Reaper_ClosesSession_WhenSuspendedLongerThanTimeout()
+    {
+        var (listener, sink, client, session, closures) = await SetupSuspendedSessionAsync(suspendedTimeoutMs: 200);
+        try
+        {
+            // Background reaper polls every ~50ms (floor) at 200ms timeout,
+            // so it should observe the session past timeout within ~250ms.
+            var reaped = await TestUtil.WaitUntilAsync(
+                () => !session.IsOpen && session.SuspendedSinceMs is null,
+                TimeSpan.FromSeconds(2));
+            Assert.True(reaped, "reaper did not close the suspended session within 2s");
+            Assert.Equal(1, Volatile.Read(ref sink.SessionClosedCalls));
+            lock (closures)
+            {
+                Assert.Single(closures);
+                Assert.Equal("suspended-timeout", closures[0]);
+            }
+            // Listener must remove the closed session from its tracking list.
+            Assert.DoesNotContain(session, listener.ActiveSessions);
+        }
+        finally
+        {
+            client.Dispose();
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Reaper_DoesNotClose_BeforeTimeout()
+    {
+        // Long timeout so the background loop never fires during the test.
+        var (listener, sink, client, session, closures) = await SetupSuspendedSessionAsync(suspendedTimeoutMs: 60_000);
+        try
+        {
+            // Drive one synchronous reaper pass with the actual current
+            // tick: should be a no-op because the session has been
+            // suspended for a few ms only.
+            listener.ReapSuspendedOnce(Environment.TickCount64);
+            Assert.True(session.IsOpen || session.State == FixpState.Suspended);
+            Assert.Equal(0, Volatile.Read(ref sink.SessionClosedCalls));
+            Assert.Empty(closures);
+        }
+        finally
+        {
+            client.Dispose();
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Reaper_DoesNotTouch_NonSuspendedSessions()
+    {
+        var sink = new NoOpEngineSink();
+        var closures = new List<string>();
+        var options = new FixpSessionOptions
+        {
+            HeartbeatIntervalMs = 60_000,
+            IdleTimeoutMs = 60_000,
+            TestRequestGraceMs = 60_000,
+            SuspendedTimeoutMs = 100,
+        };
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            sink,
+            NullLoggerFactory.Instance,
+            sessionOptions: options,
+            onSessionClosed: (_, reason) => { lock (closures) closures.Add(reason); });
+        listener.Start();
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, listener.LocalEndpoint!.Port);
+        await TestUtil.WaitUntilAsync(() => listener.ActiveSessions.Count == 1, TimeSpan.FromSeconds(2));
+        var session = listener.ActiveSessions[0];
+
+        // Session is Idle (never suspended). Sleep past the suspend
+        // timeout; the background reaper must NOT touch it.
+        await Task.Delay(400);
+        Assert.True(session.IsOpen);
+        Assert.Equal(FixpState.Idle, session.State);
+        Assert.Equal(0, Volatile.Read(ref sink.SessionClosedCalls));
+        Assert.Empty(closures);
+    }
+
+    [Fact]
+    public async Task ReaperDisabled_WhenSuspendedTimeoutMsIsZero()
+    {
+        // SuspendedTimeoutMs=0 must skip starting the reaper Task and skip
+        // the synchronous pass entirely. This is the "preserve forever"
+        // mode used by tests that want pure suspend semantics.
+        var (listener, sink, client, session, closures) = await SetupSuspendedSessionAsync(suspendedTimeoutMs: 0);
+        try
+        {
+            // Even past a generous wait, no reap.
+            await Task.Delay(300);
+            Assert.False(session.IsOpen); // transport is down (Suspended)
+            Assert.Equal(FixpState.Suspended, session.State);
+            Assert.NotNull(session.SuspendedSinceMs);
+            Assert.Equal(0, Volatile.Read(ref sink.SessionClosedCalls));
+            Assert.Empty(closures);
+            // Direct call must also be a no-op.
+            listener.ReapSuspendedOnce(long.MaxValue);
+            Assert.NotNull(session.SuspendedSinceMs);
+            Assert.Equal(0, Volatile.Read(ref sink.SessionClosedCalls));
+        }
+        finally
+        {
+            client.Dispose();
+            await listener.DisposeAsync();
+        }
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
@@ -73,9 +73,7 @@ public class FixpSessionSuspendTests
             client.Close();
 
             // Wait for the receive loop to observe EOF and run its finally.
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
-            while (session.IsAttached && DateTime.UtcNow < deadline)
-                await Task.Delay(20);
+            await TestUtil.WaitUntilAsync(() => !session.IsAttached, TimeSpan.FromSeconds(3));
 
             Assert.False(session.IsAttached);
             Assert.Equal(FixpState.Suspended, session.State);
@@ -114,14 +112,13 @@ public class FixpSessionSuspendTests
 
             client.Close();
 
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
             // Wait for IsOpen to flip false AND onClosed callback to fire.
             // IsOpen becomes false the instant Close() flips _isOpen, but
             // _onClosed is invoked a few statements later — poll on the
             // callback counter to avoid a benign race.
-            while ((session.IsOpen || Volatile.Read(ref onClosedCalls) == 0)
-                && DateTime.UtcNow < deadline)
-                await Task.Delay(20);
+            await TestUtil.WaitUntilAsync(
+                () => !session.IsOpen && Volatile.Read(ref onClosedCalls) > 0,
+                TimeSpan.FromSeconds(3));
 
             Assert.False(session.IsOpen);
             Assert.False(session.IsAttached);

--- a/tests/B3.Exchange.Gateway.Tests/TestUtil.cs
+++ b/tests/B3.Exchange.Gateway.Tests/TestUtil.cs
@@ -1,0 +1,56 @@
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Shared helpers for Gateway test polling. Centralizes the "spin until
+/// predicate or timeout" pattern so individual tests don't reinvent it
+/// (and don't subtly diverge on poll intervals or fail-mode behavior).
+/// </summary>
+internal static class TestUtil
+{
+    /// <summary>
+    /// Polls <paramref name="predicate"/> until it returns true or
+    /// <paramref name="timeout"/> elapses. Returns true if the predicate
+    /// became true within the window; false if the timeout fired first.
+    /// Callers typically follow the call with an Assert on the returned
+    /// boolean (or on the same condition the predicate observed) so the
+    /// failure message includes the actual offending state.
+    /// </summary>
+    /// <param name="poll">Optional poll interval. Defaults to 20 ms which
+    /// is short enough for sub-second timeouts typical in Gateway tests
+    /// without busy-spinning.</param>
+    public static async Task<bool> WaitUntilAsync(
+        Func<bool> predicate,
+        TimeSpan timeout,
+        TimeSpan? poll = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var pollInterval = poll ?? TimeSpan.FromMilliseconds(20);
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate()) return true;
+            await Task.Delay(pollInterval).ConfigureAwait(false);
+        }
+        return predicate();
+    }
+
+    /// <summary>
+    /// Async-predicate variant. Useful when the wait condition itself
+    /// requires awaiting (e.g., pulling a counter from a shared sink).
+    /// </summary>
+    public static async Task<bool> WaitUntilAsync(
+        Func<Task<bool>> predicate,
+        TimeSpan timeout,
+        TimeSpan? poll = null)
+    {
+        ArgumentNullException.ThrowIfNull(predicate);
+        var pollInterval = poll ?? TimeSpan.FromMilliseconds(20);
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await predicate().ConfigureAwait(false)) return true;
+            await Task.Delay(pollInterval).ConfigureAwait(false);
+        }
+        return await predicate().ConfigureAwait(false);
+    }
+}


### PR DESCRIPTION
## Why

PR #86 (#69a) introduced the FIXP `Suspended` state, which retains the `FixpSession` + claim + engine sink reference indefinitely on transport drop. Without a reaper this is a slow leak: every client reconnect storm grows the listener's session list and the engine's order-owner map without bound.

The full re-attach machinery (originally #69b) is being deferred to **#69b-2** because it requires:
- a per-connection first-frame router (Architecture A, to avoid blocking the accept loop),
- a `TryReattach` gate that races with this reaper,
- pipelined `Establish + NewOrder` test coverage,
- simultaneous-rebind / hijack-denial coverage.

This PR ships the reaper alone so the leak introduced by #69a is **capped immediately** and #69b-2 can land as a clean reattach-only diff.

## Changes

- `FixpSessionOptions.SuspendedTimeoutMs` (default 5min; 0 disables the reaper for tests that want pure suspend semantics).
- `FixpSession.SuspendedSinceMs` (long?) — set inside `Suspend()` **after** the transport teardown is fully complete (`cts.Cancel`, `transport.Close`, `Stream.Dispose`), cleared in `Close()` so concurrent reaper polls observe a coherent snapshot.
- `EntryPointListener.RunSuspendedReaperAsync` + `internal ReapSuspendedOnce(long nowMs)` — background Task polling every `Math.Max(50, Math.Min(timeout/4, 30_000))`ms; production timeout=5min → 30s poll; test timeout=200ms → 50ms poll. Disabled when `SuspendedTimeoutMs<=0`.
- Awaits the reaper task in `DisposeAsync`.

## Test helpers (process retro: deflake polling loops)

- `tests/B3.Exchange.Gateway.Tests/TestUtil.WaitUntilAsync` (sync- and async-predicate variants) replaces ad-hoc `DateTime.UtcNow` polling loops.
- Refactored 2 polling loops in `FixpSessionSuspendTests` to use it.

## Tests added (4)

- `Reaper_ClosesSession_WhenSuspendedLongerThanTimeout` — full happy path.
- `Reaper_DoesNotClose_BeforeTimeout` — direct `ReapSuspendedOnce` call with current tick is a no-op when session is fresh.
- `Reaper_DoesNotTouch_NonSuspendedSessions` — Idle session past the timeout window stays alive.
- `ReaperDisabled_WhenSuspendedTimeoutMsIsZero` — reaper Task is not started, direct call is a no-op.

163 Gateway / 326 total tests pass; format clean; reaper tests flake-checked 5x consecutively.

Refs #69 (part 1.5/3 — reaper before re-attach in #69b-2; replay in #46).
