### PR TITLE
feat(ops): operator HTTP endpoints + per-FIXP-session metrics (#70)

### DIFF
--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -201,6 +201,9 @@ healthcheck).
 | `/metrics`       | Prometheus 0.0.4 text exposition (always 200)                                   |
 | `POST /channel/{ch}/snapshot-now`  | Operator command — forces a snapshot publish on the next dispatcher cycle. 202 on enqueue, 404 unknown channel, 503 if the dispatcher's inbound queue is full. |
 | `POST /channel/{ch}/bump-version`  | Operator command — atomically bumps the incremental + snapshot `SequenceVersion`, clears the order book, resets `RptSeq` to 0, and emits a `ChannelReset_11` frame on the incremental channel under the new version. 202 on enqueue, 404 unknown channel, 503 if the queue is full. |
+| `GET /sessions`                    | JSON array of every currently-attached FIXP session (issue #70). |
+| `GET /sessions/{id}`               | JSON object for a single session by `sessionId` (e.g. `conn-2a`). 404 if unknown. |
+| `GET /firms`                       | JSON array of firms declared in `firms[]`. |
 
 `/metrics` series:
 
@@ -212,6 +215,12 @@ healthcheck).
 | `exch_instrument_defs_emitted_total`          | counter | `channel`          | Stub — incremented by the instrument-definition publisher (issue #2). |
 | `exch_dispatch_loop_last_tick_unixms`         | gauge   | `channel`          | Unix ms of the dispatcher loop's last heartbeat.                       |
 | `exch_send_queue_depth`                       | gauge   | `channel,session`  | Per-`EntryPointSession` outbound queue. `channel="all"` because the queue is shared across channels. |
+| `fixp_session_state`                          | gauge   | `session,firm`     | FIXP state machine value (Idle=0, Negotiated=1, Established=2, Suspended=3, Terminated=4). |
+| `fixp_session_outbound_seq`                   | gauge   | `session`          | Last allocated outbound `MsgSeqNum`.                                  |
+| `fixp_session_inbound_expected_seq`           | gauge   | `session`          | Highest inbound `MsgSeqNum` accepted (for gap detection).             |
+| `fixp_session_retx_buffer_depth`              | gauge   | `session`          | Number of frames currently retained for retransmission.               |
+| `fixp_session_attached_transports`            | gauge   | `session`          | 1 if a TCP transport is currently attached, 0 if Suspended/awaiting rebind. |
+| `fixp_session_last_activity_unixms`           | gauge   | `session`          | Unix ms of the last byte received on the session (liveness).          |
 
 ### Readiness today vs. once issues #1/#2 land
 
@@ -255,6 +264,28 @@ they have already discarded.
 The next snapshot publish (whether triggered by the configured cadence
 or by an operator `snapshot-now`) reflects the empty book stamped with
 the new versions.
+
+### Operator session inspection (issue #70)
+
+`GET /sessions`, `GET /sessions/{id}` and `GET /firms` expose live FIXP
+session state in JSON form so operators can correlate a peer report
+("session is stuck", "I see no fills") with the simulator's view of the
+session without scraping `/metrics`.
+
+```bash
+curl -s http://localhost:8080/firms
+# => [{"id":"FIRM01","name":"Acme","enteringFirmCode":7}]
+
+curl -s http://localhost:8080/sessions
+# => [{"sessionId":"conn-2a","firmId":"FIRM01","state":2,"sessionVerId":1,
+#      "outboundSeq":4291,"inboundExpectedSeq":1027,"retxBufferDepth":4291,
+#      "sendQueueDepth":0,"attachedTransportId":"tx-2a","lastActivityAtMs":1700000123456}]
+
+curl -s http://localhost:8080/sessions/conn-2a
+# => 200 (single object) or 404 if no session with that id is currently registered
+```
+
+`state` mirrors the values exposed by the `fixp_session_state` gauge.
 
 ### Docker `HEALTHCHECK`
 

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -43,19 +43,48 @@ public sealed class ChannelMetrics
 }
 
 /// <summary>
