### PR TITLE
feat(ops): GHCR image publish + bridge-network UMDF unicast mode (#88)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,86 @@
+name: Docker
+
+# Builds the two container images shipped by this repo and pushes them to
+# GHCR on every push to main and on tags. PR builds run docker buildx but
+# do NOT push (no credentials needed, validates the Dockerfiles only).
+#
+# Images:
+#   ghcr.io/<owner>/b3-matching            ← Dockerfile (ExchangeHost)
+#   ghcr.io/<owner>/b3-matching-synthtrader ← Dockerfile.synthtrader
+#
+# Tags applied (via docker/metadata-action):
+#   * `:latest` on the default branch
+#   * `:sha-<short>` on every push
+#   * `:<branch>` on branch pushes
+#   * `:vX.Y.Z` and `:X.Y` on `v*` tags
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    name: Build & push (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: b3-matching
+            dockerfile: Dockerfile
+          - image: b3-matching-synthtrader
+            dockerfile: Dockerfile.synthtrader
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # PR builds skip login + push; we still buildx the image to validate
+      # the Dockerfile compiles cleanly.
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,format=short
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}

--- a/README.md
+++ b/README.md
@@ -39,10 +39,38 @@ dotnet run --project src/B3.Exchange.Host -- config/exchange-simulator.json
 
 ## Docker
 
+### Build locally
+
 ```bash
 docker build -t sbeb3exchange:latest .
 docker run --rm --network host -v $(pwd)/config:/app/config sbeb3exchange:latest
 ```
+
+### Pre-built images on GHCR
+
+Every push to `main` and every `v*` tag publishes:
+
+```bash
+docker pull ghcr.io/pedrosakuma/b3-matching:latest
+docker pull ghcr.io/pedrosakuma/b3-matching-synthtrader:latest
+```
+
+Tags available: `:latest`, `:sha-<short>`, `:<branch>`, `:vX.Y.Z`, `:X.Y`.
+
+### Bridge-network mode (issue #88, preview)
+
+The default mode publishes UMDF over UDP **multicast** and so requires
+host networking. For docker-compose family deployments where multicast is
+not routable across the bridge, set `transport: "unicast"` per channel
+and point the `*.group` fields at the consumer's service name. See
+`config/exchange-simulator.bridge.json` and `docker-compose.bridge.yml`:
+
+```bash
+docker compose -f docker-compose.bridge.yml up
+```
+
+This mode is **PREVIEW** until the consumer side ships in
+[B3MarketDataPlatform#2](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/2).
 
 The host needs network access for both the multicast publish socket and the
 EntryPoint TCP listener (default port 9876).

--- a/config/exchange-simulator.bridge.json
+++ b/config/exchange-simulator.bridge.json
@@ -1,0 +1,58 @@
+{
+  // Bridge-network friendly variant of exchange-simulator.json.
+  //
+  // Use this when running the simulator inside a docker-compose project
+  // alongside a UMDF consumer (e.g. B3MarketDataPlatform) where multicast
+  // is not routable across the bridge network. The wire format is
+  // identical; only the L3 destination changes from a multicast group to
+  // a unicast hostname/port that resolves to the consumer service.
+  //
+  // To switch back to the production-shaped multicast wire, drop the
+  // "transport" field (or set it to "multicast") and put a real 224/4
+  // group in incrementalGroup / snapshot.group / instrumentDefinition.group.
+  "tcp": {
+    "listen": "0.0.0.0:9876",
+    "enteringFirm": 1,
+    "heartbeatIntervalMs": 30000,
+    "idleTimeoutMs": 30000,
+    "testRequestGraceMs": 5000
+  },
+  "auth": {
+    "devMode": true
+  },
+  "firms": [
+    { "id": "FIRM01", "name": "Alpha Corretora", "enteringFirmCode": 100 }
+  ],
+  "sessions": [
+    { "sessionId": "10101", "firmId": "FIRM01", "accessKey": "dev-key-1" }
+  ],
+  "http": {
+    "listen": "0.0.0.0:8080",
+    "livenessStaleMs": 5000
+  },
+  "channels": [
+    {
+      "channelNumber": 84,
+      // transport=unicast: each "*.group" below is treated as a DNS name
+      // (or unicast IP) and resolved at startup. Replace "marketdata" with
+      // whatever service name your compose project uses for the consumer.
+      "transport": "unicast",
+      "incrementalGroup": "marketdata",
+      "incrementalPort": 30084,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-eqt.json",
+      "snapshot": {
+        "group": "marketdata",
+        "port": 30184,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 184,
+        "group": "marketdata",
+        "port": 31084,
+        "cadenceMs": 5000
+      }
+    }
+  ]
+}

--- a/docker-compose.bridge.yml
+++ b/docker-compose.bridge.yml
@@ -1,0 +1,52 @@
+# Bridge-network friendly compose for the matching platform.
+#
+# Unlike docker-compose.synthtrader.yml (host networking, multicast wire),
+# this file runs the simulator on the default docker bridge network and
+# uses unicast UDP for UMDF so that downstream consumers can reach it via
+# service-name DNS. Designed for the B3 family compose:
+#
+#   matching-platform → marketdata (unicast UDP) → trading-host (WS)
+#
+# Status: PREVIEW. The consumer side (B3MarketDataPlatform) needs to be
+# updated to listen on a unicast UDP port — see B3MarketDataPlatform#2.
+# Until then this file boots the exchange in unicast mode but UDP packets
+# go to the configured hostname; replace "marketdata" with a real consumer
+# (or remove the service for a smoke test).
+#
+# Usage:
+#   docker compose -f docker-compose.bridge.yml up --build
+#
+# Pre-built image alternative:
+#   docker pull ghcr.io/pedrosakuma/b3-matching:latest
+#   docker compose -f docker-compose.bridge.yml up
+services:
+  exchange:
+    image: ghcr.io/pedrosakuma/b3-matching:latest
+    # Local development: replace `image:` with `build:` to rebuild from src.
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    depends_on:
+      marketdata:
+        condition: service_started
+    ports:
+      - "9876:9876"   # EntryPoint TCP
+      - "8080:8080"   # /metrics, /health/*, /sessions, /firms
+    volumes:
+      - ./config:/app/config:ro
+    command: ["/app/config/exchange-simulator.bridge.json"]
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/health/live"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
+      start_period: 5s
+
+  # Placeholder so the `marketdata` DNS name in exchange-simulator.bridge.json
+  # resolves at startup. Replace this service with the real
+  # B3MarketDataPlatform consumer (issue #88 part 2 / B3MarketDataPlatform#2)
+  # once it ships. Until then UDP packets are dropped silently — the
+  # exchange itself still boots and serves /metrics, /sessions, etc.
+  marketdata:
+    image: alpine:3.20
+    command: ["tail", "-f", "/dev/null"]

--- a/src/B3.Exchange.Core/UnicastUdpPacketSink.cs
+++ b/src/B3.Exchange.Core/UnicastUdpPacketSink.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Bridge-network friendly <see cref="IUmdfPacketSink"/> backed by a plain
+/// UDP unicast socket. Resolves the destination via DNS on construction
+/// and sends every <see cref="Publish"/> as a synchronous <c>SendTo</c>.
+///
+/// Use this sink when the downstream UMDF consumer (e.g. the
+/// <c>B3MarketDataPlatform</c> service) is reachable on a routable address
+/// — typically a service name in the same docker-compose project — but a
+/// multicast group is not. Wire format is identical to the multicast
+/// path; only the L3 destination changes.
+/// </summary>
+public sealed class UnicastUdpPacketSink : IUmdfPacketSink, IDisposable
+{
+    private readonly Socket _socket;
+    private readonly IPEndPoint _destination;
+    private readonly ILogger<UnicastUdpPacketSink> _logger;
+    private readonly string _originalHost;
+
+    public UnicastUdpPacketSink(string host, int port, ILogger<UnicastUdpPacketSink> logger)
+    {
+        ArgumentNullException.ThrowIfNull(host);
+        ArgumentNullException.ThrowIfNull(logger);
+        _logger = logger;
+        _originalHost = host;
+        // Resolve once at construction. If the operator wants follow-the-DNS
+        // semantics they should restart the host (config reload is not
+        // currently a feature). Picking the first AddressFamily.InterNetwork
+        // record keeps behaviour aligned with MulticastUdpPacketSink which
+        // is hard-coded to IPv4.
+        var addresses = Dns.GetHostAddresses(host, AddressFamily.InterNetwork);
+        if (addresses.Length == 0)
+            throw new InvalidOperationException(
+                $"unicast UDP sink: DNS lookup for '{host}' returned no IPv4 addresses");
+        _destination = new IPEndPoint(addresses[0], port);
+        _socket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        _logger.LogInformation(
+            "unicast UDP sink configured to send to {Host} ({Address}):{Port}",
+            host, addresses[0], port);
+    }
+
+    public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+    {
+        _socket.SendTo(packet, SocketFlags.None, _destination);
+    }
+
+    public void Dispose() => _socket.Dispose();
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -101,9 +101,8 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
             else
             {
-                var local = ch.LocalInterface != null ? IPAddress.Parse(ch.LocalInterface) : null;
-                sink = new MulticastUdpPacketSink(IPAddress.Parse(ch.IncrementalGroup), ch.IncrementalPort,
-                    _loggerFactory.CreateLogger<MulticastUdpPacketSink>(), local, ch.Ttl);
+                sink = BuildUdpSink(ch.Transport, ch.IncrementalGroup, ch.IncrementalPort,
+                    ch.LocalInterface, ch.Ttl);
             }
             if (sink is IDisposable d) _ownedSinks.Add(d);
             var engineLogger = _loggerFactory.CreateLogger<MatchingEngine>();
@@ -145,9 +144,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 }
                 else
                 {
-                    var local = ch.LocalInterface != null ? IPAddress.Parse(ch.LocalInterface) : null;
-                    snapSink = new MulticastUdpPacketSink(IPAddress.Parse(snap.Group), snap.Port,
-                        _loggerFactory.CreateLogger<MulticastUdpPacketSink>(), local, snap.Ttl ?? ch.Ttl);
+                    snapSink = BuildUdpSink(ch.Transport, snap.Group, snap.Port,
+                        ch.LocalInterface, snap.Ttl ?? ch.Ttl);
                 }
                 if (snapSink is IDisposable sd) _ownedSinks.Add(sd);
 
@@ -178,11 +176,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 }
                 else
                 {
-                    var local = idCfg.LocalInterface != null
-                        ? IPAddress.Parse(idCfg.LocalInterface)
-                        : (ch.LocalInterface != null ? IPAddress.Parse(ch.LocalInterface) : null);
-                    idSink = new MulticastUdpPacketSink(IPAddress.Parse(idCfg.Group), idCfg.Port,
-                        _loggerFactory.CreateLogger<MulticastUdpPacketSink>(), local, idCfg.Ttl);
+                    var localIface = idCfg.LocalInterface ?? ch.LocalInterface;
+                    idSink = BuildUdpSink(ch.Transport, idCfg.Group, idCfg.Port, localIface, idCfg.Ttl);
                 }
                 if (idSink is IDisposable idd) _ownedSinks.Add(idd);
                 byte idChan = idCfg.ChannelNumber == 0 ? ch.ChannelNumber : idCfg.ChannelNumber;
@@ -304,6 +299,26 @@ public sealed class ExchangeHost : IAsyncDisposable
                     LastActivityAtMs: s.LastActivityAtMs);
             }
         }
