### PR TITLE
gateway: accept full NewOrderSingle (102) and OrderCancelReplaceRequest (104) — #51

### DIFF
--- a/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
@@ -51,6 +51,8 @@ internal static class BusinessMessageRejectEncoder
     {
         EntryPointFrameReader.TidSimpleNewOrder => 15,    // MessageType.SimpleNewOrder
         EntryPointFrameReader.TidSimpleModifyOrder => 16, // MessageType.SimpleModifyOrder
+        EntryPointFrameReader.TidNewOrderSingle => 17,    // MessageType.NewOrderSingle
+        EntryPointFrameReader.TidOrderCancelReplaceRequest => 18, // MessageType.OrderCancelReplaceRequest
         EntryPointFrameReader.TidOrderCancelRequest => 19,// MessageType.OrderCancelRequest
         _ => 0,
     };

--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -52,6 +52,10 @@ public static class EntryPointFrameReader
     public const ushort TidSimpleNewOrder = 100;
     /// <summary>Inbound: SimpleModifyOrder (V2).</summary>
     public const ushort TidSimpleModifyOrder = 101;
+    /// <summary>Inbound: NewOrderSingle (V2). Spec §4.6.4 / #GAP-15.</summary>
+    public const ushort TidNewOrderSingle = 102;
+    /// <summary>Inbound: OrderCancelReplaceRequest (V2). Spec §4.6.4 / #GAP-15.</summary>
+    public const ushort TidOrderCancelReplaceRequest = 104;
     /// <summary>Inbound: OrderCancelRequest (V6 base, no version variants).</summary>
     public const ushort TidOrderCancelRequest = 105;
     /// <summary>Session: Sequence (FIXP, also used as heartbeat). Bidirectional.</summary>