-/// Provider of per-session send-queue depth gauges. The host wires an
-/// implementation that snapshots the active <c>FixpSession</c>
-/// queues at scrape time. The "channel" label is currently fixed to
-/// <c>"all"</c> because a session's send queue is shared across every
-/// channel that may route ExecutionReports back to it; per-channel
-/// partitioning of session queues is not implemented today.
+/// Provider of per-session diagnostics for the operator surface
+/// (issue #70). The host wires an implementation that snapshots active
+/// <c>FixpSession</c>s at scrape time. Used by both the Prometheus
+/// renderer (per-session series) and the <c>GET /sessions</c> JSON
+/// endpoint.
 /// </summary>
 public interface ISessionMetricsProvider
 {
-    IEnumerable<SessionQueueSample> Sample();
+    /// <summary>Snapshot every currently-known session as a
+    /// <see cref="SessionDiagnostics"/>. Closed sessions are filtered
+    /// by the implementation.</summary>
+    IEnumerable<SessionDiagnostics> Sample();
 }
 
-public readonly record struct SessionQueueSample(string SessionId, long QueueDepth);
+/// <summary>
+/// Diagnostic snapshot of a single FIXP session. The numeric
+/// <paramref name="State"/> matches <c>FixpState</c>: 0=Idle,
+/// 1=Negotiated, 2=Established, 3=Suspended, 4=Terminated.
+/// <paramref name="AttachedTransportId"/> is <c>null</c> when the
+/// session is Suspended (no attached TCP transport).
+/// <paramref name="LastActivityAtMs"/> is Unix milliseconds; <c>0</c>
+/// before the first inbound frame.
+/// </summary>
+public readonly record struct SessionDiagnostics(
+    string SessionId,
+    string FirmId,
+    int State,
+    ulong SessionVerId,
+    uint OutboundSeq,
+    uint InboundExpectedSeq,
+    int RetxBufferDepth,
+    long SendQueueDepth,
+    string? AttachedTransportId,
+    long LastActivityAtMs);
+
+/// <summary>
+/// Static identity for a participant (corretora). Mirror of the
+/// <c>Firm</c> record in <c>B3.Exchange.Gateway</c>, exposed in
+/// <c>B3.Exchange.Core</c> so the operator HTTP surface (issue #70) can
+/// list firms without a Core→Gateway dependency.
+/// </summary>
+public readonly record struct FirmInfo(string Id, string Name, uint EnteringFirmCode);
 
 /// <summary>
 /// Process-wide counters for FIXP session lifecycle events. Exposed via
@@ -149,17 +178,40 @@ public sealed class MetricsRegistry
 
         sb.Append("# HELP exch_send_queue_depth Per-session ExecutionReport send-queue depth (channel=\"all\" because the session queue is shared).\n");
         sb.Append("# TYPE exch_send_queue_depth gauge\n");
-        if (sessions != null)
+        SessionDiagnostics[] sessionSnap = sessions != null
+            ? sessions.Sample().ToArray()
+            : Array.Empty<SessionDiagnostics>();
+        if (sessionSnap.Length > 0)
         {
-            foreach (var s in sessions.Sample())
+            foreach (var s in sessionSnap)
             {
                 sb.Append("exch_send_queue_depth{channel=\"all\",session=\"")
                   .Append(EscapeLabel(s.SessionId))
                   .Append("\"} ")
-                  .Append(s.QueueDepth.ToString(CultureInfo.InvariantCulture))
+                  .Append(s.SendQueueDepth.ToString(CultureInfo.InvariantCulture))
                   .Append('\n');
             }
         }
