### PR TITLE
feat(#47): GAP-09 daily reset of inbound + outbound MsgSeqNum

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -178,6 +178,55 @@ public sealed class EntryPointListener : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    /// Spec §4.5.1 (#GAP-09 / issue #47): at start of each trading day the
+    /// gateway resets inbound + outbound MsgSeqNum counters to 1 and
+    /// expects every client to reconnect with a fresh
+    /// <c>Negotiate</c>+<c>Establish(nextSeqNo=1)</c>. We implement this
+    /// the conservative way — terminate every live session — because
+    /// per-session in-place reset would have to coordinate the dispatch
+    /// thread, the retransmission ring, the claim ledger, and any
+    /// in-flight Establish handshake atomically. Forcing reconnect makes
+    /// the whole transition trivially correct and is conformant with the
+    /// spec (clients are required to be able to handle this anyway).
+    ///
+    /// <para>Idempotent: calls <see cref="FixpSession.Close(string)"/> on
+    /// each currently-active session; a session that is already closed
+    /// is a no-op via the existing CAS guard. Returns the number of
+    /// sessions that were live at the moment of the snapshot.</para>
+    ///
+    /// <para>Thread-safety: snapshots <see cref="_sessions"/> under
+    /// <see cref="_lock"/>, then iterates outside the lock so
+    /// <c>Close</c> (which takes <c>_attachLock</c> on the session) does
+    /// not nest the listener's mutex. Safe to call from the HTTP thread
+    /// or from the daily-rollover scheduler timer.</para>
+    /// </summary>
+    public int TerminateAllSessions(string reason)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(reason);
+        FixpSession[] snapshot;
+        lock (_lock) snapshot = _sessions.ToArray();
+        int closed = 0;
+        foreach (var s in snapshot)
+        {
+            if (!s.IsOpen) continue;
+            try
+            {
+                s.Close(reason);
+                closed++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "terminate-all-sessions: failed to close session {ConnectionId}",
+                    s.ConnectionId);
+            }
+        }
+        _logger.LogInformation(
+            "terminated {Count} session(s) (reason={Reason})", closed, reason);
+        return closed;
+    }
+
     private async Task RunAcceptLoopAsync(CancellationToken ct)
     {
         try

--- a/src/B3.Exchange.Host/DailyResetScheduler.cs
+++ b/src/B3.Exchange.Host/DailyResetScheduler.cs
@@ -1,0 +1,192 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// Once-per-day scheduler for the trading-day rollover (#GAP-09 / issue
+/// #47, spec §4.5.1). On <see cref="Start"/> it computes the next firing
+/// instant in UTC from a local "HH:mm" + IANA-timezone pair, arms a
+/// <see cref="Timer"/>, and re-arms after each fire. The action runs on a
+/// pool thread (Timer callback) so the implementation must be quick and
+/// non-blocking — typically a single call to
+/// <c>EntryPointListener.TerminateAllSessions</c>.
+///
+/// <para>Idempotent <see cref="Trigger"/> is exposed for the operator
+/// HTTP endpoint and for tests; it bypasses the schedule entirely.</para>
+/// </summary>
+public sealed class DailyResetScheduler : IAsyncDisposable
+{
+    private readonly TimeSpan _localTime;
+    private readonly TimeZoneInfo _timezone;
+    private readonly Action _action;
+    private readonly ILogger<DailyResetScheduler> _logger;
+    private readonly Func<DateTimeOffset>? _utcNowOverride;
+    private Timer? _timer;
+    private int _disposed;
+
+    public DailyResetScheduler(string schedule, string timezone, Action action,
+        ILogger<DailyResetScheduler> logger,
+        Func<DateTimeOffset>? utcNowOverride = null)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        ArgumentNullException.ThrowIfNull(logger);
+        _localTime = ParseHHmm(schedule);
+        _timezone = ResolveTimezone(timezone);
+        _action = action;
+        _logger = logger;
+        _utcNowOverride = utcNowOverride;
+    }
+
+    /// <summary>Local time-of-day at which the scheduler fires.</summary>
+    public TimeSpan LocalTime => _localTime;
+    public TimeZoneInfo Timezone => _timezone;
+
+    public void Start()
+    {
+        if (_timer is not null) throw new InvalidOperationException("scheduler already started");
+        var now = UtcNow();
+        var next = ComputeNextFiringUtc(now, _localTime, _timezone);
+        var delay = next - now;
+        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        _logger.LogInformation(
+            "daily-reset scheduler armed: schedule={Schedule:hh\\:mm} tz={Tz} next-firing-utc={Next:o} (in {DelayMin:n1}min)",
+            _localTime, _timezone.Id, next, delay.TotalMinutes);
+        _timer = new Timer(OnTimer, null, delay, Timeout.InfiniteTimeSpan);
+    }
+
+    /// <summary>Run the rollover action immediately, regardless of
+    /// schedule. Used by the operator HTTP endpoint and by tests. Does
+    /// NOT shift the next scheduled firing.</summary>
+    public void Trigger()
+    {
+        try { _action(); }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "daily-reset action threw on manual trigger");
+            throw;
+        }
+    }
+
+    private void OnTimer(object? _)
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        try
+        {
+            _logger.LogInformation("daily-reset firing (scheduled)");
+            _action();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "daily-reset action threw");
+        }
+        finally
+        {
+            // Re-arm for the next 24h boundary even if the action threw,
+            // so a transient failure doesn't permanently disable the
+            // rollover.
+            if (Volatile.Read(ref _disposed) == 0)
+            {
+                var now = UtcNow();
+                var next = ComputeNextFiringUtc(now, _localTime, _timezone);
+                var delay = next - now;
+                if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+                try { _timer?.Change(delay, Timeout.InfiniteTimeSpan); } catch (ObjectDisposedException) { }
+                _logger.LogInformation(
+                    "daily-reset re-armed: next-firing-utc={Next:o} (in {DelayMin:n1}min)",
+                    next, delay.TotalMinutes);
+            }
+        }
+    }
+
+    private DateTimeOffset UtcNow() => _utcNowOverride?.Invoke() ?? DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Compute the next UTC instant at which the local wall-clock time
+    /// in <paramref name="tz"/> equals <paramref name="localTime"/> and
+    /// is strictly after <paramref name="nowUtc"/>. Handles DST gaps
+    /// (the local time may be invalid on the first candidate day, in
+    /// which case the next valid day is returned) and DST folds (the
+    /// earlier of the two valid instants is returned).
+    /// </summary>
+    public static DateTimeOffset ComputeNextFiringUtc(
+        DateTimeOffset nowUtc, TimeSpan localTime, TimeZoneInfo tz)
+    {
+        var localNow = TimeZoneInfo.ConvertTime(nowUtc, tz);
+        // Candidate: today at HH:mm in the local zone.
+        for (int dayOffset = 0; dayOffset < 14; dayOffset++)
+        {
+            var candidateLocal = localNow.Date.AddDays(dayOffset).Add(localTime);
+            // Skip candidates not strictly after now.
+            // (DateTime arithmetic on .Date drops the offset, which is what
+            // we want; we re-anchor below.)
+            if (tz.IsInvalidTime(candidateLocal))
+                continue; // local time falls in a DST spring-forward gap
+            DateTimeOffset candidateUtc;
+            if (tz.IsAmbiguousTime(candidateLocal))
+            {
+                // DST fall-back fold: the local wall-clock time maps to two
+                // distinct UTC instants. We want the earlier UTC instant
+                // (so the rollover doesn't fire a second time during the
+                // repeated hour). offsets.Min() would pick the most
+                // negative offset, which actually corresponds to the
+                // LATER UTC instant — convert each candidate explicitly
+                // and pick by absolute UTC time.
+                var offsets = tz.GetAmbiguousTimeOffsets(candidateLocal);
+                DateTimeOffset earliest = default;
+                bool seeded = false;
+                foreach (var off in offsets)
+                {
+                    var u = new DateTimeOffset(candidateLocal, off).ToUniversalTime();
+                    if (!seeded || u < earliest) { earliest = u; seeded = true; }
+                }
+                candidateUtc = earliest;
+            }
+            else
+            {
+                var offset = tz.GetUtcOffset(candidateLocal);
+                candidateUtc = new DateTimeOffset(candidateLocal, offset).ToUniversalTime();
+            }
+            if (candidateUtc > nowUtc) return candidateUtc;
+        }
+        // Fallback: should never reach here unless `tz` is completely
+        // pathological (every candidate invalid for two weeks). Anchor
+        // 24h out so the host doesn't busy-spin re-arming the timer.
+        return nowUtc.AddHours(24);
+    }
+
+    private static TimeSpan ParseHHmm(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+            throw new ArgumentException("dailyReset.schedule must be a non-empty 'HH:mm' string", nameof(s));
+        if (!TimeSpan.TryParseExact(s, @"h\:mm", CultureInfo.InvariantCulture, out var ts) &&
+            !TimeSpan.TryParseExact(s, @"hh\:mm", CultureInfo.InvariantCulture, out ts))
+        {
+            throw new FormatException($"dailyReset.schedule '{s}' is not a valid 'HH:mm' value");
+        }
+        if (ts < TimeSpan.Zero || ts >= TimeSpan.FromHours(24))
+            throw new FormatException($"dailyReset.schedule '{s}' must be within [00:00,24:00)");
+        return ts;
+    }
+
+    private static TimeZoneInfo ResolveTimezone(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("dailyReset.timezone must be a non-empty IANA identifier", nameof(id));
+        try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
+        catch (TimeZoneNotFoundException ex)
+        {
+            throw new ArgumentException(
+                $"dailyReset.timezone '{id}' is not a recognized IANA / Windows timezone identifier on this host. " +
+                "On Linux, ensure the tzdata package is installed.", nameof(id), ex);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return ValueTask.CompletedTask;
+        var t = _timer;
+        _timer = null;
+        return t?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -38,6 +38,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private EntryPointListener? _listener;
     private HostRouter? _router;
     private HttpServer? _http;
+    private DailyResetScheduler? _dailyReset;
 
     public ExchangeHost(HostConfig config, ILoggerFactory? loggerFactory = null,
         Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null,
@@ -57,6 +58,19 @@ public sealed class ExchangeHost : IAsyncDisposable
     public IPEndPoint? HttpEndpoint => _http?.LocalEndpoint;
     public MetricsRegistry Metrics => _metrics;
     public IReadOnlyList<ChannelDispatcher> Dispatchers => _dispatchers;
+
+    /// <summary>
+    /// On-demand trigger for the daily-rollover routine (#GAP-09 /
+    /// issue #47). Returns the number of sessions that were terminated,
+    /// or -1 if the host has not finished <see cref="StartAsync"/>.
+    /// Safe to call from any thread.
+    /// </summary>
+    public int TriggerDailyReset(string reason = "operator-trigger")
+    {
+        var listener = _listener;
+        if (listener is null) return -1;
+        return listener.TerminateAllSessions(reason);
+    }
 
     /// <summary>Firm + session credentials parsed from <c>HostConfig</c>.
     /// Built lazily on first access (or on <see cref="StartAsync"/>); empty
@@ -257,8 +271,23 @@ public sealed class ExchangeHost : IAsyncDisposable
             _http = new HttpServer(_config.Http, _metrics, probeSnapshot, dispatchersByChannel,
                 msg => _logger.LogInformation("{Message}", msg),
                 sessionsProvider: sessionProvider.Sample,
-                firms: firmInfos);
+                firms: firmInfos,
+                dailyResetTrigger: () => TriggerDailyReset("http-trigger"));
             await _http.StartAsync().ConfigureAwait(false);
+        }
+
+        // #GAP-09 (#47): daily trading-day rollover. The listener exists
+        // by this point so it is safe to capture it for the timer
+        // callback. Always terminate via the public Trigger so the
+        // scheduler logs and re-arms even if the action throws.
+        if (_config.DailyReset is { Enabled: true } drCfg)
+        {
+            _dailyReset = new DailyResetScheduler(
+                drCfg.Schedule,
+                drCfg.Timezone,
+                action: () => _listener?.TerminateAllSessions("daily-reset"),
+                logger: _loggerFactory.CreateLogger<DailyResetScheduler>());
+            _dailyReset.Start();
         }
 
         _startupProbe.MarkReady();
@@ -400,6 +429,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("exchange host shutting down");
+        if (_dailyReset != null) await _dailyReset.DisposeAsync().ConfigureAwait(false);
         if (_http != null) await _http.DisposeAsync().ConfigureAwait(false);
         foreach (var t in _snapshotTimers) await t.DisposeAsync().ConfigureAwait(false);
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -15,6 +15,7 @@ public sealed class HostConfig
     [JsonPropertyName("firms")] public List<FirmConfig> Firms { get; set; } = new();
     [JsonPropertyName("sessions")] public List<SessionConfig> Sessions { get; set; } = new();
     [JsonPropertyName("http")] public HttpConfig? Http { get; set; }
+    [JsonPropertyName("dailyReset")] public DailyResetConfig? DailyReset { get; set; }
     [JsonPropertyName("channels")] public List<ChannelConfig> Channels { get; set; } = new();
 }
 
