### PR TITLE
gateway: BusinessMessageReject taxonomy for §4.10 varData rejects (#50)

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointVarData.cs
+++ b/src/B3.Exchange.Gateway/EntryPointVarData.cs
@@ -13,11 +13,14 @@ public static class EntryPointVarData
 {
     /// <summary>One varData field declaration: spec name and the maximum
     /// payload length in bytes (the <c>length</c> primitive's
-    /// <c>maxValue</c> attribute in the SBE schema).</summary>
-    public readonly record struct Field(string Name, byte MaxLength);
+    /// <c>maxValue</c> attribute in the SBE schema). When
+    /// <see cref="RejectLineBreaks"/> is set, the validator additionally
+    /// scans the segment for CR (0x0D) / LF (0x0A) bytes (spec §4.10:
+    /// trader-identity / desk fields are single-line text).</summary>
+    public readonly record struct Field(string Name, byte MaxLength, bool RejectLineBreaks = false);
 
     private static readonly Field Memo = new("memo", 40);
-    private static readonly Field DeskID = new("deskID", 20);
+    private static readonly Field DeskID = new("deskID", 20, RejectLineBreaks: true);
     private static readonly Field NegotiateCredentials = new("credentials", 128);
     private static readonly Field NegotiateClientIp = new("clientIP", 30);
     private static readonly Field NegotiateClientAppName = new("clientAppName", 30);
@@ -49,6 +52,108 @@ public static class EntryPointVarData
     };
 
     /// <summary>
+    /// Spec §4.10 classification for a varData validation failure.
+    /// Distinguishes business-rule rejects (must answer with
+    /// <c>BusinessMessageReject(33003)</c> per spec) from protocol errors
+    /// that warrant session termination (<c>DECODING_ERROR</c>).
+    /// </summary>
+    public enum FailureKind
+    {
+        /// <summary>varData is valid.</summary>
+        None = 0,
+        /// <summary>A field exceeded its declared <see cref="Field.MaxLength"/>.
+        /// Spec §4.10: BMR(33003 "&lt;field&gt; too long").</summary>
+        FieldTooLong,
+        /// <summary>A <see cref="Field.RejectLineBreaks"/> field contained
+        /// CR or LF. Spec §4.10: BMR(33003 "Line breaks not supported in
+        /// &lt;field&gt;").</summary>
+        ContainsLineBreaks,
+        /// <summary>The varData blob is structurally malformed
+        /// (truncated, length-prefix overruns buffer, trailing bytes).
+        /// Spec §3.5 / §4.10: DECODING_ERROR → terminate session.</summary>
+        ProtocolError,
+    }
+
+    /// <summary>Structured outcome of <see cref="ValidateDetailed"/>.</summary>
+    public readonly record struct Result(FailureKind Kind, string? FieldName, string? DebugMessage)
+    {
+        public bool IsOk => Kind == FailureKind.None;
+        public bool IsBusinessReject => Kind is FailureKind.FieldTooLong or FailureKind.ContainsLineBreaks;
+
+        /// <summary>
+        /// Returns the BMR text corresponding to spec §4.10 for this
+        /// failure, or <c>null</c> if not applicable. Caller passes the
+        /// returned string as the <c>text</c> field of
+        /// <c>BusinessMessageReject(33003)</c>.
+        /// </summary>
+        public string? BmrText() => Kind switch
+        {
+            FailureKind.FieldTooLong => $"{FieldName} too long",
+            FailureKind.ContainsLineBreaks => $"Line breaks not supported in {FieldName}",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Validates <paramref name="varData"/> with full §4.10 classification
+    /// (length, line-breaks, structural). Replaces <see cref="TryValidate"/>
+    /// for callers that need to distinguish BMR-eligible failures from
+    /// protocol errors. The legacy bool-returning API is kept as a
+    /// passthrough for tests / non-strict paths.
+    /// </summary>
+    public static Result ValidateDetailed(ReadOnlySpan<byte> varData, ReadOnlySpan<Field> spec)
+    {
+        int offset = 0;
+        for (int i = 0; i < spec.Length; i++)
+        {
+            if (offset >= varData.Length)
+            {
+                if (offset == varData.Length) return new Result(FailureKind.None, null, null);
+                return new Result(FailureKind.ProtocolError, spec[i].Name,
+                    $"varData truncated at field '{spec[i].Name}' (offset {offset} > {varData.Length})");
+            }
+            byte len = varData[offset];
+            int payloadStart = offset + 1;
+            int next = payloadStart + len;
+            // Structural check first: if the declared length cannot fit
+            // in the remaining buffer, that is a protocol error
+            // (DECODING_ERROR / Terminate) — not a §4.10 BMR. Ordering
+            // matters: a frame with len=255 but only the prefix byte
+            // present must NOT be classified as FieldTooLong, since the
+            // session is fundamentally desynchronised at the SBE layer.
+            if (next > varData.Length)
+            {
+                return new Result(FailureKind.ProtocolError, spec[i].Name,
+                    $"varData field '{spec[i].Name}' length {len} overruns buffer (offset {payloadStart} + {len} > {varData.Length})");
+            }
+            if (len > spec[i].MaxLength)
+            {
+                return new Result(FailureKind.FieldTooLong, spec[i].Name,
+                    $"varData field '{spec[i].Name}' length {len} exceeds max {spec[i].MaxLength}");
+            }
+            if (spec[i].RejectLineBreaks && len > 0)
+            {
+                var payload = varData.Slice(payloadStart, len);
+                for (int b = 0; b < payload.Length; b++)
+                {
+                    if (payload[b] == 0x0A || payload[b] == 0x0D)
+                    {
+                        return new Result(FailureKind.ContainsLineBreaks, spec[i].Name,
+                            $"varData field '{spec[i].Name}' contains line break at offset {b}");
+                    }
+                }
+            }
+            offset = next;
+        }
+        if (offset != varData.Length)
+        {
+            return new Result(FailureKind.ProtocolError, null,
+                $"varData has {varData.Length - offset} trailing byte(s) after declared fields");
+        }
+        return new Result(FailureKind.None, null, null);
+    }
+
+    /// <summary>
     /// Validates that <paramref name="varData"/> is a well-formed
     /// concatenation of length-prefixed segments matching
     /// <paramref name="spec"/>. Each segment is allowed to be empty
@@ -59,41 +164,9 @@ public static class EntryPointVarData
     /// </summary>
     public static bool TryValidate(ReadOnlySpan<byte> varData, ReadOnlySpan<Field> spec, out string? error)
     {
-        error = null;
-        int offset = 0;
-        for (int i = 0; i < spec.Length; i++)
-        {
-            if (offset >= varData.Length)
-            {
-                // Per spec, varData fields are optional: a field may be omitted
-                // by truncating the trailer, but if present they must appear in
-                // order. If we're past the buffer, remaining fields are simply
-                // not present — that is OK as long as the buffer ended
-                // exactly.
-                if (offset == varData.Length) return true;
-                error = $"varData truncated at field '{spec[i].Name}' (offset {offset} > {varData.Length})";
-                return false;
-            }
-            byte len = varData[offset];
-            if (len > spec[i].MaxLength)
-            {
-                error = $"varData field '{spec[i].Name}' length {len} exceeds max {spec[i].MaxLength}";
-                return false;
-            }
-            int next = offset + 1 + len;
-            if (next > varData.Length)
-            {
-                error = $"varData field '{spec[i].Name}' length {len} overruns buffer (offset {offset + 1} + {len} > {varData.Length})";
-                return false;
-            }
-            offset = next;
-        }
-        if (offset != varData.Length)
-        {
-            error = $"varData has {varData.Length - offset} trailing byte(s) after declared fields";
-            return false;
-        }
-        return true;
+        var r = ValidateDetailed(varData, spec);
+        error = r.DebugMessage;
+        return r.IsOk;
     }
 
     /// <summary>

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -381,7 +381,11 @@ public sealed class FixpSession : IAsyncDisposable
         // Per spec §3.5, varData segments follow the fixed root block. We
         // validate them here (length-prefixed, declared per-template caps
         // from §4.10) before handing the fixed block to the typed
-        // decoders. A varData failure is always DECODING_ERROR per §4.10.
+        // decoders. Classification (#GAP-14): structural failures
+        // (truncation/overrun/trailing) are DECODING_ERROR → Terminate;
+        // §4.10 business-rule failures (length-exceeded, CR/LF in
+        // single-line text fields) on application templates are
+        // BMR(33003) and the session stays open.
         var fullBody = new ReadOnlyMemory<byte>(bodyBuf, 0, bodyLength);
         var fixedBlock = fullBody.Slice(0, info.BlockLength).Span;
         var varData = fullBody.Slice(info.BlockLength).Span;
@@ -435,9 +439,37 @@ public sealed class FixpSession : IAsyncDisposable
         }
 
         var spec = EntryPointVarData.ExpectedFor(info.TemplateId, info.Version);
-        if (!EntryPointVarData.TryValidate(varData, spec, out var varErr))
+        var varResult = EntryPointVarData.ValidateDetailed(varData, spec);
+        if (!varResult.IsOk)
         {
-            _sink.OnDecodeError(Identity, varErr ?? "decode error: varData");
+            // §4.10 (#GAP-14): length-exceeded and CR/LF rejections on
+            // application messages are business-rule failures →
+            // BMR(33003) and drop the offending frame; the session
+            // stays open. Structural protocol errors (truncation,
+            // overrun, trailing bytes) are still DECODING_ERROR →
+            // terminate. Only applies in strict mode (Negotiated): in
+            // legacy passthrough there is no business-header context to
+            // reference, so retain the legacy terminate behaviour.
+            if (_validator is not null && varResult.IsBusinessReject && IsApplicationTemplate(info.TemplateId))
+            {
+                uint refSeqNum = fixedBlock.Length >= 8
+                    ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
+                    : 0u;
+                ulong refClOrdId = fixedBlock.Length >= 28
+                    ? System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(20, 8))
+                    : 0UL;
+                WriteBusinessMessageReject(
+                    refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(info.TemplateId),
+                    refSeqNum: refSeqNum,
+                    businessRejectRefId: refClOrdId,
+                    businessRejectReason: 33003,
+                    text: varResult.BmrText());
+                _logger.LogWarning(
+                    "fixp session {ConnectionId} business reject (varData) template={Template} field={Field} kind={Kind}: {Debug}",
+                    ConnectionId, info.TemplateId, varResult.FieldName, varResult.Kind, varResult.DebugMessage);
+                return true;
+            }
+            _sink.OnDecodeError(Identity, varResult.DebugMessage ?? "decode error: varData");
             await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:varData").ConfigureAwait(false);
             return false;
         }
@@ -708,7 +740,7 @@ public sealed class FixpSession : IAsyncDisposable
             : 0UL;
 
         WriteBusinessMessageReject(
-            refMsgType: (byte)templateId,
+            refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(templateId),
             refSeqNum: hdrMsgSeqNum,
             businessRejectRefId: refClOrdId,
             businessRejectReason: 33003,

--- a/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
@@ -137,16 +137,23 @@ public class BusinessHeaderSessionIdValidationTests
                 if (n <= 0) throw new EndOfStreamException();
                 read += n;
             }
-            // BusinessRejectReason is the first uint after refMsgType/refSeqNum/RefId.
-            // Its absolute body offset depends on the encoder layout — sanity
-            // check by scanning for the magic 33003 in the BMR payload area.
-            bool found33003 = false;
-            for (int i = 0; i + 4 <= bodyBuf.Length; i++)
-            {
-                if (BinaryPrimitives.ReadUInt32LittleEndian(bodyBuf.AsSpan(i, 4)) == 33003u)
-                { found33003 = true; break; }
-            }
-            Assert.True(found33003, "BMR did not carry businessRejectReason=33003");
+            // OutboundBusinessHeader: sessionID(@0,4) + msgSeqNum(@4,4) +
+            // sendingTime(@8,8) + eventIndicator(@16) + marketSegmentID(@17)
+            // BMR payload: refMsgType(byte @18) + padding(@19) +
+            // refSeqNum(uint32 @20) + businessRejectRefId(ulong @24) +
+            // businessRejectReason(uint32 @32).
+            byte refMsgType = bodyBuf[18];
+            uint refSeqNum = BinaryPrimitives.ReadUInt32LittleEndian(bodyBuf.AsSpan(20, 4));
+            ulong businessRejectRefId = BinaryPrimitives.ReadUInt64LittleEndian(bodyBuf.AsSpan(24, 8));
+            uint businessRejectReason = BinaryPrimitives.ReadUInt32LittleEndian(bodyBuf.AsSpan(32, 4));
+            // GAP-14 fix: refMsgType MUST be the schema MessageType enum
+            // byte (15 = SimpleNewOrder), NOT the raw templateId byte
+            // (102). Locking this in so a regression to (byte)templateId
+            // is caught.
+            Assert.Equal((byte)15, refMsgType);
+            Assert.Equal(13u, refSeqNum);
+            Assert.Equal(4242UL, businessRejectRefId);
+            Assert.Equal(33003u, businessRejectReason);
             session.Close("test");
         }
         finally

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointVarDataTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointVarDataTests.cs
@@ -129,4 +129,120 @@ public class EntryPointVarDataTests
         ReadOnlySpan<byte> remaining = new byte[] { 5, 0xAA };
         Assert.False(EntryPointVarData.TryReadNext(ref remaining, out _));
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // GAP-14 (#50): ValidateDetailed classification — distinguishes
+    // §4.10 business-rule rejections (FieldTooLong / ContainsLineBreaks)
+    // from structural protocol errors.
+    // ──────────────────────────────────────────────────────────────────
+
+    private static readonly EntryPointVarData.Field DeskIdNoLineBreaks =
+        new("deskID", 20, RejectLineBreaks: true);
+
+    [Fact]
+    public void ValidateDetailed_Ok_returns_None_kind()
+    {
+        var r = EntryPointVarData.ValidateDetailed(new byte[] { 0 }, new[] { MemoField });
+        Assert.True(r.IsOk);
+        Assert.Equal(EntryPointVarData.FailureKind.None, r.Kind);
+        Assert.Null(r.BmrText());
+    }
+
+    [Fact]
+    public void ValidateDetailed_FieldTooLong_returns_BmrText_too_long()
+    {
+        var buf = new byte[1 + MemoField.MaxLength + 1];
+        buf[0] = (byte)(MemoField.MaxLength + 1);
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { MemoField });
+        Assert.Equal(EntryPointVarData.FailureKind.FieldTooLong, r.Kind);
+        Assert.True(r.IsBusinessReject);
+        Assert.Equal("memo", r.FieldName);
+        Assert.Equal("memo too long", r.BmrText());
+    }
+
+    [Fact]
+    public void ValidateDetailed_ContainsLF_in_RejectLineBreaks_field_returns_BmrText()
+    {
+        var buf = new byte[] { 3, (byte)'A', 0x0A, (byte)'B' };
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { DeskIdNoLineBreaks });
+        Assert.Equal(EntryPointVarData.FailureKind.ContainsLineBreaks, r.Kind);
+        Assert.Equal("deskID", r.FieldName);
+        Assert.Equal("Line breaks not supported in deskID", r.BmrText());
+    }
+
+    [Fact]
+    public void ValidateDetailed_ContainsCR_in_RejectLineBreaks_field_returns_BmrText()
+    {
+        var buf = new byte[] { 3, (byte)'A', 0x0D, (byte)'B' };
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { DeskIdNoLineBreaks });
+        Assert.Equal(EntryPointVarData.FailureKind.ContainsLineBreaks, r.Kind);
+        Assert.Equal("Line breaks not supported in deskID", r.BmrText());
+    }
+
+    [Fact]
+    public void ValidateDetailed_LineBreak_in_field_without_flag_is_accepted()
+    {
+        // Memo (no RejectLineBreaks) is allowed to contain LF/CR.
+        var buf = new byte[] { 3, (byte)'A', 0x0A, (byte)'B' };
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { MemoField });
+        Assert.True(r.IsOk);
+    }
+
+    [Fact]
+    public void ValidateDetailed_Truncated_is_protocol_error_not_BMR()
+    {
+        // Length prefix 5 but only 2 bytes of payload follow → overrun.
+        var buf = new byte[] { 5, 0xAA, 0xBB };
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { MemoField });
+        Assert.Equal(EntryPointVarData.FailureKind.ProtocolError, r.Kind);
+        Assert.False(r.IsBusinessReject);
+        Assert.Null(r.BmrText());
+    }
+
+    [Fact]
+    public void ValidateDetailed_TrailingBytes_is_protocol_error()
+    {
+        // Memo declared 1 byte, but buffer has trailing data.
+        var buf = new byte[] { 1, (byte)'X', 0xFF };
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { MemoField });
+        Assert.Equal(EntryPointVarData.FailureKind.ProtocolError, r.Kind);
+    }
+
+    [Fact]
+    public void DeskID_field_in_OrderCancelRequest_spec_rejects_line_breaks()
+    {
+        var spec = EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidOrderCancelRequest, 0);
+        Assert.Equal(2, spec.Length);
+        Assert.Equal("deskID", spec[0].Name);
+        Assert.True(spec[0].RejectLineBreaks);
+        Assert.Equal("memo", spec[1].Name);
+        Assert.False(spec[1].RejectLineBreaks);
+    }
+
+    [Fact]
+    public void ValidateDetailed_DeskIdTooLong_returns_BmrText_too_long()
+    {
+        // deskID max=20; declare 21 with full payload present.
+        var buf = new byte[1 + 21];
+        buf[0] = 21;
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { DeskIdNoLineBreaks });
+        Assert.Equal(EntryPointVarData.FailureKind.FieldTooLong, r.Kind);
+        Assert.Equal("deskID too long", r.BmrText());
+    }
+
+    [Fact]
+    public void ValidateDetailed_LengthAboveMax_with_truncated_payload_is_protocol_error()
+    {
+        // Regression for GPT-5.5 review of #50: a length prefix that
+        // both (a) exceeds max AND (b) overruns the buffer must be
+        // classified as ProtocolError (DECODING_ERROR / Terminate)
+        // rather than FieldTooLong (BMR / keep session). The structural
+        // failure dominates because the SBE stream is desynchronised.
+        var buf = new byte[] { 200 }; // declares 200 bytes but supplies 0
+        var r = EntryPointVarData.ValidateDetailed(buf, new[] { MemoField });
+        Assert.Equal(EntryPointVarData.FailureKind.ProtocolError, r.Kind);
+        Assert.False(r.IsBusinessReject);
+        Assert.Null(r.BmrText());
+    }
 }
