### PR TITLE
Bump ER encoders to V3 + propagate inbound receivedTime (#49)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -70,6 +70,17 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private bool _hasCurrentSession;
     private ulong _currentClOrdId;
     private ulong _currentOrigClOrdId;
+    /// <summary>
+    /// Ingress timestamp of the inbound command currently being dispatched
+    /// (#GAP-11 / #49). Captured from the command's <c>EnteredAtNanos</c> at
+    /// the start of <see cref="ProcessOne"/> and reset to
+    /// <see cref="ulong.MaxValue"/> (the SBE null sentinel for
+    /// <c>UTCTimestampNanosOptional</c>) in the <c>finally</c> so engine-
+    /// originated events that fire outside command processing (iceberg
+    /// restate, stop triggers, etc.) emit ER frames with the
+    /// <c>receivedTime</c> field nulled.
+    /// </summary>
+    private ulong _currentReceivedTimeNanos = ulong.MaxValue;
 
     private SnapshotRotator? _snapshotRotator;
 
@@ -215,6 +226,13 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _hasCurrentSession = item.HasSession;
         _currentClOrdId = item.ClOrdId;
         _currentOrigClOrdId = item.OrigClOrdId;
+        _currentReceivedTimeNanos = item.Kind switch
+        {
+            WorkKind.New => item.NewOrder?.EnteredAtNanos ?? ulong.MaxValue,
+            WorkKind.Cancel => item.Cancel?.EnteredAtNanos ?? ulong.MaxValue,
+            WorkKind.Replace => item.Replace?.EnteredAtNanos ?? ulong.MaxValue,
+            _ => ulong.MaxValue,
+        };
         _packetWritten = 0;
         try
         {
@@ -275,6 +293,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             _hasCurrentSession = false;
             _currentClOrdId = 0;
             _currentOrigClOrdId = 0;
+            _currentReceivedTimeNanos = ulong.MaxValue;
         }
     }
 
@@ -498,7 +517,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         Commit(n);
 
         if (_hasCurrentSession)
-            _outbound.WriteExecutionReportNew(_currentSession, _currentClOrdId, e);
+            _outbound.WriteExecutionReportNew(_currentSession, _currentClOrdId, e, _currentReceivedTimeNanos);
     }
 
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e)
@@ -537,7 +556,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             if (owner.ClOrdId != 0)
                 _clOrdIdIndex.Remove((owner.Firm, owner.ClOrdId));
             _outbound.WriteExecutionReportCancel(owner.Session, e,
-                _currentClOrdId != 0 ? _currentClOrdId : owner.ClOrdId, owner.ClOrdId);
+                _currentClOrdId != 0 ? _currentClOrdId : owner.ClOrdId, owner.ClOrdId,
+                _currentReceivedTimeNanos);
         }
     }
 

--- a/src/B3.Exchange.Core/CoreOutbound.cs
+++ b/src/B3.Exchange.Core/CoreOutbound.cs
@@ -33,17 +33,20 @@ namespace B3.Exchange.Core;
 /// </summary>
 public interface ICoreOutbound
 {
-    bool WriteExecutionReportNew(SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e);
+    bool WriteExecutionReportNew(SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e,
+        ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor,
         long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty);
 
     bool WriteExecutionReportCancel(SessionId session, in OrderCanceledEvent e,
-        ulong clOrdIdValue, ulong origClOrdIdValue);
+        ulong clOrdIdValue, ulong origClOrdIdValue,
+        ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportModify(SessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
-        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq);
+        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
+        ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportReject(SessionId session, in RejectEvent e, ulong clOrdIdValue);
 }

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -24,9 +24,18 @@ internal static class ExecutionReportEncoder
     private const ulong UTCTimestampNullValue = ulong.MaxValue;
     private const long PriceNullMantissa = long.MinValue;
 
