### PR TITLE
ci: run CodeQL on main pushes + nightly (drop per-PR runs)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,16 @@
 name: CodeQL
 
+# Strategy: don't gate PRs on CodeQL (16min/run × every push = high cost
+# for a small benefit on an active-dev repo). Run on every push to main
+# to catch what actually lands, and nightly to surface CWE rule updates
+# from GitHub's curated query pack without manual intervention. PRs get
+# fast feedback from `ci.yml` (build + test + format).
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
-    - cron: "23 4 * * 1"
+    - cron: "23 4 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Drops the per-PR CodeQL run (~16min) since PRs already get build+test+format signal from ci.yml. CodeQL keeps running on every push to main and nightly at 04:23 UTC so updated security queries land within a day. Manual dispatch retained.

Trade-off accepted: a vulnerable pattern can sneak through review and only get flagged when it lands in main (or by the next nightly). For a small active-dev repo this is net positive — 16min × N PRs/day is the bigger cost.