+
+        // Per-session diagnostics series (issue #70).
+        EmitSessionGauge(sb, sessionSnap, "fixp_session_state",
+            "Current FIXP state (0=Idle, 1=Negotiated, 2=Established, 3=Suspended, 4=Terminated).",
+            withFirmLabel: true, s => s.State);
+        EmitSessionGauge(sb, sessionSnap, "fixp_session_outbound_seq",
+            "Last allocated outbound MsgSeqNum on this session (peer's next-expected is this+1).",
+            withFirmLabel: false, s => (long)s.OutboundSeq);
+        EmitSessionGauge(sb, sessionSnap, "fixp_session_inbound_expected_seq",
+            "Highest inbound MsgSeqNum accepted on this session (next-expected is this+1).",
+            withFirmLabel: false, s => (long)s.InboundExpectedSeq);
+        EmitSessionGauge(sb, sessionSnap, "fixp_session_retx_buffer_depth",
+            "Number of business frames buffered for replay on this session.",
+            withFirmLabel: false, s => s.RetxBufferDepth);
+        EmitSessionGauge(sb, sessionSnap, "fixp_session_attached_transports",
+            "1 if a TCP transport is currently attached, 0 if Suspended.",
+            withFirmLabel: false, s => s.AttachedTransportId is null ? 0 : 1);
+        EmitSessionGauge(sb, sessionSnap, "fixp_session_last_activity_unixms",
+            "Unix time (ms) of the most recent inbound frame on this session; 0 if nothing yet.",
+            withFirmLabel: false, s => s.LastActivityAtMs);
 
         EmitProcessCounter(sb, "exch_session_established_total",
             "Total FIXP sessions that have transitioned into Established (initial Establish + rebind via #69b).",
@@ -211,6 +263,20 @@ public sealed class MetricsRegistry
               .Append("\"} ")
               .Append(selector(c).ToString(CultureInfo.InvariantCulture))
               .Append('\n');
+        }
+    }
+
+    private static void EmitSessionGauge(StringBuilder sb, SessionDiagnostics[] sessions,
+        string name, string help, bool withFirmLabel, Func<SessionDiagnostics, long> selector)
+    {
+        sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
+        sb.Append("# TYPE ").Append(name).Append(" gauge\n");
+        foreach (var s in sessions)
+        {
+            sb.Append(name).Append("{session=\"").Append(EscapeLabel(s.SessionId)).Append('"');
+            if (withFirmLabel)
+                sb.Append(",firm=\"").Append(EscapeLabel(s.FirmId)).Append('"');
+            sb.Append("} ").Append(selector(s).ToString(CultureInfo.InvariantCulture)).Append('\n');
         }
     }
 

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -206,6 +206,38 @@ public sealed class FixpSession : IAsyncDisposable
     /// </summary>
     public int SendQueueDepth => _transport.SendQueueDepth;
 
