### PR TITLE
gateway: NotApplied on inbound MsgSeqNum gap (#45)

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -66,6 +66,8 @@ public static class EntryPointFrameReader
     public const ushort TidRetransmission = 13;
     /// <summary>Session: RetransmitReject (FIXP, outbound). See spec §4.5.6.</summary>
     public const ushort TidRetransmitReject = 14;
+    /// <summary>Session: NotApplied (FIXP, outbound). See spec §4.5.5 / §4.6.2.</summary>
+    public const ushort TidNotApplied = 8;
     /// <summary>Outbound only: NegotiateResponse (template id 2).</summary>
     public const ushort TidNegotiateResponse = 2;
     /// <summary>Outbound only: NegotiateReject (template id 3).</summary>

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -423,6 +423,15 @@ public sealed class FixpSession : IAsyncDisposable
             // the session).
             if (!TryAcceptBusinessHeaderSessionId(info.TemplateId, fixedBlock))
                 return true;
+
+            // §4.5.5 / §4.6.2 (#GAP-07): inbound MsgSeqNum gap detection.
+            // On gap (received > expected) emit NotApplied(fromSeqNo=expected,
+            // count=received-expected) AND advance expected past the gap
+            // (the new message is still applied — flow is idempotent).
+            // Duplicates (received <= expected) are dropped silently
+            // because the spec defines the inbound stream as idempotent.
+            if (!TryAcceptBusinessHeaderMsgSeqNum(fixedBlock))
+                return true;
         }
 
         var spec = EntryPointVarData.ExpectedFor(info.TemplateId, info.Version);
@@ -708,6 +717,84 @@ public sealed class FixpSession : IAsyncDisposable
             "fixp session {ConnectionId} rejected business message: sessionID {Got} != negotiated {Expected} (template={Template})",
             ConnectionId, hdrSessionId, SessionId, templateId);
         return false;
+    }
+
+    /// <summary>
+    /// Spec §4.5.5 / §4.6.2 (#GAP-07): inbound MsgSeqNum gap detection.
+    /// Reads <c>InboundBusinessHeader.msgSeqNum</c> at body[4..8] and
+    /// compares to the next-expected counter
+    /// (<c>LastIncomingSeqNo + 1</c>):
+    ///
+    /// <list type="bullet">
+    ///   <item><description>received == expected → advance and accept (return true).</description></item>
+    ///   <item><description>received &gt; expected → emit one
+    ///     <c>NotApplied(fromSeqNo=expected, count=received-expected)</c>,
+    ///     advance past the gap (received), and accept the new message
+    ///     (return true). The flow is idempotent — the gap window is
+    ///     recoverable by the client at its discretion.</description></item>
+    ///   <item><description>received &lt;= LastIncomingSeqNo → duplicate
+    ///     (e.g. PossResend on a client retransmit). Drop silently;
+    ///     return false so the dispatch loop skips engine enqueue.
+    ///     Idempotence per spec means the gateway never applies the
+    ///     same MsgSeqNum twice.</description></item>
+    /// </list>
+    ///
+    /// Called only in strict mode.
+    /// </summary>
+    internal bool TryAcceptBusinessHeaderMsgSeqNum(ReadOnlySpan<byte> fixedBlock)
+    {
+        uint hdrMsgSeqNum = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4));
+
+        // Duplicate / replay: drop silently. Includes hdrMsgSeqNum == 0
+        // (a peer that hasn't started numbering yet — defensive: don't
+        // advance to 0).
+        if (hdrMsgSeqNum == 0 || hdrMsgSeqNum <= LastIncomingSeqNo)
+        {
+            _logger.LogDebug(
+                "fixp session {ConnectionId} dropping duplicate inbound msgSeqNum={SeqNum} (last accepted={Last})",
+                ConnectionId, hdrMsgSeqNum, LastIncomingSeqNo);
+            return false;
+        }
+
+        uint expected = LastIncomingSeqNo + 1;
+        if (hdrMsgSeqNum > expected)
+        {
+            uint gap = hdrMsgSeqNum - expected;
+            // NotApplied is a session-level frame: does NOT take an
+            // outbound MsgSeqNum, so it goes straight to the transport
+            // (no AppendAndEnqueueLocked / RetransmitBuffer involvement).
+            // Holding _outboundLock keeps NotApplied from interleaving
+            // inside an in-progress replay block (issue #46) or between
+            // an ER and its trailing Sequence.
+            var frame = new byte[SessionFrameEncoder.NotAppliedTotal];
+            SessionFrameEncoder.EncodeNotApplied(frame, fromSeqNo: expected, count: gap);
+            bool enqueued;
+            lock (_outboundLock)
+            {
+                enqueued = _transport.TryEnqueueFrame(frame);
+            }
+            if (!enqueued)
+            {
+                // Send queue full / transport closing: do NOT advance and
+                // do NOT accept. The transport will tear down the session;
+                // dropping this message preserves the "NotApplied + apply"
+                // coupling under failure (we never apply a gapped message
+                // without successfully signaling the gap).
+                _logger.LogWarning(
+                    "fixp session {ConnectionId} could not enqueue NotApplied (transport closing or queue full); dropping inbound msgSeqNum={SeqNum}",
+                    ConnectionId, hdrMsgSeqNum);
+                return false;
+            }
+            _logger.LogWarning(
+                "fixp session {ConnectionId} inbound gap detected: expected={Expected} received={Got} gap={Gap}; sent NotApplied",
+                ConnectionId, expected, hdrMsgSeqNum, gap);
+        }
+
+        // Always advance to the new high-water mark on acceptance,
+        // even when there was a gap (idempotent: the new message is
+        // applied regardless of any missing predecessors).
+        LastIncomingSeqNo = hdrMsgSeqNum;
+        return true;
     }
 
     /// <summary>

