### PR TITLE
ops: SessionLifecycleMetrics (established/suspended/rebound/reaped)

### DIFF
--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -58,6 +58,30 @@ public interface ISessionMetricsProvider
 public readonly record struct SessionQueueSample(string SessionId, long QueueDepth);
 
 /// <summary>
+/// Process-wide counters for FIXP session lifecycle events. Exposed via
+/// <see cref="MetricsRegistry.Sessions"/>. All increments are atomic and
+/// safe to call from any thread (state-machine transitions, listener
+/// reaper, etc).
+/// </summary>
+public sealed class SessionLifecycleMetrics
+{
+    private long _established;
+    private long _suspended;
+    private long _rebound;
+    private long _reaped;
+
+    public long Established => Interlocked.Read(ref _established);
+    public long Suspended => Interlocked.Read(ref _suspended);
+    public long Rebound => Interlocked.Read(ref _rebound);
+    public long Reaped => Interlocked.Read(ref _reaped);
+
+    public void IncEstablished() => Interlocked.Increment(ref _established);
+    public void IncSuspended() => Interlocked.Increment(ref _suspended);
+    public void IncRebound() => Interlocked.Increment(ref _rebound);
+    public void IncReaped() => Interlocked.Increment(ref _reaped);
+}
+
+/// <summary>
 /// Central registry of channel metrics + a Prometheus text-format
 /// renderer. Hand-rolled to avoid taking a dependency on
 /// <c>prometheus-net</c> (see issue #5 / project conventions).
@@ -67,6 +91,9 @@ public sealed class MetricsRegistry
     private readonly Dictionary<byte, ChannelMetrics> _channels = new();
     private readonly object _lock = new();
     private ISessionMetricsProvider? _sessions;
+    private readonly SessionLifecycleMetrics _sessionLifecycle = new();
+
+    public SessionLifecycleMetrics Sessions => _sessionLifecycle;
 
     public ChannelMetrics RegisterChannel(byte channelNumber)
     {
@@ -134,7 +161,27 @@ public sealed class MetricsRegistry
             }
         }
 
+        EmitProcessCounter(sb, "exch_session_established_total",
+            "Total FIXP sessions that have transitioned into Established (initial Establish + rebind via #69b).",
+            _sessionLifecycle.Established);
+        EmitProcessCounter(sb, "exch_session_suspended_total",
+            "Total FIXP sessions that have transitioned into Suspended (transport drop while Established, issue #69a).",
+            _sessionLifecycle.Suspended);
+        EmitProcessCounter(sb, "exch_session_rebound_total",
+            "Total successful re-attaches of a Suspended session via Establish on a new TCP connection (issue #69b).",
+            _sessionLifecycle.Rebound);
+        EmitProcessCounter(sb, "exch_session_reaped_total",
+            "Total Suspended FIXP sessions closed by the listener's CoD/suspended reaper after exceeding SuspendedTimeoutMs.",
+            _sessionLifecycle.Reaped);
+
         return sb.ToString();
