### PR TITLE
Map RejectReason to FIX OrdRejReason wire codes (#53)

### DIFF
--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -216,7 +216,7 @@ internal static class ExecutionReportEncoder
     public static int EncodeExecReportReject(Span<byte> dst,
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         ulong clOrdIdValue, ulong origClOrdIdValue, long securityId, long orderIdOrZero,
-        byte rejectReason, ulong transactTimeNanos)
+        uint rejectReason, ulong transactTimeNanos)
     {
         if (dst.Length < ExecReportRejectTotal) throw new ArgumentException("buffer too small for ER_Reject", nameof(dst));
         EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportRejectTotal,
@@ -229,7 +229,11 @@ internal static class ExecutionReportEncoder
         MemoryMarshal.Write(body.Slice(20, 8), in clOrdIdValue);
         // SecondaryOrderID@28 = 0 (null)
         MemoryMarshal.Write(body.Slice(36, 8), in securityId);
-        body[44] = rejectReason;                                            // OrdRejReason (overlap SecExchange)
+        // OrdRejReason: schema type RejReason is uint32 (#GAP-17 / #53).
+        // Field overlaps SecurityExchange (offset 44) per the SBE schema;
+        // writing the full 4 LE bytes leaves SecurityExchange unset, which
+        // matches the engine's behaviour today (we never populate it).
+        MemoryMarshal.Write(body.Slice(44, 4), in rejectReason);            // OrdRejReason (overlap SecExchange)
         MemoryMarshal.Write(body.Slice(48, 8), in transactTimeNanos);
         ulong zeroExecId = 0;
         MemoryMarshal.Write(body.Slice(56, 8), in zeroExecId);              // ExecID 0

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -1397,7 +1397,7 @@ public sealed class FixpSession : IAsyncDisposable
     public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue)
     {
         if (!IsOpen) return false;
-        byte rej = MapRejectReason(e.Reason);
+        uint rej = MapRejectReason(e.Reason);
         var exact = new byte[ExecutionReportEncoder.ExecReportRejectTotal];
         lock (_outboundLock)
         {
@@ -1457,12 +1457,36 @@ public sealed class FixpSession : IAsyncDisposable
         }
     }
 
-    private static byte MapRejectReason(RejectReason r) => r switch
+    /// <summary>
+    /// Maps engine <see cref="RejectReason"/> to the FIX OrdRejReason wire code
+    /// emitted on ExecutionReport_Reject (#GAP-17 / issue #53). Standard FIX 4.4
+    /// codes used:
+    ///   0  = Broker / exchange option (generic / no closer match)
+    ///   1  = Unknown symbol
+    ///   3  = Order exceeds limit (used here for price-band / tick / non-positive price)
+    ///   5  = Unknown order
+    ///   11 = Unsupported order characteristic (used for invalid quantity and
+    ///        Market/IOC-only constraints not satisfied by the inbound order)
+    /// Engine reasons that have no direct FIX peer (e.g. <see cref="RejectReason.MarketNoLiquidity"/>,
+    /// <see cref="RejectReason.FokUnfillable"/>, <see cref="RejectReason.SelfTradePrevention"/>)
+    /// fall through to 0 (Broker/exchange option) — context is conveyed via the
+    /// <c>Text</c> tag where applicable.
+    /// </summary>
+    internal static uint MapRejectReason(RejectReason r) => r switch
     {
-        // OrdRejReason wire codes: 0=BrokerExchangeOption (generic), 1=UnknownSymbol,
-        // 3=OrderExceedsLimit, 5=UnknownOrder, 6=DuplicateOrder, 11=UnsupportedOrderCharacteristic.
-        // Engine RejectReason values mapped to nearest wire code; unmapped => 0.
-        _ => 0,
+        RejectReason.UnknownInstrument => 1u,
+        RejectReason.UnknownOrderId => 5u,
+        RejectReason.PriceOutOfBand => 3u,
+        RejectReason.PriceNotOnTick => 3u,
+        RejectReason.PriceNonPositive => 3u,
+        RejectReason.QuantityNonPositive => 11u,
+        RejectReason.QuantityNotMultipleOfLot => 11u,
+        RejectReason.MarketNotImmediateOrCancel => 11u,
+        RejectReason.InvalidTimeInForceForMarket => 11u,
+        RejectReason.MarketNoLiquidity => 0u,
+        RejectReason.FokUnfillable => 0u,
+        RejectReason.SelfTradePrevention => 0u,
+        _ => 0u,
     };
 
     public void Close() => Close("close");

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -107,13 +107,13 @@ public class ExecutionReportEncoderTests
         int n = ExecutionReportEncoder.EncodeExecReportReject(buf,
             sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
             clOrdIdValue: 7, origClOrdIdValue: 0, securityId: 333, orderIdOrZero: 0,
-            rejectReason: 5, transactTimeNanos: 0UL);
+            rejectReason: 5u, transactTimeNanos: 0UL);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportRejectTotal, n);
         var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal(7UL, MemoryMarshal.Read<ulong>(body.Slice(20, 8)));            // ClOrdID
         Assert.Equal(333L, MemoryMarshal.Read<long>(body.Slice(36, 8)));            // SecurityID
