### PR TITLE
GAP-21 (#57): §4.10 basic CR/LF and over-length varData validations

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointFixedIdentifiers.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFixedIdentifiers.cs
@@ -1,0 +1,119 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Validates the fixed-block ASCII identifier slots
+/// (<c>senderLocation</c>, <c>enteringTrader</c>, <c>executingTrader</c>)
+/// that appear in the root SBE blocks of EntryPoint application
+/// templates per spec §4.10. The fields are space- or NUL-padded ASCII;
+/// any embedded CR (0x0D) / LF (0x0A) byte must trigger
+/// <c>BusinessMessageReject(33003 "Line breaks not supported in
+/// &lt;fieldName&gt;")</c>.
+///
+/// Length rejection is not applicable here because the schema fixes the
+/// slot width (5 or 10 bytes); over-length cases are instead detected by
+/// the varData walker (see <see cref="EntryPointVarData"/>).
+/// </summary>
+public static class EntryPointFixedIdentifiers
+{
+    /// <summary>Field declaration: (spec name, byte offset within the
+    /// fixed block, slot length).</summary>
+    public readonly record struct Slot(string Name, int Offset, int Length);
+
+    // NewOrderSingleV2 (templateId=102, BlockLength=125): senderLocation@32(10),
+    // enteringTrader@42(5), executingTrader@100(5).
+    private static readonly Slot[] NewOrderSingleSlots =
+    [
+        new("senderLocation", 32, 10),
+        new("enteringTrader", 42, 5),
+        new("executingTrader", 100, 5),
+    ];
+
+    // OrderCancelReplaceRequestV2 (templateId=104, BlockLength=142):
+    // senderLocation@32(10), enteringTrader@42(5), executingTrader@116(5).
+    private static readonly Slot[] OrderCancelReplaceSlots =
+    [
+        new("senderLocation", 32, 10),
+        new("enteringTrader", 42, 5),
+        new("executingTrader", 116, 5),
+    ];
+
+    // OrderCancelRequest V0 (templateId=105, BlockLength=76):
+    // senderLocation@56(10), enteringTrader@66(5), executingTrader@71(5).
+    private static readonly Slot[] OrderCancelSlots =
+    [
+        new("senderLocation", 56, 10),
+        new("enteringTrader", 66, 5),
+        new("executingTrader", 71, 5),
+    ];
+
+    // NewOrderCross V6 (templateId=106, root BlockLength=84):
+    // senderLocation@28(10), enteringTrader@38(5), executingTrader@43(5).
+    private static readonly Slot[] NewOrderCrossSlots =
+    [
+        new("senderLocation", 28, 10),
+        new("enteringTrader", 38, 5),
+        new("executingTrader", 43, 5),
+    ];
+
+    private static readonly Slot[] None = [];
+
+    /// <summary>Returns the identifier slots a given template carries in
+    /// its fixed block. Templates without identifier slots
+    /// (SimpleNewOrder, SimpleModifyOrder, session-layer frames) return
+    /// an empty span.</summary>
+    public static ReadOnlySpan<Slot> ExpectedFor(ushort templateId, ushort version) => (templateId, version) switch
+    {
+        (EntryPointFrameReader.TidNewOrderSingle, 2) => NewOrderSingleSlots,
+        (EntryPointFrameReader.TidOrderCancelReplaceRequest, 2) => OrderCancelReplaceSlots,
+        (EntryPointFrameReader.TidOrderCancelRequest, 0) => OrderCancelSlots,
+        (EntryPointFrameReader.TidNewOrderCross, 6) => NewOrderCrossSlots,
+        _ => None,
+    };
+
+    /// <summary>Returns <c>true</c> iff <paramref name="field"/> contains
+    /// at least one CR (0x0D) or LF (0x0A) byte. Allocation-free; safe to
+    /// call on the per-frame hot path.</summary>
+    public static bool ContainsCrLf(ReadOnlySpan<byte> field)
+    {
+        for (int i = 0; i < field.Length; i++)
+        {
+            byte b = field[i];
+            if (b == 0x0A || b == 0x0D) return true;
+        }
+        return false;
+    }
+
+    /// <summary>Validation outcome for the identifier sweep.</summary>
+    public readonly record struct Result(bool ContainsLineBreak, string? FieldName)
+    {
+        public bool IsOk => !ContainsLineBreak;
+
+        /// <summary>Returns the BMR text mandated by spec §4.10
+        /// (<c>"Line breaks not supported in &lt;fieldName&gt;"</c>) or
+        /// <c>null</c> when the result is valid.</summary>
+        public string? BmrText() => ContainsLineBreak ? $"Line breaks not supported in {FieldName}" : null;
+    }
+
+    /// <summary>Scans every identifier slot defined for <paramref name="templateId"/>
+    /// for CR/LF bytes. Returns the first offending field name (schema
+    /// declaration order) so the caller can answer with
+    /// <c>BusinessMessageReject(33003)</c>.</summary>
+    public static Result Validate(ushort templateId, ushort version, ReadOnlySpan<byte> fixedBlock)
+    {
+        var slots = ExpectedFor(templateId, version);
+        for (int i = 0; i < slots.Length; i++)
+        {
+            var s = slots[i];
+            if (s.Offset + s.Length > fixedBlock.Length)
+            {
+                // Defensive: caller has already validated BlockLength so
+                // this should be unreachable, but skip silently rather
+                // than throw — the framing layer owns wire integrity.
+                continue;
+            }
+            if (ContainsCrLf(fixedBlock.Slice(s.Offset, s.Length)))
+                return new Result(ContainsLineBreak: true, FieldName: s.Name);
+        }
+        return new Result(ContainsLineBreak: false, FieldName: null);
+    }
+}

--- a/src/B3.Exchange.Gateway/EntryPointVarData.cs
+++ b/src/B3.Exchange.Gateway/EntryPointVarData.cs
@@ -32,6 +32,12 @@ public static class EntryPointVarData
     private static readonly Field[] NewOrderSingleFields = [DeskID, Memo];
     private static readonly Field[] OrderCancelReplaceFields = [DeskID, Memo];
     private static readonly Field[] OrderCancelFields = [DeskID, Memo];
+    /// <summary>NewOrderCross trailing varData fields (after the
+    /// NoSides repeating group). Schema order: DeskID, Memo. Same
+    /// length and line-break rules as the other application templates
+    /// (spec §4.10).</summary>
+    public static ReadOnlySpan<Field> NewOrderCrossFields => _newOrderCrossFields;
+    private static readonly Field[] _newOrderCrossFields = [DeskID, Memo];
     private static readonly Field[] NegotiateFields =
         [NegotiateCredentials, NegotiateClientIp, NegotiateClientAppName, NegotiateClientAppVersion];
     private static readonly Field[] EstablishFields = [EstablishCredentials];

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -516,6 +516,36 @@ public sealed class FixpSession : IAsyncDisposable
             }
         }
 