+    }
+
+    private static void EmitProcessCounter(StringBuilder sb, string name, string help, long value)
+    {
+        sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
+        sb.Append("# TYPE ").Append(name).Append(" counter\n");
+        sb.Append(name).Append(' ').Append(value.ToString(CultureInfo.InvariantCulture)).Append('\n');
     }
 
     private static void EmitCounter(StringBuilder sb, string name, string help,

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -165,6 +165,7 @@ public sealed class EntryPointListener : IAsyncDisposable
             {
                 if (s.TryReapIfSuspended(thresholdMs))
                 {
+                    _sessionOptions.LifecycleMetrics?.IncReaped();
                     _logger.LogInformation(
                         "reaped suspended session {ConnectionId} sessionId={SessionId} (timeout={TimeoutMs}ms)",
                         s.ConnectionId, s.SessionId, timeoutMs);

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -180,8 +180,23 @@ public sealed class FixpSession : IAsyncDisposable
     /// </summary>
     internal FixpAction ApplyTransition(FixpEvent ev)
     {
-        var t = FixpStateMachine.Apply(State, ev);
+        var prev = State;
+        var t = FixpStateMachine.Apply(prev, ev);
         State = t.NewState;
+        var metrics = _options.LifecycleMetrics;
+        if (metrics != null && t.Action == FixpAction.Accept && prev != t.NewState)
+        {
+            switch (t.NewState)
+            {
+                case FixpState.Established:
+                    metrics.IncEstablished();
+                    if (prev == FixpState.Suspended) metrics.IncRebound();
+                    break;
+                case FixpState.Suspended:
+                    metrics.IncSuspended();
+                    break;
+            }
+        }
         return t.Action;
     }
 

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -51,6 +51,18 @@ public sealed record FixpSessionOptions
     /// </summary>
     public int RetransmitBufferCapacity { get; init; } = 1024;
 
+    /// <summary>
+    /// Optional process-wide session lifecycle counters. When non-null,
+    /// the session increments <see cref="SessionLifecycleMetrics.Established"/>
+    /// (and <see cref="SessionLifecycleMetrics.Rebound"/> for re-attach)
+    /// on transitions into <c>Established</c>, and
+    /// <see cref="SessionLifecycleMetrics.Suspended"/> on demotions into
+    /// <c>Suspended</c>. Reaped is incremented by the listener after a
+    /// successful reap. Optional so unit tests can construct sessions
+    /// without wiring <c>MetricsRegistry</c>.
+    /// </summary>
+    public B3.Exchange.Core.SessionLifecycleMetrics? LifecycleMetrics { get; init; }
+
     public static FixpSessionOptions Default { get; } = new();
 
     internal void Validate()

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -205,6 +205,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             HeartbeatIntervalMs = _config.Tcp.HeartbeatIntervalMs,
             IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,
             TestRequestGraceMs = _config.Tcp.TestRequestGraceMs,
+            LifecycleMetrics = _metrics.Sessions,
         };
         // Phase 2 (#42): real Negotiate handshake. The validator is pure
         // (no IO); the claim ledger lives for the host process lifetime

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -58,6 +58,44 @@ public class MetricsRegistryTests
         Assert.Equal("startup", p.Name);
     }
 
+    [Fact]
+    public void SessionLifecycleCounters_AreRendered_AndExposeMonotonicCounts()
+    {
+        var reg = new MetricsRegistry();
+        reg.Sessions.IncEstablished();
+        reg.Sessions.IncEstablished();
+        reg.Sessions.IncSuspended();
+        reg.Sessions.IncRebound();
+        reg.Sessions.IncReaped();
+        reg.Sessions.IncReaped();
+        reg.Sessions.IncReaped();
+
+        Assert.Equal(2, reg.Sessions.Established);
+        Assert.Equal(1, reg.Sessions.Suspended);
+        Assert.Equal(1, reg.Sessions.Rebound);
+        Assert.Equal(3, reg.Sessions.Reaped);
+
+        var text = reg.RenderProm();
+        Assert.Contains("# TYPE exch_session_established_total counter\n", text);
+        Assert.Contains("exch_session_established_total 2\n", text);
+        Assert.Contains("exch_session_suspended_total 1\n", text);
+        Assert.Contains("exch_session_rebound_total 1\n", text);
+        Assert.Contains("exch_session_reaped_total 3\n", text);
+    }
+
+    [Fact]
+    public void SessionLifecycleCounters_AreZeroByDefault_AndStillRendered()
+    {
+        var reg = new MetricsRegistry();
+        var text = reg.RenderProm();
+        // Counters MUST be rendered even at zero so scrapers don't see them
+        // appear/disappear; this matches Prometheus best practices.
+        Assert.Contains("exch_session_established_total 0\n", text);
+        Assert.Contains("exch_session_suspended_total 0\n", text);
+        Assert.Contains("exch_session_rebound_total 0\n", text);
+        Assert.Contains("exch_session_reaped_total 0\n", text);
+    }
+
     private sealed class StubSessionProvider : ISessionMetricsProvider
     {
         private readonly SessionQueueSample[] _samples;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
@@ -190,4 +190,46 @@ public class EntryPointListenerReaperTests
             await listener.DisposeAsync();
         }
     }
+
+    [Fact]
+    public async Task Reaper_increments_LifecycleMetrics_Reaped_counter()
+    {
+        var sink = new NoOpEngineSink();
+        var metrics = new SessionLifecycleMetrics();
+        var options = new FixpSessionOptions
+        {
+            HeartbeatIntervalMs = 60_000,
+            IdleTimeoutMs = 60_000,
+            TestRequestGraceMs = 60_000,
+            SuspendedTimeoutMs = 200,
+            LifecycleMetrics = metrics,
+        };
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            sink,
+            NullLoggerFactory.Instance,
+            sessionOptions: options);
+        listener.Start();
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, listener.LocalEndpoint!.Port);
+        var registered = await TestUtil.WaitUntilAsync(
+            () => listener.ActiveSessions.Count == 1, TimeSpan.FromSeconds(2));
+        Assert.True(registered);
+        var session = listener.ActiveSessions[0];
+        session.ApplyTransition(FixpEvent.Negotiate);
+        session.ApplyTransition(FixpEvent.Establish);
+        Assert.Equal(1, metrics.Established);
+        client.Close();
+        var suspended = await TestUtil.WaitUntilAsync(
+            () => session.State == FixpState.Suspended, TimeSpan.FromSeconds(2));
+        Assert.True(suspended);
+        Assert.Equal(1, metrics.Suspended);
+
+        var reaped = await TestUtil.WaitUntilAsync(
+            () => metrics.Reaped >= 1, TimeSpan.FromSeconds(2));
+        Assert.True(reaped, $"reaper did not increment Reaped within 2s (Reaped={metrics.Reaped})");
+        // Sanity: Rebound stays zero (we never re-attached).
+        Assert.Equal(0, metrics.Rebound);
+    }
 }