-        Assert.Equal((byte)5, body[44]);                                            // OrdRejReason
+        Assert.Equal(5u, MemoryMarshal.Read<uint>(body.Slice(44, 4)));              // OrdRejReason (uint32, overlaps SecExchange)
     }
 
     [Fact]

--- a/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
@@ -1,0 +1,48 @@
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Locks the engine RejectReason -> FIX OrdRejReason wire-code mapping
+/// (#GAP-17 / issue #53). Standard FIX 4.4 codes:
+///   0  = Broker / exchange option (generic / catch-all)
+///   1  = Unknown symbol
+///   3  = Order exceeds limit
+///   5  = Unknown order
+///   11 = Unsupported order characteristic
+/// </summary>
+public class MapRejectReasonTests
+{
+    [Theory]
+    [InlineData(RejectReason.UnknownInstrument, 1u)]
+    [InlineData(RejectReason.UnknownOrderId, 5u)]
+    [InlineData(RejectReason.PriceOutOfBand, 3u)]
+    [InlineData(RejectReason.PriceNotOnTick, 3u)]
+    [InlineData(RejectReason.PriceNonPositive, 3u)]
+    [InlineData(RejectReason.QuantityNonPositive, 11u)]
+    [InlineData(RejectReason.QuantityNotMultipleOfLot, 11u)]
+    [InlineData(RejectReason.MarketNotImmediateOrCancel, 11u)]
+    [InlineData(RejectReason.InvalidTimeInForceForMarket, 11u)]
+    [InlineData(RejectReason.MarketNoLiquidity, 0u)]
+    [InlineData(RejectReason.FokUnfillable, 0u)]
+    [InlineData(RejectReason.SelfTradePrevention, 0u)]
+    public void MapRejectReason_ProducesExpectedWireCode(RejectReason reason, uint expected)
+    {
+        Assert.Equal(expected, FixpSession.MapRejectReason(reason));
+    }
+
+    [Fact]
+    public void MapRejectReason_CoversEveryEnumValue()
+    {
+        // Guard: if a new RejectReason is added to the engine, this test forces
+        // the maintainer to extend the switch (otherwise the new value would
+        // silently fall through to 0 = generic, hiding diagnostics from clients).
+        foreach (var r in System.Enum.GetValues<RejectReason>())
+        {
+            // Should not throw and must return one of the documented wire codes.
+            uint code = FixpSession.MapRejectReason(r);
+            Assert.Contains(code, new uint[] { 0u, 1u, 3u, 5u, 11u });
+        }
+    }
+}

--- a/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
@@ -179,7 +179,7 @@ public class WireFormatCompatTests
         ExecutionReportEncoder.EncodeExecReportReject(frame,
             sessionId: 1, msgSeqNum: 2, sendingTimeNanos: 3,
             clOrdIdValue: clOrd, origClOrdIdValue: 0, securityId: secId, orderIdOrZero: 0,
-            rejectReason: 99, transactTimeNanos: 4);
+            rejectReason: 99u, transactTimeNanos: 4);
 
         var body = frame.Slice(SbeHeaderSize);
         var er = EntryPointClient.DecodeExecReportReject(body);


### PR DESCRIPTION
Closes #53.

Implements GAP-17: replaces the `_ => 0` catch-all in
`FixpSession.MapRejectReason` with per-reason mappings to the standard
FIX 4.4 OrdRejReason codes used by the B3 EntryPoint spec.

| Engine `RejectReason` | OrdRejReason |
|---|---|
| `UnknownInstrument` | `1` Unknown symbol |
| `UnknownOrderId` | `5` Unknown order |
| `PriceOutOfBand`, `PriceNotOnTick`, `PriceNonPositive` | `3` Order exceeds limit |
| `QuantityNonPositive`, `QuantityNotMultipleOfLot`, `MarketNotImmediateOrCancel`, `InvalidTimeInForceForMarket` | `11` Unsupported order characteristic |
| `MarketNoLiquidity`, `FokUnfillable`, `SelfTradePrevention` | `0` Broker / exchange option |

### Schema-correctness fix (drive-by)

`RejReason` is `uint32` per the SBE schema. The encoder was writing only
the low byte at offset 44; works for codes ≤ 255 thanks to `body.Clear()`,
but the field width was wrong on the wire. Widened
`EncodeExecReportReject(rejectReason)` to `uint` and write all four LE
bytes (still overlaps the unset `SecurityExchange` per the schema's union
layout).

### Tests

- New `MapRejectReasonTests`:
  - `[Theory]` per enum value asserting expected wire code.
  - `CoversEveryEnumValue` reflects over `RejectReason` so a future engine
    addition forces the maintainer to extend the switch (guard against
    silent fall-through to `0`).
- Updated `ExecutionReportEncoderTests` and the synthetic-trader
  `WireFormatCompatTests` to the `uint` signature.

### Local verification

- `dotnet build -c Release` — 0 warnings, 0 errors.
- `dotnet test --no-build -c Release` — 458 passed (one transient
  flake on `RetransmitReject_when_send_queue_too_small_returns_SYSTEM_BUSY`
  on first run, passes on retry).
- `dotnet format --verify-no-changes --severity warn` — clean.