+    }
+
+    private IUmdfPacketSink BuildUdpSink(UmdfTransport transport, string host, int port,
+        string? localInterface, byte ttl)
+    {
+        if (transport == UmdfTransport.Unicast)
+        {
+            // Unicast mode is bridge-network friendly: `host` is treated as
+            // a DNS name (or IP literal) and resolved on construction. The
+            // multicast-only options (TTL, local interface) are ignored —
+            // log a warning if the operator set them so they don't expect
+            // multicast routing semantics.
+            if (localInterface is not null)
+                _logger.LogWarning("transport=unicast: ignoring localInterface='{Iface}' (multicast-only)", localInterface);
+            return new UnicastUdpPacketSink(host, port,
+                _loggerFactory.CreateLogger<UnicastUdpPacketSink>());
+        }
+        var local = localInterface != null ? IPAddress.Parse(localInterface) : null;
+        return new MulticastUdpPacketSink(IPAddress.Parse(host), port,
+            _loggerFactory.CreateLogger<MulticastUdpPacketSink>(), local, ttl);
     }
 
     private FirmRegistry BuildFirmRegistry()

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -116,6 +116,20 @@ public sealed class ChannelConfig
     [JsonPropertyName("instruments")] public string InstrumentsFile { get; set; } = "";
 
     /// <summary>