-    public const int ExecReportNewBlock = 144;
-    public const int ExecReportModifyBlock = 160;
-    public const int ExecReportCancelBlock = 156;
+    // ER_New / ER_Modify / ER_Cancel are encoded against the **V3** schema so the
+    // optional `receivedTime` (tag 35544) field is wire-addressable (#GAP-11 / #49).
+    // Block lengths and trailing field offsets verified against the generated
+    // `B3.Entrypoint.Fixp.Sbe.V6.V3` structs:
+    //   ER_New    BLOCK_LENGTH = 172  receivedTime@144  + crossType@162 / crossPriori@163 / mmProtReset@164 nulls
+    //   ER_Modify BLOCK_LENGTH = 183  receivedTime@160  + mmProtReset@178 null
+    //   ER_Cancel BLOCK_LENGTH = 182  receivedTime@156  (no non-zero trailing nulls)
+    // ER_Trade and ER_Reject continue to ride the V2 schema; #49 explicitly
+    // scopes to ER_New/Modify/Cancel.
+    public const int ExecReportNewBlock = 172;
+    public const int ExecReportModifyBlock = 183;
+    public const int ExecReportCancelBlock = 182;
     public const int ExecReportTradeBlock = 154;
     public const int ExecReportRejectBlock = 138;
 
@@ -77,11 +86,11 @@ internal static class ExecutionReportEncoder
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         Matching.Side side, ulong clOrdIdValue, long secondaryOrderId, long securityId, long orderId,
         ulong execId, ulong transactTimeNanos, Matching.OrderType ordType, Matching.TimeInForce tif,
-        long orderQty, long? priceMantissa)
+        long orderQty, long? priceMantissa, ulong receivedTimeNanos = UTCTimestampNullValue)
     {
         if (dst.Length < ExecReportNewTotal) throw new ArgumentException("buffer too small for ER_New", nameof(dst));
         EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportNewTotal,
-            ExecReportNewBlock, EntryPointFrameReader.TidExecutionReportNew, version: 2);
+            ExecReportNewBlock, EntryPointFrameReader.TidExecutionReportNew, version: 3);
         var body = dst.Slice(HeaderSize, ExecReportNewBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -103,6 +112,12 @@ internal static class ExecutionReportEncoder
         long px = priceMantissa ?? PriceNullMantissa;
         MemoryMarshal.Write(body.Slice(104, 8), in px);
         MemoryMarshal.Write(body.Slice(112, 8), in nullPx);                 // StopPx
+        // V3 trailing fields: receivedTime + non-zero null sentinels.
+        MemoryMarshal.Write(body.Slice(144, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
+        // ordTagID@155 null=0 already, investorID@156 null=zeros already, strategyID@168 null=0 already.
+        body[162] = 255;                                                    // CrossType null
+        body[163] = 255;                                                    // CrossPrioritization null
+        body[164] = 255;                                                    // MmProtectionReset null
         return ExecReportNewTotal;
     }
 
@@ -110,11 +125,12 @@ internal static class ExecutionReportEncoder
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         Matching.Side side, ulong clOrdIdValue, ulong origClOrdIdValue, long secondaryOrderId,
         long securityId, long orderId, ulong execId, ulong transactTimeNanos,
-        long leavesQty, long cumQty, long orderQty, long priceMantissa)
+        long leavesQty, long cumQty, long orderQty, long priceMantissa,
+        ulong receivedTimeNanos = UTCTimestampNullValue)
     {
         if (dst.Length < ExecReportModifyTotal) throw new ArgumentException("buffer too small for ER_Modify", nameof(dst));
         EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportModifyTotal,
-            ExecReportModifyBlock, EntryPointFrameReader.TidExecutionReportModify, version: 2);
+            ExecReportModifyBlock, EntryPointFrameReader.TidExecutionReportModify, version: 3);
         var body = dst.Slice(HeaderSize, ExecReportModifyBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -138,6 +154,10 @@ internal static class ExecutionReportEncoder
         MemoryMarshal.Write(body.Slice(120, 8), in orderQty);
         MemoryMarshal.Write(body.Slice(128, 8), in priceMantissa);
         MemoryMarshal.Write(body.Slice(136, 8), in nullPx);                 // StopPx
+        // V3 trailing fields: receivedTime@160 + mmProtectionReset@178 null sentinel.
+        MemoryMarshal.Write(body.Slice(160, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
+        // ordTagID@171 null=0 already, investorID@172 null=zeros already, strategyID@179 null=0 already.
+        body[178] = 255;                                                    // MmProtectionReset null
         return ExecReportModifyTotal;
     }
 
@@ -145,11 +165,12 @@ internal static class ExecutionReportEncoder
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         Matching.Side side, ulong clOrdIdValue, ulong origClOrdIdValue, long secondaryOrderId,
         long securityId, long orderId, ulong execId, ulong transactTimeNanos,
-        long cumQty, long orderQty, long? priceMantissa)
+        long cumQty, long orderQty, long? priceMantissa,
+        ulong receivedTimeNanos = UTCTimestampNullValue)
     {
         if (dst.Length < ExecReportCancelTotal) throw new ArgumentException("buffer too small for ER_Cancel", nameof(dst));
         EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportCancelTotal,
-            ExecReportCancelBlock, EntryPointFrameReader.TidExecutionReportCancel, version: 2);
+            ExecReportCancelBlock, EntryPointFrameReader.TidExecutionReportCancel, version: 3);
         var body = dst.Slice(HeaderSize, ExecReportCancelBlock);
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
@@ -173,6 +194,9 @@ internal static class ExecutionReportEncoder
         MemoryMarshal.Write(body.Slice(124, 8), in px);                     // Price
         long nullPx = PriceNullMantissa;
         MemoryMarshal.Write(body.Slice(132, 8), in nullPx);                 // StopPx