@@ -104,6 +105,33 @@ public sealed class HttpConfig
     /// milliseconds. Default 5000 (5s).
     /// </summary>
     [JsonPropertyName("livenessStaleMs")] public int LivenessStaleMs { get; set; } = 5000;
+}
+
+/// <summary>
+/// Daily trading-day rollover (#GAP-09 / issue #47, spec §4.5.1). When
+/// <see cref="Enabled"/> is true the host schedules a once-per-day timer
+/// that fires at <see cref="Schedule"/> in <see cref="Timezone"/> and
+/// terminates every live session, forcing each client to reconnect with
+/// a fresh <c>Negotiate</c>+<c>Establish(nextSeqNo=1)</c>. Operators can
+/// also trigger the rollover on demand via <c>POST /admin/daily-reset</c>
+/// regardless of this flag.
+/// </summary>
+public sealed class DailyResetConfig
+{
+    /// <summary>When false (default) the scheduled timer is not armed —
+    /// the operator endpoint still works.</summary>
+    [JsonPropertyName("enabled")] public bool Enabled { get; set; }
+
+    /// <summary>Local-time-of-day "HH:mm" (24h) at which the rollover
+    /// fires. Defaults to <c>"18:00"</c>, the B3 cash-equity post-trading
+    /// boundary.</summary>
+    [JsonPropertyName("schedule")] public string Schedule { get; set; } = "18:00";
+
+    /// <summary>IANA time zone identifier in which <see cref="Schedule"/>
+    /// is interpreted. Defaults to <c>"America/Sao_Paulo"</c>; the
+    /// platform's <c>TimeZoneInfo</c> store must recognize the value
+    /// (Linux containers ship with the IANA database).</summary>
+    [JsonPropertyName("timezone")] public string Timezone { get; set; } = "America/Sao_Paulo";
 }
 
 public sealed class ChannelConfig

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -33,6 +33,7 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly IReadOnlyDictionary<byte, ChannelDispatcher> _dispatchers;
     private readonly Func<IEnumerable<SessionDiagnostics>>? _sessionsProvider;
     private readonly IReadOnlyList<FirmInfo> _firms;