--- a/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
@@ -1,0 +1,107 @@
+using System.IO;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Verifies that <see cref="FixpSession.ApplyTransition"/> increments the
+/// process-wide <see cref="SessionLifecycleMetrics"/> exactly when state
+/// transitions cross the canonical lifecycle edges that ops cares about
+/// (Established / Suspended / Rebound). Reaped is incremented by the
+/// listener and is covered by <see cref="EntryPointListenerReaperTests"/>
+/// in a separate hook.
+/// </summary>
+public class SessionLifecycleMetricsWiringTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static FixpSession NewSession(SessionLifecycleMetrics metrics)
+    {
+        // No real transport: drive ApplyTransition directly. The session
+        // is never Started so the recv loop is dormant.
+        return new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: Stream.Null, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance,
+            options: new FixpSessionOptions { LifecycleMetrics = metrics });
+    }
+
+    [Fact]
+    public void Initial_Negotiate_then_Establish_increments_Established_only()
+    {
+        var m = new SessionLifecycleMetrics();
+        var s = NewSession(m);
+
+        s.ApplyTransition(FixpEvent.Negotiate);
+        Assert.Equal(0, m.Established);
+
+        s.ApplyTransition(FixpEvent.Establish);
+        Assert.Equal(1, m.Established);
+        Assert.Equal(0, m.Suspended);
+        Assert.Equal(0, m.Rebound);
+    }
+
+    [Fact]
+    public void Detach_from_Established_increments_Suspended()
+    {
+        var m = new SessionLifecycleMetrics();
+        var s = NewSession(m);
+        s.ApplyTransition(FixpEvent.Negotiate);
+        s.ApplyTransition(FixpEvent.Establish);
+
+        s.ApplyTransition(FixpEvent.Detach);
+        Assert.Equal(1, m.Suspended);
+    }
+
+    [Fact]
+    public void Establish_from_Suspended_increments_BOTH_Established_and_Rebound()
+    {
+        var m = new SessionLifecycleMetrics();
+        var s = NewSession(m);
+        s.ApplyTransition(FixpEvent.Negotiate);
+        s.ApplyTransition(FixpEvent.Establish); // 1st Established
+        s.ApplyTransition(FixpEvent.Detach);    // → Suspended
+        Assert.Equal(1, m.Established);
+        Assert.Equal(1, m.Suspended);
+
+        s.ApplyTransition(FixpEvent.Establish); // re-attach
+        Assert.Equal(2, m.Established);
+        Assert.Equal(1, m.Rebound);
+    }
+
+    [Fact]
+    public void Same_state_transition_does_not_double_count()
+    {
+        var m = new SessionLifecycleMetrics();
+        var s = NewSession(m);
+        s.ApplyTransition(FixpEvent.Negotiate);
+        s.ApplyTransition(FixpEvent.Establish);
+        // A second Establish on an already-Established session is rejected
+        // by the state machine (no-op); must not bump Established again.
+        s.ApplyTransition(FixpEvent.Establish);
+        Assert.Equal(1, m.Established);
+        Assert.Equal(0, m.Rebound);
+    }
+
+    [Fact]
+    public void Without_LifecycleMetrics_session_does_not_throw()
+    {
+        // Sanity: optional wiring; tests + legacy callers may omit metrics.
+        var s = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: Stream.Null, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance);
+        s.ApplyTransition(FixpEvent.Negotiate);
+        s.ApplyTransition(FixpEvent.Establish);
+        s.ApplyTransition(FixpEvent.Detach);
+    }
+}


### PR DESCRIPTION
Phase 4 ops scope: process-wide FIXP session lifecycle counters in MetricsRegistry, exposed via /metrics.

## Counters
- exch_session_established_total — every transition into Established (initial + rebind)
- exch_session_suspended_total — every Established → Suspended demotion (#69a)
- exch_session_rebound_total — every Suspended → Established re-attach (#69b); also bumps Established (Established >= Rebound is monitorable invariant)
- exch_session_reaped_total — incremented by EntryPointListener after TryReapIfSuspended success

## Wiring
Single chokepoint in FixpSession.ApplyTransition (gated on Action==Accept && prev!=next so no-op transitions don't double-count). LifecycleMetrics is optional on FixpSessionOptions; ExchangeHost wires it; legacy/test callers may omit.

## Tests (+6)
MetricsRegistry rendering (happy + zero-default), wiring (5 cases incl. rebind double-bump and same-state idempotence), reaper integration (Reaped++ on real reap). 365 total pass; format clean.