+    /// UDP transport mode for the incremental, snapshot, and instrumentDef
+    /// publishers. <c>multicast</c> (default) preserves legacy behaviour and
+    /// expects <c>IncrementalGroup</c>/<c>Snapshot.Group</c>/
+    /// <c>InstrumentDefinition.Group</c> to be IPv4 multicast addresses.
+    /// <c>unicast</c> is the bridge-network-friendly mode introduced for
+    /// docker-compose setups where multicast is not routable: the
+    /// <c>*.Group</c> fields are then treated as DNS hostnames (e.g.
+    /// <c>"marketdata"</c>) or unicast IPs and resolved at startup.
+    /// </summary>
+    [JsonPropertyName("transport")]
+    [JsonConverter(typeof(UmdfTransportJsonConverter))]
+    public UmdfTransport Transport { get; set; } = UmdfTransport.Multicast;
+
+    /// <summary>
     /// Self-trade prevention policy applied by this channel's matching engine.
     /// Defaults to <c>none</c> (preserves legacy behaviour). Accepted values
     /// (case-insensitive): <c>none</c>, <c>cancel-aggressor</c>,
@@ -139,6 +153,39 @@ public sealed class ChannelConfig
     /// instrument definitions are published for this channel.
     /// </summary>
     [JsonPropertyName("instrumentDefinition")] public InstrumentDefinitionConfig? InstrumentDefinition { get; set; }