+        // V3 trailing fields: receivedTime@156 + ordTagID/investorID/strategyID/actionRequestedFromSessionID
+        // null sentinels are all zero (handled by body.Clear() above).
+        MemoryMarshal.Write(body.Slice(156, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
         return ExecReportCancelTotal;
     }
 

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -1325,7 +1325,7 @@ public sealed class FixpSession : IAsyncDisposable
             ConnectionId, code);
     }
 
-    public bool WriteExecutionReportNew(in OrderAcceptedEvent e)
+    public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
     {
         if (!IsOpen) return false;
         ulong clOrd = ulong.TryParse(e.ClOrdId, out var v) ? v : 0;
@@ -1337,7 +1337,8 @@ public sealed class FixpSession : IAsyncDisposable
                 e.Side, clOrd, e.OrderId, e.SecurityId, e.OrderId,
                 (ulong)e.RptSeq, e.InsertTimestampNanos,
                 OrderType.Limit, TimeInForce.Day,
-                e.RemainingQuantity, e.PriceMantissa);
+                e.RemainingQuantity, e.PriceMantissa,
+                receivedTimeNanos);
             return AppendAndEnqueueLocked(exact);
         }
     }
@@ -1362,7 +1363,8 @@ public sealed class FixpSession : IAsyncDisposable
         }
     }
 
-    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue)
+    public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue,
+        ulong receivedTimeNanos = ulong.MaxValue)
     {
         if (!IsOpen) return false;
         var exact = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
@@ -1373,13 +1375,15 @@ public sealed class FixpSession : IAsyncDisposable
                 e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
                 e.SecurityId, e.OrderId,
                 (ulong)e.RptSeq, e.TransactTimeNanos,
-                cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa);
+                cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa,
+                receivedTimeNanos);
             return AppendAndEnqueueLocked(exact);
         }
     }
 
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
-        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq)
+        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
+        ulong receivedTimeNanos = ulong.MaxValue)
     {
         if (!IsOpen) return false;
         var exact = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
@@ -1389,7 +1393,8 @@ public sealed class FixpSession : IAsyncDisposable
                 SessionId, NextMsgSeqNum(), transactTimeNanos,
                 side, clOrdIdValue, origClOrdIdValue, orderId,
                 securityId, orderId, (ulong)rptSeq, transactTimeNanos,
-                leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa);
+                leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa,
+                receivedTimeNanos: receivedTimeNanos);
             return AppendAndEnqueueLocked(exact);
         }
     }

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -38,10 +38,11 @@ public sealed class GatewayRouter : ICoreOutbound
         _logger = logger;
     }
 