+    /// <summary>Number of in-buffer business frames available to replay
+    /// in response to a <c>RetransmitRequest</c>. Diagnostic only.</summary>
+    public int RetxBufferDepth => _retxBuffer.Count;
+
+    /// <summary>Last allocated outbound MsgSeqNum (the value the next
+    /// emitted business frame's <c>NextMsgSeqNum()</c> call will return
+    /// is <c>OutboundSeq + 1</c>). Diagnostic only.</summary>
+    public uint OutboundSeq => (uint)Volatile.Read(ref _msgSeqNum);
+
+    /// <summary>Unix epoch time (ms) of the most recent inbound frame
+    /// (including session-layer Sequence/heartbeats). Zero if nothing has
+    /// been received yet. Distinct from <c>_lastInboundMs</c>, which is
+    /// monotonic ticks used by the watchdog. Diagnostic only.</summary>
+    public long LastActivityAtMs => Volatile.Read(ref _lastInboundUnixMs);
+    private long _lastInboundUnixMs;
+
+    /// <summary>True while the session is registered with the gateway —
+    /// covers Established AND Suspended states. Distinct from
+    /// <see cref="IsOpen"/>, which also requires a live transport and
+    /// therefore goes false during Suspended. Used by diagnostics
+    /// providers (e.g. <c>/sessions</c>) so suspended sessions remain
+    /// observable. Diagnostic only.</summary>
+    public bool IsRegistered => Volatile.Read(ref _isOpen) == 1;
+
+    /// <summary>Stable handle for the currently-attached TCP transport,
+    /// or <c>null</c> when the session is Suspended (no attached
+    /// transport). Format <c>"tx-&lt;hex(connectionId)&gt;"</c>.
+    /// Diagnostic only.</summary>
+    public string? AttachedTransportId => IsAttached
+        ? "tx-" + ConnectionId.ToString("x", System.Globalization.CultureInfo.InvariantCulture)
+        : null;
+
     public FixpSession(long connectionId, uint enteringFirm, uint sessionId,
         Stream stream, IInboundCommandSink sink, ILogger<FixpSession> logger,
         Func<ulong>? nowNanos = null,
@@ -244,6 +276,7 @@ public sealed class FixpSession : IAsyncDisposable
         // in Established state per spec §4.5 (issue #69).
         _transport = CreateBoundTransport(stream);
         Volatile.Write(ref _lastInboundMs, NowMs());
+        Volatile.Write(ref _lastInboundUnixMs, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
     }
 
     /// <summary>
@@ -303,6 +336,7 @@ public sealed class FixpSession : IAsyncDisposable
                     // Any well-framed inbound frame counts as liveness, including
                     // session-layer Sequence (heartbeat) frames.
                     Volatile.Write(ref _lastInboundMs, NowMs());
+                    Volatile.Write(ref _lastInboundUnixMs, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
                     Volatile.Write(ref _probeOutstanding, 0);
                     if (!await DispatchInboundAsync(info, bodyBuf, info.BodyLength).ConfigureAwait(false))
                     {

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -242,15 +242,27 @@ public sealed class ExchangeHost : IAsyncDisposable
         _listener.Start();
         _logger.LogInformation("entrypoint listening on {Endpoint}", _listener.LocalEndpoint);
 
-        _metrics.SetSessionProvider(new ListenerSessionProvider(_listener));
+        var sessionProvider = new ListenerSessionProvider(_listener, firmRegistry);
+        _metrics.SetSessionProvider(sessionProvider);
 
         if (_config.Http != null)
         {
             IReadOnlyList<IReadinessProbe> probeSnapshot;
             lock (_probesLock) probeSnapshot = _probes.ToList();
             var dispatchersByChannel = _dispatchers.ToDictionary(d => d.ChannelNumber);
+            // Snapshot firms once at startup (FirmRegistry is immutable
+            // after build) and expose them as plain DTOs to HttpServer
+            // to avoid leaking Gateway types into the operator surface.
+            var firmInfos = firmRegistry.Firms.Values
+                .Select(f => new FirmInfo(f.Id, f.Name, f.EnteringFirmCode))
+                .ToList();
+            // Reuse the SAME provider instance that's already wired into
+            // MetricsRegistry so /sessions and /metrics observe exactly
+            // the same snapshot of live sessions on each scrape.
             _http = new HttpServer(_config.Http, _metrics, probeSnapshot, dispatchersByChannel,
-                msg => _logger.LogInformation("{Message}", msg));
+                msg => _logger.LogInformation("{Message}", msg),
+                sessionsProvider: sessionProvider.Sample,
+                firms: firmInfos);
             await _http.StartAsync().ConfigureAwait(false);
         }
 
@@ -260,15 +272,36 @@ public sealed class ExchangeHost : IAsyncDisposable
     private sealed class ListenerSessionProvider : ISessionMetricsProvider
     {
         private readonly EntryPointListener _listener;
-        public ListenerSessionProvider(EntryPointListener listener) { _listener = listener; }
-        public IEnumerable<SessionQueueSample> Sample()
+        private readonly FirmRegistry _firms;
+        public ListenerSessionProvider(EntryPointListener listener, FirmRegistry firms)
         {
+            _listener = listener;
+            _firms = firms;
+        }
+        public IEnumerable<SessionDiagnostics> Sample()
+        {
+            // Build a one-shot reverse index (wire EnteringFirm code → firm Id).
+            // Cheap to rebuild each scrape since firm count is small (a handful)
+            // and FirmRegistry is immutable.
+            var byCode = new Dictionary<uint, string>();
+            foreach (var f in _firms.Firms.Values)
+                byCode[f.EnteringFirmCode] = f.Id;
+
             foreach (var s in _listener.ActiveSessions)
             {
-                if (!s.IsOpen) continue;
-                yield return new SessionQueueSample(
+                if (!s.IsRegistered) continue;
+                var firmId = byCode.TryGetValue(s.EnteringFirm, out var id) ? id : "unknown";
+                yield return new SessionDiagnostics(
                     SessionId: "conn-" + s.ConnectionId.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                    QueueDepth: s.SendQueueDepth);
+                    FirmId: firmId,
+                    State: (int)s.State,
+                    SessionVerId: s.SessionVerId,
+                    OutboundSeq: s.OutboundSeq,
+                    InboundExpectedSeq: s.LastIncomingSeqNo,
+                    RetxBufferDepth: s.RetxBufferDepth,
+                    SendQueueDepth: s.SendQueueDepth,
+                    AttachedTransportId: s.AttachedTransportId,
+                    LastActivityAtMs: s.LastActivityAtMs);
             }
         }
     }

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -31,18 +31,24 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly MetricsRegistry _metrics;
     private readonly IReadOnlyList<IReadinessProbe> _probes;
     private readonly IReadOnlyDictionary<byte, ChannelDispatcher> _dispatchers;
+    private readonly Func<IEnumerable<SessionDiagnostics>>? _sessionsProvider;
+    private readonly IReadOnlyList<FirmInfo> _firms;
     private readonly Action<string>? _log;
     private WebApplication? _app;
 
     public HttpServer(HttpConfig config, MetricsRegistry metrics,
         IReadOnlyList<IReadinessProbe> probes,
         IReadOnlyDictionary<byte, ChannelDispatcher> dispatchers,
-        Action<string>? log = null)
+        Action<string>? log = null,
+        Func<IEnumerable<SessionDiagnostics>>? sessionsProvider = null,
+        IReadOnlyList<FirmInfo>? firms = null)
     {
         _config = config;
         _metrics = metrics;
         _probes = probes;
         _dispatchers = dispatchers;
+        _sessionsProvider = sessionsProvider;
+        _firms = firms ?? Array.Empty<FirmInfo>();
         _log = log;
     }
 
@@ -106,6 +112,26 @@ public sealed class HttpServer : IAsyncDisposable
         app.MapGet("/metrics", () =>
             Results.Text(_metrics.RenderProm(), "text/plain; version=0.0.4; charset=utf-8"));
 
+        // Operator diagnostics endpoints (issue #70). Read-only.
+        app.MapGet("/sessions", () =>
+        {
+            var arr = SnapshotSessions();
+            return Results.Text(SerializeSessions(arr), "application/json");
+        });
+
+        app.MapGet("/sessions/{id}", (string id, HttpContext ctx) =>
+        {
+            var match = SnapshotSessions().FirstOrDefault(s => s.SessionId == id);
+            if (match.SessionId is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+                return Results.Text($"unknown session '{id}'\n", "text/plain");
+            }
+            return Results.Text(SerializeSession(match), "application/json");
+        });
+
+        app.MapGet("/firms", () => Results.Text(SerializeFirms(_firms), "application/json"));
+
         // Operator endpoints (issue #6). All work is dispatched via the
         // channel's inbound queue so the engine state mutation happens on
         // the dispatch thread; the HTTP handler returns 202 Accepted as soon
@@ -132,6 +158,105 @@ public sealed class HttpServer : IAsyncDisposable
             LocalEndpoint = ep;
 
         _log?.Invoke($"http listening on {LocalEndpoint}");
+    }
+
+    private SessionDiagnostics[] SnapshotSessions()
+    {
+        if (_sessionsProvider is null) return Array.Empty<SessionDiagnostics>();
+        return _sessionsProvider().ToArray();
+    }
+
+    // Hand-rolled JSON to keep the slim builder lean (no source-gen, no
+    // Newtonsoft). All field values are well-formed by construction
+    // except SessionId/FirmId/AttachedTransportId which are routed
+    // through JsonEscape.
+
+    private static string SerializeSessions(SessionDiagnostics[] sessions)
+    {
+        var sb = new System.Text.StringBuilder(64 + sessions.Length * 256);
+        sb.Append('[');
+        for (int i = 0; i < sessions.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            AppendSession(sb, sessions[i]);
+        }
+        sb.Append(']');
+        return sb.ToString();
+    }
+
+    private static string SerializeSession(SessionDiagnostics s)
+    {
+        var sb = new System.Text.StringBuilder(256);
+        AppendSession(sb, s);
+        return sb.ToString();
+    }
+
+    private static void AppendSession(System.Text.StringBuilder sb, SessionDiagnostics s)
+    {
+        sb.Append('{');
+        sb.Append("\"sessionId\":\"").Append(JsonEscape(s.SessionId)).Append("\",");
+        sb.Append("\"firmId\":\"").Append(JsonEscape(s.FirmId)).Append("\",");
+        sb.Append("\"state\":").Append(s.State.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"sessionVerId\":").Append(s.SessionVerId.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"outboundSeq\":").Append(s.OutboundSeq.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"inboundExpectedSeq\":").Append(s.InboundExpectedSeq.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"retxBufferDepth\":").Append(s.RetxBufferDepth.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"sendQueueDepth\":").Append(s.SendQueueDepth.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append(',');
+        sb.Append("\"attachedTransportId\":");
+        if (s.AttachedTransportId is null) sb.Append("null"); else sb.Append('"').Append(JsonEscape(s.AttachedTransportId)).Append('"');
+        sb.Append(',');
+        sb.Append("\"lastActivityAtMs\":").Append(s.LastActivityAtMs.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        sb.Append('}');
+    }
+
+    private static string SerializeFirms(IReadOnlyList<FirmInfo> firms)
+    {
+        var sb = new System.Text.StringBuilder(64 + firms.Count * 96);
+        sb.Append('[');
+        for (int i = 0; i < firms.Count; i++)
+        {
+            if (i > 0) sb.Append(',');
+            var f = firms[i];
+            sb.Append("{\"id\":\"").Append(JsonEscape(f.Id)).Append("\",")
+              .Append("\"name\":\"").Append(JsonEscape(f.Name)).Append("\",")
+              .Append("\"enteringFirmCode\":").Append(f.EnteringFirmCode.ToString(System.Globalization.CultureInfo.InvariantCulture))
+              .Append('}');
+        }
+        sb.Append(']');
+        return sb.ToString();
+    }
+
+    private static string JsonEscape(string s)
+    {
+        // Fast path: no escaping needed when there are no quotes, backslashes,
+        // or control chars (< U+0020).
+        bool needs = false;
+        foreach (var c in s)
+        {
+            if (c == '\\' || c == '"' || c < 0x20) { needs = true; break; }
+        }
+        if (!needs) return s;
+        var sb = new System.Text.StringBuilder(s.Length + 8);
+        foreach (var ch in s)
+        {
+            switch (ch)
+            {
+                case '\\': sb.Append("\\\\"); break;
+                case '"': sb.Append("\\\""); break;
+                case '\n': sb.Append("\\n"); break;
+                case '\r': sb.Append("\\r"); break;
+                case '\t': sb.Append("\\t"); break;
+                case '\b': sb.Append("\\b"); break;
+                case '\f': sb.Append("\\f"); break;
+                default:
+                    if (ch < 0x20)
+                        sb.Append("\\u").Append(((int)ch).ToString("x4", System.Globalization.CultureInfo.InvariantCulture));
+                    else
+                        sb.Append(ch);
+                    break;
+            }
+        }
+        return sb.ToString();
     }
 
     private IResult HandleOperatorEnqueue(HttpContext ctx, int channelNumber,

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -18,7 +18,10 @@ public class MetricsRegistryTests
 
         reg.SetSessionProvider(new StubSessionProvider(new[]
         {
-            new SessionQueueSample("conn-42", 7),
+            new SessionDiagnostics(
+                SessionId: "conn-42", FirmId: "FIRM01", State: 3, SessionVerId: 17,
+                OutboundSeq: 4291, InboundExpectedSeq: 1027, RetxBufferDepth: 4291,
+                SendQueueDepth: 7, AttachedTransportId: "tx-2a", LastActivityAtMs: 1700000123456),
         }));
 
         var text = reg.RenderProm();
@@ -34,9 +37,16 @@ public class MetricsRegistryTests
         Assert.Contains("# TYPE exch_dispatch_loop_last_tick_unixms gauge\n", text);
         Assert.Contains("exch_dispatch_loop_last_tick_unixms{channel=\"84\"} 1700000000000\n", text);
 
-        // Session gauge.
+        // Session gauges (issue #70 + legacy send-queue depth).
         Assert.Contains("# TYPE exch_send_queue_depth gauge\n", text);
         Assert.Contains("exch_send_queue_depth{channel=\"all\",session=\"conn-42\"} 7\n", text);
+        Assert.Contains("# TYPE fixp_session_state gauge\n", text);
+        Assert.Contains("fixp_session_state{session=\"conn-42\",firm=\"FIRM01\"} 3\n", text);
+        Assert.Contains("fixp_session_outbound_seq{session=\"conn-42\"} 4291\n", text);
+        Assert.Contains("fixp_session_inbound_expected_seq{session=\"conn-42\"} 1027\n", text);
+        Assert.Contains("fixp_session_retx_buffer_depth{session=\"conn-42\"} 4291\n", text);
+        Assert.Contains("fixp_session_attached_transports{session=\"conn-42\"} 1\n", text);
+        Assert.Contains("fixp_session_last_activity_unixms{session=\"conn-42\"} 1700000123456\n", text);
     }
 
     [Fact]
@@ -98,8 +108,8 @@ public class MetricsRegistryTests
 
     private sealed class StubSessionProvider : ISessionMetricsProvider
     {
-        private readonly SessionQueueSample[] _samples;
-        public StubSessionProvider(SessionQueueSample[] samples) { _samples = samples; }
-        public IEnumerable<SessionQueueSample> Sample() => _samples;
+        private readonly SessionDiagnostics[] _samples;
+        public StubSessionProvider(SessionDiagnostics[] samples) { _samples = samples; }
+        public IEnumerable<SessionDiagnostics> Sample() => _samples;
     }
 }

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -190,6 +190,90 @@ public class HttpServerTests
         Assert.Equal(System.Net.HttpStatusCode.NotFound, unknownBump.StatusCode);
     }
 