--- a/src/B3.Exchange.Gateway/SessionFrameEncoder.cs
+++ b/src/B3.Exchange.Gateway/SessionFrameEncoder.cs
@@ -15,6 +15,37 @@ internal static class SessionFrameEncoder
     public const int SequenceTotal = HeaderSize + SequenceBlock;
 
     /// <summary>
+    /// NotApplied (templateId=8) carries 8 bytes of body: FromSeqNo
+    /// (uint32 @0) + Count (uint32 @4). Per spec §4.5.5 the gateway
+    /// emits one of these whenever it detects an inbound MsgSeqNum gap.
+    /// NotApplied is a session-layer message and does NOT consume an
+    /// outbound MsgSeqNum.
+    /// </summary>
+    public const int NotAppliedBlock = 8;
+    public const int NotAppliedTotal = HeaderSize + NotAppliedBlock;
+
+    /// <summary>
+    /// Writes a <c>NotApplied</c> (templateId=8) frame announcing a gap
+    /// of <paramref name="count"/> messages starting at
+    /// <paramref name="fromSeqNo"/> (the first MsgSeqNum the gateway
+    /// EXPECTED but did NOT receive). Per spec §4.5.5 / §4.6.2 this is
+    /// idempotent: the gateway accepts the new (higher) message and
+    /// advances its expected counter past the gap; the client may then
+    /// retransmit, send something else, or do nothing.
+    /// </summary>
+    public static int EncodeNotApplied(Span<byte> dst, uint fromSeqNo, uint count)
+    {
+        if (dst.Length < NotAppliedTotal)
+            throw new ArgumentException("buffer too small for NotApplied frame", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)NotAppliedTotal,
+            blockLength: NotAppliedBlock,
+            templateId: EntryPointFrameReader.TidNotApplied, version: 0);
+        MemoryMarshal.Write(dst.Slice(HeaderSize, 4), in fromSeqNo);
+        MemoryMarshal.Write(dst.Slice(HeaderSize + 4, 4), in count);
+        return NotAppliedTotal;
+    }
+
+    /// <summary>
     /// Writes a <c>Sequence</c> (templateId=9) frame. In FIXP this message
     /// doubles as the heartbeat: the server emits it when no other outbound
     /// traffic has been sent within the heartbeat interval, and as a probe