-    public bool WriteExecutionReportNew(ContractsSessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e)
+    public bool WriteExecutionReportNew(ContractsSessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e,
+        ulong receivedTimeNanos = ulong.MaxValue)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportNew"); return false; }
-        return s.WriteExecutionReportNew(e);
+        return s.WriteExecutionReportNew(e, receivedTimeNanos);
     }
 
     public bool WriteExecutionReportTrade(ContractsSessionId session, in TradeEvent e, bool isAggressor,
@@ -52,19 +53,21 @@ public sealed class GatewayRouter : ICoreOutbound
     }
 
     public bool WriteExecutionReportCancel(ContractsSessionId session, in OrderCanceledEvent e,
-        ulong clOrdIdValue, ulong origClOrdIdValue)
+        ulong clOrdIdValue, ulong origClOrdIdValue,
+        ulong receivedTimeNanos = ulong.MaxValue)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportCancel"); return false; }
-        return s.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue);
+        return s.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos);
     }
 
     public bool WriteExecutionReportModify(ContractsSessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
-        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq)
+        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
+        ulong receivedTimeNanos = ulong.MaxValue)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportModify"); return false; }
         return s.WriteExecutionReportModify(securityId, orderId, clOrdIdValue, origClOrdIdValue,
-            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq);
+            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos);
     }
 
     public bool WriteExecutionReportReject(ContractsSessionId session, in RejectEvent e, ulong clOrdIdValue)

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -70,12 +70,15 @@ public sealed class EntryPointClient : IAsyncDisposable
     // Per-template expected block lengths (mirroring ExecutionReportEncoder
     // constants in B3.Exchange.Gateway, which is internal). Used as a
     // tighter, schema-aware validation before allocating the body buffer.
+    // ER_New/Modify/Cancel were bumped to V3 in #49 (#GAP-11) to carry the
+    // optional `receivedTime` (tag 35544) trailing field; ER_Trade and
+    // ER_Reject continue to ride V2.
     // Returns -1 for unknown template IDs (caller falls back to MaxAcceptedBlockLength).
     private static int ExpectedBlockLength(ushort templateId) => templateId switch
     {
-        EntryPointFrameReader.TidExecutionReportNew => 144,
-        EntryPointFrameReader.TidExecutionReportModify => 160,
-        EntryPointFrameReader.TidExecutionReportCancel => 156,
+        EntryPointFrameReader.TidExecutionReportNew => 172,
+        EntryPointFrameReader.TidExecutionReportModify => 183,
+        EntryPointFrameReader.TidExecutionReportCancel => 182,
         EntryPointFrameReader.TidExecutionReportTrade => 154,
         EntryPointFrameReader.TidExecutionReportReject => 138,
         _ => -1,

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -45,6 +45,7 @@ public class ChannelDispatcherTests
         public List<TradeEvent> Trades { get; } = new();
         public bool CaptureCancelIds { get; set; }
         public List<(ulong ClOrdId, ulong OrigClOrdId)> CancelIds { get; } = new();
+        public ulong LastReceivedTime { get; set; } = ulong.MaxValue;
 
         public FakeSession(RecordingOutbound outbound) { outbound.Register(this); }
     }
@@ -56,14 +57,14 @@ public class ChannelDispatcherTests
         private FakeSession? Find(B3.Exchange.Contracts.SessionId id)
             => _sessions.TryGetValue(id, out var s) ? s : null;
 
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e)
-        { if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); } return true; }
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        { if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
         { if (Find(session) is { } s) { s.Trades.Add(e); s.Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); } return true; }