+    private readonly Func<int>? _dailyResetTrigger;
     private readonly Action<string>? _log;
     private WebApplication? _app;
 
@@ -41,7 +42,8 @@ public sealed class HttpServer : IAsyncDisposable
         IReadOnlyDictionary<byte, ChannelDispatcher> dispatchers,
         Action<string>? log = null,
         Func<IEnumerable<SessionDiagnostics>>? sessionsProvider = null,
-        IReadOnlyList<FirmInfo>? firms = null)
+        IReadOnlyList<FirmInfo>? firms = null,
+        Func<int>? dailyResetTrigger = null)
     {
         _config = config;
         _metrics = metrics;
@@ -49,6 +51,7 @@ public sealed class HttpServer : IAsyncDisposable
         _dispatchers = dispatchers;
         _sessionsProvider = sessionsProvider;
         _firms = firms ?? Array.Empty<FirmInfo>();
+        _dailyResetTrigger = dailyResetTrigger;
         _log = log;
     }
 
@@ -144,6 +147,24 @@ public sealed class HttpServer : IAsyncDisposable
 
         app.MapPost("/channel/{ch:int}/bump-version", (int ch, HttpContext ctx) =>
             HandleOperatorEnqueue(ctx, ch, d => d.EnqueueOperatorBumpVersion(), "bump-version"));