--- a/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
@@ -1,0 +1,221 @@
+using System.Buffers.Binary;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #45 (#GAP-07) — inbound MsgSeqNum tracking + NotApplied gap
+/// signaling. Spec §4.5.5 / §4.6.2: the inbound flow is idempotent —
+/// on a gap (received &gt; expected) the gateway accepts the new
+/// message AND emits one <c>NotApplied(fromSeqNo=expected, count=N)</c>.
+/// Duplicates (received &lt;= LastIncomingSeqNo) are dropped silently.
+/// </summary>
+public class InboundMsgSeqNumGapTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static async Task<(NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        tcp.Stop();
+        return (new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static byte[] BuildBody(uint headerSessionId, uint headerMsgSeqNum, int totalLen)
+    {
+        var body = new byte[totalLen];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), headerSessionId);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(4, 4), headerMsgSeqNum);
+        return body;
+    }
+
+    private static FixpSession NewStartedSession(NetworkStream server)
+    {
+        var session = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: server, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance);
+        session.Start();
+        session.ApplyTransition(FixpEvent.Negotiate);
+        session.ApplyTransition(FixpEvent.Establish);
+        return session;
+    }
+
+    private static async Task<byte[]?> TryReadFrameAsync(NetworkStream ns, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var head = new byte[EntryPointFrameReader.WireHeaderSize];
+        try
+        {
+            int read = 0;
+            while (read < head.Length)
+            {
+                int n = await ns.ReadAsync(head.AsMemory(read), cts.Token);
+                if (n <= 0) return null;
+                read += n;
+            }
+            ushort msgLen = BinaryPrimitives.ReadUInt16LittleEndian(head.AsSpan(0, 2));
+            int bodyLen = msgLen - EntryPointFrameReader.WireHeaderSize;
+            var body = new byte[bodyLen];
+            read = 0;
+            while (read < bodyLen)
+            {
+                int n = await ns.ReadAsync(body.AsMemory(read), cts.Token);
+                if (n <= 0) return null;
+                read += n;
+            }
+            var full = new byte[msgLen];
+            head.CopyTo(full, 0);
+            body.CopyTo(full, head.Length);
+            return full;
+        }
+        catch (OperationCanceledException) { return null; }
+    }
+
+    [Fact]
+    public async Task FirstMessage_with_seq_1_is_accepted_no_NotApplied()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+
+            var body = BuildBody(100, headerMsgSeqNum: 1, totalLen: 82);
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(body));
+            Assert.Equal(1u, session.LastIncomingSeqNo);
+
+            var frame = await TryReadFrameAsync(client.GetStream(), TimeSpan.FromMilliseconds(150));
+            Assert.Null(frame); // no session frame should be emitted
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Sequential_messages_advance_LastIncomingSeqNo_and_emit_nothing()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+
+            for (uint i = 1; i <= 5; i++)
+                Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, i, 82)));
+            Assert.Equal(5u, session.LastIncomingSeqNo);
+
+            Assert.Null(await TryReadFrameAsync(client.GetStream(), TimeSpan.FromMilliseconds(150)));
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Gap_emits_one_NotApplied_with_correct_FromSeqNo_and_Count_and_advances_past_gap()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+
+            // Receive 1, 2, then jump to 7 (gap of 4: missing 3,4,5,6).
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 1, 82)));
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 2, 82)));
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 7, 82)));
+            Assert.Equal(7u, session.LastIncomingSeqNo);
+
+            var frame = await TryReadFrameAsync(client.GetStream(), TimeSpan.FromSeconds(2));
+            Assert.NotNull(frame);
+            ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(frame.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+            Assert.Equal(EntryPointFrameReader.TidNotApplied, tid);
+            uint fromSeqNo = BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(EntryPointFrameReader.WireHeaderSize, 4));
+            uint count = BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(EntryPointFrameReader.WireHeaderSize + 4, 4));
+            Assert.Equal(3u, fromSeqNo);
+            Assert.Equal(4u, count);
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Duplicate_message_below_high_water_is_dropped_silently()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 1, 82)));
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 2, 82)));
+            // Replay of 1 and 2 — must be dropped silently (return false,
+            // no NotApplied) and LastIncomingSeqNo must not regress.
+            Assert.False(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 1, 82)));
+            Assert.False(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 2, 82)));
+            Assert.Equal(2u, session.LastIncomingSeqNo);
+
+            Assert.Null(await TryReadFrameAsync(client.GetStream(), TimeSpan.FromMilliseconds(150)));
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Zero_msgSeqNum_is_dropped_silently_and_does_not_regress_high_water()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+
+            Assert.False(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 0, 82)));
+            Assert.Equal(0u, session.LastIncomingSeqNo);
+
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 1, 82)));
+            Assert.False(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 0, 82)));
+            Assert.Equal(1u, session.LastIncomingSeqNo);
+
+            Assert.Null(await TryReadFrameAsync(client.GetStream(), TimeSpan.FromMilliseconds(150)));
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Gap_of_one_emits_NotApplied_count_1()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 1, 82)));
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(BuildBody(100, 3, 82)));
+            Assert.Equal(3u, session.LastIncomingSeqNo);
+
+            var frame = await TryReadFrameAsync(client.GetStream(), TimeSpan.FromSeconds(2));
+            Assert.NotNull(frame);
+            uint fromSeqNo = BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(EntryPointFrameReader.WireHeaderSize, 4));
+            uint count = BinaryPrimitives.ReadUInt32LittleEndian(frame.AsSpan(EntryPointFrameReader.WireHeaderSize + 4, 4));
+            Assert.Equal(2u, fromSeqNo);
+            Assert.Equal(1u, count);
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+}