+        // §4.10 (#GAP-21): CR/LF in fixed-block identifier slots
+        // (senderLocation / enteringTrader / executingTrader) on the four
+        // application templates that carry them must answer with
+        // BMR(33003 "Line breaks not supported in <field>"). Runs after
+        // the varData walker so a per-template empty slot table (Simple*
+        // templates have no identifier fields) is a cheap no-op.
+        if (_validator is not null && IsApplicationTemplate(info.TemplateId))
+        {
+            var idResult = EntryPointFixedIdentifiers.Validate(info.TemplateId, info.Version, fixedBlock);
+            if (!idResult.IsOk)
+            {
+                uint refSeqNum = fixedBlock.Length >= 8
+                    ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
+                    : 0u;
+                ulong refRefId = fixedBlock.Length >= 28
+                    ? System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(20, 8))
+                    : 0UL;
+                WriteBusinessMessageReject(
+                    refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(info.TemplateId),
+                    refSeqNum: refSeqNum,
+                    businessRejectRefId: refRefId,
+                    businessRejectReason: 33003,
+                    text: idResult.BmrText());
+                _logger.LogWarning(
+                    "fixp session {ConnectionId} business reject (identifier line-break) template={Template} field={Field}",
+                    ConnectionId, info.TemplateId, idResult.FieldName);
+                return true;
+            }
+        }
+
         switch (info.TemplateId)
         {
             case EntryPointFrameReader.TidSequence:

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -646,10 +646,18 @@ internal static class InboundMessageDecoder
         // 5. Walk varData (DeskID + Memo) so trailing garbage / oversize
         // segments are caught the same way as for other application
         // templates. We do not surface their contents to the engine.
-        int varCursor = sidesEnd;
-        if (!TryWalkCrossVarData(body, ref varCursor, out var varMessage))
+        // §4.10 (#GAP-21): over-length and CR/LF in deskID are
+        // BusinessMessageReject(33003) — not session-terminating.
+        var varSpan = body.Slice(sidesEnd);
+        var varResult = EntryPointVarData.ValidateDetailed(varSpan, EntryPointVarData.NewOrderCrossFields);
+        if (!varResult.IsOk)
         {
-            message = varMessage;
+            if (varResult.IsBusinessReject)
+            {
+                message = varResult.BmrText();
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
+            message = varResult.DebugMessage;
             return InboundDecodeOutcome.DecodeError;
         }
 
@@ -682,51 +690,6 @@ internal static class InboundMessageDecoder
             EnteredAtNanos: enteredAtNanos);
         cross = new CrossOrderCommand(buy, sell, buyClOrd, sellClOrd, crossId);
         return InboundDecodeOutcome.Success;
-    }
-
-    /// <summary>
-    /// Validates the trailing DeskID + Memo varData for NewOrderCross
-    /// (length-prefixed bytes per spec §3.5). Mirrors the limits used
-    /// by <c>EntryPointVarData</c> for other application templates so
-    /// the simulator's behavior is uniform across templates that carry
-    /// these fields. Trailing bytes after the last expected segment are
-    /// rejected as a structural decode error.
-    /// </summary>
-    private static bool TryWalkCrossVarData(ReadOnlySpan<byte> body, ref int cursor, out string? message)
-    {
-        message = null;
-        // (Field name, max length in bytes). DeskID is 20, Memo is 40,
-        // matching EntryPointVarData's spec for the other application
-        // templates that carry these segments.
-        for (int i = 0; i < 2; i++)
-        {
-            string name = i == 0 ? "deskID" : "memo";
-            byte max = i == 0 ? (byte)20 : (byte)40;
-            if (cursor >= body.Length)
-            {
-                message = $"NewOrderCross varData truncated before {name} length prefix";
-                return false;
-            }
-            byte len = body[cursor];
-            cursor += 1;
-            if (len > max)
-            {
-                message = $"NewOrderCross varData {name} too long ({len} > {max})";
-                return false;
-            }
-            if (cursor + len > body.Length)
-            {
-                message = $"NewOrderCross varData {name} payload overruns frame";
-                return false;
-            }
-            cursor += len;
-        }
-        if (cursor != body.Length)
-        {
-            message = $"NewOrderCross has trailing bytes after varData ({body.Length - cursor})";
-            return false;
-        }
-        return true;
     }
 
     private static bool TryMapSide(byte b, out Side side)

