### PR TITLE
gateway: FIXP RetransmitRequest/Retransmission/RetransmitReject (#46)

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -60,6 +60,12 @@ public static class EntryPointFrameReader
     public const ushort TidNegotiate = 1;
     /// <summary>Session: Establish (FIXP, inbound only). See spec §4.5.3.</summary>
     public const ushort TidEstablish = 4;
+    /// <summary>Session: RetransmitRequest (FIXP, inbound). See spec §4.5.6.</summary>
+    public const ushort TidRetransmitRequest = 12;
+    /// <summary>Session: Retransmission (FIXP, outbound). See spec §4.5.6.</summary>
+    public const ushort TidRetransmission = 13;
+    /// <summary>Session: RetransmitReject (FIXP, outbound). See spec §4.5.6.</summary>
+    public const ushort TidRetransmitReject = 14;
     /// <summary>Outbound only: NegotiateResponse (template id 2).</summary>
     public const ushort TidNegotiateResponse = 2;
     /// <summary>Outbound only: NegotiateReject (template id 3).</summary>
@@ -89,6 +95,7 @@ public static class EntryPointFrameReader
         (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.
         (TidNegotiate, 0) => 28,                 // NegotiateData.BLOCK_LENGTH (V6 schema, root version 0)
         (TidEstablish, 0) => 42,                 // EstablishData.BLOCK_LENGTH
+        (TidRetransmitRequest, 0) => 20,         // RetransmitRequestData.BLOCK_LENGTH
         _ => -1
     };
 

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -51,6 +51,36 @@ public sealed class FixpSession : IAsyncDisposable
     /// <see cref="TryReattach"/> bound to the new snapshot).
     /// </summary>
     private readonly object _attachLock = new();
+    /// <summary>
+    /// Serializes outbound business-frame production (sequence-number
+    /// allocation + retransmit-buffer append + send-queue enqueue) and
+    /// retransmission replay blocks. Held by every live business write
+    /// (<see cref="WriteExecutionReportNew"/> &amp;c.) for the entire
+    /// allocate-encode-buffer-enqueue triplet, and held by
+    /// <see cref="ProcessAndEnqueueRetransmitRequest"/> for the entire
+    /// header + N replay clones + trailing Sequence block. This
+    /// guarantees (a) no live frame interleaves the replay block on the
+    /// wire and (b) the trailing Sequence's <c>nextSeqNo</c> matches
+    /// the next live seq the peer will see (issue #46, gpt-5.5
+    /// critique).
+    /// </summary>
+    private readonly object _outboundLock = new();
+    /// <summary>
+    /// Per-session retransmission ring buffer (issue #46, spec §4.5.6).
+    /// Holds copies of the wire frames for ExecutionReport_* and
+    /// BusinessMessageReject — the buffered business templates that
+    /// carry an <c>OutboundBusinessHeader.MsgSeqNum</c>. Not preserved
+    /// across <see cref="Close"/>; preserved across
+    /// <see cref="Suspend"/> / <see cref="TryReattach"/> so a new
+    /// transport can recover via <c>RetransmitRequest</c>.
+    /// </summary>
+    private readonly RetransmitBuffer _retxBuffer;
+    /// <summary>0 / 1 — set via <see cref="Interlocked.CompareExchange"/>
+    /// for the duration of a single retransmission replay (per spec
+    /// §4.5.6: "one outstanding request at a time"). Cleared after the
+    /// last frame of the replay block is enqueued under
+    /// <see cref="_outboundLock"/>.</summary>
+    private int _retxInProgress;
     /// <summary>The wire SessionID currently claimed in <see cref="_claims"/>,
     /// or 0 if no claim is held. Tracked so <see cref="Close"/> can
     /// release the claim using the value from the moment the claim was
@@ -184,6 +214,7 @@ public sealed class FixpSession : IAsyncDisposable
         _nowNanos = nowNanos ?? DefaultNowNanos;
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
+        _retxBuffer = new RetransmitBuffer(_options.RetransmitBufferCapacity);
         _onClosed = onClosed;
         _validator = negotiationValidator;
         _establishValidator = establishValidator;
@@ -396,6 +427,9 @@ public sealed class FixpSession : IAsyncDisposable
                     var step = ProcessEstablish(fixedBlock);
                     return await ExecuteEstablishStepAsync(step).ConfigureAwait(false);
                 }
+            case EntryPointFrameReader.TidRetransmitRequest:
+                ProcessAndEnqueueRetransmitRequest(fixedBlock);
+                return true;
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                 {
@@ -848,8 +882,16 @@ public sealed class FixpSession : IAsyncDisposable
         // so we must peek instead of incrementing — otherwise the Establish
         // handshake would observe a phantom gap (e.g. an idle heartbeat
         // before Establish would push EstablishAck.nextSeqNo off by one).
-        SessionFrameEncoder.EncodeSequence(frame, PeekNextMsgSeqNum());
-        _transport.TryEnqueueFrame(frame);
+        //
+        // Outbound lock: serializes against the replay block in
+        // ProcessAndEnqueueRetransmitRequest so a watchdog-driven
+        // heartbeat cannot land inside the Retransmission/replay/Sequence
+        // sequence on the wire (gpt-5.5 review #1).
+        lock (_outboundLock)
+        {
+            SessionFrameEncoder.EncodeSequence(frame, PeekNextMsgSeqNum());
+            _transport.TryEnqueueFrame(frame);
+        }
     }
 
     private static async Task ReadExactlyAsync(Stream s, byte[] buf, CancellationToken ct)
@@ -873,94 +915,246 @@ public sealed class FixpSession : IAsyncDisposable
     /// <c>Sequence</c> frames, which announce but do not consume.</summary>
     private uint PeekNextMsgSeqNum() => (uint)(Volatile.Read(ref _msgSeqNum) + 1);
 