-        public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue)
-        { if (Find(session) is { } s) { s.Cancels.Add(e); s.Calls.Add("Cancel"); if (s.CaptureCancelIds) s.CancelIds.Add((clOrdIdValue, origClOrdIdValue)); } return true; }
-        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq)
-        { if (Find(session) is { } s) { s.Calls.Add("Modify"); } return true; }
+        public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue, ulong receivedTimeNanos = ulong.MaxValue)
+        { if (Find(session) is { } s) { s.Cancels.Add(e); s.Calls.Add("Cancel"); s.LastReceivedTime = receivedTimeNanos; if (s.CaptureCancelIds) s.CancelIds.Add((clOrdIdValue, origClOrdIdValue)); } return true; }
+        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue)
+        { if (Find(session) is { } s) { s.Calls.Add("Modify"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue)
         { if (Find(session) is { } s) { s.Rejects.Add(e); s.Calls.Add("Reject"); } return true; }
     }
@@ -155,6 +156,34 @@ public class ChannelDispatcherTests
         Assert.Single(reply.Cancels);
         Assert.Equal(oid, reply.Cancels[0].OrderId);
         Assert.Single(pkt.Packets);
+    }
+
+    [Fact]
+    public void ExecReports_PropagateInboundReceivedTime_FromCommandEnteredAt()
+    {
+        // #49 / #GAP-11: ER frames emitted while processing an inbound command
+        // must carry that command's ingress timestamp so clients can measure
+        // gateway latency. After processing returns, the dispatcher resets
+        // the per-command timestamp so engine-originated events emitted
+        // outside command context (e.g. iceberg restate) get the SBE null
+        // sentinel (ulong.MaxValue) and not a stale value.
+        var (disp, _, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        const ulong newReceivedAt = 1_700_000_000_111_111_111UL;
+        disp.EnqueueNewOrder(
+            new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, newReceivedAt),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        Assert.Equal(newReceivedAt, reply.LastReceivedTime);
+
+        long oid = reply.News[0].OrderId;
+        const ulong cancelReceivedAt = 1_700_000_000_222_222_222UL;
+        disp.EnqueueCancel(
+            new CancelOrderCommand("1", Petr, oid, cancelReceivedAt),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL, origClOrdIdValue: 0UL);
+        DrainInbound(disp);
+        Assert.Equal(cancelReceivedAt, reply.LastReceivedTime);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -336,9 +336,9 @@ public class ChannelDispatcherSnapshotTests
 
 internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Core.ICoreOutbound
 {
-    public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e) => true;
+    public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
-    public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq) => true;
+    public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue, ulong receivedTimeNanos = ulong.MaxValue) => true;
+    public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
 }

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -19,12 +19,12 @@ public class ExecutionReportEncoderTests
             orderQty: 10, priceMantissa: 12_3450L);
 
         Assert.Equal(ExecutionReportEncoder.ExecReportNewTotal, n);
-        // SBE header at offset SOFH(4)..SOFH+8: BlockLength=144, TemplateId=200, SchemaId=1, Version=2
+        // SBE header at offset SOFH(4)..SOFH+8: BlockLength=172, TemplateId=200, SchemaId=1, Version=3 (#49 / #GAP-11)
         var hdr = buf.AsSpan(EntryPointFrameReader.SofhSize, EntryPointFrameReader.SbeHeaderSize);
         Assert.Equal((ushort)ExecutionReportEncoder.ExecReportNewBlock, MemoryMarshal.Read<ushort>(hdr.Slice(0, 2)));
         Assert.Equal((ushort)EntryPointFrameReader.TidExecutionReportNew, MemoryMarshal.Read<ushort>(hdr.Slice(2, 2)));
         Assert.Equal((ushort)1, MemoryMarshal.Read<ushort>(hdr.Slice(4, 2)));