--- a/tests/B3.Exchange.Gateway.Tests/InboundIdentifierValidationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundIdentifierValidationTests.cs
@@ -1,0 +1,301 @@
+using System.Runtime.InteropServices;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #57 (#GAP-21) — spec §4.10 basic gateway validations applied to
+/// the identifier fields shared across the order-entry templates:
+///
+/// <list type="bullet">
+///   <item>CR (0x0D) / LF (0x0A) in <c>senderLocation</c>,
+///         <c>enteringTrader</c>, <c>executingTrader</c> (fixed-block
+///         ASCII slots) and <c>deskID</c> (varData segment) →
+///         <c>BusinessMessageReject(33003 "Line breaks not supported in
+///         &lt;fieldName&gt;")</c>.</item>
+///   <item><c>memo</c> / <c>deskID</c> varData payload exceeding the
+///         schema-declared maximum length →
+///         <c>BusinessMessageReject(33003 "&lt;fieldName&gt; too
+///         long")</c>.</item>
+/// </list>
+///
+/// These tests exercise the validators directly. End-to-end coverage
+/// (the FixpSession dispatch path that turns the validator result into a
+/// wire-level BMR frame) lives in
+/// <see cref="BusinessHeaderSessionIdValidationTests"/> for sessionID
+/// rejects; the per-template CR/LF rejects share the same exit path
+/// (WriteBusinessMessageReject with reason=33003).
+/// </summary>
+public class InboundIdentifierValidationTests
+{
+    // ---------------------- helpers ----------------------
+
+    private static byte[] BuildFixed(int blockLength)
+    {
+        // Pad with spaces to mimic the wire (ASCII trader fields are
+        // space- or NUL-padded; we use spaces so the validator does not
+        // see incidental NUL bytes that could mask issues if a future
+        // change inspects them).
+        var b = new byte[blockLength];
+        b.AsSpan().Fill(0x20);
+        return b;
+    }
+
+    private static void WriteAscii(byte[] body, int offset, int length, string s)
+    {
+        var slot = body.AsSpan(offset, length);
+        slot.Fill(0x20);
+        for (int i = 0; i < s.Length && i < length; i++) slot[i] = (byte)s[i];
+    }
+
+    // ---------------------- ContainsCrLf ----------------------
+
+    [Fact]
+    public void ContainsCrLf_returns_false_for_clean_ascii()
+    {
+        Assert.False(EntryPointFixedIdentifiers.ContainsCrLf(System.Text.Encoding.ASCII.GetBytes("TRADER")));
+        Assert.False(EntryPointFixedIdentifiers.ContainsCrLf(System.Text.Encoding.ASCII.GetBytes("     ")));
+        Assert.False(EntryPointFixedIdentifiers.ContainsCrLf(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Theory]
+    [InlineData("AB\rCD")]
+    [InlineData("AB\nCD")]
+    [InlineData("\nABCD")]
+    [InlineData("ABCD\r")]
+    public void ContainsCrLf_returns_true_for_any_crlf_byte(string content)
+    {
+        Assert.True(EntryPointFixedIdentifiers.ContainsCrLf(System.Text.Encoding.ASCII.GetBytes(content)));
+    }
+
+    // ---------------------- per-template fixed identifier sweep ----------------------
+
+    public static IEnumerable<object[]> IdentifierSlotsByTemplate()
+    {
+        // (templateId, version, blockLength, fieldName, offset, length)
+        yield return new object[] { EntryPointFrameReader.TidNewOrderSingle, (ushort)2, 125, "senderLocation", 32, 10 };
+        yield return new object[] { EntryPointFrameReader.TidNewOrderSingle, (ushort)2, 125, "enteringTrader", 42, 5 };
+        yield return new object[] { EntryPointFrameReader.TidNewOrderSingle, (ushort)2, 125, "executingTrader", 100, 5 };
+
+        yield return new object[] { EntryPointFrameReader.TidOrderCancelReplaceRequest, (ushort)2, 142, "senderLocation", 32, 10 };
+        yield return new object[] { EntryPointFrameReader.TidOrderCancelReplaceRequest, (ushort)2, 142, "enteringTrader", 42, 5 };
+        yield return new object[] { EntryPointFrameReader.TidOrderCancelReplaceRequest, (ushort)2, 142, "executingTrader", 116, 5 };
+
+        yield return new object[] { EntryPointFrameReader.TidOrderCancelRequest, (ushort)0, 76, "senderLocation", 56, 10 };
+        yield return new object[] { EntryPointFrameReader.TidOrderCancelRequest, (ushort)0, 76, "enteringTrader", 66, 5 };
+        yield return new object[] { EntryPointFrameReader.TidOrderCancelRequest, (ushort)0, 76, "executingTrader", 71, 5 };
+
+        yield return new object[] { EntryPointFrameReader.TidNewOrderCross, (ushort)6, 84, "senderLocation", 28, 10 };
+        yield return new object[] { EntryPointFrameReader.TidNewOrderCross, (ushort)6, 84, "enteringTrader", 38, 5 };
+        yield return new object[] { EntryPointFrameReader.TidNewOrderCross, (ushort)6, 84, "executingTrader", 43, 5 };
+    }
+
+    [Theory]
+    [MemberData(nameof(IdentifierSlotsByTemplate))]
+    public void Validate_rejects_LF_in_identifier(ushort tid, ushort ver, int blockLen, string field, int offset, int length)
+    {
+        var body = BuildFixed(blockLen);
+        WriteAscii(body, offset, length, "AB\nCD");
+        var r = EntryPointFixedIdentifiers.Validate(tid, ver, body);
+        Assert.False(r.IsOk);
+        Assert.Equal(field, r.FieldName);
+        Assert.Equal($"Line breaks not supported in {field}", r.BmrText());
+    }
+
+    [Theory]
+    [MemberData(nameof(IdentifierSlotsByTemplate))]
+    public void Validate_rejects_CR_in_identifier(ushort tid, ushort ver, int blockLen, string field, int offset, int length)
+    {
+        var body = BuildFixed(blockLen);
+        WriteAscii(body, offset, length, "AB\rCD");
+        var r = EntryPointFixedIdentifiers.Validate(tid, ver, body);
+        Assert.False(r.IsOk);
+        Assert.Equal(field, r.FieldName);
+        Assert.Equal($"Line breaks not supported in {field}", r.BmrText());
+    }
+
+    [Theory]
+    [InlineData(EntryPointFrameReader.TidNewOrderSingle, (ushort)2, 125)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelReplaceRequest, (ushort)2, 142)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelRequest, (ushort)0, 76)]
+    [InlineData(EntryPointFrameReader.TidNewOrderCross, (ushort)6, 84)]
+    public void Validate_passes_clean_identifiers(ushort tid, ushort ver, int blockLen)
+    {
+        var body = BuildFixed(blockLen);
+        var r = EntryPointFixedIdentifiers.Validate(tid, ver, body);
+        Assert.True(r.IsOk);
+        Assert.Null(r.FieldName);
+        Assert.Null(r.BmrText());
+    }
+
+    [Theory]
+    [InlineData(EntryPointFrameReader.TidSimpleNewOrder, (ushort)2)]
+    [InlineData(EntryPointFrameReader.TidSimpleModifyOrder, (ushort)2)]
+    public void Validate_skips_templates_without_identifier_slots(ushort tid, ushort ver)
+    {
+        // SimpleNewOrder / SimpleModifyOrder do not carry the identifier
+        // fields in their fixed block; CR/LF anywhere in the body must
+        // not produce a §4.10 BMR for these templates.
+        var body = new byte[200];
+        for (int i = 0; i < body.Length; i++) body[i] = 0x0A; // all LF
+        var r = EntryPointFixedIdentifiers.Validate(tid, ver, body);
+        Assert.True(r.IsOk);
+    }
+
+    // ---------------------- varData over-length / CR-LF on DeskID + Memo ----------------------
+
+    [Fact]
+    public void VarData_DeskID_too_long_returns_business_reject_with_spec_text()
+    {
+        // DeskID schema cap is 20 bytes; declare 21 to trigger
+        // FieldTooLong (BMR-eligible per §4.10).
+        var spec = EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidNewOrderSingle, 2);
+        var blob = new byte[1 /*deskLen*/ + 21 /*payload*/ + 1 /*memoLen*/];
+        blob[0] = 21;
+        // bytes 1..21 are 0x00 — payload content does not affect length check.
+        // blob[22] = 0 (memoLen = 0)
+        var r = EntryPointVarData.ValidateDetailed(blob, spec);
+        Assert.True(r.IsBusinessReject);
+        Assert.Equal(EntryPointVarData.FailureKind.FieldTooLong, r.Kind);
+        Assert.Equal("deskID", r.FieldName);
+        Assert.Equal("deskID too long", r.BmrText());
+    }
+
+    [Fact]
+    public void VarData_Memo_too_long_returns_business_reject_with_spec_text()
+    {
+        // Memo schema cap is 40 bytes; declare 41 on a SimpleNewOrder
+        // (Memo-only varData) to trigger FieldTooLong.
+        var spec = EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidSimpleNewOrder, 2);
+        var blob = new byte[1 + 41];
+        blob[0] = 41;
+        var r = EntryPointVarData.ValidateDetailed(blob, spec);
+        Assert.True(r.IsBusinessReject);
+        Assert.Equal(EntryPointVarData.FailureKind.FieldTooLong, r.Kind);
+        Assert.Equal("memo", r.FieldName);
+        Assert.Equal("memo too long", r.BmrText());
+    }
+
+    [Theory]
+    [InlineData((byte)0x0A)]
+    [InlineData((byte)0x0D)]
+    public void VarData_DeskID_with_line_break_returns_business_reject_with_spec_text(byte breakByte)
+    {
+        var spec = EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidOrderCancelReplaceRequest, 2);
+        var blob = new byte[1 + 4 + 1];
+        blob[0] = 4;
+        blob[1] = (byte)'A';
+        blob[2] = breakByte;
+        blob[3] = (byte)'B';
+        blob[4] = (byte)'C';
+        blob[5] = 0; // memo length = 0
+        var r = EntryPointVarData.ValidateDetailed(blob, spec);
+        Assert.True(r.IsBusinessReject);
+        Assert.Equal(EntryPointVarData.FailureKind.ContainsLineBreaks, r.Kind);
+        Assert.Equal("deskID", r.FieldName);
+        Assert.Equal("Line breaks not supported in deskID", r.BmrText());
+    }
+
+    // ---------------------- NewOrderCross varData propagation ----------------------
+
+    private const uint FirmNull = 0xFFFFFFFFu;
+    private const uint SessionFirm = 4242u;
+
+    private static byte[] BuildCrossWithVarData(byte deskIdLen, byte memoLen, byte? deskByte = null)
+    {
+        const int sidesBytes = 2 * 22;
+        int total = 84 + 3 + sidesBytes + 1 + deskIdLen + 1 + memoLen;
+        var body = new byte[total];
+        Span<byte> s = body;
+
+        // Root: minimum required for a Limit cross.
+        ulong cross = 7777UL;
+        long sec = 12345L;
+        ulong qty = 100UL;
+        long price = 100_0000L;
+        MemoryMarshal.Write(s.Slice(20, 8), in cross);
+        MemoryMarshal.Write(s.Slice(48, 8), in sec);
+        MemoryMarshal.Write(s.Slice(56, 8), in qty);
+        MemoryMarshal.Write(s.Slice(64, 8), in price);
+        ushort crossedIndNull = 65535;
+        MemoryMarshal.Write(s.Slice(72, 2), in crossedIndNull);
+        s[74] = 255; // crossType null
+        s[75] = 255; // crossPri null
+        // s[76..84] maxSweepQty = 0
+
+        // NoSides group header (3 bytes).
+        ushort gbl = 22;
+        int cursor = 84;
+        MemoryMarshal.Write(s.Slice(cursor, 2), in gbl);
+        s[cursor + 2] = 2;
+        cursor += 3;
+
+        // Side 0: Buy.
+        s[cursor + 0] = (byte)'1';
+        uint firmNullLocal = FirmNull;
+        MemoryMarshal.Write(s.Slice(cursor + 6, 4), in firmNullLocal);
+        ulong c0 = 1001UL;
+        MemoryMarshal.Write(s.Slice(cursor + 10, 8), in c0);
+        cursor += 22;
+        // Side 1: Sell.
+        s[cursor + 0] = (byte)'2';
+        MemoryMarshal.Write(s.Slice(cursor + 6, 4), in firmNullLocal);
+        ulong c1 = 1002UL;
+        MemoryMarshal.Write(s.Slice(cursor + 10, 8), in c1);
+        cursor += 22;
+
+        // varData.
+        s[cursor++] = deskIdLen;
+        if (deskByte is byte db)
+        {
+            for (int i = 0; i < deskIdLen; i++) s[cursor + i] = db;
+        }
+        cursor += deskIdLen;
+        s[cursor++] = memoLen;
+        cursor += memoLen;
+
+        return body;
+    }
+
+    [Fact]
+    public void NewOrderCross_DeskId_too_long_returns_UnsupportedFeature_with_spec_text()
+    {
+        var body = BuildCrossWithVarData(deskIdLen: 21, memoLen: 0);
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+            body, SessionFirm, 1UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal("deskID too long", msg);
+    }
+
+    [Fact]
+    public void NewOrderCross_Memo_too_long_returns_UnsupportedFeature_with_spec_text()
+    {
+        var body = BuildCrossWithVarData(deskIdLen: 0, memoLen: 41);
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+            body, SessionFirm, 1UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal("memo too long", msg);
+    }
+
+    [Theory]
+    [InlineData((byte)0x0A)]
+    [InlineData((byte)0x0D)]
+    public void NewOrderCross_DeskId_with_line_break_returns_UnsupportedFeature_with_spec_text(byte breakByte)
+    {
+        // Fill the deskID payload entirely with the offending byte so any
+        // index inside the payload trips the line-break detector.
+        var body = BuildCrossWithVarData(deskIdLen: 4, memoLen: 0, deskByte: breakByte);
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+            body, SessionFirm, 1UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal("Line breaks not supported in deskID", msg);
+    }
+
+    [Fact]
+    public void NewOrderCross_Clean_varData_returns_Success()
+    {
+        var body = BuildCrossWithVarData(deskIdLen: 5, memoLen: 10, deskByte: (byte)'X');
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+            body, SessionFirm, 1UL, out _, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs
@@ -251,15 +251,17 @@ public class NewOrderCrossDecoderTests
     [Fact]
     public void DecodeError_VarDataTruncated()
     {
-        // Build a normal cross then truncate before the Memo length byte
-        // to exercise the "truncated before <field>" path.
-        var body = BuildCross();
-        // Body has root(84) + group(3+44) + deskLen(1) + memoLen(1) = 133.
-        // Truncate to 132 (drop memo length prefix).
-        var truncated = body.AsSpan(0, body.Length - 1).ToArray();
+        // Build a cross whose deskID declares 10 bytes of payload but
+        // truncate the buffer so the declared length overruns it. The
+        // shared validator (EntryPointVarData.ValidateDetailed) classifies
+        // an over-running length prefix as a structural protocol error
+        // (DECODING_ERROR), distinct from an over-length payload (which
+        // is a §4.10 BMR — see UnsupportedFeature_DeskIdTooLong).
+        var body = BuildCross(deskIdLen: 10);
+        var truncated = body.AsSpan(0, body.Length - 5).ToArray();
         var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
             truncated, SessionFirm, 1UL, out _, out _, out var msg);
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
-        Assert.Contains("memo", msg);
+        Assert.Contains("deskID", msg);
     }
 }