### PR DESCRIPTION
## Summary

B3 spec §4.5.5 / §4.6.2 (#GAP-07): the gateway tracks `businessHeader.msgSeqNum` on every inbound business message in strict mode. On a gap (received > expected) it emits one session-layer `NotApplied(fromSeqNo=expected, count=gap)` frame and accepts the new message. Duplicates and `msgSeqNum=0` are dropped silently (idempotent inbound flow per spec).

## Behavior

| Inbound seq | Outcome |
|---|---|
| `== expected` | accept; advance `LastIncomingSeqNo` |
| `> expected` | emit one NotApplied(fromSeq=expected, count=gap); accept; advance |
| `<= LastIncomingSeqNo` or `0` | drop silently; no frame on the wire |

## Notes

- NotApplied is a **session frame** (TID=8) — does **not** consume an outbound MsgSeqNum and does **not** enter the retransmit buffer.
- Enqueue is wrapped in `_outboundLock` so NotApplied cannot interleave inside an in-progress replay block (#46) or between an ER and its trailing Sequence.
- If the send queue rejects NotApplied (transport closing / queue full), the inbound message is dropped — preserves the 'NotApplied + apply' coupling under failure.
- `LastIncomingSeqNo` (previously declared but never written) is now the canonical inbound counter.

## Dispatch order (strict mode)

state-machine gate → sessionID validate (#48 BMR) → **MsgSeqNum gap (this PR)** → varData → decoder → engine

## Tests

6 new tests in `InboundMsgSeqNumGapTests`:
- in-order seq=1 → accept, no frame
- 5 sequential messages advance counter, no frame
- gap 1,2,7 → NotApplied(fromSeq=3, count=4)
- gap 1,3 → NotApplied(fromSeq=2, count=1)
- duplicate seq dropped silently, counter does not regress
- msgSeqNum=0 dropped silently

Following the precedent in `BusinessHeaderSessionIdValidationTests` (#48), tests exercise the helper directly rather than the full TCP→dispatch path.

Closes #45