@@ -93,6 +97,8 @@ public static class EntryPointFrameReader
     {
         (TidSimpleNewOrder, 2) => 82,            // SimpleNewOrderV2.MESSAGE_SIZE
         (TidSimpleModifyOrder, 2) => 98,         // SimpleModifyOrderV2.MESSAGE_SIZE
+        (TidNewOrderSingle, 2) => 125,           // NewOrderSingleV2.MESSAGE_SIZE
+        (TidOrderCancelReplaceRequest, 2) => 142, // OrderCancelReplaceRequestV2.MESSAGE_SIZE
         (TidOrderCancelRequest, 0) => 76,        // OrderCancelRequest.MESSAGE_SIZE (V6 base)
         (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.
         (TidNegotiate, 0) => 28,                 // NegotiateData.BLOCK_LENGTH (V6 schema, root version 0)

--- a/src/B3.Exchange.Gateway/EntryPointVarData.cs
+++ b/src/B3.Exchange.Gateway/EntryPointVarData.cs
@@ -29,6 +29,8 @@ public static class EntryPointVarData
 
     private static readonly Field[] SimpleNewOrderFields = [Memo];
     private static readonly Field[] SimpleModifyOrderFields = [Memo];
+    private static readonly Field[] NewOrderSingleFields = [DeskID, Memo];
+    private static readonly Field[] OrderCancelReplaceFields = [DeskID, Memo];
     private static readonly Field[] OrderCancelFields = [DeskID, Memo];
     private static readonly Field[] NegotiateFields =
         [NegotiateCredentials, NegotiateClientIp, NegotiateClientAppName, NegotiateClientAppVersion];
@@ -45,6 +47,8 @@ public static class EntryPointVarData
     {
         (EntryPointFrameReader.TidSimpleNewOrder, 2) => SimpleNewOrderFields,
         (EntryPointFrameReader.TidSimpleModifyOrder, 2) => SimpleModifyOrderFields,
+        (EntryPointFrameReader.TidNewOrderSingle, 2) => NewOrderSingleFields,
+        (EntryPointFrameReader.TidOrderCancelReplaceRequest, 2) => OrderCancelReplaceFields,
         (EntryPointFrameReader.TidOrderCancelRequest, 0) => OrderCancelFields,
         (EntryPointFrameReader.TidNegotiate, 0) => NegotiateFields,
         (EntryPointFrameReader.TidEstablish, 0) => EstablishFields,

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -545,6 +545,42 @@ public sealed class FixpSession : IAsyncDisposable
                 _sink.OnDecodeError(Identity, rpErr ?? "decode error: SimpleModifyOrder");
                 await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:SimpleModifyOrder").ConfigureAwait(false);
                 return false;
+            case EntryPointFrameReader.TidNewOrderSingle:
+                {
+                    var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+                        fixedBlock, EnteringFirm, now, out var nos, out var nosClOrd, out var nosMsg);
+                    if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
+                    {
+                        _sink.EnqueueNewOrder(nos, Identity, EnteringFirm, nosClOrd);
+                        return true;
+                    }
+                    if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
+                    {
+                        WriteApplicationBusinessReject(info.TemplateId, fixedBlock, nosClOrd, nosMsg ?? "unsupported");
+                        return true;
+                    }
+                    _sink.OnDecodeError(Identity, nosMsg ?? "decode error: NewOrderSingle");
+                    await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:NewOrderSingle").ConfigureAwait(false);
+                    return false;
+                }
+            case EntryPointFrameReader.TidOrderCancelReplaceRequest:
+                {
+                    var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+                        fixedBlock, now, out var ocr, out var ocrClOrd, out var ocrOrigClOrd, out var ocrMsg);
+                    if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
+                    {
+                        _sink.EnqueueReplace(ocr, Identity, EnteringFirm, ocrClOrd, ocrOrigClOrd);
+                        return true;
+                    }
+                    if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
+                    {
+                        WriteApplicationBusinessReject(info.TemplateId, fixedBlock, ocrClOrd, ocrMsg ?? "unsupported");
+                        return true;
+                    }
+                    _sink.OnDecodeError(Identity, ocrMsg ?? "decode error: OrderCancelReplaceRequest");
+                    await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:OrderCancelReplaceRequest").ConfigureAwait(false);
+                    return false;
+                }
             case EntryPointFrameReader.TidOrderCancelRequest:
                 if (InboundMessageDecoder.TryDecodeCancel(fixedBlock, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
                 {
@@ -741,7 +777,36 @@ public sealed class FixpSession : IAsyncDisposable
     private static bool IsApplicationTemplate(ushort templateId)
         => templateId == EntryPointFrameReader.TidSimpleNewOrder
         || templateId == EntryPointFrameReader.TidSimpleModifyOrder
+        || templateId == EntryPointFrameReader.TidNewOrderSingle
+        || templateId == EntryPointFrameReader.TidOrderCancelReplaceRequest
         || templateId == EntryPointFrameReader.TidOrderCancelRequest;
+
+    /// <summary>
+    /// Emits a <c>BusinessMessageReject(33003)</c> for an application
+    /// frame whose wire body decoded but requested an unsupported
+    /// sub-feature (e.g. stop-order, iceberg, RLP, GTC). The session
+    /// stays open; spec §4.10 / #GAP-15. <paramref name="fixedBlock"/>
+    /// is the inbound body whose first 8 bytes are the
+    /// <c>InboundBusinessHeader</c>: <c>sessionID</c> (offset 0) and
+    /// <c>msgSeqNum</c> (offset 4). The supplied
+    /// <paramref name="clOrdId"/> is forwarded as
+    /// <c>businessRejectRefId</c> so the peer can correlate.
+    /// </summary>
+    private void WriteApplicationBusinessReject(ushort templateId, ReadOnlySpan<byte> fixedBlock, ulong clOrdId, string text)
+    {
+        uint refSeqNum = fixedBlock.Length >= 8
+            ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
+            : 0u;
+        WriteBusinessMessageReject(
+            refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(templateId),
+            refSeqNum: refSeqNum,
+            businessRejectRefId: clOrdId,
+            businessRejectReason: 33003,
+            text: text);
+        _logger.LogWarning(
+            "fixp session {ConnectionId} business reject (unsupported feature) template={Template} text={Text}",
+            ConnectionId, templateId, text);
+    }
 
     /// <summary>
     /// Spec §4.6.3.1 / §4.10 (#GAP-10): validates that an inbound business

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -51,7 +51,75 @@ internal static class InboundMessageDecoder
         public const int Side = 52;           // byte
     }
 
+    /// <summary>
+    /// Body offsets for NewOrderSingleV2 (id=102, BlockLength=125). The
+    /// fixed root carries the supported subset (ClOrdID/SecurityID/Side/
+    /// OrdType/TimeInForce/OrderQty/Price) plus the sub-feature flags
+    /// (StopPx/MinQty/MaxFloor/RoutingInstruction/MmProtectionReset/
+    /// SelfTradePreventionInstruction/ExpireDate) that the engine does
+    /// not implement; presence of the latter triggers a
+    /// <c>BusinessMessageReject(33003)</c> rather than terminating the
+    /// session (#GAP-15).
+    /// </summary>
+    private static class NewOrderSingleOffsets
+    {
+        public const int MmProtectionReset = 19;  // bool byte (0=false)
+        public const int ClOrdID = 20;            // ulong
+        public const int Stp = 47;                // SelfTradePreventionInstruction (0=NONE)
+        public const int SecurityID = 48;         // ulong
+        public const int Side = 56;               // byte
+        public const int OrdType = 57;            // byte
+        public const int TimeInForce = 58;        // byte
+        public const int RoutingInstruction = 59; // byte (255 == null)
+        public const int OrderQty = 60;           // ulong
+        public const int PriceMantissa = 68;      // long (PriceOptional, MinValue == NULL)
+        public const int StopPxMantissa = 76;     // long (MinValue == NULL)
+        public const int MinQty = 84;             // ulong (0 == null)
+        public const int MaxFloor = 92;           // ulong (0 == null)
+        public const int ExpireDate = 105;        // ushort (0 == null)
+    }
+
+    /// <summary>
+    /// Body offsets for OrderCancelReplaceRequestV2 (id=104, BlockLength=142).
+    /// </summary>
+    private static class OrderCancelReplaceOffsets
+    {
+        public const int MmProtectionReset = 19;  // bool byte
+        public const int ClOrdID = 20;            // ulong
+        public const int Stp = 47;                // SelfTradePreventionInstruction
+        public const int SecurityID = 48;         // ulong
+        public const int Side = 56;               // byte
+        public const int OrdType = 57;            // byte
+        public const int TimeInForce = 58;        // byte (optional, '\0' == 0 == null)
+        public const int RoutingInstruction = 59; // byte (255 == null)
+        public const int OrderQty = 60;           // ulong
+        public const int PriceMantissa = 68;      // long
+        public const int OrderID = 76;            // ulong (0 == null)
+        public const int OrigClOrdID = 84;        // ulong (0 == null)
+        public const int StopPxMantissa = 92;     // long (MinValue == NULL)
+        public const int MinQty = 100;            // ulong (0 == null)
+        public const int MaxFloor = 108;          // ulong (0 == null)
+        public const int ExpireDate = 122;        // ushort (0 == null)
+    }
+
+    private const byte RoutingInstructionNull = 255;
+    private const byte TimeInForceOptionalNull = 0; // schema null = '\0'
+
     private const long PriceNull = long.MinValue;
+
+    /// <summary>
+    /// Three-valued outcome for the full NewOrderSingle (102) and
+    /// OrderCancelReplaceRequest (104) decoders. Distinguishes
+    /// session-terminating wire errors (<see cref="DecodeError"/>) from
+    /// recoverable business rejects (<see cref="UnsupportedFeature"/>)
+    /// per spec §4.10 / #GAP-15.
+    /// </summary>
+    public enum InboundDecodeOutcome
+    {
+        Success = 0,
+        DecodeError = 1,
+        UnsupportedFeature = 2,
+    }
 
     public static bool TryDecodeNewOrder(ReadOnlySpan<byte> body, uint enteringFirm, ulong enteredAtNanos,
         out NewOrderCommand cmd, out ulong clOrdIdValue, out string? error)
@@ -127,6 +195,254 @@ internal static class InboundMessageDecoder
         return true;
     }
 
+    /// <summary>
+    /// Decodes a NewOrderSingleV2 (id=102) body for #GAP-15. Returns
+    /// <see cref="InboundDecodeOutcome.Success"/> when the order maps
+    /// onto the engine's supported subset (Market/Limit, Day/IOC/FOK, no
+    /// stop / iceberg / minimum-fill / RLP). Returns
+    /// <see cref="InboundDecodeOutcome.UnsupportedFeature"/> with a
+    /// <c>BusinessMessageReject(33003)</c>-bound text when the wire fields
+    /// are individually valid but request a feature the engine does not
+    /// implement; the caller emits BMR and keeps the session open.
+    /// Returns <see cref="InboundDecodeOutcome.DecodeError"/> for wire
+    /// values that violate the SBE schema (unmapped Side / OrdType / TIF
+    /// bytes); the caller terminates with DECODING_ERROR.
+    /// </summary>
+    public static InboundDecodeOutcome TryDecodeNewOrderSingle(
+        ReadOnlySpan<byte> body, uint enteringFirm, ulong enteredAtNanos,
+        out NewOrderCommand cmd, out ulong clOrdIdValue, out string? message)
+    {
+        cmd = null!;
+        clOrdIdValue = 0;
+        message = null;
+
+        ulong clOrdId = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.ClOrdID, 8));
+        long secId = MemoryMarshal.Read<long>(body.Slice(NewOrderSingleOffsets.SecurityID, 8));
+        byte sideByte = body[NewOrderSingleOffsets.Side];
+        byte ordTypeByte = body[NewOrderSingleOffsets.OrdType];
+        byte tifByte = body[NewOrderSingleOffsets.TimeInForce];
+        byte routing = body[NewOrderSingleOffsets.RoutingInstruction];
+        long qty = (long)MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.OrderQty, 8));
+        long priceMantissa = MemoryMarshal.Read<long>(body.Slice(NewOrderSingleOffsets.PriceMantissa, 8));
+        long stopPx = MemoryMarshal.Read<long>(body.Slice(NewOrderSingleOffsets.StopPxMantissa, 8));
+        ulong minQty = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.MinQty, 8));
+        ulong maxFloor = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.MaxFloor, 8));
+        byte mmpReset = body[NewOrderSingleOffsets.MmProtectionReset];
+        byte stp = body[NewOrderSingleOffsets.Stp];
+        ushort expireDate = MemoryMarshal.Read<ushort>(body.Slice(NewOrderSingleOffsets.ExpireDate, 2));
+
+        clOrdIdValue = clOrdId;
+
+        if (!TryMapSide(sideByte, out var side))
+        {
+            message = $"invalid Side={sideByte}";
+            return InboundDecodeOutcome.DecodeError;
+        }
+        if (!TryClassifyOrdType(ordTypeByte, out var ordType, out var ordTypeUnsupported))
+        {
+            message = ordTypeUnsupported is not null
+                ? $"OrdType={ordTypeByte:X2} not supported (only Market, Limit)"
+                : $"invalid OrdType={ordTypeByte}";
+            return ordTypeUnsupported is not null
+                ? InboundDecodeOutcome.UnsupportedFeature
+                : InboundDecodeOutcome.DecodeError;
+        }
+        if (!TryClassifyTif(tifByte, out var tif, out var tifUnsupported))
+        {
+            message = tifUnsupported is not null
+                ? $"TimeInForce={(char)tifByte} not supported (only Day, IOC, FOK)"
+                : $"invalid TimeInForce={tifByte}";
+            return tifUnsupported is not null
+                ? InboundDecodeOutcome.UnsupportedFeature
+                : InboundDecodeOutcome.DecodeError;
+        }
+        if (stopPx != PriceNull)
+        {
+            message = "Stop orders not supported (StopPx must be NULL)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (maxFloor != 0)
+        {
+            message = "Iceberg orders not supported (MaxFloor must be NULL)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (minQty != 0)
+        {
+            message = "Minimum-fill orders not supported (MinQty must be NULL)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (routing != RoutingInstructionNull)
+        {
+            message = $"RoutingInstruction={routing} not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (mmpReset != 0)
+        {
+            message = "MMProtectionReset not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (stp != 0)
+        {
+            message = "SelfTradePreventionInstruction not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (expireDate != 0)
+        {
+            message = "ExpireDate not supported (only Day/IOC/FOK)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+
+        long enginePrice = ordType == OrderType.Market ? 0L : (priceMantissa == PriceNull ? 0L : priceMantissa);
+
+        cmd = new NewOrderCommand(
+            ClOrdId: clOrdId.ToString(),
+            SecurityId: secId,
+            Side: side,
+            Type: ordType,
+            Tif: tif,
+            PriceMantissa: enginePrice,
+            Quantity: qty,
+            EnteringFirm: enteringFirm,
+            EnteredAtNanos: enteredAtNanos);
+        return InboundDecodeOutcome.Success;
+    }
+
+    /// <summary>
+    /// Decodes an OrderCancelReplaceRequestV2 (id=104) body for #GAP-15.
+    /// See <see cref="TryDecodeNewOrderSingle"/> for the outcome contract.
+    /// TimeInForce on this template is optional in the schema; absence is
+    /// accepted (replace inherits the original order's TIF).
+    /// </summary>
+    public static InboundDecodeOutcome TryDecodeOrderCancelReplace(
+        ReadOnlySpan<byte> body, ulong enteredAtNanos,
+        out ReplaceOrderCommand cmd, out ulong clOrdIdValue, out ulong origClOrdIdValue, out string? message)
+    {
+        cmd = null!;
+        clOrdIdValue = 0;
+        origClOrdIdValue = 0;
+        message = null;
+
+        ulong clOrdId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.ClOrdID, 8));
+        long secId = MemoryMarshal.Read<long>(body.Slice(OrderCancelReplaceOffsets.SecurityID, 8));
+        byte sideByte = body[OrderCancelReplaceOffsets.Side];
+        byte ordTypeByte = body[OrderCancelReplaceOffsets.OrdType];
+        byte tifByte = body[OrderCancelReplaceOffsets.TimeInForce];
+        byte routing = body[OrderCancelReplaceOffsets.RoutingInstruction];
+        long qty = (long)MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrderQty, 8));
+        long priceMantissa = MemoryMarshal.Read<long>(body.Slice(OrderCancelReplaceOffsets.PriceMantissa, 8));
+        ulong orderId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrderID, 8));
+        ulong origClOrdId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrigClOrdID, 8));
+        long stopPx = MemoryMarshal.Read<long>(body.Slice(OrderCancelReplaceOffsets.StopPxMantissa, 8));
+        ulong minQty = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.MinQty, 8));
+        ulong maxFloor = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.MaxFloor, 8));
+        byte mmpReset = body[OrderCancelReplaceOffsets.MmProtectionReset];
+        byte stp = body[OrderCancelReplaceOffsets.Stp];
+        ushort expireDate = MemoryMarshal.Read<ushort>(body.Slice(OrderCancelReplaceOffsets.ExpireDate, 2));
+
+        clOrdIdValue = clOrdId;
+        origClOrdIdValue = origClOrdId;
+
+        if (!TryMapSide(sideByte, out _))
+        {
+            message = $"invalid Side={sideByte}";
+            return InboundDecodeOutcome.DecodeError;
+        }
+        if (!TryClassifyOrdType(ordTypeByte, out var ordType, out var ordTypeUnsupported))
+        {
+            message = ordTypeUnsupported is not null
+                ? $"OrdType={ordTypeByte:X2} not supported (only Limit on replace)"
+                : $"invalid OrdType={ordTypeByte}";
+            return ordTypeUnsupported is not null
+                ? InboundDecodeOutcome.UnsupportedFeature
+                : InboundDecodeOutcome.DecodeError;
+        }
+        // Replace path can only carry through Limit semantics — the
+        // engine's ReplaceOrderCommand has no Type field and reuses the
+        // resting order's existing type. Reject Market replace requests
+        // explicitly so we don't silently lie about what we did.
+        if (ordType != OrderType.Limit)
+        {
+            message = "Market replace not supported (only Limit replace)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        // TimeInForce on this template is optional in the schema (null =
+        // '\0'), meaning "do not change". Anything else than null or Day
+        // would request a TIF transition the engine cannot perform on
+        // a resting order, so reject with BMR rather than silently
+        // accepting and applying the wrong semantics.
+        if (tifByte != TimeInForceOptionalNull)
+        {
+            if (!TryClassifyTif(tifByte, out var tif, out var tifUnsupported))
+            {
+                message = tifUnsupported is not null
+                    ? $"TimeInForce={(char)tifByte} not supported on replace (omit or use Day)"
+                    : $"invalid TimeInForce={tifByte}";
+                return tifUnsupported is not null
+                    ? InboundDecodeOutcome.UnsupportedFeature
+                    : InboundDecodeOutcome.DecodeError;
+            }
+            if (tif != TimeInForce.Day)
+            {
+                message = "TIF change on replace not supported (omit or use Day)";
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
+        }
+        if (stopPx != PriceNull)
+        {
+            message = "Stop orders not supported (StopPx must be NULL)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (maxFloor != 0)
+        {
+            message = "Iceberg orders not supported (MaxFloor must be NULL)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (minQty != 0)
+        {
+            message = "Minimum-fill orders not supported (MinQty must be NULL)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (routing != RoutingInstructionNull)
+        {
+            message = $"RoutingInstruction={routing} not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (mmpReset != 0)
+        {
+            message = "MMProtectionReset not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (stp != 0)
+        {
+            message = "SelfTradePreventionInstruction not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (expireDate != 0)
+        {
+            message = "ExpireDate not supported (only Day/IOC/FOK)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (orderId == 0 && origClOrdId == 0)
+        {
+            message = "OrderCancelReplaceRequest requires either OrderID or OrigClOrdID";
+            return InboundDecodeOutcome.DecodeError;
+        }
+        if (priceMantissa == PriceNull)
+        {
+            message = "OrderCancelReplaceRequest requires Price (replace cannot remove price)";
+            return InboundDecodeOutcome.DecodeError;
+        }
+
+        cmd = new ReplaceOrderCommand(
+            ClOrdId: clOrdId.ToString(),
+            SecurityId: secId,
+            OrderId: (long)orderId,
+            NewPriceMantissa: priceMantissa,
+            NewQuantity: qty,
+            EnteredAtNanos: enteredAtNanos);
+        return InboundDecodeOutcome.Success;
+    }
+
     public static bool TryDecodeCancel(ReadOnlySpan<byte> body, ulong enteredAtNanos,
         out CancelOrderCommand cmd, out ulong clOrdIdValue, out ulong origClOrdIdValue, out string? error)
     {
@@ -184,6 +500,70 @@ internal static class InboundMessageDecoder
             case (byte)'3': tif = TimeInForce.IOC; return true;
             case (byte)'4': tif = TimeInForce.FOK; return true;
             default: tif = default; return false;
+        }
+    }
+
+    /// <summary>
+    /// Three-way OrdType classification used by the
+    /// NewOrderSingle/OrderCancelReplaceRequest decoders. Returns
+    /// <c>true</c> for the supported subset (Market=1, Limit=2). Returns
+    /// <c>false</c> with <paramref name="unsupportedReason"/> set when the
+    /// byte is a schema-valid OrdType the engine does not implement
+    /// (Stop=3, StopLimit=4, MarketWithLeftover=K, RLP=W, Pegged=P —
+    /// schema enum values per <c>schemas/b3-entrypoint-messages-8.4.2.xml</c>).
+    /// Returns <c>false</c> with <paramref name="unsupportedReason"/>
+    /// <c>null</c> for bytes that are not part of the FIX OrdType
+    /// enumeration at all — caller terminates with DECODING_ERROR.
+    /// </summary>
+    private static bool TryClassifyOrdType(byte b, out OrderType type, out string? unsupportedReason)
+    {
+        unsupportedReason = null;
+        switch (b)
+        {
+            case (byte)'1': type = OrderType.Market; return true;
+            case (byte)'2': type = OrderType.Limit; return true;
+            case (byte)'3': // STOP_LOSS
+            case (byte)'4': // STOP_LIMIT
+            case (byte)'K': // MARKET_WITH_LEFTOVER_AS_LIMIT
+            case (byte)'W': // RLP
+            case (byte)'P': // PEGGED_MIDPOINT
+                type = default;
+                unsupportedReason = "unsupported OrdType";
+                return false;
+            default:
+                type = default;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Three-way TimeInForce classification. Returns <c>true</c> for the
+    /// supported subset (Day=0, IOC=3, FOK=4). For other schema-valid
+    /// values (GTC=1, GTD=6, AtTheClose=7, GoodForAuction='A') returns
+    /// <c>false</c> with <paramref name="unsupportedReason"/> populated.
+    /// For bytes not in the schema returns <c>false</c> with the reason
+    /// <c>null</c>. The schema-NULL byte ('\0') is always reported as a
+    /// wire decode error here; callers that accept optional TIF must
+    /// short-circuit before invoking this helper.
+    /// </summary>
+    private static bool TryClassifyTif(byte b, out TimeInForce tif, out string? unsupportedReason)
+    {
+        unsupportedReason = null;
+        switch (b)
+        {
+            case (byte)'0': tif = TimeInForce.Day; return true;
+            case (byte)'3': tif = TimeInForce.IOC; return true;
+            case (byte)'4': tif = TimeInForce.FOK; return true;
+            case (byte)'1': // GOOD_TILL_CANCEL
+            case (byte)'6': // GOOD_TILL_DATE
+            case (byte)'7': // AT_THE_CLOSE
+            case (byte)'A': // GOOD_FOR_AUCTION
+                tif = default;
+                unsupportedReason = "unsupported TimeInForce";
+                return false;
+            default:
+                tif = default;
+                return false;
         }
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -1,0 +1,473 @@
+using System.Runtime.InteropServices;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Unit tests for #GAP-15 — full NewOrderSingle (102) and
+/// OrderCancelReplaceRequest (104) decoders. Validates the supported
+/// happy-path subset, the BMR-eligible "unsupported feature" branch, and
+/// the DECODING_ERROR (terminate) branch.
+/// </summary>
+public class NewOrderSingleAndReplaceDecoderTests
+{
+    private const long PriceNull = long.MinValue;
+    private const byte RoutingNull = 255;
+
+    private static byte[] BuildNewOrderSingleV2(
+        ulong clOrdId = 99UL,
+        long secId = 12345L,
+        byte side = (byte)'1',
+        byte ordType = (byte)'2',
+        byte tif = (byte)'0',
+        byte routing = RoutingNull,
+        long qty = 100L,
+        long price = 12_3400L,
+        long stopPx = PriceNull,
+        ulong minQty = 0UL,
+        ulong maxFloor = 0UL)
+    {
+        var body = new byte[125];
+        Span<byte> s = body;
+        MemoryMarshal.Write(s.Slice(20, 8), in clOrdId);
+        MemoryMarshal.Write(s.Slice(48, 8), in secId);
+        s[56] = side;
+        s[57] = ordType;
+        s[58] = tif;
+        s[59] = routing;
+        MemoryMarshal.Write(s.Slice(60, 8), in qty);
+        MemoryMarshal.Write(s.Slice(68, 8), in price);
+        MemoryMarshal.Write(s.Slice(76, 8), in stopPx);
+        MemoryMarshal.Write(s.Slice(84, 8), in minQty);
+        MemoryMarshal.Write(s.Slice(92, 8), in maxFloor);
+        return body;
+    }
+
+    private static byte[] BuildOrderCancelReplaceV2(
+        ulong clOrdId = 200UL,
+        long secId = 12345L,
+        byte side = (byte)'1',
+        byte ordType = (byte)'2',
+        byte tif = (byte)'0',
+        byte routing = RoutingNull,
+        long qty = 100L,
+        long price = 12_3400L,
+        ulong orderId = 42UL,
+        ulong origClOrdId = 99UL,
+        long stopPx = PriceNull,
+        ulong minQty = 0UL,
+        ulong maxFloor = 0UL)
+    {
+        var body = new byte[142];
+        Span<byte> s = body;
+        MemoryMarshal.Write(s.Slice(20, 8), in clOrdId);
+        MemoryMarshal.Write(s.Slice(48, 8), in secId);
+        s[56] = side;
+        s[57] = ordType;
+        s[58] = tif;
+        s[59] = routing;
+        MemoryMarshal.Write(s.Slice(60, 8), in qty);
+        MemoryMarshal.Write(s.Slice(68, 8), in price);
+        MemoryMarshal.Write(s.Slice(76, 8), in orderId);
+        MemoryMarshal.Write(s.Slice(84, 8), in origClOrdId);
+        MemoryMarshal.Write(s.Slice(92, 8), in stopPx);
+        MemoryMarshal.Write(s.Slice(100, 8), in minQty);
+        MemoryMarshal.Write(s.Slice(108, 8), in maxFloor);
+        return body;
+    }
+
+    // ---------------- NewOrderSingle (102) ----------------
+
+    [Fact]
+    public void NewOrderSingle_LimitDay_HappyPath()
+    {
+        var body = BuildNewOrderSingleV2(clOrdId: 1234UL, qty: 50, price: 12_3450L);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, enteringFirm: 7, enteredAtNanos: 1_000_000UL,
+            out var cmd, out var clOrd, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(1234UL, clOrd);
+        Assert.Equal(Side.Buy, cmd.Side);
+        Assert.Equal(OrderType.Limit, cmd.Type);
+        Assert.Equal(TimeInForce.Day, cmd.Tif);
+        Assert.Equal(50L, cmd.Quantity);
+        Assert.Equal(12_3450L, cmd.PriceMantissa);
+        Assert.Equal(7u, cmd.EnteringFirm);
+    }
+
+    [Theory]
+    [InlineData((byte)'0', TimeInForce.Day)]
+    [InlineData((byte)'3', TimeInForce.IOC)]
+    [InlineData((byte)'4', TimeInForce.FOK)]
+    public void NewOrderSingle_AcceptsSupportedTif(byte tifByte, TimeInForce expected)
+    {
+        var body = BuildNewOrderSingleV2(tif: tifByte);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(expected, cmd.Tif);
+    }
+
+    [Fact]
+    public void NewOrderSingle_MarketDropsPrice()
+    {
+        var body = BuildNewOrderSingleV2(ordType: (byte)'1', price: PriceNull);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(OrderType.Market, cmd.Type);
+        Assert.Equal(0L, cmd.PriceMantissa);
+    }
+
+    [Fact]
+    public void NewOrderSingle_StopPxRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2(stopPx: 11_0000L);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Stop", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_MaxFloorRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2(maxFloor: 10UL);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Iceberg", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_MinQtyRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2(minQty: 5UL);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Minimum-fill", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_RoutingInstructionRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2(routing: 1);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("RoutingInstruction", msg);
+    }
+
+    [Theory]
+    [InlineData((byte)'3')] // Stop
+    [InlineData((byte)'4')] // StopLimit
+    [InlineData((byte)'W')] // RLP
+    [InlineData((byte)'K')] // MARKET_WITH_LEFTOVER_AS_LIMIT
+    [InlineData((byte)'P')] // PEGGED_MIDPOINT
+    public void NewOrderSingle_UnsupportedOrdTypeReturnsBmr(byte ordTypeByte)
+    {
+        var body = BuildNewOrderSingleV2(ordType: ordTypeByte);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("OrdType", msg);
+    }
+
+    [Theory]
+    [InlineData((byte)'1')] // GTC
+    [InlineData((byte)'6')] // GTD
+    [InlineData((byte)'7')] // AtTheClose
+    [InlineData((byte)'A')] // GoodForAuction
+    public void NewOrderSingle_UnsupportedTifReturnsBmr(byte tifByte)
+    {
+        var body = BuildNewOrderSingleV2(tif: tifByte);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("TimeInForce", msg);
+    }
+
+    [Theory]
+    [InlineData((byte)'5')] // not in schema
+    [InlineData((byte)'X')] // not in schema
+    [InlineData((byte)0)]   // null on a required field
+    public void NewOrderSingle_InvalidOrdTypeByteTerminates(byte ordTypeByte)
+    {
+        var body = BuildNewOrderSingleV2(ordType: ordTypeByte);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("OrdType", msg);
+    }
+
+    [Theory]
+    [InlineData((byte)'2')] // OPG — not in schema
+    [InlineData((byte)'5')] // not in schema
+    [InlineData((byte)0)]   // null on required TIF
+    public void NewOrderSingle_InvalidTifByteTerminates(byte tifByte)
+    {
+        var body = BuildNewOrderSingleV2(tif: tifByte);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("TimeInForce", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_InvalidSideTerminates()
+    {
+        var body = BuildNewOrderSingleV2(side: 0xAB);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("Side", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_MmProtectionResetRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2();
+        body[19] = 1;
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("MMProtectionReset", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_SelfTradePreventionRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2();
+        body[47] = 1; // CANCEL_AGGRESSOR_ORDER
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("SelfTradePrevention", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_ExpireDateRejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2();
+        ushort expire = 0x1234;
+        MemoryMarshal.Write(((Span<byte>)body).Slice(105, 2), in expire);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("ExpireDate", msg);
+    }
+
+    // ---------------- OrderCancelReplaceRequest (104) ----------------
+
+    [Fact]
+    public void OrderCancelReplace_HappyPath_ByOrderId()
+    {
+        var body = BuildOrderCancelReplaceV2(clOrdId: 555UL, orderId: 42UL, origClOrdId: 0UL,
+            qty: 25, price: 50_0000L);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 1_000UL, out var cmd, out var clOrd, out var origClOrd, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(555UL, clOrd);
+        Assert.Equal(0UL, origClOrd);
+        Assert.Equal(42L, cmd.OrderId);
+        Assert.Equal(25L, cmd.NewQuantity);
+        Assert.Equal(50_0000L, cmd.NewPriceMantissa);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_HappyPath_ByOrigClOrdId()
+    {
+        var body = BuildOrderCancelReplaceV2(clOrdId: 555UL, orderId: 0UL, origClOrdId: 99UL);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out var origClOrd, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(99UL, origClOrd);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_TifNullAccepted()
+    {
+        var body = BuildOrderCancelReplaceV2(tif: 0); // schema NULL = '\0'
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_StopPxRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2(stopPx: 50_0000L);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Stop", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_MaxFloorRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2(maxFloor: 10UL);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Iceberg", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_MinQtyRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2(minQty: 5UL);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Minimum-fill", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_RequiresOrderIdOrOrigClOrdId()
+    {
+        var body = BuildOrderCancelReplaceV2(orderId: 0UL, origClOrdId: 0UL);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("OrderID", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_RequiresPrice()
+    {
+        var body = BuildOrderCancelReplaceV2(price: PriceNull);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("Price", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_MarketRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2(ordType: (byte)'1');
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Market replace", msg);
+    }
+
+    [Theory]
+    [InlineData((byte)'3')] // IOC
+    [InlineData((byte)'4')] // FOK
+    public void OrderCancelReplace_NonDayTifRejectsAsUnsupported(byte tifByte)
+    {
+        var body = BuildOrderCancelReplaceV2(tif: tifByte);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("TIF", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_DayTifAccepted()
+    {
+        var body = BuildOrderCancelReplaceV2(tif: (byte)'0');
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_MmProtectionResetRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2();
+        body[19] = 1;
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("MMProtectionReset", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_SelfTradePreventionRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2();
+        body[47] = 2;
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("SelfTradePrevention", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_ExpireDateRejectsAsUnsupported()
+    {
+        var body = BuildOrderCancelReplaceV2();
+        ushort expire = 0x1234;
+        MemoryMarshal.Write(((Span<byte>)body).Slice(122, 2), in expire);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("ExpireDate", msg);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/RejectEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/RejectEncoderTests.cs
@@ -114,4 +114,20 @@ public class RejectEncoderTests
         Assert.Equal((byte)0, trailer[0]);
         Assert.Equal((byte)BusinessMessageRejectEncoder.MaxTextLength, trailer[1]);
     }
+
+    /// <summary>
+    /// #GAP-15 — locking in the schema MessageType enum bytes for the
+    /// templates the gateway maps to BMR(33003) refMsgType. A regression
+    /// to the raw templateId byte (e.g. 102/104) would silently break
+    /// compatibility with strict clients that decode refMsgType against
+    /// the schema enum.
+    /// </summary>
+    [Theory]
+    [InlineData(EntryPointFrameReader.TidSimpleNewOrder, (byte)15)]
+    [InlineData(EntryPointFrameReader.TidSimpleModifyOrder, (byte)16)]
+    [InlineData(EntryPointFrameReader.TidNewOrderSingle, (byte)17)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelReplaceRequest, (byte)18)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelRequest, (byte)19)]
+    public void MapRefMsgTypeFromTemplateId_MatchesSchemaMessageType(ushort tid, byte expected)
+        => Assert.Equal(expected, BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(tid));
 }


### PR DESCRIPTION
Closes #51 (#GAP-15).

Adds full-template decoders, frame-length wiring, varData specs (`[deskID, memo]`) and dispatch arms for `NewOrderSingleV2` (id=102, BlockLength=125) and `OrderCancelReplaceRequestV2` (id=104, BlockLength=142).

## Behaviour

- **Happy path** maps the supported subset (Market/Limit, Day/IOC/FOK, no stop/iceberg/min-fill/RLP) onto the existing `NewOrderCommand` / `ReplaceOrderCommand` records — same engine path as today's `Simple*` templates.
- **Schema-valid sub-feature requests** (`StopPx`, `MaxFloor`, `MinQty`, `RoutingInstruction`, `MMProtectionReset`, `SelfTradePreventionInstruction`, `ExpireDate`, schema-valid-but-unsupported `OrdType`/`TIF` values) → `BusinessMessageReject(33003)` with explicit text; session stays open per spec §4.10.
- **Schema-invalid wire bytes** (bytes not in the FIX enum) → `Terminate(DECODING_ERROR)` — preserved decoder contract.
- **OCR is stricter than NOS**: `ReplaceOrderCommand` has no Type/TIF, so requesting a Market replace or a non-Day TIF transition would silently downgrade to Day-Limit. Both now reject with BMR instead.

## Wiring

- `EntryPointFrameReader`: new `Tid` constants + `ExpectedInboundBlockLength` entries (125, 142).
- `EntryPointVarData`: `[DeskID, Memo]` for both templates.
- `BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId`: 102→17, 104→18 (matches schema `MessageType` enum bytes).
- `FixpSession.IsApplicationTemplate`: includes 102/104 so existing GAP-10/14 sessionID and varData rejects also fire on these templates.
- `FixpSession.WriteApplicationBusinessReject`: new helper that reads `sessionID`/`msgSeqNum` from the inbound business header and emits `BMR(33003)`.

## Tests

- `NewOrderSingleAndReplaceDecoderTests` (43 tests): happy paths, every sub-feature reject, OrdType/TIF enum partitioning (supported / schema-valid-unsupported / invalid), OCR-specific rules.
- `RejectEncoderTests`: new theory locking `refMsgType` for all 5 application templates against schema `MessageType` bytes.
- **Full suite**: 445 tests pass (267 in Gateway), `dotnet build -c Release` clean (warnings-as-errors), `dotnet format --verify-no-changes` clean.

## Review notes

GPT-5.5 rubber-duck pass caught two real bugs that are addressed in this PR:

1. **Wrong enum partitioning**: I had `OrdType=5` and `TIF=2/5` listed as schema-valid-unsupported and was missing `TIF=A` (GoodForAuction). Fixed against the actual schema enum (`OrdType` valid: `1,2,3,4,K,W,P`; `TIF` valid: `0,1,3,4,6,7,A`).
2. **OCR silently dropped Type/TIF**: `ReplaceOrderCommand` has no Type/TIF field, so `OrdType=Market` or `TIF=IOC/FOK` on template 104 would be acknowledged but processed as Day-Limit. Now BMR'd.

Also added rejects for `MMProtectionReset`, `SelfTradePreventionInstruction`, and `ExpireDate` — fields that today are silently ignored despite requesting actual matching-engine behaviour.