### PR TITLE
gateway: rebind transport to Suspended FixpSession on new TCP (#69b-2)

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -152,21 +152,24 @@ public sealed class EntryPointListener : IAsyncDisposable
     {
         var timeoutMs = _sessionOptions.SuspendedTimeoutMs;
         if (timeoutMs <= 0) return;
+        var thresholdMs = nowMs - timeoutMs;
         FixpSession[] snapshot;
         lock (_lock) snapshot = _sessions.ToArray();
         foreach (var s in snapshot)
         {
-            var since = s.SuspendedSinceMs;
-            if (since is null) continue;
-            // Defensive: only reap sessions that are still formally
-            // Suspended. A concurrent re-attach (#69b-2) will clear
-            // SuspendedSinceMs before we re-check.
-            if (s.State != FixpState.Suspended) continue;
-            if (nowMs - since.Value < timeoutMs) continue;
-            _logger.LogInformation(
-                "reaping suspended session {ConnectionId} sessionId={SessionId} (suspended for {AgeMs}ms, timeout={TimeoutMs}ms)",
-                s.ConnectionId, s.SessionId, nowMs - since.Value, timeoutMs);
-            try { s.Close("suspended-timeout"); }
+            // Per-session atomic reap: the session re-validates state
+            // and SuspendedSinceMs under its own _attachLock so a
+            // concurrent re-attach (#69b-2) racing the reap cannot lose
+            // the connection.
+            try
+            {
+                if (s.TryReapIfSuspended(thresholdMs))
+                {
+                    _logger.LogInformation(
+                        "reaped suspended session {ConnectionId} sessionId={SessionId} (timeout={TimeoutMs}ms)",
+                        s.ConnectionId, s.SessionId, timeoutMs);
+                }
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "reaper failed to close session {ConnectionId}", s.ConnectionId);
@@ -186,30 +189,12 @@ public sealed class EntryPointListener : IAsyncDisposable
                 catch (ObjectDisposedException) { return; }
 
                 sock.NoDelay = true;
-                var identity = _identityFactory(sock.RemoteEndPoint);
-                _logger.LogInformation("accepted connection {ConnectionId} from {Remote} sessionId={SessionId}",
-                    identity.ConnectionId, sock.RemoteEndPoint, identity.SessionId);
-                var stream = new NetworkStream(sock, ownsSocket: true);
-
-                // Wrap onClosed to remove session from _sessions (so the
-                // disconnected FixpSession + its NetworkStream/Socket
-                // become GC-eligible) before invoking the external callback.
-                Action<FixpSession, string> onClosed = (s, reason) =>
-                {
-                    _registry.Deregister(s);
-                    lock (_lock) _sessions.Remove(s);
-                    _onSessionClosed?.Invoke(s, reason);
-                };
-
-                var session = new FixpSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
-                    stream, _sink, _loggerFactory.CreateLogger<FixpSession>(),
-                    options: _sessionOptions, onClosed: onClosed,
-                    negotiationValidator: _negotiationValidator,
-                    sessionClaims: _sessionClaims,
-                    establishValidator: _establishValidator);
-                _registry.Register(session);
-                lock (_lock) _sessions.Add(session);
-                session.Start();
+                // Per-connection task: parses the first frame to decide
+                // re-attach (#69b-2) vs new session, with a hard timeout
+                // (FirstFrameTimeoutMs) so a slowloris client cannot pin
+                // an accept slot indefinitely. We deliberately do NOT
+                // await this — accept must remain responsive.
+                _ = Task.Run(() => HandleAcceptedConnectionAsync(sock, ct));
             }
         }
         catch (OperationCanceledException) { }
@@ -217,6 +202,169 @@ public sealed class EntryPointListener : IAsyncDisposable
         {
             _logger.LogError(ex, "entrypoint accept loop terminated unexpectedly");
         }