-        Assert.Equal((ushort)2, MemoryMarshal.Read<ushort>(hdr.Slice(6, 2)));
+        Assert.Equal((ushort)3, MemoryMarshal.Read<ushort>(hdr.Slice(6, 2)));
 
         var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
         Assert.Equal((uint)42, MemoryMarshal.Read<uint>(body.Slice(0, 4)));        // SessionId
@@ -135,5 +135,92 @@ public class ExecutionReportEncoderTests
         Assert.Equal(21UL, MemoryMarshal.Read<ulong>(body.Slice(96, 8)));           // OrigClOrdID
         Assert.Equal(75L, MemoryMarshal.Read<long>(body.Slice(120, 8)));            // OrderQty
         Assert.Equal(99_0000L, MemoryMarshal.Read<long>(body.Slice(128, 8)));       // Price
+    }
+
+    // ====== #49 / #GAP-11: receivedTime (tag 35544) round-trip ======
+    //
+    // ER_New / ER_Modify / ER_Cancel were bumped to V3 to expose the optional
+    // `receivedTime` trailing field. Tests below lock both the populated and
+    // null sentinel paths and the V3 trailing optional null sentinels that
+    // body.Clear() alone cannot satisfy (they default to a non-zero "null"
+    // value per SBE schema).
+
+    [Fact]
+    public void EncodeNew_V3ReceivedTime_PopulatedAndNullSentinelsRoundTrip()
+    {
+        const ulong received = 1_700_000_000_123_456_789UL;
+        var buf = new byte[ExecutionReportEncoder.ExecReportNewTotal];
+        int n = ExecutionReportEncoder.EncodeExecReportNew(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 1, secondaryOrderId: 0,
+            securityId: 1, orderId: 1, execId: 0, transactTimeNanos: 0,
+            ordType: OrderType.Limit, tif: TimeInForce.Day,
+            orderQty: 10, priceMantissa: 100_0000L,
+            receivedTimeNanos: received);
+        Assert.Equal(ExecutionReportEncoder.ExecReportNewTotal, n);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal(received, MemoryMarshal.Read<ulong>(body.Slice(144, 8)));    // ReceivedTime
+        Assert.Equal((byte)255, body[162]);                                       // CrossType null
+        Assert.Equal((byte)255, body[163]);                                       // CrossPrioritization null
+        Assert.Equal((byte)255, body[164]);                                       // MmProtectionReset null
+
+        var bufNull = new byte[ExecutionReportEncoder.ExecReportNewTotal];
+        ExecutionReportEncoder.EncodeExecReportNew(bufNull,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 1, secondaryOrderId: 0,
+            securityId: 1, orderId: 1, execId: 0, transactTimeNanos: 0,
+            ordType: OrderType.Limit, tif: TimeInForce.Day,
+            orderQty: 10, priceMantissa: 100_0000L);
+        var bodyNull = bufNull.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal(ulong.MaxValue, MemoryMarshal.Read<ulong>(bodyNull.Slice(144, 8))); // null sentinel
+    }
+
+    [Fact]
+    public void EncodeModify_V3ReceivedTime_PopulatedAndNullSentinelsRoundTrip()
+    {
+        const ulong received = 1_700_000_000_222_222_222UL;
+        var buf = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        ExecutionReportEncoder.EncodeExecReportModify(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 22, origClOrdIdValue: 21, secondaryOrderId: 0,
+            securityId: 7, orderId: 1234, execId: 0UL, transactTimeNanos: 0UL,
+            leavesQty: 50, cumQty: 25, orderQty: 75, priceMantissa: 99_0000L,
+            receivedTimeNanos: received);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal(received, MemoryMarshal.Read<ulong>(body.Slice(160, 8)));    // ReceivedTime
+        Assert.Equal((byte)255, body[178]);                                       // MmProtectionReset null
+
+        var bufNull = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        ExecutionReportEncoder.EncodeExecReportModify(bufNull,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 22, origClOrdIdValue: 21, secondaryOrderId: 0,
+            securityId: 7, orderId: 1234, execId: 0UL, transactTimeNanos: 0UL,
+            leavesQty: 50, cumQty: 25, orderQty: 75, priceMantissa: 99_0000L);
+        var bodyNull = bufNull.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal(ulong.MaxValue, MemoryMarshal.Read<ulong>(bodyNull.Slice(160, 8)));
+    }
+
+    [Fact]
+    public void EncodeCancel_V3ReceivedTime_PopulatedAndNullSentinelsRoundTrip()
+    {
+        const ulong received = 1_700_000_000_333_333_333UL;
+        var buf = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        ExecutionReportEncoder.EncodeExecReportCancel(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 1, origClOrdIdValue: 0, secondaryOrderId: 0,
+            securityId: 7, orderId: 1, execId: 0, transactTimeNanos: 0,
+            cumQty: 0, orderQty: 100, priceMantissa: 100_0000L,
+            receivedTimeNanos: received);
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal(received, MemoryMarshal.Read<ulong>(body.Slice(156, 8)));    // ReceivedTime
+
+        var bufNull = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        ExecutionReportEncoder.EncodeExecReportCancel(bufNull,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 1, origClOrdIdValue: 0, secondaryOrderId: 0,
+            securityId: 7, orderId: 1, execId: 0, transactTimeNanos: 0,
+            cumQty: 0, orderQty: 100, priceMantissa: 100_0000L);
+        var bodyNull = bufNull.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal(ulong.MaxValue, MemoryMarshal.Read<ulong>(bodyNull.Slice(156, 8)));
     }
 }

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -89,7 +89,7 @@ public class ExchangeHostE2ETests
 
         var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
         Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