+


### PR DESCRIPTION
## Summary

Implements B3 spec §4.10 (#GAP-14): variable-length field violations on application messages must answer with `BusinessMessageReject(206, reason=33003)` and drop the offending frame, not Terminate the session.

## Behavior

| Failure | Old | New |
|---|---|---|
| varData field length > max | Terminate(DECODING_ERROR) | **BMR(33003 "<field> too long")**, drop, session stays open |
| CR/LF in deskID | (not checked) | **BMR(33003 "Line breaks not supported in deskID")**, drop |
| varData truncated / overrun / trailing | Terminate(DECODING_ERROR) | unchanged — still Terminate |
| Above failures in legacy passthrough | Terminate | unchanged — still Terminate |

## Implementation

- `EntryPointVarData.Field` gains a `RejectLineBreaks` flag. Set on `DeskID` only — memo allows CR/LF per FIX convention and is not in the §4.10 single-line list.
- New `EntryPointVarData.ValidateDetailed` returns structured `Result(FailureKind, FieldName, DebugMessage)` with `BmrText()` helper.
- **Validation order matters**: structural overrun is checked BEFORE max-length, so a desynchronised frame (e.g. len=255 with no payload) is classified as ProtocolError → Terminate, not FieldTooLong → BMR. (Fix from GPT-5.5 review.)
- Dispatch routes business-rule failures on application templates in strict mode to `WriteBusinessMessageReject(33003, BmrText())`.
- **Bonus fix**: `refMsgType` in #48's sessionID-mismatch BMR was passing the raw templateId byte (102) instead of the schema MessageType enum byte (15). Now uses `BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId`.

## Tests

- 8 new `EntryPointVarDataTests` covering each `ValidateDetailed` outcome including the overrun-vs-too-long ordering regression.
- Extended `BusinessHeaderSessionIdValidationTests` to lock in `refMsgType=15`, `refSeqNum`, `businessRejectRefId`, `businessRejectReason` so the #48 fix can't regress.
- 217/217 gateway tests pass.

## Out of scope

`senderLocation` / `enteringTrader` / `executingTrader` CR/LF checks live on NewOrderSingle 102 / OCR 104 templates (not yet decoded). Deferred to **#51 GAP-15**.

Closes #50