+    }
+
+    /// <summary>
+    /// Per-connection handler: reads exactly one FIXP frame from the
+    /// new socket (within <see cref="FixpSessionOptions.FirstFrameTimeoutMs"/>),
+    /// inspects its templateId, and either re-attaches to an existing
+    /// <see cref="FixpSession"/> or constructs a new one with the
+    /// already-consumed bytes prepended to the stream.
+    /// </summary>
+    private async Task HandleAcceptedConnectionAsync(Socket sock, CancellationToken ct)
+    {
+        NetworkStream stream;
+        try { stream = new NetworkStream(sock, ownsSocket: true); }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "failed to wrap accepted socket; closing");
+            try { sock.Dispose(); } catch { }
+            return;
+        }
+
+        // Legacy / no-rebind mode: there are no session claims to consult,
+        // so the first-frame router has nothing to do. Construct the
+        // FixpSession eagerly around the raw stream as in the pre-#69b
+        // listener — this preserves test ergonomics that assert
+        // ActiveSessions.Count grows immediately on TCP accept (the
+        // ApplyTransition seam in EntryPointListenerReaperTests / the
+        // wire-driven heartbeat tests rely on this).
+        if (_sessionClaims is null)
+        {
+            ConstructAndStartSession(stream, sock, firstFrame: null);
+            return;
+        }
+
+        // Read the first frame under a strict per-connection timeout.
+        byte[] firstFrame;
+        ushort templateId;
+        try
+        {
+            using var firstFrameCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            firstFrameCts.CancelAfter(_sessionOptions.FirstFrameTimeoutMs);
+            (firstFrame, templateId) = await ReadFirstFrameAsync(stream, firstFrameCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation(
+                "first-frame timeout from {Remote}; closing socket",
+                SafeRemote(sock));
+            try { stream.Dispose(); } catch { }
+            return;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogInformation(ex,
+                "failed to read first frame from {Remote}; closing socket",
+                SafeRemote(sock));
+            try { stream.Dispose(); } catch { }
+            return;
+        }
+
+        // Re-attach decision: only meaningful when the first message is
+        // an Establish targeting an already-claimed sessionId currently
+        // held by a Suspended FixpSession with matching SessionVerId.
+        if (templateId == EntryPointFrameReader.TidEstablish
+            && firstFrame.Length >= EntryPointFrameReader.WireHeaderSize + EstablishDecoder.BlockLength
+            && EstablishDecoder.TryDecode(
+                firstFrame.AsSpan(EntryPointFrameReader.WireHeaderSize, EstablishDecoder.BlockLength),
+                out var req, out _))
+        {
+            if (_sessionClaims.TryGetActiveClaim(req.SessionId, out var holder, out var lastVerId)
+                && holder is FixpSession existing
+                && existing.SessionVerId == req.SessionVerId
+                && req.SessionVerId == lastVerId
+                && existing.State == FixpState.Suspended)
+            {
+                var prepended = new PrependedStream(firstFrame, stream);
+                if (existing.TryReattach(prepended))
+                {
+                    _logger.LogInformation(
+                        "re-attached transport to existing session {ConnectionId} (sessionId={SessionId} from {Remote})",
+                        existing.ConnectionId, existing.SessionId, SafeRemote(sock));
+                    return;
+                }
+                _logger.LogInformation(
+                    "re-attach raced and lost for sessionId={SessionId} from {Remote}; closing new socket",
+                    req.SessionId, SafeRemote(sock));
+                try { prepended.Dispose(); } catch { }
+                return;
+            }
+        }
+
+        ConstructAndStartSession(stream, sock, firstFrame);
+    }
+
+    private void ConstructAndStartSession(NetworkStream stream, Socket sock, byte[]? firstFrame)
+    {
+        var identity = _identityFactory(SafeRemote(sock));
+        _logger.LogInformation("accepted connection {ConnectionId} from {Remote} sessionId={SessionId}",
+            identity.ConnectionId, SafeRemote(sock), identity.SessionId);
+
+        Action<FixpSession, string> onClosed = (s, reason) =>
+        {
+            _registry.Deregister(s);
+            lock (_lock) _sessions.Remove(s);
+            _onSessionClosed?.Invoke(s, reason);
+        };
+
+        Stream sessionStream = firstFrame is null ? stream : new PrependedStream(firstFrame, stream);
+        var session = new FixpSession(identity.ConnectionId, identity.EnteringFirm, identity.SessionId,
+            sessionStream, _sink, _loggerFactory.CreateLogger<FixpSession>(),
+            options: _sessionOptions, onClosed: onClosed,
+            negotiationValidator: _negotiationValidator,
+            sessionClaims: _sessionClaims,
+            establishValidator: _establishValidator);
+        _registry.Register(session);
+        lock (_lock) _sessions.Add(session);
+        session.Start();
+    }
+
+    /// <summary>
+    /// Reads exactly one FIXP frame (SOFH + SBE header + body) from
+    /// <paramref name="stream"/>, returning the raw bytes (so they can be
+    /// replayed via <see cref="PrependedStream"/>) and the parsed
+    /// <c>templateId</c>. Throws <see cref="OperationCanceledException"/>
+    /// on <paramref name="ct"/>.
+    /// </summary>
+    private static async Task<(byte[] frame, ushort templateId)> ReadFirstFrameAsync(Stream stream, CancellationToken ct)
+    {
+        var header = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, header, ct).ConfigureAwait(false);
+        if (!EntryPointFrameReader.TryParseInboundHeader(header, out var info, out _, out _))
+        {
+            // Either malformed or unsupported. Return the header anyway
+            // so the downstream FixpSession can run its own decoder and
+            // emit the proper FIXP error response (Terminate / etc.).
+            return (header, info.TemplateId);
+        }
+        if (info.MessageLength <= EntryPointFrameReader.WireHeaderSize)
+            return (header, info.TemplateId);
+
+        var full = new byte[info.MessageLength];
+        Buffer.BlockCopy(header, 0, full, 0, header.Length);
+        await ReadExactAsync(stream, full.AsMemory(header.Length), ct).ConfigureAwait(false);
+        return (full, info.TemplateId);
+    }
+
+    private static Task ReadExactAsync(Stream stream, byte[] buffer, CancellationToken ct)
+        => ReadExactAsync(stream, buffer.AsMemory(), ct);
+
+    private static async Task ReadExactAsync(Stream stream, Memory<byte> buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer[read..], ct).ConfigureAwait(false);
+            if (n <= 0) throw new EndOfStreamException("peer closed before first frame completed");
+            read += n;
+        }
+    }
+
+    private static EndPoint? SafeRemote(Socket sock)
+    {
+        try { return sock.RemoteEndPoint; }
+        catch { return null; }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -27,16 +27,30 @@ public sealed class FixpSession : IAsyncDisposable
     private const int InboundHeaderSize = EntryPointFrameReader.WireHeaderSize;
     private const int DefaultSendQueueCapacity = 1024;
 
-    private readonly TcpTransport _transport;
+    private TcpTransport _transport;
     private readonly IInboundCommandSink _sink;
     private readonly ILogger<FixpSession> _logger;
-    private readonly CancellationTokenSource _cts = new();
+    private readonly ILogger<TcpTransport> _transportLogger;
+    private readonly int _sendQueueCapacity;
+    private CancellationTokenSource _cts = new();
     private readonly Func<ulong> _nowNanos;
     private readonly FixpSessionOptions _options;
     private readonly Action<FixpSession, string>? _onClosed;
     private readonly NegotiationValidator? _validator;
     private readonly EstablishValidator? _establishValidator;
     private readonly SessionClaimRegistry? _claims;
+    /// <summary>
+    /// Serializes lifecycle transitions: <see cref="Suspend"/>,
+    /// <see cref="Close"/>, and <see cref="TryReattach"/> all hold this
+    /// lock so a concurrent reaper-driven Close can't race a peer-driven
+    /// rebind. The dispatch / receive / watchdog hot paths do NOT take
+    /// the lock; they operate on a captured snapshot of
+    /// <see cref="_transport"/> / <see cref="_cts"/> and tolerate the
+    /// snapshot becoming stale across a re-attach (the old transport's
+    /// Close will exit their loops naturally; new loops are started by
+    /// <see cref="TryReattach"/> bound to the new snapshot).
+    /// </summary>
+    private readonly object _attachLock = new();
     /// <summary>The wire SessionID currently claimed in <see cref="_claims"/>,
     /// or 0 if no claim is held. Tracked so <see cref="Close"/> can
     /// release the claim using the value from the moment the claim was
@@ -165,6 +179,8 @@ public sealed class FixpSession : IAsyncDisposable
         Identity = new ContractsSessionId("conn-" + connectionId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         _sink = sink;
         _logger = logger;
+        _transportLogger = transportLogger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TcpTransport>.Instance;
+        _sendQueueCapacity = sendQueueCapacity;
         _nowNanos = nowNanos ?? DefaultNowNanos;
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
@@ -180,11 +196,24 @@ public sealed class FixpSession : IAsyncDisposable
         // OnTransportClosed handler so transport-driven teardown can be
         // demoted to a Suspend (preserving the FIXP session) when we are
         // in Established state per spec §4.5 (issue #69).
-        _transport = new TcpTransport(connectionId, stream,
-            transportLogger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TcpTransport>.Instance,
-            sendQueueCapacity,
-            onClose: reason => OnTransportClosed(reason));
+        _transport = CreateBoundTransport(stream);
         Volatile.Write(ref _lastInboundMs, NowMs());
+    }
+
+    /// <summary>
+    /// Builds a <see cref="TcpTransport"/> whose <c>onClose</c> callback
+    /// captures the transport instance and forwards it to
+    /// <see cref="OnTransportClosed(string, TcpTransport?)"/> so a stale
+    /// callback from a previous transport generation (post-rebind, see
+    /// <see cref="TryReattach"/>) is ignored instead of tearing down the
+    /// freshly attached session.
+    /// </summary>
+    private TcpTransport CreateBoundTransport(Stream stream)
+    {
+        TcpTransport? bound = null;
+        bound = new TcpTransport(ConnectionId, stream, _transportLogger, _sendQueueCapacity,
+            onClose: reason => OnTransportClosed(reason, bound));
+        return bound;
     }
 
     public void Start()
@@ -203,7 +232,12 @@ public sealed class FixpSession : IAsyncDisposable
 
     private async Task RunReceiveLoopAsync(CancellationToken ct)
     {
-        var stream = _transport.Stream;
+        // Capture the transport this loop is bound to so a stale callback
+        // after a re-attach (#69b-2) can be detected and ignored: a new
+        // recv loop bound to a fresh transport will be the only owner of
+        // the close decision for the new transport.
+        var ownTransport = _transport;
+        var stream = ownTransport.Stream;
         var headerBuf = new byte[InboundHeaderSize];
         try
         {
@@ -246,8 +280,11 @@ public sealed class FixpSession : IAsyncDisposable
         {
             // Transport-side EOF: defer to the central handler so the
             // Established → Suspended demotion (issue #69) is observed
-            // identically to a transport-callback-driven teardown.
-            OnTransportClosed("recv-eof");
+            // identically to a transport-callback-driven teardown. Pass
+            // the captured transport so a stale callback from a previous
+            // generation (post-rebind) is filtered out by
+            // OnTransportClosed.
+            OnTransportClosed("recv-eof", ownTransport);
         }
     }
 
@@ -733,6 +770,13 @@ public sealed class FixpSession : IAsyncDisposable
     /// </summary>
     private async Task RunWatchdogLoopAsync(CancellationToken ct)
     {
+        // Capture the transport this loop is bound to so a stale tick
+        // after a re-attach (#69b-2) can be detected and a teardown
+        // refused. Without this guard, a watchdog from the OLD transport
+        // could complete its Task.Delay just as the cancellation arrives,
+        // observe stale liveness fields, and call Close("idle-timeout")
+        // against the freshly attached session.
+        var ownTransport = _transport;
         // Tick at a fraction of the smallest configured interval so we react
         // promptly without busy-polling. Capped to keep tests responsive.
         int tickMs = Math.Max(1, Math.Min(_options.HeartbeatIntervalMs,
@@ -743,10 +787,13 @@ public sealed class FixpSession : IAsyncDisposable
             {
                 await Task.Delay(tickMs, ct).ConfigureAwait(false);
                 if (!IsOpen) return;
+                // A re-attach replaced the transport this loop was bound
+                // to; surrender to the new watchdog and exit.
+                if (!ReferenceEquals(_transport, ownTransport)) return;
 
                 long now = NowMs();
                 long sinceIn = now - Volatile.Read(ref _lastInboundMs);
-                long sinceOut = now - _transport.LastOutboundTickMs;
+                long sinceOut = now - ownTransport.LastOutboundTickMs;
 
                 // Idle teardown: if a probe is outstanding and grace elapsed
                 // without any inbound, close. The grace clock starts from the
@@ -756,10 +803,11 @@ public sealed class FixpSession : IAsyncDisposable
                 if (sinceIn >= (long)_options.IdleTimeoutMs + _options.TestRequestGraceMs &&
                     Volatile.Read(ref _probeOutstanding) == 1)
                 {
-                    // Seam for issue #11: a future BusinessReject (templateId=206)
-                    // should be enqueued here before close so the peer learns
-                    // the reason. Today we close with a logged reason string.
-                    Close("idle-timeout");
+                    // Generation-aware close: another reattach could have
+                    // raced in between the snapshot above and the close
+                    // call below; CloseIfTransportCurrent re-validates
+                    // under _attachLock.
+                    CloseIfTransportCurrent("idle-timeout", ownTransport);
                     return;
                 }
 
@@ -940,28 +988,51 @@ public sealed class FixpSession : IAsyncDisposable
 
     public void Close() => Close("close");
 
+    private void OnTransportClosed(string reason) => OnTransportClosed(reason, originatingTransport: null);
+
     /// <summary>
-    /// Routes a transport-side teardown (network IO error, EOF, or
-    /// transport-initiated close) into either a session-preserving
+    /// Routes a transport-side teardown into either a session-preserving
     /// <see cref="Suspend"/> (when we are <see cref="FixpState.Established"/>
     /// per spec §4.5 / issue #69) or a full <see cref="Close"/>. Idempotent
     /// — multiple callers (transport callback, receive-loop finally, watchdog)
     /// converge here without repeating side effects.
+    ///
+    /// <para><paramref name="originatingTransport"/> identifies the transport
+    /// instance whose teardown triggered this call. After a re-attach
+    /// (#69b-2) the OLD transport's recv-loop / send-loop / onClose
+    /// callbacks may still be in flight; if those fire after the new
+    /// transport is installed, they would otherwise erroneously close or
+    /// suspend the freshly attached session. We compare against the
+    /// session's current <c>_transport</c> snapshot and drop the stale
+    /// callback. <c>null</c> means "from an unknown source"; treated as
+    /// authoritative for backward compatibility.</para>
     /// </summary>
-    private void OnTransportClosed(string reason)
+    private void OnTransportClosed(string reason, TcpTransport? originatingTransport)
     {
         if (Volatile.Read(ref _isOpen) == 0) return;
-        // Re-entrancy guard: Suspend() itself calls _transport.Close(...),
-        // which will fire this callback a second time. Once we have detached
-        // (or are about to detach), defer to whichever branch already took
-        // ownership rather than escalating to a full Close.
-        if (Volatile.Read(ref _isAttached) == 0) return;
-        if (State == FixpState.Established)
+        // Decision must run under _attachLock so the generation check and
+        // the actual lifecycle transition can't be split by a concurrent
+        // TryReattach. Without the lock a stale callback could pass the
+        // generation check, get preempted while the new transport is
+        // installed, then close the new generation.
+        lock (_attachLock)
         {
-            Suspend(reason);
-            return;
+            if (Volatile.Read(ref _isOpen) == 0) return;
+            // Stale callback from a prior transport generation — ignore.
+            if (originatingTransport is not null && !ReferenceEquals(originatingTransport, _transport))
+                return;
+            // Re-entrancy guard: Suspend() itself calls _transport.Close(...),
+            // which will fire this callback a second time. Once we have detached
+            // (or are about to detach), defer to whichever branch already took
+            // ownership rather than escalating to a full Close.
+            if (Volatile.Read(ref _isAttached) == 0) return;
+            if (State == FixpState.Established)
+            {
+                SuspendLocked(reason);
+                return;
+            }
+            CloseLocked(reason);
         }
-        Close(reason);
     }
 
     /// <summary>
@@ -976,6 +1047,19 @@ public sealed class FixpSession : IAsyncDisposable
     /// </summary>
     public void Suspend(string reason)
     {
+        lock (_attachLock)
+        {
+            SuspendLocked(reason);
+        }
+    }
+
+    /// <summary>
+    /// Body of <see cref="Suspend(string)"/>; assumes the caller already
+    /// holds <see cref="_attachLock"/>. Idempotent — second caller is a
+    /// no-op via the <see cref="_isAttached"/> CAS.
+    /// </summary>
+    private void SuspendLocked(string reason)
+    {
         // Atomically flip the attachment flag; second caller is a no-op.
         if (Interlocked.Exchange(ref _isAttached, 0) == 0) return;
         _logger.LogInformation("fixp session {ConnectionId} suspending (reason={Reason})",
@@ -983,31 +1067,15 @@ public sealed class FixpSession : IAsyncDisposable
         var action = ApplyTransition(FixpEvent.Detach);
         if (action != FixpAction.Accept || State != FixpState.Suspended)
         {
-            // State machine refused the demotion (e.g. we were already past
-            // Established when the transport died). Fall back to Close so we
-            // don't leave a half-broken session registered.
             _logger.LogInformation(
                 "fixp session {ConnectionId} suspend declined (state={State} action={Action}); closing instead",
                 ConnectionId, State, action);
-            Close(reason);
+            CloseLocked(reason);
             return;
         }
-        // Tear down the dead transport + cancel loops. Claim/registration are
-        // intentionally retained for re-attach. We do NOT call
-        // _sink.OnSessionClosed nor _onClosed because, from the engine's
-        // and the listener's perspective, the FIXP session is still alive.
         try { _cts.Cancel(); } catch { }
         try { _transport.Close(reason); } catch { }
-        // Dispose the dead NetworkStream/socket explicitly. Otherwise the
-        // suspended session keeps the underlying file descriptor open until
-        // re-attach (issue #69b) swaps in a new transport, or until GC
-        // finalizes the stream — under repeated client reconnects this would
-        // leak FDs. The stream owns its socket (NetworkStream(sock,
-        // ownsSocket:true) in EntryPointListener), so disposing it closes
-        // the socket too. Re-attach will install a fresh stream.
         try { _transport.Stream.Dispose(); } catch { }
-        // Stamp the suspension timestamp last, so the reaper only observes
-        // Suspended sessions whose teardown is fully complete.
         Volatile.Write(ref _suspendedSinceMs, NowMs());
     }
 
@@ -1017,7 +1085,38 @@ public sealed class FixpSession : IAsyncDisposable
     /// listener (or tests) can log it. <see cref="Close()"/> is the
     /// no-reason convenience overload.
     /// </summary>
+    /// <summary>
+    /// Generation-aware close: closes the session only if
+    /// <paramref name="originatingTransport"/> is still the current
+    /// transport. Used by background loops (watchdog) that may have
+    /// raced past their cancellation token after a re-attach (#69b-2).
+    /// </summary>
+    private void CloseIfTransportCurrent(string reason, TcpTransport originatingTransport)
+    {
+        lock (_attachLock)
+        {
+            if (!ReferenceEquals(_transport, originatingTransport)) return;
+            CloseLocked(reason);
+        }
+    }
+
     public void Close(string reason)
+    {
+        lock (_attachLock)
+        {
+            CloseLocked(reason);
+        }
+    }
+
+    /// <summary>
+    /// Body of <see cref="Close(string)"/>; assumes the caller already
+    /// holds <see cref="_attachLock"/>. Called directly from
+    /// <see cref="Suspend"/> when the state-machine refuses to demote
+    /// (so we don't try to re-acquire the lock recursively, and so the
+    /// transition from "trying to suspend" to "actually closing" is
+    /// atomic from the perspective of a concurrent re-attach).
+    /// </summary>
+    private void CloseLocked(string reason)
     {
         if (Interlocked.Exchange(ref _isOpen, 0) == 0) return;
         Volatile.Write(ref _isAttached, 0);
@@ -1043,6 +1142,114 @@ public sealed class FixpSession : IAsyncDisposable
         // the lifetime of every resting order it placed → unbounded memory.
         try { _sink.OnSessionClosed(Identity); } catch { }
         try { _onClosed?.Invoke(this, reason); } catch { }
+    }
+
+    /// <summary>
+    /// Re-attach a freshly accepted transport to this Suspended FIXP
+    /// session (issue #69b-2). Called by <see cref="EntryPointListener"/>
+    /// after it has parsed the new connection's first frame and
+    /// determined that it is an <c>Establish</c> targeting our
+    /// <see cref="SessionId"/> with a matching <see cref="SessionVerId"/>.
+    /// The buffered first frame must be replayable through
+    /// <paramref name="rebindStream"/> (e.g. a <see cref="PrependedStream"/>);
+    /// the new receive loop will read it, drive
+    /// <see cref="ProcessEstablish"/>, send the <c>EstablishAck</c> and
+    /// transition the state machine Suspended → Established.
+    ///
+    /// <para>Returns <c>false</c> (without disposing
+    /// <paramref name="rebindStream"/>) when the session is no longer
+    /// re-attachable (closed, never suspended, or another re-attach won
+    /// the race). The caller is responsible for closing the new socket
+    /// in that case.</para>
+    /// </summary>
+    public bool TryReattach(Stream rebindStream)
+    {
+        ArgumentNullException.ThrowIfNull(rebindStream);
+        // Snapshot the previous loop tasks so we can JOIN with them
+        // before installing the new transport. This guarantees that any
+        // in-flight dispatch from the old receive loop (which still
+        // reads `_transport`) has fully run to completion before a new
+        // generation can be observed — eliminating the race in which an
+        // old dispatch path's continuation would close or write to the
+        // freshly attached transport.
+        Task? oldRecv;
+        Task? oldWatchdog;
+        lock (_attachLock)
+        {
+            if (Volatile.Read(ref _isOpen) == 0) return false;
+            if (Volatile.Read(ref _isAttached) == 1) return false;
+            if (State != FixpState.Suspended) return false;
+            oldRecv = _recvTask;
+            oldWatchdog = _watchdogTask;
+        }
+        // Drain old loops outside the lock to avoid holding _attachLock
+        // across an await of arbitrary duration. Loops were already
+        // cancelled (and the old stream disposed) in Suspend, so this
+        // join should complete promptly. Bound by a short timeout as a
+        // belt-and-suspenders against runaway tasks; on timeout we skip
+        // the attempt and let the caller close the new socket — the
+        // suspended-session reaper will eventually clean up.
+        if (oldRecv is not null)
+        {
+            try { if (!oldRecv.Wait(TimeSpan.FromSeconds(2))) return false; } catch { }
+        }
+        if (oldWatchdog is not null)
+        {
+            try { if (!oldWatchdog.Wait(TimeSpan.FromSeconds(2))) return false; } catch { }
+        }
+        lock (_attachLock)
+        {
+            // Re-validate after the unlock-await-relock window: a
+            // concurrent Close (e.g. reaper) may have terminated the
+            // session while we waited.
+            if (Volatile.Read(ref _isOpen) == 0) return false;
+            if (Volatile.Read(ref _isAttached) == 1) return false;
+            if (State != FixpState.Suspended) return false;
+
+            _logger.LogInformation(
+                "fixp session {ConnectionId} re-attaching transport (sessionId={SessionId} sessionVerId={SessionVerId})",
+                ConnectionId, SessionId, SessionVerId);
+
+            try { _cts.Dispose(); } catch { }
+            _cts = new CancellationTokenSource();
+            _transport = CreateBoundTransport(rebindStream);
+            Volatile.Write(ref _suspendedSinceMs, 0);
+            Volatile.Write(ref _lastInboundMs, NowMs());
+            Volatile.Write(ref _isAttached, 1);
+
+            // Spin up new send / recv / watchdog loops bound to the fresh
+            // transport + cancellation source. The buffered Establish frame
+            // already inside `rebindStream` will flow through the recv loop
+            // and drive ProcessEstablish → state machine Suspended → Established.
+            _transport.StartSendLoop(_cts.Token);
+            _recvTask = Task.Run(() => RunReceiveLoopAsync(_cts.Token));
+            _watchdogTask = Task.Run(() => RunWatchdogLoopAsync(_cts.Token));
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Atomic suspended-session reap (issue #69b-2): if this session is
+    /// still in <see cref="FixpState.Suspended"/> and its
+    /// <see cref="SuspendedSinceMs"/> is at or before
+    /// <paramref name="thresholdMs"/>, fully closes the session and
+    /// returns <c>true</c>. Otherwise leaves the session untouched and
+    /// returns <c>false</c>. Holds <see cref="_attachLock"/> for the
+    /// duration so a concurrent <see cref="TryReattach"/> cannot race
+    /// in between the snapshot the reaper made and the close decision.
+    /// </summary>
+    internal bool TryReapIfSuspended(long thresholdMs)
+    {
+        lock (_attachLock)
+        {
+            if (Volatile.Read(ref _isOpen) == 0) return false;
+            if (State != FixpState.Suspended) return false;
+            var since = Volatile.Read(ref _suspendedSinceMs);
+            if (since == 0) return false;
+            if (since > thresholdMs) return false;
+            CloseLocked("suspended-timeout");
+            return true;
+        }
     }
 
     public async ValueTask DisposeAsync()

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -28,6 +28,17 @@ public sealed record FixpSessionOptions
     public int IdleTimeoutMs { get; init; } = 30_000;
     public int TestRequestGraceMs { get; init; } = 5_000;
     public int SuspendedTimeoutMs { get; init; } = 5 * 60_000;
+    /// <summary>
+    /// Per-connection budget (ms) for the listener's first-frame router
+    /// (issue #69b-2) to read the SOFH+SBE header + body of the first
+    /// FIXP message and decide whether to route the new transport into
+    /// an existing Suspended <see cref="FixpSession"/> (re-attach) or to
+    /// construct a fresh session. Slowloris connections that fail to
+    /// emit a complete first frame within this window are closed
+    /// without ever instantiating a <see cref="FixpSession"/>. Default
+    /// is 5 s; tests override to sub-second.
+    /// </summary>
+    public int FirstFrameTimeoutMs { get; init; } = 5_000;
 
     public static FixpSessionOptions Default { get; } = new();
 
@@ -37,5 +48,6 @@ public sealed record FixpSessionOptions
         if (IdleTimeoutMs <= 0) throw new ArgumentOutOfRangeException(nameof(IdleTimeoutMs));
         if (TestRequestGraceMs <= 0) throw new ArgumentOutOfRangeException(nameof(TestRequestGraceMs));
         if (SuspendedTimeoutMs < 0) throw new ArgumentOutOfRangeException(nameof(SuspendedTimeoutMs));
+        if (FirstFrameTimeoutMs <= 0) throw new ArgumentOutOfRangeException(nameof(FirstFrameTimeoutMs));
     }
 }

--- a/src/B3.Exchange.Gateway/PrependedStream.cs
+++ b/src/B3.Exchange.Gateway/PrependedStream.cs
@@ -1,0 +1,92 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Read-side stream wrapper that returns a fixed in-memory <c>prefix</c>
+/// before delegating to an inner <see cref="Stream"/>. Used by the
+/// per-connection first-frame router in <see cref="EntryPointListener"/>:
+/// the listener reads enough bytes to decide whether the connection is a
+/// rebind (issue #69b-2) or a fresh session, then prepends those already-
+/// consumed bytes to the underlying <see cref="System.Net.Sockets.NetworkStream"/>
+/// so the downstream <see cref="FixpSession"/> can re-process them through
+/// its normal receive loop without duplicated decoders.
+///
+/// <para>Write-side and disposal are forwarded as-is to the inner
+/// stream. Only the read paths are buffered.</para>
+/// </summary>
+internal sealed class PrependedStream : Stream
+{
+    private readonly byte[] _prefix;
+    private readonly Stream _inner;
+    private int _prefixPos;
+
+    public PrependedStream(byte[] prefix, Stream inner)
+    {
+        ArgumentNullException.ThrowIfNull(prefix);
+        ArgumentNullException.ThrowIfNull(inner);
+        _prefix = prefix;
+        _inner = inner;
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanWrite => _inner.CanWrite;
+    public override bool CanSeek => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+    public override void Flush() => _inner.Flush();
+    public override Task FlushAsync(CancellationToken ct) => _inner.FlushAsync(ct);
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var fromPrefix = ReadFromPrefix(buffer.AsSpan(offset, count));
+        if (fromPrefix > 0) return fromPrefix;
+        return _inner.Read(buffer, offset, count);
+    }
+
+    public override int Read(Span<byte> buffer)
+    {
+        var fromPrefix = ReadFromPrefix(buffer);
+        if (fromPrefix > 0) return fromPrefix;
+        return _inner.Read(buffer);
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken ct)
+    {
+        var fromPrefix = ReadFromPrefix(buffer.AsSpan(offset, count));
+        if (fromPrefix > 0) return fromPrefix;
+        return await _inner.ReadAsync(buffer.AsMemory(offset, count), ct).ConfigureAwait(false);
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default)
+    {
+        var fromPrefix = ReadFromPrefix(buffer.Span);
+        if (fromPrefix > 0) return fromPrefix;
+        return await _inner.ReadAsync(buffer, ct).ConfigureAwait(false);
+    }
+
+    private int ReadFromPrefix(Span<byte> dest)
+    {
+        var remaining = _prefix.Length - _prefixPos;
+        if (remaining <= 0) return 0;
+        var take = Math.Min(remaining, dest.Length);
+        _prefix.AsSpan(_prefixPos, take).CopyTo(dest);
+        _prefixPos += take;
+        return take;
+    }
+
+    public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+    public override void Write(ReadOnlySpan<byte> buffer) => _inner.Write(buffer);
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken ct) => _inner.WriteAsync(buffer, offset, count, ct);
+    public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default) => _inner.WriteAsync(buffer, ct);
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing) _inner.Dispose();
+        base.Dispose(disposing);
+    }
+
+    public override ValueTask DisposeAsync() => _inner.DisposeAsync();
+}

--- a/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
+++ b/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
@@ -84,6 +84,36 @@ public sealed class SessionClaimRegistry
     }
 
     /// <summary>
+    /// Returns the live owner of <paramref name="sessionId"/>, if any,
+    /// along with the recorded last-seen sessionVerID. Used by the
+    /// rebind path (#69b-2): if the new transport's <c>Establish</c>
+    /// targets a sessionId currently claimed by a <see cref="FixpSession"/>
+    /// in <see cref="FixpState.Suspended"/> with matching sessionVerID,
+    /// the listener routes the new transport to that existing session
+    /// instead of constructing a fresh one.
+    ///
+    /// <para>Returns <c>false</c> if no claim is currently held. Returns
+    /// <c>true</c> with <paramref name="holder"/> set to the live owner
+    /// otherwise; the caller is responsible for downcasting to the
+    /// concrete session type.</para>
+    /// </summary>
+    public bool TryGetActiveClaim(uint sessionId, out object holder, out ulong sessionVerId)
+    {
+        lock (_lock)
+        {
+            if (_activeClaims.TryGetValue(sessionId, out var owner))
+            {
+                holder = owner;
+                sessionVerId = _lastSessionVerId.TryGetValue(sessionId, out var v) ? v : 0UL;
+                return true;
+            }
+        }
+        holder = null!;
+        sessionVerId = 0UL;
+        return false;
+    }
+
+    /// <summary>
     /// Releases the claim for <paramref name="sessionId"/> if (and only
     /// if) it is currently held by <paramref name="claimToken"/>. Safe to
     /// call from any thread; safe to call multiple times. Does not

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
@@ -1,0 +1,141 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #69b-2: <see cref="FixpSession.TryReattach"/> must accept a
+/// fresh transport only when the session is currently Suspended (and
+/// open and not already attached). Negative cases must leave session
+/// state untouched and return false so the listener closes the new
+/// socket.
+/// </summary>
+public class FixpSessionReattachTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static async Task<(TcpListener tcp, NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        return (tcp, new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static async Task<FixpSession> NewSuspendedSessionAsync()
+    {
+        var (_, serverStream, client) = await ConnectPairAsync();
+        var session = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: serverStream, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance);
+        session.Start();
+        session.ApplyTransition(FixpEvent.Negotiate);
+        session.ApplyTransition(FixpEvent.Establish);
+        client.Close();
+        await TestUtil.WaitUntilAsync(
+            () => session.State == FixpState.Suspended && session.SuspendedSinceMs is not null,
+            TimeSpan.FromSeconds(3));
+        Assert.Equal(FixpState.Suspended, session.State);
+        return session;
+    }
+
+    [Fact]
+    public async Task TryReattach_returns_false_when_not_suspended()
+    {
+        var (_, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var session = new FixpSession(
+                connectionId: 1, enteringFirm: 7, sessionId: 100,
+                stream: serverStream, sink: new NoOpEngineSink(),
+                logger: NullLogger<FixpSession>.Instance);
+            session.Start();
+            // Still Idle / attached → re-attach must refuse.
+            using var fakeStream = new MemoryStream();
+            Assert.False(session.TryReattach(fakeStream));
+            session.Close("test-cleanup");
+        }
+        finally { client.Close(); }
+    }
+
+    [Fact]
+    public async Task TryReattach_returns_false_after_close()
+    {
+        var session = await NewSuspendedSessionAsync();
+        session.Close("test-close");
+        using var fakeStream = new MemoryStream();
+        Assert.False(session.TryReattach(fakeStream));
+    }
+
+    [Fact]
+    public async Task TryReattach_clears_SuspendedSinceMs_and_marks_attached()
+    {
+        var session = await NewSuspendedSessionAsync();
+        try
+        {
+            // Provide a stream the new recv loop can read from; we won't
+            // feed it a real Establish frame but we don't need to — we
+            // only assert TryReattach's pre/post conditions. The loop
+            // will block on the empty stream until we close the session.
+            var (_, serverStream, client) = await ConnectPairAsync();
+            try
+            {
+                Assert.True(session.TryReattach(serverStream));
+                Assert.True(session.IsAttached);
+                Assert.Null(session.SuspendedSinceMs);
+                // State machine still Suspended until the recv loop
+                // processes a real Establish — TryReattach itself does
+                // not advance the state machine.
+                Assert.Equal(FixpState.Suspended, session.State);
+            }
+            finally { client.Close(); }
+        }
+        finally
+        {
+            session.Close("test-cleanup");
+            await session.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task TryReattach_concurrent_calls_only_one_wins()
+    {
+        var session = await NewSuspendedSessionAsync();
+        try
+        {
+            var (_, s1, c1) = await ConnectPairAsync();
+            var (_, s2, c2) = await ConnectPairAsync();
+            try
+            {
+                using var barrier = new ManualResetEventSlim(false);
+                var winners = 0;
+                var t1 = Task.Run(() => { barrier.Wait(); if (session.TryReattach(s1)) Interlocked.Increment(ref winners); });
+                var t2 = Task.Run(() => { barrier.Wait(); if (session.TryReattach(s2)) Interlocked.Increment(ref winners); });
+                barrier.Set();
+                await Task.WhenAll(t1, t2);
+                Assert.Equal(1, winners);
+            }
+            finally { c1.Close(); c2.Close(); }
+        }
+        finally
+        {
+            session.Close("test-cleanup");
+            await session.DisposeAsync();
+        }
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/PrependedStreamTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/PrependedStreamTests.cs
@@ -1,0 +1,66 @@
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class PrependedStreamTests
+{
+    [Fact]
+    public async Task ReadAsync_returns_prefix_then_inner()
+    {
+        var prefix = new byte[] { 1, 2, 3 };
+        var inner = new MemoryStream(new byte[] { 4, 5, 6 });
+        var s = new PrependedStream(prefix, inner);
+
+        var buf = new byte[8];
+        int n1 = await s.ReadAsync(buf.AsMemory(0, 8));
+        // ReadAsync may return prefix in one call; subsequent reads
+        // pull from inner. Concatenate until we observe EOF.
+        var read = new List<byte>();
+        read.AddRange(buf.AsSpan(0, n1).ToArray());
+        while (true)
+        {
+            int n = await s.ReadAsync(buf.AsMemory(0, 8));
+            if (n == 0) break;
+            read.AddRange(buf.AsSpan(0, n).ToArray());
+        }
+        Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6 }, read.ToArray());
+    }
+
+    [Fact]
+    public void Read_partial_prefix_then_remainder()
+    {
+        var prefix = new byte[] { 10, 20, 30, 40 };
+        var inner = new MemoryStream(new byte[] { 50 });
+        var s = new PrependedStream(prefix, inner);
+
+        var buf = new byte[2];
+        Assert.Equal(2, s.Read(buf, 0, 2));
+        Assert.Equal(new byte[] { 10, 20 }, buf);
+        Assert.Equal(2, s.Read(buf, 0, 2));
+        Assert.Equal(new byte[] { 30, 40 }, buf);
+        Assert.Equal(1, s.Read(buf, 0, 2));
+        Assert.Equal((byte)50, buf[0]);
+        Assert.Equal(0, s.Read(buf, 0, 2));
+    }
+
+    [Fact]
+    public void Write_forwards_to_inner()
+    {
+        var prefix = new byte[] { 1 };
+        var inner = new MemoryStream();
+        var s = new PrependedStream(prefix, inner);
+        s.Write(new byte[] { 99, 100 }, 0, 2);
+        Assert.Equal(new byte[] { 99, 100 }, inner.ToArray());
+    }
+
+    [Fact]
+    public void Empty_prefix_passes_through()
+    {
+        var inner = new MemoryStream(new byte[] { 7, 8 });
+        var s = new PrependedStream(Array.Empty<byte>(), inner);
+        var buf = new byte[4];
+        int n = s.Read(buf, 0, 4);
+        Assert.Equal(2, n);
+        Assert.Equal(new byte[] { 7, 8 }, buf.AsSpan(0, 2).ToArray());
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/SessionClaimRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionClaimRegistryTests.cs
@@ -68,4 +68,31 @@ public class SessionClaimRegistryTests
     {
         Assert.Equal(0UL, new SessionClaimRegistry().CurrentSessionVerId(99999));
     }
+
+    [Fact]
+    public void TryGetActiveClaim_returns_holder_and_version_for_active()
+    {
+        var r = new SessionClaimRegistry();
+        var owner = new object();
+        r.TryClaim(42, 7, owner);
+        Assert.True(r.TryGetActiveClaim(42, out var holder, out var ver));
+        Assert.Same(owner, holder);
+        Assert.Equal(7UL, ver);
+    }
+
+    [Fact]
+    public void TryGetActiveClaim_returns_false_when_unknown()
+    {
+        Assert.False(new SessionClaimRegistry().TryGetActiveClaim(42, out _, out _));
+    }
+
+    [Fact]
+    public void TryGetActiveClaim_returns_false_after_release()
+    {
+        var r = new SessionClaimRegistry();
+        var owner = new object();
+        r.TryClaim(42, 7, owner);
+        r.Release(42, owner);
+        Assert.False(r.TryGetActiveClaim(42, out _, out _));
+    }
 }


### PR DESCRIPTION
Implements #69 part 2 (transport rebind). Builds on #69a (Suspended state, #86) and #69b-1 (suspended-session reaper, #87).

## What

Peer reconnects over a fresh TCP and sends \`Establish\` for a sessionId held by a Suspended \`FixpSession\` with matching \`SessionVerId\` → the new transport is routed into the **existing** session instance instead of constructing a new one. This preserves \`Identity\`, which preserves engine-side order ownership for orders that were resting at the moment the original transport dropped.

## Architecture

- \`EntryPointListener\` now spawns a per-connection task (no longer blocks accept). In rebind mode it parses the first FIXP frame under \`FirstFrameTimeoutMs\` (default 5s, slowloris cap) and decides re-attach vs new session. Bytes are wrapped in a \`PrependedStream\` so the existing recv loop replays the frame.
- \`FixpSession.TryReattach(Stream)\` validates state under a new \`_attachLock\`, drains old recv/watchdog tasks (2s join), then installs a fresh \`TcpTransport\` + \`CancellationTokenSource\` and starts new loops.
- Generation-aware teardown: recv loop and watchdog capture their bound transport; \`OnTransportClosed\` / \`CloseIfTransportCurrent\` re-validate generation under \`_attachLock\` so stale callbacks from the old transport can't close or suspend the freshly attached one.
- \`TryReapIfSuspended\` replaces the listener's free-running reaper logic: per-session atomic reap under \`_attachLock\` so a successful re-attach can't lose to a stale reaper snapshot.

## New components

- \`PrependedStream\`: read-side stream wrapper returning a prefix before delegating; writes pass through.
- \`SessionClaimRegistry.TryGetActiveClaim\`: lookup for the listener's re-attach decision.
- \`FixpSessionOptions.FirstFrameTimeoutMs\`: per-connection budget for first-frame router.

## Tests

- \`PrependedStreamTests\` (4)
- \`FixpSessionReattachTests\` (4: not-suspended → false, after-close → false, success clears suspended-since + marks attached, concurrent calls → only one wins)
- \`SessionClaimRegistryTests\` gain \`TryGetActiveClaim\` coverage

337 tests pass; \`dotnet format\` clean. Two GPT-5.5 review passes; addressed: stale recv-loop teardown, reaper-vs-rebind race, stale-callback-vs-reattach interleaving, stale-watchdog teardown, in-flight dispatch from old recv loop.

## Follow-ups (not in this PR)

- E2E wire-driven rebind test in \`B3.Exchange.Host.Tests\` (needs client-side handshake encoders; deferred, justifies its own PR with full FIXP frame builders).
- Replay buffer for ExecutionReports lost during the suspended window — that's #46 / #69c.
- Credentials reauth on rebind (security hardening; tracked separately).

Closes part of #69.