-        Assert.Equal(2, er1.Version);
+        Assert.Equal(3, er1.Version);
 
         // Second order on the SAME session: SELL PETR4 100 @ 12.34 → fully
         // crosses the resting BUY. Aggressor session sees ER_Trade (no New —

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -18,10 +18,10 @@ public class HostRouterTests
     private sealed class RecordingOutbound : ICoreOutbound
     {
         public List<RejectEvent> Rejects { get; } = new();
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e) => true;
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
-        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq) => true;
+        public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) { Rejects.Add(e); return true; }
     }
 


### PR DESCRIPTION
Closes #49.

Bumps ExecutionReport_New/Modify/Cancel from schema V2 to V3 so the optional `receivedTime` field (FIX tag 35544) can be carried back to the originating session, enabling client-side gateway-latency measurement.

### Wire changes
- ER_New BlockLength 144 → 172, `receivedTime` at offset 144, V3 trailing null sentinels (CrossType=255, CrossPrioritization=255, MmProtectionReset=255).
- ER_Modify BlockLength 160 → 183, `receivedTime` at offset 160, MmProtectionReset=255.
- ER_Cancel BlockLength 156 → 182, `receivedTime` at offset 156.
- SBE schema header version bumped 2 → 3.

### Plumbing
- `ICoreOutbound.WriteExecutionReport{New,Cancel,Modify}` take an optional `receivedTimeNanos` (default = `ulong.MaxValue`, the UTCTimestampNanos null sentinel).
- `ChannelDispatcher` captures `EnteredAtNanos` from the inbound command at start of `ProcessOne` and resets to null in `finally`, so engine-originated emissions (iceberg restate, stop triggers, snapshot rotation) carry the null sentinel as required.
- `FixpSession` + `GatewayRouter` forward the value to the encoder.

### Tests
- New encoder tests assert `receivedTime` bytes for both populated and null paths on all three ER variants, plus the V3 trailing sentinels.
- New `ChannelDispatcher` test verifies the inbound `EnteredAtNanos` reaches the outbound ER for NewOrder and Cancel.
- Existing version=2 assertions bumped to 3.
- SyntheticTrader `EntryPointClient` block-length validator updated for V3 sizes.