+    /// <summary>
+    /// Decodes and processes a FIXP <c>RetransmitRequest</c> (template
+    /// id 12), per spec §4.5.6 and issue #46. Runs on the dispatch
+    /// (recv-loop) thread.
+    ///
+    /// <para>State machine routing (already encoded in
+    /// <see cref="FixpStateMachine"/>): <c>Established → Replay</c>;
+    /// <c>Suspended → DeferredToReestablish</c> (silently drop); other
+    /// states → <c>DropSilently</c>. Validation order before replay:
+    /// <c>SessionID</c> match, timestamp non-zero, count bounds, in-flight
+    /// gate (CAS), then the buffer's window check (<c>OUT_OF_RANGE</c>
+    /// vs <c>INVALID_FROMSEQNO</c>).</para>
+    ///
+    /// <para>On accept: encodes a <c>Retransmission</c> header with
+    /// <c>nextSeqNo = request.fromSeqNo</c> and <c>count = actual</c>,
+    /// enqueues all replay clones (each carrying the
+    /// <c>PossResend</c> bit), and finally enqueues a <c>Sequence</c>
+    /// frame whose <c>nextSeqNo</c> is the next live business seq
+    /// (i.e. <see cref="PeekNextMsgSeqNum"/>). The entire block is
+    /// enqueued under <see cref="_outboundLock"/> so live business
+    /// writes cannot interleave it on the wire and so the trailing
+    /// Sequence's seq matches what the peer will see next.</para>
+    /// </summary>
+    private void ProcessAndEnqueueRetransmitRequest(ReadOnlySpan<byte> fixedBlock)
+    {
+        // Layout (BLOCK_LENGTH=20): SessionID(4) | Timestamp(8 ulong) |
+        // FromSeqNo(4 uint) | Count(4 uint).
+        if (fixedBlock.Length < 20) return; // header validator already enforced this; defensive
+        uint reqSessionId = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(0, 4));
+        ulong reqTimestamp = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(4, 8));
+        uint fromSeq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(12, 4));
+        uint count = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(16, 4));
+
+        var action = ApplyTransition(FixpEvent.RetransmitRequest);
+        if (action != FixpAction.Replay)
+        {
+            // DropSilently / DeferredToReestablish / Terminal: per spec,
+            // emit nothing. Suspended sessions have no live transport
+            // anyway; a request that arrives in any pre-Established state
+            // is simply ignored and the peer is expected to drive the
+            // handshake before requesting recovery.
+            _logger.LogDebug("session {ConnectionId} retransmit-request action={Action} state={State} dropped",
+                ConnectionId, action, State);
+            return;
+        }
+
+        // Spec validations BEFORE single-in-flight gate so a malformed
+        // request doesn't leave the gate held.
+        if (reqSessionId != SessionId)
+        {
+            EnqueueRetransmitReject(reqTimestamp, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_SESSION);
+            return;
+        }
+        if (reqTimestamp == 0UL)
+        {
+            EnqueueRetransmitReject(reqTimestamp, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_TIMESTAMP);
+            return;
+        }
+
+        // One-outstanding-request gate. Cleared in the finally below
+        // after the entire replay block is enqueued under _outboundLock,
+        // so a subsequent request can never see partial state.
+        if (Interlocked.CompareExchange(ref _retxInProgress, 1, 0) != 0)
+        {
+            EnqueueRetransmitReject(reqTimestamp, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.RETRANSMIT_IN_PROGRESS);
+            return;
+        }
+        try
+        {
+            // Buffer combines count-bounds + window check under one lock
+            // (no TOCTOU between FirstAvailable read and clone copy).
+            var snap = _retxBuffer.TryGet(fromSeq, count);
+            if (snap.RejectCode is { } code)
+            {
+                EnqueueRetransmitReject(reqTimestamp, code);
+                return;
+            }
+
+            // Hold the outbound lock for the entire block so (a) no live
+            // business frame interleaves on the wire and (b) the
+            // trailing Sequence's nextSeqNo matches the next live seq
+            // the peer will see (gpt-5.5 critique #1, #2).
+            lock (_outboundLock)
+            {
+                // Backpressure: TcpTransport's bounded send queue can
+                // drop frames if it overflows mid-replay (gpt-5.5 review
+                // #2). Reserve capacity for the FULL block (header +
+                // clones + trailer) under the outbound lock; if the
+                // queue cannot accept the burst, reject with SYSTEM_BUSY
+                // rather than advertise an exact count we can't deliver.
+                int needed = 2 + snap.Frames.Length;
+                if (_transport.SendQueueDepth + needed > _sendQueueCapacity)
+                {
+                    EnqueueRetransmitReject(reqTimestamp,
+                        B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.SYSTEM_BUSY);
+                    return;
+                }
+
+                var headerFrame = new byte[RetransmissionEncoder.RetransmissionTotal];
+                RetransmissionEncoder.EncodeRetransmission(headerFrame,
+                    SessionId, reqTimestamp,
+                    firstRetransmittedSeqNo: snap.FirstSeq, count: snap.ActualCount);
+                _transport.TryEnqueueFrame(headerFrame);
+
+                for (int i = 0; i < snap.Frames.Length; i++)
+                    _transport.TryEnqueueFrame(snap.Frames[i]);
+
+                var trailer = new byte[SessionFrameEncoder.SequenceTotal];
+                SessionFrameEncoder.EncodeSequence(trailer, PeekNextMsgSeqNum());
+                _transport.TryEnqueueFrame(trailer);
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _retxInProgress, 0);
+        }
+    }
+
+    private void EnqueueRetransmitReject(ulong requestTimestampNanos,
+        B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode code)
+    {
+        var frame = new byte[RetransmissionEncoder.RetransmitRejectTotal];
+        RetransmissionEncoder.EncodeRetransmitReject(frame, SessionId, requestTimestampNanos, code);
+        _transport.TryEnqueueFrame(frame);
+        _logger.LogInformation("session {ConnectionId} retransmit-reject code={Code}",
+            ConnectionId, code);
+    }
+
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e)
     {
         if (!IsOpen) return false;
-        var frame = ArrayPool<byte>.Shared.Rent(ExecutionReportEncoder.ExecReportNewTotal);
         ulong clOrd = ulong.TryParse(e.ClOrdId, out var v) ? v : 0;
-        int n = ExecutionReportEncoder.EncodeExecReportNew(frame.AsSpan(0, ExecutionReportEncoder.ExecReportNewTotal),
-            SessionId, NextMsgSeqNum(), e.InsertTimestampNanos,
-            e.Side, clOrd, e.OrderId, e.SecurityId, e.OrderId,
-            (ulong)e.RptSeq, e.InsertTimestampNanos,
-            OrderType.Limit, TimeInForce.Day,
-            e.RemainingQuantity, e.PriceMantissa);
-        return TryEnqueueExact(frame, n);
+        var exact = new byte[ExecutionReportEncoder.ExecReportNewTotal];
+        lock (_outboundLock)
+        {
+            ExecutionReportEncoder.EncodeExecReportNew(exact,
+                SessionId, NextMsgSeqNum(), e.InsertTimestampNanos,
+                e.Side, clOrd, e.OrderId, e.SecurityId, e.OrderId,
+                (ulong)e.RptSeq, e.InsertTimestampNanos,
+                OrderType.Limit, TimeInForce.Day,
+                e.RemainingQuantity, e.PriceMantissa);
+            return AppendAndEnqueueLocked(exact);
+        }
     }
 
     public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
     {
         if (!IsOpen) return false;
-        var frame = ArrayPool<byte>.Shared.Rent(ExecutionReportEncoder.ExecReportTradeTotal);
         var side = isAggressor ? e.AggressorSide : (e.AggressorSide == Side.Buy ? Side.Sell : Side.Buy);
-        int n = ExecutionReportEncoder.EncodeExecReportTrade(frame.AsSpan(0, ExecutionReportEncoder.ExecReportTradeTotal),
-            SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
-            side, clOrdIdValue, ownerOrderId, e.SecurityId, ownerOrderId,
-            e.Quantity, e.PriceMantissa,
-            (ulong)e.RptSeq, e.TransactTimeNanos, leavesQty, cumQty,
-            isAggressor, e.TradeId,
-            isAggressor ? e.RestingFirm : e.AggressorFirm,
-            tradeDate: 0,
-            orderQty: leavesQty + cumQty);
-        return TryEnqueueExact(frame, n);
+        var exact = new byte[ExecutionReportEncoder.ExecReportTradeTotal];
+        lock (_outboundLock)
+        {
+            ExecutionReportEncoder.EncodeExecReportTrade(exact,
+                SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
+                side, clOrdIdValue, ownerOrderId, e.SecurityId, ownerOrderId,
+                e.Quantity, e.PriceMantissa,
+                (ulong)e.RptSeq, e.TransactTimeNanos, leavesQty, cumQty,
+                isAggressor, e.TradeId,
+                isAggressor ? e.RestingFirm : e.AggressorFirm,
+                tradeDate: 0,
+                orderQty: leavesQty + cumQty);
+            return AppendAndEnqueueLocked(exact);
+        }
     }
 
     public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         if (!IsOpen) return false;