### PR DESCRIPTION
Closes #57

Implements the basic gateway validations in spec §4.10:

- **CR/LF rejection** in fixed-block identifier fields (`senderLocation`, `enteringTrader`, `executingTrader`) for NewOrderSingleV2, OrderCancelReplaceRequestV2, OrderCancelRequest, and NewOrderCrossV2.
- **CR/LF rejection** in `deskID` varData (already enforced by `EntryPointVarData`; now also applied uniformly to NewOrderCross via the shared validator).
- **Over-length rejection** for `deskID` and `memo` varData.

On failure the session emits `BusinessMessageReject` with `BusinessRejectReason=33003` and the spec text (`"<field> too long"` / `"Line breaks not supported in <field>"`). The session stays open.

### Implementation

- New `EntryPointFixedIdentifiers` validator with per-template slot tables and CR/LF detection.
- `FixpSession.DispatchInboundAsync` runs the identifier sweep right after the existing varData walk, gated to application templates.
- `InboundMessageDecoder.TryDecodeNewOrderCross` now reuses `EntryPointVarData.ValidateDetailed` instead of a bespoke walker; business-reject results map to `UnsupportedFeature` with the spec text, protocol errors map to `DecodeError`.

### Tests

- 32 new tests in `InboundIdentifierValidationTests` covering `ContainsCrLf`, per-template/per-slot CR/LF rejection, clean-pass per template, Simple* template skip, and NewOrderCross-specific paths.
- `NewOrderCross VarDataTruncated` test rewritten to fit the shared validator behavior (overrun rather than missing-tail).

### Verification

- `dotnet build -c Release`: 0 warnings, 0 errors.
- `dotnet test -c Release`: 342/342 gateway tests pass; full suite green.
- `dotnet format --verify-no-changes`: clean.