+}
+
+public enum UmdfTransport
+{
+    /// <summary>UDP multicast (legacy default; matches B3 production wire).</summary>
+    Multicast,
+    /// <summary>UDP unicast — destination is a DNS hostname or unicast IP.
+    /// Used for docker-compose bridge-network setups.</summary>
+    Unicast,
+}
+
+public sealed class UmdfTransportJsonConverter : JsonConverter<UmdfTransport>
+{
+    public override UmdfTransport Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var s = reader.GetString();
+        return s?.ToLowerInvariant() switch
+        {
+            null or "" or "multicast" => UmdfTransport.Multicast,
+            "unicast" => UmdfTransport.Unicast,
+            _ => throw new JsonException($"unknown transport value '{s}' (expected: multicast|unicast)"),
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, UmdfTransport value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value switch
+        {
+            UmdfTransport.Multicast => "multicast",
+            UmdfTransport.Unicast => "unicast",
+            _ => throw new JsonException($"unknown UmdfTransport value: {value}"),
+        });
+    }
 }
 
 public sealed class SelfTradePreventionJsonConverter : JsonConverter<B3.Exchange.Matching.SelfTradePrevention>

--- a/tests/B3.Exchange.Core.Tests/UnicastUdpPacketSinkTests.cs
+++ b/tests/B3.Exchange.Core.Tests/UnicastUdpPacketSinkTests.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Core.Tests;
+
+public class UnicastUdpPacketSinkTests
+{
+    [Fact]
+    public void Publish_DeliversPacket_ToConfiguredLoopbackUdpEndpoint()
+    {
+        // Bind a transient receiver on loopback to capture what the sink sends.
+        using var receiver = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        receiver.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        receiver.ReceiveTimeout = 2000;
+        var port = ((IPEndPoint)receiver.LocalEndPoint!).Port;
+
+        using var sink = new UnicastUdpPacketSink("127.0.0.1", port,
+            NullLogger<UnicastUdpPacketSink>.Instance);
+
+        var payload = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        sink.Publish(channelNumber: 84, payload);
+
+        var buf = new byte[64];
+        var received = receiver.Receive(buf);
+        Assert.Equal(payload.Length, received);
+        Assert.Equal(payload, buf.AsSpan(0, received).ToArray());
+    }
+
+    [Fact]
+    public void Constructor_Throws_WhenHostnameDoesNotResolve()
+    {
+        // RFC 6761 reserves `.invalid` so this is guaranteed never to resolve.
+        Assert.ThrowsAny<Exception>(() =>
+            new UnicastUdpPacketSink("nonexistent-host.invalid", 30084,
+                NullLogger<UnicastUdpPacketSink>.Instance));
+    }
+}


### PR DESCRIPTION
Closes #88.

## Part 1 — GHCR image publish
- New `.github/workflows/docker.yml` builds both `Dockerfile` and `Dockerfile.synthtrader` via buildx and pushes to:
  - `ghcr.io/<owner>/b3-matching`
  - `ghcr.io/<owner>/b3-matching-synthtrader`
- Tag strategy: `:latest` (main only), `:sha-<short>`, `:<branch>`, `:vX.Y.Z`, `:X.Y` on `v*` tags. PR builds buildx without push.

## Part 2 — Unicast UDP transport (PREVIEW)
Picks **Option A** from the issue: keep wire format identical, swap multicast for unicast UDP so the simulator works on a docker bridge.

- New `UmdfTransport` enum on `ChannelConfig` (`multicast` default | `unicast`).
- New `UnicastUdpPacketSink` (DNS-resolved at construction, simple `SendTo`).
- `ExchangeHost.BuildUdpSink` factory routes incremental, snapshot, and instrumentDef sinks consistently.
- Sample `config/exchange-simulator.bridge.json` + `docker-compose.bridge.yml` (with a placeholder `marketdata` service so DNS resolves at startup until B3MarketDataPlatform#2 ships the real consumer).
- README updated.

## Tests
- 386 tests passing; 2 new unit tests for `UnicastUdpPacketSink` (loopback delivery + bad-hostname exception).
- `dotnet format --verify-no-changes` clean.
- Default behaviour preserved: existing configs without `transport` continue to use the multicast sink.

## Cross-repo coordination
Part 2 is **PREVIEW** until [B3MarketDataPlatform#2](https://github.com/pedrosakuma/B3MarketDataPlatform/issues/2) lands the consumer-side unicast listener. Wire-format choice (UMDF over UDP unicast) is documented so the consumer can match it.