+    [Fact]
+    public async Task SessionsAndFirms_ExposeOperatorJson_AndUnknownSessionReturns404()
+    {
+        // Issue #70 acceptance: GET /sessions, /sessions/{id}, /firms.
+        var (cfg, sink) = BuildConfig();
+        cfg.Firms.Add(new FirmConfig { Id = "FIRM01", Name = "Acme", EnteringFirmCode = 7 });
+        cfg.Sessions.Add(new SessionConfig { SessionId = "1", FirmId = "FIRM01" });
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+
+        // /firms — returns the configured firms as JSON.
+        using var firmsResp = await client.GetAsync("/firms");
+        Assert.Equal(System.Net.HttpStatusCode.OK, firmsResp.StatusCode);
+        var firmsBody = await firmsResp.Content.ReadAsStringAsync();
+        Assert.Contains("\"id\":\"FIRM01\"", firmsBody);
+        Assert.Contains("\"name\":\"Acme\"", firmsBody);
+        Assert.Contains("\"enteringFirmCode\":7", firmsBody);
+
+        // /sessions — returns an empty array when no clients are connected.
+        using var sessionsResp = await client.GetAsync("/sessions");
+        Assert.Equal(System.Net.HttpStatusCode.OK, sessionsResp.StatusCode);
+        var sessionsBody = await sessionsResp.Content.ReadAsStringAsync();
+        Assert.Equal("[]", sessionsBody.Trim());
+
+        // /sessions/{id} — 404 on unknown id.
+        using var unknown = await client.GetAsync("/sessions/conn-99999");
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, unknown.StatusCode);
+    }
+
+    [Fact]
+    public async Task SessionsEndpoint_RevealsConnectedTcpClient()
+    {
+        // Issue #70: validate /sessions exposes a real connected client.
+        // RequireFixpHandshake=false so a plain TCP connect is enough.
+        var (cfg, sink) = BuildConfig();
+        cfg.Firms.Add(new FirmConfig { Id = "FIRM01", Name = "Acme", EnteringFirmCode = 7 });
+        cfg.Sessions.Add(new SessionConfig { SessionId = "1", FirmId = "FIRM01" });
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+        var tcp = host.TcpEndpoint!;
+
+        using var tcpClient = new System.Net.Sockets.TcpClient();
+        await tcpClient.ConnectAsync(tcp.Address, tcp.Port);
+
+        using var http_client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+        // Poll because session registration races the TCP accept.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        string body = "[]";
+        while (DateTime.UtcNow < deadline)
+        {
+            using var resp = await http_client.GetAsync("/sessions");
+            body = await resp.Content.ReadAsStringAsync();
+            if (body.Contains("\"sessionId\"", StringComparison.Ordinal)) break;
+            await Task.Delay(50);
+        }
+
+        // Parse the JSON to validate shape and pick out the session id.
+        using var doc = System.Text.Json.JsonDocument.Parse(body);
+        Assert.Equal(System.Text.Json.JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.True(doc.RootElement.GetArrayLength() >= 1, "expected at least one session in /sessions");
+        var first = doc.RootElement[0];
+        var sid = first.GetProperty("sessionId").GetString()!;
+        Assert.StartsWith("conn-", sid);
+        Assert.Equal("FIRM01", first.GetProperty("firmId").GetString());
+        // State 0..4 are valid (Idle..Terminated). For an unauthenticated
+        // TCP connect with handshake disabled the session sits in Idle (0).
+        var state = first.GetProperty("state").GetInt32();
+        Assert.InRange(state, 0, 4);
+        Assert.StartsWith("tx-", first.GetProperty("attachedTransportId").GetString());
+        Assert.True(first.GetProperty("lastActivityAtMs").GetInt64() > 0);
+
+        // /sessions/{id} returns the same single session object.
+        using var oneResp = await http_client.GetAsync($"/sessions/{sid}");
+        Assert.Equal(System.Net.HttpStatusCode.OK, oneResp.StatusCode);
+        var oneBody = await oneResp.Content.ReadAsStringAsync();
+        using var oneDoc = System.Text.Json.JsonDocument.Parse(oneBody);
+        Assert.Equal(System.Text.Json.JsonValueKind.Object, oneDoc.RootElement.ValueKind);
+        Assert.Equal(sid, oneDoc.RootElement.GetProperty("sessionId").GetString());
+    }
+
     private sealed class RecordingPacketSink : IUmdfPacketSink
     {
         public List<byte[]> Packets { get; } = new();


### PR DESCRIPTION
Closes #70.

## Summary

Adds the operator-facing HTTP surface and Prometheus per-session gauges so on-call can correlate a peer report ("my session is stuck") with the simulator's view of FIXP state without scraping logs.

### Endpoints

| Path                  | Behaviour |
|-----------------------|-----------|
| GET /sessions         | JSON array of every registered FIXP session (Established AND Suspended). |
| GET /sessions/{id}    | JSON object, 404 on unknown id (id format `conn-<hex(connectionId)>`). |
| GET /firms            | JSON array of declared firms (id, name, enteringFirmCode). |

### Metrics added

- `fixp_session_state{session,firm}` — 0=Idle, 1=Negotiated, 2=Established, 3=Suspended, 4=Terminated.
- `fixp_session_outbound_seq{session}`, `fixp_session_inbound_expected_seq{session}`
- `fixp_session_retx_buffer_depth{session}`
- `fixp_session_attached_transports{session}` (1=attached, 0=Suspended/awaiting rebind)
- `fixp_session_last_activity_unixms{session}` (Unix-ms; tracked separately from the monotonic tick the watchdog uses)
- `exch_send_queue_depth{channel,session}` — retained for back-compat.

### Architectural notes

- `MetricsRegistry.ISessionMetricsProvider.Sample()` now returns the richer `SessionDiagnostics` record (replaces `SessionQueueSample`). `MetricsRegistryTests` updated.
- `ExchangeHost` hoists the `ListenerSessionProvider` so `/metrics` and `/sessions` observe the same provider instance.
- `FixpSession` exposes a new `IsRegistered` property so the diagnostics provider can include Suspended sessions (whose transport is detached) — `IsOpen` would have hidden them.
- `HttpServer.JsonEscape` now escapes all `U+0000..U+001F` control chars.

### Tests

- `MetricsRegistryTests`: extended to assert the 6 new per-session series.
- `HttpServerTests`: `/firms` + empty `/sessions` + 404 on unknown id; new `SessionsEndpoint_RevealsConnectedTcpClient` exercises the JSON shape end-to-end with a real TCP client connected.

Pre-PR: build (Release), 384 tests passing, `dotnet format --verify-no-changes` clean.

### Follow-ups deferred (noted for future PRs, not blocking)

- Per-session inbound/outbound message **counters** + retransmit-replay counter (issue spec mentions these; require new Interlocked fields + hooks in `NextMsgSeqNum` / `ProcessAndEnqueueRetransmitRequest`).
- Auth on the operator endpoints — currently unauthenticated. Default `HttpConfig.Listen` should remain bound to a trusted network or localhost until then.