-        var frame = ArrayPool<byte>.Shared.Rent(ExecutionReportEncoder.ExecReportCancelTotal);
-        int n = ExecutionReportEncoder.EncodeExecReportCancel(frame.AsSpan(0, ExecutionReportEncoder.ExecReportCancelTotal),
-            SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
-            e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
-            e.SecurityId, e.OrderId,
-            (ulong)e.RptSeq, e.TransactTimeNanos,
-            cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa);
-        return TryEnqueueExact(frame, n);
+        var exact = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        lock (_outboundLock)
+        {
+            ExecutionReportEncoder.EncodeExecReportCancel(exact,
+                SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
+                e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
+                e.SecurityId, e.OrderId,
+                (ulong)e.RptSeq, e.TransactTimeNanos,
+                cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa);
+            return AppendAndEnqueueLocked(exact);
+        }
     }
 
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
         Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq)
     {
         if (!IsOpen) return false;
-        var frame = ArrayPool<byte>.Shared.Rent(ExecutionReportEncoder.ExecReportModifyTotal);
-        int n = ExecutionReportEncoder.EncodeExecReportModify(frame.AsSpan(0, ExecutionReportEncoder.ExecReportModifyTotal),
-            SessionId, NextMsgSeqNum(), transactTimeNanos,
-            side, clOrdIdValue, origClOrdIdValue, orderId,
-            securityId, orderId, (ulong)rptSeq, transactTimeNanos,
-            leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa);
-        return TryEnqueueExact(frame, n);
+        var exact = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        lock (_outboundLock)
+        {
+            ExecutionReportEncoder.EncodeExecReportModify(exact,
+                SessionId, NextMsgSeqNum(), transactTimeNanos,
+                side, clOrdIdValue, origClOrdIdValue, orderId,
+                securityId, orderId, (ulong)rptSeq, transactTimeNanos,
+                leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa);
+            return AppendAndEnqueueLocked(exact);
+        }
     }
 
     public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue)
     {
         if (!IsOpen) return false;
-        var frame = ArrayPool<byte>.Shared.Rent(ExecutionReportEncoder.ExecReportRejectTotal);
         byte rej = MapRejectReason(e.Reason);
-        int n = ExecutionReportEncoder.EncodeExecReportReject(frame.AsSpan(0, ExecutionReportEncoder.ExecReportRejectTotal),
-            SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
-            clOrdIdValue, origClOrdIdValue: 0, e.SecurityId, e.OrderIdOrZero,
-            rej, e.TransactTimeNanos);
-        return TryEnqueueExact(frame, n);
+        var exact = new byte[ExecutionReportEncoder.ExecReportRejectTotal];
+        lock (_outboundLock)
+        {
+            ExecutionReportEncoder.EncodeExecReportReject(exact,
+                SessionId, NextMsgSeqNum(), e.TransactTimeNanos,
+                clOrdIdValue, origClOrdIdValue: 0, e.SecurityId, e.OrderIdOrZero,
+                rej, e.TransactTimeNanos);
+            return AppendAndEnqueueLocked(exact);
+        }
     }
 
-    private bool TryEnqueueExact(byte[] frame, int written)
+    /// <summary>
+    /// Must be called with <see cref="_outboundLock"/> held. Reads the
+    /// already-allocated <c>MsgSeqNum</c> back out of the encoded
+    /// frame, appends to the retx buffer, then enqueues onto the
+    /// transport. Centralizes the two-step "buffer + enqueue" so every
+    /// business-frame write site has identical semantics.
+    /// </summary>
+    private bool AppendAndEnqueueLocked(byte[] exact)
     {
-        // Send loop writes the entire array, so we must hand it a tight buffer.
-        // The encoder buffer (`frame`) was rented from ArrayPool and may be
-        // larger than `written`. Copy out exactly `written` bytes into a fresh
-        // non-pool array and return the rented buffer to the pool.
-        var exact = new byte[written];
-        Buffer.BlockCopy(frame, 0, exact, 0, written);
-        ArrayPool<byte>.Shared.Return(frame);
+        // OutboundBusinessHeader.MsgSeqNum sits at body offset 4
+        // (SessionID(4) | MsgSeqNum(4) | …) → absolute offset
+        // WireHeaderSize + 4 = 16. Read it back so the buffer key
+        // exactly matches what's on the wire.
+        uint seq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(
+            exact.AsSpan(EntryPointFrameReader.WireHeaderSize + 4, 4));
+        // Append BEFORE enqueue: per spec recovery semantics, any seq
+        // that has been allocated MUST be replayable, even if the local
+        // send queue rejects the frame (gpt-5.5 critique #9).
+        _retxBuffer.Append(seq, exact);
         return _transport.TryEnqueueFrame(exact);
     }
 
     public bool WriteSessionReject(byte terminationCode)
     {
         if (!IsOpen) return false;
-        var frame = ArrayPool<byte>.Shared.Rent(SessionRejectEncoder.TerminateTotal);
-        int n = SessionRejectEncoder.EncodeTerminate(frame.AsSpan(0, SessionRejectEncoder.TerminateTotal),
-            SessionId, 0, terminationCode);
-        bool result = TryEnqueueExact(frame, n);
+        var exact = new byte[SessionRejectEncoder.TerminateTotal];
+        SessionRejectEncoder.EncodeTerminate(exact, SessionId, 0, terminationCode);
+        bool result = _transport.TryEnqueueFrame(exact);
         Close();
         return result;
     }