+
+        // #GAP-09 (#47): on-demand trading-day rollover. Terminates every
+        // live FIXP session so clients reconnect with Negotiate +
+        // Establish(nextSeqNo=1). The scheduled timer (HostConfig.dailyReset)
+        // fires the same path. Returns 202 Accepted with the count of
+        // sessions terminated (0 if the listener has none); 503 if the
+        // host has not yet finished StartAsync.
+        app.MapPost("/admin/daily-reset", (HttpContext ctx) =>
+        {
+            if (_dailyResetTrigger is null)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                return Results.Text("daily-reset not wired (host not started)\n", "text/plain");
+            }
+            int closed = _dailyResetTrigger();
+            ctx.Response.StatusCode = StatusCodes.Status202Accepted;
+            return Results.Text($"accepted daily-reset terminated={closed}\n", "text/plain");
+        });
 
         await app.StartAsync(ct).ConfigureAwait(false);
         _app = app;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Spec §4.5.1 / #GAP-09 (issue #47): the trading-day rollover must
+/// terminate every active FIXP session so clients reconnect with a
+/// fresh Negotiate + Establish(nextSeqNo=1). The listener exposes
+/// <see cref="EntryPointListener.TerminateAllSessions"/> as the
+/// transport-level primitive that both the scheduled timer and the
+/// operator HTTP endpoint hit.
+/// </summary>
+public class EntryPointListenerDailyResetTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    [Fact]
+    public async Task TerminateAllSessions_ClosesEveryLiveSession_AndCallsCallback()
+    {
+        var sink = new NoOpEngineSink();
+        var closures = new List<string>();
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            sink,
+            NullLoggerFactory.Instance,
+            sessionOptions: new FixpSessionOptions
+            {
+                HeartbeatIntervalMs = 60_000,
+                IdleTimeoutMs = 60_000,
+                TestRequestGraceMs = 60_000,
+                SuspendedTimeoutMs = 0, // disable reaper so it can't race us
+            },
+            onSessionClosed: (_, reason) => { lock (closures) closures.Add(reason); });
+        listener.Start();
+        try
+        {
+            // Open two clients and wait until both are registered.
+            var c1 = new TcpClient(); await c1.ConnectAsync(IPAddress.Loopback, listener.LocalEndpoint!.Port);
+            var c2 = new TcpClient(); await c2.ConnectAsync(IPAddress.Loopback, listener.LocalEndpoint!.Port);
+
+            var registered = await TestUtil.WaitUntilAsync(
+                () => listener.ActiveSessions.Count(s => s.IsOpen) == 2,
+                TimeSpan.FromSeconds(2));
+            Assert.True(registered, $"both sessions should register (have {listener.ActiveSessions.Count})");
+
+            int closed = listener.TerminateAllSessions("daily-reset");
+            Assert.Equal(2, closed);
+
+            // All sessions are closed (IsOpen=false) and the callback fired
+            // for each with the supplied reason.
+            var allClosed = await TestUtil.WaitUntilAsync(
+                () => listener.ActiveSessions.All(s => !s.IsOpen),
+                TimeSpan.FromSeconds(2));
+            Assert.True(allClosed);
+            lock (closures)
+            {
+                Assert.Equal(2, closures.Count);
+                Assert.All(closures, r => Assert.Equal("daily-reset", r));
+            }
+
+            c1.Close(); c2.Close();
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task TerminateAllSessions_OnEmptyListener_ReturnsZero()
+    {
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            NullLoggerFactory.Instance,
+            sessionOptions: new FixpSessionOptions
+            {
+                HeartbeatIntervalMs = 60_000,
+                IdleTimeoutMs = 60_000,
+                TestRequestGraceMs = 60_000,
+                SuspendedTimeoutMs = 0,
+            });
+        listener.Start();
+        try
+        {
+            Assert.Equal(0, listener.TerminateAllSessions("daily-reset"));
+        }
+        finally
+        {
+            await listener.DisposeAsync();
+        }
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/DailyResetSchedulerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/DailyResetSchedulerTests.cs
@@ -1,0 +1,116 @@
+using B3.Exchange.Host;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Pure unit tests for <see cref="DailyResetScheduler.ComputeNextFiringUtc"/>.
+/// Schedules and timezones are deterministic given a fixed "now"; we use
+/// America/Sao_Paulo because that's the production default and because
+/// it currently does NOT observe DST (offset is fixed UTC-3 since 2019),
+/// which keeps the assertions stable. UTC is also exercised as a sanity
+/// check that requires no tzdata fixups.
+/// </summary>
+public class DailyResetSchedulerTests
+{
+    [Fact]
+    public void NextFiring_BeforeTodaysSchedule_ReturnsTodayInUtc()
+    {
+        var brt = TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo");
+        // 2026-04-30 12:00 BRT == 15:00Z. Schedule is 18:00 BRT == 21:00Z
+        // same day. So we expect today.
+        var now = new DateTimeOffset(2026, 4, 30, 15, 0, 0, TimeSpan.Zero);
+        var next = DailyResetScheduler.ComputeNextFiringUtc(now, TimeSpan.FromHours(18), brt);
+        Assert.Equal(new DateTimeOffset(2026, 4, 30, 21, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void NextFiring_AfterTodaysSchedule_ReturnsTomorrowInUtc()
+    {
+        var brt = TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo");
+        // 2026-04-30 22:00 BRT == 2026-05-01 01:00Z. Schedule 18:00 BRT
+        // already passed today, so expect tomorrow at 18:00 BRT == 21:00Z.
+        var now = new DateTimeOffset(2026, 5, 1, 1, 0, 0, TimeSpan.Zero);
+        var next = DailyResetScheduler.ComputeNextFiringUtc(now, TimeSpan.FromHours(18), brt);
+        Assert.Equal(new DateTimeOffset(2026, 5, 1, 21, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void NextFiring_ExactBoundary_RollsToNextDay()
+    {
+        var brt = TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo");
+        // Now is exactly the schedule instant — must be STRICTLY after,
+        // so we get tomorrow.
+        var now = new DateTimeOffset(2026, 4, 30, 21, 0, 0, TimeSpan.Zero);
+        var next = DailyResetScheduler.ComputeNextFiringUtc(now, TimeSpan.FromHours(18), brt);
+        Assert.Equal(new DateTimeOffset(2026, 5, 1, 21, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void NextFiring_Utc_ReturnsExpectedInstant()
+    {
+        var utc = TimeZoneInfo.Utc;
+        var now = new DateTimeOffset(2026, 4, 30, 5, 0, 0, TimeSpan.Zero);
+        var next = DailyResetScheduler.ComputeNextFiringUtc(now, TimeSpan.FromHours(18), utc);
+        Assert.Equal(new DateTimeOffset(2026, 4, 30, 18, 0, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void Constructor_RejectsBadSchedule()
+    {
+        Action a = () => new DailyResetScheduler(
+            "25:00", "UTC", () => { }, NullLogger<DailyResetScheduler>.Instance);
+        Assert.Throws<FormatException>(a);
+    }
+
+    [Fact]
+    public void Constructor_RejectsBadTimezone()
+    {
+        Action a = () => new DailyResetScheduler(
+            "18:00", "Mars/Olympus", () => { }, NullLogger<DailyResetScheduler>.Instance);
+        Assert.Throws<ArgumentException>(a);
+    }
+
+    [Fact]
+    public void NextFiring_DstFallBack_PicksEarlierUtcInstant()
+    {
+        // America/New_York fall-back 2026: clocks move 02:00 EDT (UTC-4)
+        // back to 01:00 EST (UTC-5) on 2026-11-01. A schedule of "01:30"
+        // local is therefore ambiguous on that date — there is one
+        // 01:30 EDT (= 05:30 UTC) and one 01:30 EST (= 06:30 UTC). The
+        // scheduler must pick the EARLIER UTC instant (05:30 UTC) so
+        // the rollover does not fire twice during the repeated hour.
+        TimeZoneInfo ny;
+        try { ny = TimeZoneInfo.FindSystemTimeZoneById("America/New_York"); }
+        catch (TimeZoneNotFoundException) { return; /* tzdata unavailable */ }
+        var now = new DateTimeOffset(2026, 11, 1, 0, 0, 0, TimeSpan.Zero); // 2026-11-01 00:00Z
+        var next = DailyResetScheduler.ComputeNextFiringUtc(now, TimeSpan.FromMinutes(90), ny);
+        Assert.Equal(new DateTimeOffset(2026, 11, 1, 5, 30, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void NextFiring_DstSpringForward_SkipsInvalidLocalTimeToNextDay()
+    {
+        // America/New_York spring-forward 2026: 02:00 → 03:00 on
+        // 2026-03-08, so 02:30 local does not exist that day. The
+        // scheduler must skip to the next valid day's 02:30 EDT.
+        TimeZoneInfo ny;
+        try { ny = TimeZoneInfo.FindSystemTimeZoneById("America/New_York"); }
+        catch (TimeZoneNotFoundException) { return; /* tzdata unavailable */ }
+        var now = new DateTimeOffset(2026, 3, 8, 5, 0, 0, TimeSpan.Zero); // 00:00 EST
+        var next = DailyResetScheduler.ComputeNextFiringUtc(now, TimeSpan.FromMinutes(150), ny);
+        // 02:30 on 2026-03-09 is EDT (UTC-4) → 06:30 UTC.
+        Assert.Equal(new DateTimeOffset(2026, 3, 9, 6, 30, 0, TimeSpan.Zero), next);
+    }
+
+    [Fact]
+    public void Trigger_InvokesAction()
+    {
+        int count = 0;
+        var s = new DailyResetScheduler("18:00", "UTC", () => Interlocked.Increment(ref count),
+            NullLogger<DailyResetScheduler>.Instance);
+        s.Trigger();
+        s.Trigger();
+        Assert.Equal(2, count);
+    }
+}


### PR DESCRIPTION
Closes #47.

## Summary
Spec §4.5.1: at start of each trading day the gateway resets seq numbers to 1; clients reconnect with `Establish(nextSeqNo=1)`.

Implementation chooses **terminate-and-reconnect**: at rollover every live FixpSession is closed and clients perform a fresh `Negotiate+Establish`. Avoids in-place coordination of dispatch thread / retx ring / claim ledger / in-flight handshake.

## Components
- `EntryPointListener.TerminateAllSessions(reason)` — public primitive.
- `DailyResetScheduler` — Timer-based, IANA-tz aware, handles DST gap (skip) and DST fold (earlier UTC). Re-arms in `finally` so a thrown action doesn't permanently disable rollover.
- `HostConfig.DailyReset { Enabled, Schedule, Timezone }` — defaults disabled; `18:00 America/Sao_Paulo` when enabled.
- `POST /admin/daily-reset` — on-demand, returns `202 terminated=N`.

## Rubber-duck (GPT-5.5) findings addressed
- ✅ DST fold bug: `offsets.Min()` was picking the LATER UTC instant. Fixed by computing UTC for each candidate and picking the smallest. Added explicit America/New_York fall-back test.
- 📝 Deferred (called out in commit body): protocol-level Terminate frame before close, /admin/* auth, conformance ambiguity around Establish-only vs full Negotiate reconnect. None block.

## Tests
- 9 `DailyResetScheduler` unit tests (today/tomorrow/boundary/UTC/DST-fold/DST-gap + validation + Trigger).
- 2 listener integration tests.
- 397 total tests pass; format clean.