@@ -970,12 +1164,15 @@ public sealed class FixpSession : IAsyncDisposable
     {
         if (!IsOpen) return false;
         int textLen = string.IsNullOrEmpty(text) ? 0 : Math.Min(text.Length, BusinessMessageRejectEncoder.MaxTextLength);
-        var frame = ArrayPool<byte>.Shared.Rent(BusinessMessageRejectEncoder.TotalSize(textLen));
-        int n = BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(
-            frame.AsSpan(0, BusinessMessageRejectEncoder.TotalSize(textLen)),
-            SessionId, NextMsgSeqNum(), _nowNanos(),
-            refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text);
-        return TryEnqueueExact(frame, n);
+        int total = BusinessMessageRejectEncoder.TotalSize(textLen);
+        var exact = new byte[total];
+        lock (_outboundLock)
+        {
+            BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(
+                exact, SessionId, NextMsgSeqNum(), _nowNanos(),
+                refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text);
+            return AppendAndEnqueueLocked(exact);
+        }
     }
 
     private static byte MapRejectReason(RejectReason r) => r switch

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -40,6 +40,17 @@ public sealed record FixpSessionOptions
     /// </summary>
     public int FirstFrameTimeoutMs { get; init; } = 5_000;
 
+    /// <summary>
+    /// Per-session capacity (in frames) of the outbound retransmission
+    /// ring buffer that backs FIXP <c>RetransmitRequest</c> recovery
+    /// (issue #46, spec §4.5.6). Buffered templates are
+    /// ExecutionReport_* and BusinessMessageReject (the templates that
+    /// carry an <c>OutboundBusinessHeader.MsgSeqNum</c>). Default 1024
+    /// satisfies the spec minimum (≥1000 messages per request) with one
+    /// extra slot of headroom.
+    /// </summary>
+    public int RetransmitBufferCapacity { get; init; } = 1024;
+
     public static FixpSessionOptions Default { get; } = new();
 
     internal void Validate()
@@ -49,5 +60,6 @@ public sealed record FixpSessionOptions
         if (TestRequestGraceMs <= 0) throw new ArgumentOutOfRangeException(nameof(TestRequestGraceMs));
         if (SuspendedTimeoutMs < 0) throw new ArgumentOutOfRangeException(nameof(SuspendedTimeoutMs));
         if (FirstFrameTimeoutMs <= 0) throw new ArgumentOutOfRangeException(nameof(FirstFrameTimeoutMs));
+        if (RetransmitBufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(RetransmitBufferCapacity));
     }
 }

--- a/src/B3.Exchange.Gateway/RetransmissionEncoder.cs
+++ b/src/B3.Exchange.Gateway/RetransmissionEncoder.cs
@@ -1,0 +1,68 @@
+using System.Runtime.InteropServices;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Byte-level encoders for FIXP retransmission session-layer responses
+/// (template ids 13 / 14 — see spec §4.5.6 and EntryPoint schema V6).
+///
+/// <para>Both messages are session-layer and do NOT consume an outbound
+/// business <c>MsgSeqNum</c> (same as <c>Sequence</c>). They share the
+/// same SOFH+SBE 12-byte wire header as every other FIXP frame.</para>
+/// </summary>
+internal static class RetransmissionEncoder
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+
+    public const int RetransmissionBlock = 20;
+    public const int RetransmissionTotal = HeaderSize + RetransmissionBlock;
+
+    public const int RetransmitRejectBlock = 13;
+    public const int RetransmitRejectTotal = HeaderSize + RetransmitRejectBlock;
+
+    /// <summary>
+    /// Encodes a <c>Retransmission</c> frame announcing the start of a
+    /// replay block. Per the SBE schema, <c>nextSeqNo</c> is the
+    /// sequence number of the FIRST replayed message (i.e. the
+    /// request's <c>fromSeqNo</c>), not the live next seq — the
+    /// parameter is named <paramref name="firstRetransmittedSeqNo"/>
+    /// to make this hard to misuse.
+    /// </summary>
+    public static int EncodeRetransmission(Span<byte> dst,
+        uint sessionId, ulong requestTimestampNanos,
+        uint firstRetransmittedSeqNo, uint count)
+    {
+        if (dst.Length < RetransmissionTotal)
+            throw new ArgumentException("buffer too small for Retransmission", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)RetransmissionTotal,
+            blockLength: RetransmissionBlock,
+            templateId: EntryPointFrameReader.TidRetransmission, version: 0);
+        var body = dst.Slice(HeaderSize, RetransmissionBlock);
+        body.Clear();
+        MemoryMarshal.Write(body.Slice(0, 4), in sessionId);
+        MemoryMarshal.Write(body.Slice(4, 8), in requestTimestampNanos);
+        MemoryMarshal.Write(body.Slice(12, 4), in firstRetransmittedSeqNo);
+        MemoryMarshal.Write(body.Slice(16, 4), in count);
+        return RetransmissionTotal;
+    }
+
+    /// <summary>
+    /// Encodes a <c>RetransmitReject</c> frame.
+    /// </summary>
+    public static int EncodeRetransmitReject(Span<byte> dst,
+        uint sessionId, ulong requestTimestampNanos,
+        B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode code)
+    {
+        if (dst.Length < RetransmitRejectTotal)
+            throw new ArgumentException("buffer too small for RetransmitReject", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)RetransmitRejectTotal,
+            blockLength: RetransmitRejectBlock,
+            templateId: EntryPointFrameReader.TidRetransmitReject, version: 0);
+        var body = dst.Slice(HeaderSize, RetransmitRejectBlock);
+        body.Clear();
+        MemoryMarshal.Write(body.Slice(0, 4), in sessionId);
+        MemoryMarshal.Write(body.Slice(4, 8), in requestTimestampNanos);
+        body[12] = (byte)code;
+        return RetransmitRejectTotal;
+    }
+}

--- a/src/B3.Exchange.Gateway/RetransmitBuffer.cs
+++ b/src/B3.Exchange.Gateway/RetransmitBuffer.cs
@@ -1,0 +1,173 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Per-session bounded ring buffer of recently-emitted business frames,
+/// keyed by FIXP <c>MsgSeqNum</c>. Used by issue #46 to satisfy
+/// <c>RetransmitRequest</c>s per spec §4.5.6.
+///
+/// <para>Producer (<see cref="Append"/>) is the session's outbound write
+/// path under the FixpSession outbound serialization lock; consumer
+/// (<see cref="TryGet"/>) is the inbound dispatch thread that handles
+/// <c>RetransmitRequest</c>. The buffer takes its own internal lock so
+/// validation + cloning happen as a single atomic snapshot — there is no
+/// TOCTOU window between checking the seq window and reading the frames.</para>
+///
+/// <para>Replayed frames are deep-copied and have the
+/// <c>OutboundBusinessHeader.EventIndicator.PossResend</c> bit (0x01)
+/// set on the copy. The stored originals are never mutated, so a session
+/// can serve many overlapping replays without corrupting the live stream
+/// (per #GAP-13).</para>
+///
+/// <para>Bounded by <see cref="Capacity"/>: when full, the oldest entry
+/// is evicted. <see cref="FirstAvailableSeqOrZero"/> tracks the lowest
+/// retained seq (zero before the first append). <see cref="LastSeqOrZero"/>
+/// is the highest. Combined with the request validator, this lets the
+/// caller distinguish <c>OUT_OF_RANGE</c> (below window) from
+/// <c>INVALID_FROMSEQNO</c> (above window) per #46 acceptance criteria.</para>
+/// </summary>
+internal sealed class RetransmitBuffer
+{
+    /// <summary>Absolute byte offset of the
+    /// <c>OutboundBusinessHeader.EventIndicator</c> within a wire frame
+    /// (SOFH 4 + SBE 8 + BusinessHeader prefix 16 = 28). All buffered
+    /// business templates (ExecutionReport_*, BusinessMessageReject)
+    /// share this layout — see ExecutionReportEncoder.WriteBusinessHeader.</summary>
+    public const int EventIndicatorAbsoluteOffset = EntryPointFrameReader.WireHeaderSize + 16;
+
+    /// <summary>EventIndicator bit for PossResend (per FIXP V6 schema
+    /// EventIndicator set: PossResend = 1).</summary>
+    public const byte PossResendBit = 0x01;
+
+    /// <summary>Spec §4.5.6: max messages allowed in a single
+    /// RetransmitRequest.</summary>
+    public const int MaxRequestCount = 1000;
+
+    private readonly object _lock = new();
+    private readonly byte[]?[] _frames;
+    private readonly uint[] _seqs;
+    private int _head;        // next write index
+    private int _count;
+    private uint _lastSeq;
+
+    public int Capacity { get; }
+
+    public RetransmitBuffer(int capacity)
+    {
+        if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
+        Capacity = capacity;
+        _frames = new byte[]?[capacity];
+        _seqs = new uint[capacity];
+    }
+
+    /// <summary>
+    /// Appends a wire frame (SOFH+SBE+body) to the buffer at the given
+    /// sequence number. The buffer takes a reference; do not mutate
+    /// <paramref name="frame"/> after calling. Evicts the oldest entry
+    /// if the buffer is full.
+    /// </summary>
+    public void Append(uint seq, byte[] frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        lock (_lock)
+        {
+            _frames[_head] = frame;
+            _seqs[_head] = seq;
+            _head = (_head + 1) % Capacity;
+            if (_count < Capacity) _count++;
+            _lastSeq = seq;
+        }
+    }
+
+    /// <summary>Snapshot of the lowest seq currently retained, or 0 if
+    /// the buffer is empty.</summary>
+    public uint FirstAvailableSeqOrZero
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (_count == 0) return 0;
+                int firstIndex = (_head - _count + Capacity) % Capacity;
+                return _seqs[firstIndex];
+            }
+        }
+    }
+
+    /// <summary>Snapshot of the highest seq currently retained, or 0
+    /// if the buffer is empty.</summary>
+    public uint LastSeqOrZero
+    {
+        get { lock (_lock) { return _count == 0 ? 0u : _lastSeq; } }
+    }
+
+    public int Count { get { lock (_lock) { return _count; } } }
+
+    /// <summary>
+    /// Outcome of <see cref="TryGet"/>. On success <see cref="Frames"/>
+    /// holds <see cref="ActualCount"/> deep-copied frames in seq order
+    /// starting at <see cref="FirstSeq"/> (= the request's
+    /// <c>fromSeqNo</c> when accepted), each with the
+    /// <c>PossResend</c> bit set. On failure <see cref="RejectCode"/>
+    /// is non-null.
+    /// </summary>
+    public readonly record struct GetResult(
+        byte[][] Frames,
+        uint FirstSeq,
+        uint ActualCount,
+        B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode? RejectCode);
+
+    /// <summary>
+    /// Validates and clones the requested seq range under a single lock.
+    /// Validation order: count bounds → empty buffer → fromSeq window
+    /// (below = OUT_OF_RANGE, above = INVALID_FROMSEQNO). On accept,
+    /// clamps the response to <c>min(count, lastSeq - fromSeq + 1)</c>
+    /// when the request extends past what's been produced.
+    /// </summary>
+    public GetResult TryGet(uint fromSeq, uint requestedCount)
+    {
+        // Per spec / schema range; map count==0 to INVALID_COUNT and
+        // count>1000 to REQUEST_LIMIT_EXCEEDED. (See gpt-5.5 critique
+        // for taxonomy choice.)
+        if (requestedCount == 0)
+            return new(Array.Empty<byte[]>(), 0, 0, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_COUNT);
+        if (requestedCount > MaxRequestCount)
+            return new(Array.Empty<byte[]>(), 0, 0, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.REQUEST_LIMIT_EXCEEDED);
+
+        lock (_lock)
+        {
+            if (_count == 0)
+            {
+                // No history at all — treat as "above window".
+                return new(Array.Empty<byte[]>(), 0, 0, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO);
+            }
+
+            int firstIndex = (_head - _count + Capacity) % Capacity;
+            uint firstSeq = _seqs[firstIndex];
+            uint lastSeq = _lastSeq;
+
+            if (fromSeq < firstSeq)
+                return new(Array.Empty<byte[]>(), 0, 0, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.OUT_OF_RANGE);
+            if (fromSeq > lastSeq)
+                return new(Array.Empty<byte[]>(), 0, 0, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO);
+
+            // Promote to ulong for clamp arithmetic per gpt-5.5 critique
+            // — fromSeq+count near uint.MaxValue can overflow.
+            ulong available = (ulong)lastSeq - fromSeq + 1UL;
+            uint actual = (uint)Math.Min(requestedCount, available);
+
+            var clones = new byte[actual][];
+            int offsetFromFirst = (int)(fromSeq - firstSeq);
+            for (uint i = 0; i < actual; i++)
+            {
+                int idx = (firstIndex + offsetFromFirst + (int)i) % Capacity;
+                var src = _frames[idx]!;
+                var clone = new byte[src.Length];
+                Buffer.BlockCopy(src, 0, clone, 0, src.Length);
+                if (clone.Length > EventIndicatorAbsoluteOffset)
+                    clone[EventIndicatorAbsoluteOffset] |= PossResendBit;
+                clones[i] = clone;
+            }
+            return new(clones, fromSeq, actual, null);
+        }
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
@@ -1,0 +1,376 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// End-to-end-ish tests for issue #46: the FixpSession buffers business
+/// frames it sends and serves <c>RetransmitRequest</c>s with
+/// <c>Retransmission</c> + replays-with-PossResend + a trailing
+/// <c>Sequence</c>, or a <c>RetransmitReject</c> on validation failure.
+/// </summary>
+public class FixpSessionRetransmitTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static async Task<(NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        tcp.Stop();
+        return (new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static byte[] BuildRetransmitRequest(uint sessionId, ulong timestampNanos, uint fromSeqNo, uint count)
+    {
+        const int total = EntryPointFrameReader.WireHeaderSize + 20;
+        var f = new byte[total];
+        EntryPointFrameReader.WriteHeader(f, messageLength: (ushort)total,
+            blockLength: 20, templateId: EntryPointFrameReader.TidRetransmitRequest, version: 0);
+        var body = f.AsSpan(EntryPointFrameReader.WireHeaderSize, 20);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), timestampNanos);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(12, 4), fromSeqNo);
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(16, 4), count);
+        return f;
+    }
+
+    private static OrderAcceptedEvent NewER(uint rptSeq, long orderId)
+        => new(SecurityId: 1234, OrderId: orderId, ClOrdId: orderId.ToString(),
+            Side: Side.Buy, PriceMantissa: 100_0000, RemainingQuantity: 10,
+            EnteringFirm: 7, InsertTimestampNanos: 1_000_000UL * rptSeq, RptSeq: rptSeq);
+
+    private static async Task<(ushort templateId, byte[] frame)> ReadOneFrameAsync(NetworkStream s, CancellationToken ct)
+    {
+        var hdr = new byte[EntryPointFrameReader.WireHeaderSize];
+        int total = 0;
+        while (total < hdr.Length)
+        {
+            int n = await s.ReadAsync(hdr.AsMemory(total), ct);
+            if (n == 0) throw new EndOfStreamException();
+            total += n;
+        }
+        if (!EntryPointFrameReader.TryParseInboundHeader(hdr, out var info, out _, out _))
+        {
+            // Outbound templates aren't recognized inbound — parse manually.
+            ushort messageLen = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(0, 2));
+            ushort tid = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(6, 2));
+            int bodyLen = messageLen - EntryPointFrameReader.WireHeaderSize;
+            var body = new byte[bodyLen];
+            int btotal = 0;
+            while (btotal < bodyLen)
+            {
+                int n = await s.ReadAsync(body.AsMemory(btotal), ct);
+                if (n == 0) throw new EndOfStreamException();
+                btotal += n;
+            }
+            var full = new byte[messageLen];
+            Buffer.BlockCopy(hdr, 0, full, 0, hdr.Length);
+            Buffer.BlockCopy(body, 0, full, hdr.Length, body.Length);
+            return (tid, full);
+        }
+        var bbody = new byte[info.BodyLength];
+        int t2 = 0;
+        while (t2 < info.BodyLength)
+        {
+            int n = await s.ReadAsync(bbody.AsMemory(t2), ct);
+            if (n == 0) throw new EndOfStreamException();
+            t2 += n;
+        }
+        var fl = new byte[info.MessageLength];
+        Buffer.BlockCopy(hdr, 0, fl, 0, hdr.Length);
+        Buffer.BlockCopy(bbody, 0, fl, hdr.Length, bbody.Length);
+        return (info.TemplateId, fl);
+    }
+
+    private static FixpSession NewEstablishedSession(NetworkStream serverSide, uint sessionId = 100)
+    {
+        var session = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: sessionId,
+            stream: serverSide, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance);
+        session.Start();
+        session.ApplyTransition(FixpEvent.Negotiate);
+        session.ApplyTransition(FixpEvent.Establish);
+        return session;
+    }
+
+    [Fact]
+    public async Task Replay_returns_Retransmission_then_clones_with_PossResend_then_Sequence()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewEstablishedSession(serverSide);
+            // Produce 3 ER_New frames → seqs 1,2,3.
+            session.WriteExecutionReportNew(NewER(1, 1001));
+            session.WriteExecutionReportNew(NewER(2, 1002));
+            session.WriteExecutionReportNew(NewER(3, 1003));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            // Drain the 3 live ER frames.
+            for (int i = 0; i < 3; i++)
+            {
+                var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+                Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, tid);
+                // Live frames must NOT have PossResend.
+                Assert.Equal(0, frame[RetransmitBuffer.EventIndicatorAbsoluteOffset] & RetransmitBuffer.PossResendBit);
+            }
+
+            // Send RetransmitRequest(fromSeq=2, count=2).
+            var req = BuildRetransmitRequest(sessionId: 100, timestampNanos: 12345UL,
+                fromSeqNo: 2, count: 2);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            // Expect: Retransmission header → 2 clones → trailing Sequence.
+            var (tid1, retxHdr) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidRetransmission, tid1);
+            // nextSeqNo (offset 24) == 2; count (offset 28) == 2.
+            Assert.Equal(2u, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(retxHdr.AsSpan(24, 4)));
+            Assert.Equal(2u, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(retxHdr.AsSpan(28, 4)));
+
+            for (int i = 0; i < 2; i++)
+            {
+                var (tid2, clone) = await ReadOneFrameAsync(clientStream, cts.Token);
+                Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, tid2);
+                Assert.Equal(RetransmitBuffer.PossResendBit,
+                    clone[RetransmitBuffer.EventIndicatorAbsoluteOffset] & RetransmitBuffer.PossResendBit);
+            }
+
+            var (tid3, seqFrame) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidSequence, tid3);
+            // Sequence.nextSeqNo == 4 (next live seq we'll allocate).
+            Assert.Equal(4u, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(seqFrame.AsSpan(EntryPointFrameReader.WireHeaderSize, 4)));
+
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RetransmitReject_when_fromSeqNo_above_window()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewEstablishedSession(serverSide);
+            session.WriteExecutionReportNew(NewER(1, 1001));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            // Drain the 1 live ER.
+            await ReadOneFrameAsync(clientStream, cts.Token);
+
+            var req = BuildRetransmitRequest(sessionId: 100, timestampNanos: 1UL,
+                fromSeqNo: 99, count: 1);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidRetransmitReject, tid);
+            Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO, frame[24]);
+
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RetransmitReject_when_session_id_mismatch_returns_INVALID_SESSION()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewEstablishedSession(serverSide, sessionId: 100);
+            session.WriteExecutionReportNew(NewER(1, 1001));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await ReadOneFrameAsync(clientStream, cts.Token);
+
+            // Wrong sessionId in request body.
+            var req = BuildRetransmitRequest(sessionId: 999, timestampNanos: 1UL,
+                fromSeqNo: 1, count: 1);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidRetransmitReject, tid);
+            Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_SESSION, frame[24]);
+
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RetransmitReject_when_timestamp_zero_returns_INVALID_TIMESTAMP()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewEstablishedSession(serverSide);
+            session.WriteExecutionReportNew(NewER(1, 1001));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await ReadOneFrameAsync(clientStream, cts.Token);
+
+            var req = BuildRetransmitRequest(sessionId: 100, timestampNanos: 0UL,
+                fromSeqNo: 1, count: 1);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidRetransmitReject, tid);
+            Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_TIMESTAMP, frame[24]);
+
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RetransmitReject_when_count_zero_returns_INVALID_COUNT()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewEstablishedSession(serverSide);
+            session.WriteExecutionReportNew(NewER(1, 1001));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await ReadOneFrameAsync(clientStream, cts.Token);
+
+            var req = BuildRetransmitRequest(sessionId: 100, timestampNanos: 1UL,
+                fromSeqNo: 1, count: 0);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidRetransmitReject, tid);
+            Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_COUNT, frame[24]);
+
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RetransmitReject_when_count_exceeds_max_returns_REQUEST_LIMIT_EXCEEDED()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewEstablishedSession(serverSide);
+            session.WriteExecutionReportNew(NewER(1, 1001));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            await ReadOneFrameAsync(clientStream, cts.Token);
+
+            var req = BuildRetransmitRequest(sessionId: 100, timestampNanos: 1UL,
+                fromSeqNo: 1, count: 1001);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidRetransmitReject, tid);
+            Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.REQUEST_LIMIT_EXCEEDED, frame[24]);
+
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task RetransmitReject_when_send_queue_too_small_returns_SYSTEM_BUSY()
+    {
+        var (serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            // Tiny send queue so a 3-frame replay block (header + 1 + trailer)
+            // can't fit if even one slot is occupied; we don't drain the
+            // 3 ER frames before the request, so depth >= 3 > capacity.
+            var session = new FixpSession(
+                connectionId: 1, enteringFirm: 7, sessionId: 100,
+                stream: serverSide, sink: new NoOpEngineSink(),
+                logger: NullLogger<FixpSession>.Instance,
+                sendQueueCapacity: 4);
+            session.Start();
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+
+            // Pre-fill the send queue without draining (don't read clientStream
+            // yet — backpressure pins frames in the queue).
+            session.WriteExecutionReportNew(NewER(1, 1001));
+            session.WriteExecutionReportNew(NewER(2, 1002));
+            session.WriteExecutionReportNew(NewER(3, 1003));
+            session.WriteExecutionReportNew(NewER(4, 1004));
+
+            var clientStream = client.GetStream();
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+
+            // Request a 3-message replay; with depth 4 + needed (2+3=5) > capacity 4
+            // the gateway must respond SYSTEM_BUSY before any block is enqueued.
+            var req = BuildRetransmitRequest(sessionId: 100, timestampNanos: 1UL,
+                fromSeqNo: 1, count: 3);
+            await clientStream.WriteAsync(req, cts.Token);
+
+            // Drain enough frames until we see the RetransmitReject.
+            for (int i = 0; i < 10; i++)
+            {
+                var (tid, frame) = await ReadOneFrameAsync(clientStream, cts.Token);
+                if (tid == EntryPointFrameReader.TidRetransmitReject)
+                {
+                    Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.SYSTEM_BUSY, frame[24]);
+                    session.Close("test");
+                    return;
+                }
+            }
+            Assert.Fail("did not observe RetransmitReject(SYSTEM_BUSY)");
+        }
+        finally
+        {
+            client.Close();
+            serverSide.Dispose();
+        }
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/RetransmissionEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/RetransmissionEncoderTests.cs
@@ -1,0 +1,53 @@
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Wire-layout tests for <see cref="RetransmissionEncoder"/> (issue #46
+/// session-layer responses to <c>RetransmitRequest</c>).
+/// </summary>
+public class RetransmissionEncoderTests
+{
+    [Fact]
+    public void EncodeRetransmission_layout_is_stable()
+    {
+        Span<byte> buf = stackalloc byte[RetransmissionEncoder.RetransmissionTotal];
+        int n = RetransmissionEncoder.EncodeRetransmission(buf,
+            sessionId: 0xDEADBEEFu, requestTimestampNanos: 0x0102030405060708UL,
+            firstRetransmittedSeqNo: 42u, count: 3u);
+        Assert.Equal(RetransmissionEncoder.RetransmissionTotal, n);
+
+        // SOFH (0..3): messageLength = 32 LE; encodingType = 0xEB50 LE.
+        Assert.Equal((ushort)RetransmissionEncoder.RetransmissionTotal,
+            System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(0, 2)));
+
+        // SBE header (4..11): blockLength=20, templateId=13, schemaId, version=0.
+        Assert.Equal((ushort)20, System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(4, 2)));
+        Assert.Equal((ushort)EntryPointFrameReader.TidRetransmission,
+            System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(6, 2)));
+
+        // Body (12..31): SessionID(4) | Timestamp(8) | NextSeqNo(4) | Count(4)
+        Assert.Equal(0xDEADBEEFu, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(12, 4)));
+        Assert.Equal(0x0102030405060708UL, System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(buf.Slice(16, 8)));
+        Assert.Equal(42u, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(24, 4)));
+        Assert.Equal(3u, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(28, 4)));
+    }
+
+    [Fact]
+    public void EncodeRetransmitReject_layout_is_stable()
+    {
+        Span<byte> buf = stackalloc byte[RetransmissionEncoder.RetransmitRejectTotal];
+        int n = RetransmissionEncoder.EncodeRetransmitReject(buf,
+            sessionId: 7u, requestTimestampNanos: 99UL,
+            B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.OUT_OF_RANGE);
+        Assert.Equal(RetransmissionEncoder.RetransmitRejectTotal, n);
+
+        Assert.Equal((ushort)13,
+            System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(4, 2))); // blockLength
+        Assert.Equal((ushort)EntryPointFrameReader.TidRetransmitReject,
+            System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(buf.Slice(6, 2)));
+        Assert.Equal(7u, System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(buf.Slice(12, 4)));
+        Assert.Equal(99UL, System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(buf.Slice(16, 8)));
+        Assert.Equal((byte)B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.OUT_OF_RANGE, buf[24]);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/RetransmitBufferTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/RetransmitBufferTests.cs
@@ -1,0 +1,130 @@
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Tests for <see cref="RetransmitBuffer"/> (issue #46).
+/// </summary>
+public class RetransmitBufferTests
+{
+    private static byte[] FrameWithSeq(uint seq, byte[]? body = null)
+    {
+        // Synthetic 64-byte business frame with a writable EventIndicator
+        // byte at offset 28. Real frames are produced by ExecutionReportEncoder
+        // and have the same layout invariants.
+        var f = new byte[64];
+        // mark the seq into the buffer for assertion clarity
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(f.AsSpan(0, 4), seq);
+        if (body is not null) Buffer.BlockCopy(body, 0, f, 4, Math.Min(body.Length, 60));
+        return f;
+    }
+
+    [Fact]
+    public void Append_then_TryGet_returns_clones_with_PossResend_set()
+    {
+        var buf = new RetransmitBuffer(8);
+        buf.Append(1, FrameWithSeq(1));
+        buf.Append(2, FrameWithSeq(2));
+        buf.Append(3, FrameWithSeq(3));
+
+        var snap = buf.TryGet(fromSeq: 2, requestedCount: 2);
+        Assert.Null(snap.RejectCode);
+        Assert.Equal(2u, snap.FirstSeq);
+        Assert.Equal(2u, snap.ActualCount);
+        Assert.Equal(2, snap.Frames.Length);
+        // Clone must have PossResend bit at offset 28; original must NOT.
+        Assert.Equal(RetransmitBuffer.PossResendBit, (byte)(snap.Frames[0][28] & RetransmitBuffer.PossResendBit));
+        Assert.Equal(RetransmitBuffer.PossResendBit, (byte)(snap.Frames[1][28] & RetransmitBuffer.PossResendBit));
+    }
+
+    [Fact]
+    public void TryGet_does_not_mutate_stored_frames()
+    {
+        var buf = new RetransmitBuffer(4);
+        var original = FrameWithSeq(1);
+        buf.Append(1, original);
+        var snap = buf.TryGet(1, 1);
+        Assert.Equal(0, original[28]);              // stored original untouched
+        Assert.Equal(RetransmitBuffer.PossResendBit, snap.Frames[0][28]);
+        // Repeated calls always return PossResend on the clone (no carry-over corruption).
+        var snap2 = buf.TryGet(1, 1);
+        Assert.Equal(0, original[28]);
+        Assert.Equal(RetransmitBuffer.PossResendBit, snap2.Frames[0][28]);
+    }
+
+    [Fact]
+    public void Eviction_advances_FirstAvailable()
+    {
+        var buf = new RetransmitBuffer(3);
+        for (uint i = 1; i <= 5; i++) buf.Append(i, FrameWithSeq(i));
+        Assert.Equal(3u, buf.FirstAvailableSeqOrZero);     // 1,2 evicted
+        Assert.Equal(5u, buf.LastSeqOrZero);
+        Assert.Equal(3, buf.Count);
+    }
+
+    [Fact]
+    public void TryGet_below_window_returns_OUT_OF_RANGE()
+    {
+        var buf = new RetransmitBuffer(3);
+        for (uint i = 1; i <= 5; i++) buf.Append(i, FrameWithSeq(i));     // window = [3,5]
+        var snap = buf.TryGet(fromSeq: 1, requestedCount: 2);
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.OUT_OF_RANGE, snap.RejectCode);
+    }
+
+    [Fact]
+    public void TryGet_above_window_returns_INVALID_FROMSEQNO()
+    {
+        var buf = new RetransmitBuffer(8);
+        buf.Append(10, FrameWithSeq(10));
+        var snap = buf.TryGet(fromSeq: 11, requestedCount: 1);
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO, snap.RejectCode);
+    }
+
+    [Fact]
+    public void TryGet_empty_buffer_returns_INVALID_FROMSEQNO()
+    {
+        var buf = new RetransmitBuffer(4);
+        var snap = buf.TryGet(1, 1);
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO, snap.RejectCode);
+    }
+
+    [Fact]
+    public void TryGet_count_zero_returns_INVALID_COUNT()
+    {
+        var buf = new RetransmitBuffer(4);
+        buf.Append(1, FrameWithSeq(1));
+        var snap = buf.TryGet(1, 0);
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_COUNT, snap.RejectCode);
+    }
+
+    [Fact]
+    public void TryGet_count_above_max_returns_REQUEST_LIMIT_EXCEEDED()
+    {
+        var buf = new RetransmitBuffer(2048);
+        for (uint i = 1; i <= 2000; i++) buf.Append(i, FrameWithSeq(i));
+        var snap = buf.TryGet(1, 1001);
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.REQUEST_LIMIT_EXCEEDED, snap.RejectCode);
+    }
+
+    [Fact]
+    public void TryGet_clamps_count_when_request_extends_past_last()
+    {
+        var buf = new RetransmitBuffer(8);
+        for (uint i = 1; i <= 3; i++) buf.Append(i, FrameWithSeq(i));
+        var snap = buf.TryGet(fromSeq: 2, requestedCount: 10);
+        Assert.Null(snap.RejectCode);
+        Assert.Equal(2u, snap.FirstSeq);
+        Assert.Equal(2u, snap.ActualCount);                     // clamped to last (3) - 2 + 1 = 2
+        Assert.Equal(2, snap.Frames.Length);
+    }
+
+    [Fact]
+    public void TryGet_overflow_arithmetic_does_not_wrap()
+    {
+        // fromSeq = uint.MaxValue, count > 1 — naive add would overflow.
+        // Here the buffer is empty; we expect INVALID_FROMSEQNO not a crash.
+        var buf = new RetransmitBuffer(4);
+        var snap = buf.TryGet(uint.MaxValue, 5);
+        Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO, snap.RejectCode);
+    }
+}


### PR DESCRIPTION
Implements FIXP retransmission per spec §4.5.6.

## What
- Per-session ring buffer (default 1024 frames) of recent business messages.
- RetransmitRequest dispatch → Retransmission header + N PossResend clones + trailing Sequence.
- Outbound lock serializes business writes, replay block, and heartbeat Sequences (no interleave; trailer's nextSeqNo always matches next live).
- Backpressure-safe: pre-reserves send-queue capacity; replies SYSTEM_BUSY if it can't fit the full block.

## Reject codes
INVALID_COUNT / REQUEST_LIMIT_EXCEEDED / OUT_OF_RANGE / INVALID_FROMSEQNO / INVALID_SESSION / INVALID_TIMESTAMP / RETRANSMIT_IN_PROGRESS / SYSTEM_BUSY.

## Tests
+19 tests (buffer unit, encoder wire-layout, FixpSession TCP-loopback for happy + each reject). 356 total pass; format clean.

Closes part of #46. PossResend bit (#GAP-13) now wired.

Two GPT-5.5 review passes — addressed heartbeat interleave + unhandled queue overflow.