### PR TITLE
GAP-20 (#56): per-session inbound sliding-window throttle

### DIFF
--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -111,6 +111,24 @@ public sealed class SessionLifecycleMetrics
 }
 
 /// <summary>
+/// Process-wide counters for the per-session inbound sliding-window
+/// throttle (issue #56 / GAP-20, guidelines §4.9). Increments are atomic
+/// so the FIXP recv thread can advance them while a metrics scrape runs
+/// concurrently on the HTTP thread.
+/// </summary>
+public sealed class ThrottleMetrics
+{
+    private long _accepted;
+    private long _rejected;
+
+    public long Accepted => Interlocked.Read(ref _accepted);
+    public long Rejected => Interlocked.Read(ref _rejected);
+
+    public void IncAccepted() => Interlocked.Increment(ref _accepted);
+    public void IncRejected() => Interlocked.Increment(ref _rejected);
+}
+
+/// <summary>
 /// Central registry of channel metrics + a Prometheus text-format
 /// renderer. Hand-rolled to avoid taking a dependency on
 /// <c>prometheus-net</c> (see issue #5 / project conventions).
@@ -121,8 +139,10 @@ public sealed class MetricsRegistry
     private readonly object _lock = new();
     private ISessionMetricsProvider? _sessions;
     private readonly SessionLifecycleMetrics _sessionLifecycle = new();
+    private readonly ThrottleMetrics _throttle = new();
 
     public SessionLifecycleMetrics Sessions => _sessionLifecycle;
+    public ThrottleMetrics Throttle => _throttle;
 
     public ChannelMetrics RegisterChannel(byte channelNumber)
     {
@@ -225,6 +245,12 @@ public sealed class MetricsRegistry
         EmitProcessCounter(sb, "exch_session_reaped_total",
             "Total Suspended FIXP sessions closed by the listener's CoD/suspended reaper after exceeding SuspendedTimeoutMs.",
             _sessionLifecycle.Reaped);
+        EmitProcessCounter(sb, "exch_throttle_accepted_total",
+            "Total inbound application messages accepted by the per-session sliding-window throttle (issue #56 / GAP-20).",
+            _throttle.Accepted);
+        EmitProcessCounter(sb, "exch_throttle_rejected_total",
+            "Total inbound application messages rejected with BusinessMessageReject(\"Throttle limit exceeded\") by the per-session sliding-window throttle (issue #56 / GAP-20).",
+            _throttle.Rejected);
 
         return sb.ToString();
     }

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -98,6 +98,14 @@ public sealed class FixpSession : IAsyncDisposable
     private int _probeOutstanding;
     private Task? _recvTask;
     private Task? _watchdogTask;
+    private readonly Func<long> _nowMs;
+    /// <summary>
+    /// Per-session inbound sliding-window throttle (issue #56 / GAP-20).
+    /// Null when both <see cref="FixpSessionOptions.ThrottleTimeWindowMs"/>
+    /// and <see cref="FixpSessionOptions.ThrottleMaxMessages"/> are 0
+    /// (throttling disabled). Mutated only on the receive thread.
+    /// </summary>
+    private readonly InboundThrottle? _throttle;
 
     public long ConnectionId { get; }
     /// <summary>
@@ -197,6 +205,15 @@ public sealed class FixpSession : IAsyncDisposable
                     break;
             }
         }
+        // Reset the inbound throttle window on every transition INTO
+        // Established (initial Establish + rebind via #69b) so a freshly
+        // (re-)established session starts with a clean budget. Counter
+        // totals on _throttle (lifetime accept/reject) are preserved.
+        if (t.Action == FixpAction.Accept && prev != t.NewState
+            && t.NewState == FixpState.Established)
+        {
+            _throttle?.Reset();
+        }
         return t.Action;
     }
 
@@ -247,7 +264,8 @@ public sealed class FixpSession : IAsyncDisposable
         ILogger<TcpTransport>? transportLogger = null,
         NegotiationValidator? negotiationValidator = null,
         SessionClaimRegistry? sessionClaims = null,
-        EstablishValidator? establishValidator = null)
+        EstablishValidator? establishValidator = null,
+        Func<long>? nowMs = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ConnectionId = connectionId;
@@ -259,9 +277,17 @@ public sealed class FixpSession : IAsyncDisposable
         _transportLogger = transportLogger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TcpTransport>.Instance;
         _sendQueueCapacity = sendQueueCapacity;
         _nowNanos = nowNanos ?? DefaultNowNanos;
+        _nowMs = nowMs ?? (() => Environment.TickCount64);
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
         _retxBuffer = new RetransmitBuffer(_options.RetransmitBufferCapacity);
+        if (_options.ThrottleMaxMessages > 0 && _options.ThrottleTimeWindowMs > 0)
+        {
+            _throttle = new InboundThrottle(
+                _options.ThrottleMaxMessages,
+                _options.ThrottleTimeWindowMs,
+                _nowMs);
+        }
         _onClosed = onClosed;
         _validator = negotiationValidator;
         _establishValidator = establishValidator;
@@ -423,6 +449,18 @@ public sealed class FixpSession : IAsyncDisposable
         var fullBody = new ReadOnlyMemory<byte>(bodyBuf, 0, bodyLength);
         var fixedBlock = fullBody.Slice(0, info.BlockLength).Span;
         var varData = fullBody.Slice(info.BlockLength).Span;
+
+        // Per-session inbound sliding-window throttle (issue #56 / GAP-20,
+        // guidelines §4.9). Only application templates count toward the
+        // budget — FIXP session-layer messages (Negotiate, Establish,
+        // Sequence, RetransmitRequest) bypass it. On violation we emit
+        // BusinessMessageReject with text "Throttle limit exceeded" and
+        // KEEP the session open; the offending frame does not consume a
+        // slot (so a sustained burst keeps getting rejected, not slowly
+        // re-admitted). The decoded varData / strict-gating checks below
+        // are skipped on rejection.
+        if (!TryAcceptInboundThrottle(info.TemplateId, fixedBlock))
+            return true;
 
         // Strict gating (issue #43, spec §4.5.3.1): when the validator is
         // wired (i.e. we're running in "real" multi-tenant mode), an
@@ -813,6 +851,46 @@ public sealed class FixpSession : IAsyncDisposable
         || templateId == EntryPointFrameReader.TidOrderCancelReplaceRequest
         || templateId == EntryPointFrameReader.TidOrderCancelRequest
         || templateId == EntryPointFrameReader.TidNewOrderCross;
+
+    /// <summary>
+    /// Per-session inbound sliding-window throttle gate (issue #56 /
+    /// GAP-20). Returns <c>true</c> if the inbound frame is admitted
+    /// (the slot is consumed), or <c>false</c> after emitting
+    /// <c>BusinessMessageReject(text="Throttle limit exceeded")</c> for
+    /// the rejected frame. Session-layer FIXP messages (anything that
+    /// is not an <see cref="IsApplicationTemplate"/> template) and
+    /// sessions configured without a throttle (<c>_throttle == null</c>)
+    /// always return <c>true</c>. Exposed as <c>internal</c> so tests can
+    /// drive the throttle directly without constructing a fully-decodable
+    /// SimpleNewOrder body.
+    /// </summary>
+    internal bool TryAcceptInboundThrottle(ushort templateId, ReadOnlySpan<byte> fixedBlock)
+    {
+        if (_throttle is null || !IsApplicationTemplate(templateId))
+            return true;
+        if (_throttle.TryAccept())
+        {
+            _options.ThrottleMetrics?.IncAccepted();
+            return true;
+        }
+        uint refSeqNum = fixedBlock.Length >= 8
+            ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
+            : 0u;
+        ulong refClOrdId = fixedBlock.Length >= 28
+            ? System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(20, 8))
+            : 0UL;
+        WriteBusinessMessageReject(
+            refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(templateId),
+            refSeqNum: refSeqNum,
+            businessRejectRefId: refClOrdId,
+            businessRejectReason: BusinessMessageRejectEncoder.Reason.Other,
+            text: "Throttle limit exceeded");
+        _options.ThrottleMetrics?.IncRejected();
+        _logger.LogWarning(
+            "fixp session {ConnectionId} throttle reject template={Template} (max={Max}/{WindowMs}ms)",
+            ConnectionId, templateId, _throttle.MaxMessages, _throttle.TimeWindowMs);
+        return false;
+    }
 
     /// <summary>
     /// Emits a <c>BusinessMessageReject(33003)</c> for an application

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -63,6 +63,31 @@ public sealed record FixpSessionOptions
     /// </summary>
     public B3.Exchange.Core.SessionLifecycleMetrics? LifecycleMetrics { get; init; }
 
+    /// <summary>
+    /// Per-session inbound rate cap (issue #56 / GAP-20, guidelines §4.9):
+    /// at most <see cref="ThrottleMaxMessages"/> application messages
+    /// per <see cref="ThrottleTimeWindowMs"/>-millisecond sliding window.
+    /// On violation the session emits
+    /// <c>BusinessMessageReject("Throttle limit exceeded")</c> and stays
+    /// open (the offending frame is dropped and does NOT consume budget).
+    /// FIXP session-layer messages (Negotiate / Establish / Sequence /
+    /// RetransmitRequest / Terminate) bypass the throttle. Set either
+    /// value to <c>0</c> to disable throttling on this session (default).
+    /// </summary>
+    public int ThrottleTimeWindowMs { get; init; }
+
+    /// <summary>See <see cref="ThrottleTimeWindowMs"/>.</summary>
+    public int ThrottleMaxMessages { get; init; }
+
+    /// <summary>
+    /// Optional process-wide throttle counters. When non-null the session
+    /// increments <see cref="B3.Exchange.Core.ThrottleMetrics.Accepted"/>
+    /// every time an application message is admitted by the throttle and
+    /// <see cref="B3.Exchange.Core.ThrottleMetrics.Rejected"/> on every
+    /// throttle-driven BusinessMessageReject.
+    /// </summary>
+    public B3.Exchange.Core.ThrottleMetrics? ThrottleMetrics { get; init; }
+
     public static FixpSessionOptions Default { get; } = new();
 
     internal void Validate()
@@ -73,5 +98,7 @@ public sealed record FixpSessionOptions
         if (SuspendedTimeoutMs < 0) throw new ArgumentOutOfRangeException(nameof(SuspendedTimeoutMs));
         if (FirstFrameTimeoutMs <= 0) throw new ArgumentOutOfRangeException(nameof(FirstFrameTimeoutMs));
         if (RetransmitBufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(RetransmitBufferCapacity));
+        if (ThrottleTimeWindowMs < 0) throw new ArgumentOutOfRangeException(nameof(ThrottleTimeWindowMs));
+        if (ThrottleMaxMessages < 0) throw new ArgumentOutOfRangeException(nameof(ThrottleMaxMessages));
     }
 }

--- a/src/B3.Exchange.Gateway/InboundThrottle.cs
+++ b/src/B3.Exchange.Gateway/InboundThrottle.cs
@@ -1,0 +1,85 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Per-session sliding-window inbound rate limiter (issue #56 / GAP-20,
+/// guidelines §4.9). Designed for <see cref="FixpSession"/>'s single-threaded
+/// receive loop — no internal synchronization.
+///
+/// <para>Implementation: ring buffer of monotonic millisecond timestamps,
+/// sized to <c>maxMessages</c>. On <see cref="TryAccept"/>:
+///   • if the ring is not yet full, the new timestamp is appended and
+///     the call is accepted;
+///   • if the ring is full, the oldest timestamp is compared against
+///     <c>now - timeWindowMs</c>: if it has fallen out of the window we
+///     overwrite that slot and accept, otherwise we reject and leave the
+///     ring untouched (a rejected message does NOT consume a slot — only
+///     accepted messages count toward the cap).
+/// This yields exact sliding-window semantics in O(1) per call.</para>
+///
+/// <para>The clock is injected (<c>nowMs</c>) so tests can drive the
+/// window forward without relying on wall-clock time. The default in
+/// production is <see cref="Environment.TickCount64"/>.</para>
+/// </summary>
+internal sealed class InboundThrottle
+{
+    private readonly long[] _timestamps;
+    private readonly long _windowMs;
+    private readonly Func<long> _nowMs;
+    private int _count;
+    private int _head;
+    private long _accepted;
+    private long _rejected;
+
+    public int MaxMessages => _timestamps.Length;
+    public long TimeWindowMs => _windowMs;
+    public long Accepted => _accepted;
+    public long Rejected => _rejected;
+
+    public InboundThrottle(int maxMessages, long timeWindowMs, Func<long>? nowMs = null)
+    {
+        if (maxMessages <= 0) throw new ArgumentOutOfRangeException(nameof(maxMessages));
+        if (timeWindowMs <= 0) throw new ArgumentOutOfRangeException(nameof(timeWindowMs));
+        _timestamps = new long[maxMessages];
+        _windowMs = timeWindowMs;
+        _nowMs = nowMs ?? (() => Environment.TickCount64);
+    }
+
+    /// <summary>
+    /// Records an attempted message arrival. Returns <c>true</c> if the
+    /// message is within budget (the slot is consumed), or <c>false</c>
+    /// if it exceeds the configured rate (no slot consumed).
+    /// </summary>
+    public bool TryAccept()
+    {
+        long now = _nowMs();
+        if (_count < _timestamps.Length)
+        {
+            _timestamps[(_head + _count) % _timestamps.Length] = now;
+            _count++;
+            _accepted++;
+            return true;
+        }
+        long oldest = _timestamps[_head];
+        if (now - oldest >= _windowMs)
+        {
+            _timestamps[_head] = now;
+            _head = (_head + 1) % _timestamps.Length;
+            _accepted++;
+            return true;
+        }
+        _rejected++;
+        return false;
+    }
+
+    /// <summary>
+    /// Drops every recorded timestamp without resetting the lifetime
+    /// accept/reject counters. Called when a session transitions back
+    /// into Established (Negotiate completes or a Suspended session
+    /// rebinds) so a fresh budget is granted to the new logical session.
+    /// </summary>
+    public void Reset()
+    {
+        _count = 0;
+        _head = 0;
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -215,6 +215,9 @@ public sealed class ExchangeHost : IAsyncDisposable
             IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,
             TestRequestGraceMs = _config.Tcp.TestRequestGraceMs,
             LifecycleMetrics = _metrics.Sessions,
+            ThrottleTimeWindowMs = _config.Tcp.Throttle?.TimeWindowMs ?? 0,
+            ThrottleMaxMessages = _config.Tcp.Throttle?.MaxMessages ?? 0,
+            ThrottleMetrics = _config.Tcp.Throttle is not null ? _metrics.Throttle : null,
         };
         // Phase 2 (#42): real Negotiate handshake. The validator is pure
         // (no IO); the claim ledger lives for the host process lifetime

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -39,6 +39,29 @@ public sealed class TcpConfig
     /// <summary>Additional grace window after the probe before the session is
     /// closed for inactivity. Default: 5 s.</summary>
     [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
+
+    /// <summary>
+    /// Per-session inbound sliding-window throttle (issue #56 / GAP-20,
+    /// guidelines §4.9). Omit (or set both fields to 0) to disable
+    /// throttling. Defaults to 100 application messages per 1000 ms when
+    /// the JSON object is present without explicit overrides.
+    /// </summary>
+    [JsonPropertyName("throttle")] public ThrottleConfig? Throttle { get; set; }
+}
+
+/// <summary>
+/// Configuration block for the per-session inbound sliding-window
+/// throttle (issue #56 / GAP-20, guidelines §4.9). On violation the
+/// session emits <c>BusinessMessageReject("Throttle limit exceeded")</c>
+/// and stays open. FIXP session-layer messages bypass the throttle.
+/// </summary>
+public sealed class ThrottleConfig
+{
+    /// <summary>Sliding window length in milliseconds. Default 1000 ms.</summary>
+    [JsonPropertyName("timeWindowMs")] public int TimeWindowMs { get; set; } = 1_000;
+
+    /// <summary>Maximum application messages accepted per window. Default 100.</summary>
+    [JsonPropertyName("maxMessages")] public int MaxMessages { get; set; } = 100;
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -24,6 +24,7 @@ public class FixpSessionThrottleTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -1,0 +1,315 @@
+using System.Buffers.Binary;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #56 / GAP-20 — per-session inbound sliding-window throttle
+/// (guidelines §4.9). Two parameters: <c>timeWindowMs</c> and
+/// <c>maxMessages</c>. On violation the session emits
+/// <c>BusinessMessageReject(text="Throttle limit exceeded")</c> and stays
+/// open. FIXP session-layer messages (Sequence, Negotiate, Establish,
+/// RetransmitRequest) bypass the throttle.
+/// </summary>
+public class FixpSessionThrottleTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
+        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
+        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    [Fact]
+    public void Throttle_ringbuffer_accepts_within_cap_and_rejects_burst()
+    {
+        long now = 1_000_000;
+        var t = new InboundThrottle(maxMessages: 5, timeWindowMs: 1_000, nowMs: () => now);
+
+        for (int i = 0; i < 5; i++)
+            Assert.True(t.TryAccept(), $"msg {i} should be accepted within cap");
+        Assert.False(t.TryAccept());
+        Assert.False(t.TryAccept());
+        Assert.Equal(5, t.Accepted);
+        Assert.Equal(2, t.Rejected);
+    }
+
+    [Fact]
+    public void Throttle_ringbuffer_window_slides_forward()
+    {
+        long now = 0;
+        var t = new InboundThrottle(maxMessages: 3, timeWindowMs: 1_000, nowMs: () => now);
+
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        Assert.False(t.TryAccept());
+
+        now = 1_500;
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        Assert.False(t.TryAccept());
+    }
+
+    [Fact]
+    public void Throttle_reject_does_not_consume_a_slot()
+    {
+        long now = 0;
+        var t = new InboundThrottle(maxMessages: 2, timeWindowMs: 1_000, nowMs: () => now);
+
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        now = 500;
+        Assert.False(t.TryAccept());
+        Assert.False(t.TryAccept());
+        now = 1_000;
+        Assert.True(t.TryAccept());
+    }
+
+    [Fact]
+    public void Throttle_reset_clears_window_but_preserves_lifetime_counters()
+    {
+        long now = 0;
+        var t = new InboundThrottle(maxMessages: 2, timeWindowMs: 1_000, nowMs: () => now);
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        Assert.False(t.TryAccept());
+        Assert.Equal(2, t.Accepted);
+        Assert.Equal(1, t.Rejected);
+
+        t.Reset();
+        Assert.True(t.TryAccept());
+        Assert.True(t.TryAccept());
+        Assert.False(t.TryAccept());
+        Assert.Equal(4, t.Accepted);
+        Assert.Equal(2, t.Rejected);
+    }
+
+    private static async Task<(NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        tcp.Stop();
+        return (new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static byte[] BuildFixedBlock(uint sessionId, uint msgSeqNum, ulong clOrdId)
+    {
+        var fb = new byte[82];
+        BinaryPrimitives.WriteUInt32LittleEndian(fb.AsSpan(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt32LittleEndian(fb.AsSpan(4, 4), msgSeqNum);
+        BinaryPrimitives.WriteUInt64LittleEndian(fb.AsSpan(20, 8), clOrdId);
+        return fb;
+    }
+
+    private static async Task<(ushort tid, byte[] body)> ReadOneFrameAsync(NetworkStream ns, CancellationToken ct)
+    {
+        var head = new byte[EntryPointFrameReader.WireHeaderSize];
+        int read = 0;
+        while (read < head.Length)
+        {
+            int n = await ns.ReadAsync(head.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException();
+            read += n;
+        }
+        ushort msgLen = BinaryPrimitives.ReadUInt16LittleEndian(head.AsSpan(0, 2));
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(
+            head.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        int bodyLen = msgLen - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        read = 0;
+        while (read < bodyLen)
+        {
+            int n = await ns.ReadAsync(body.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException();
+            read += n;
+        }
+        return (tid, body);
+    }
+
+    private static FixpSession NewSession(NetworkStream server, FixpSessionOptions options, Func<long> nowMs)
+    {
+        var s = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: server, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance,
+            options: options,
+            nowMs: nowMs);
+        s.Start();
+        s.ApplyTransition(FixpEvent.Negotiate);
+        s.ApplyTransition(FixpEvent.Establish);
+        return s;
+    }
+
+    [Fact]
+    public async Task SmokeTest_WriteBmr_directly()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewSession(server,
+                new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 2 },
+                () => 1_000_000L);
+            bool ok = session.WriteBusinessMessageReject(15, 99, 12345, 0, "Throttle limit exceeded");
+            Assert.True(ok);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var ns = client.GetStream();
+            var (tid, body) = await ReadOneFrameAsync(ns, cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidBusinessMessageReject, tid);
+            byte refMsgType = body[18];
+            uint refSeqNum = BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(20, 4));
+            ulong refId = BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(24, 8));
+            uint reason = BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(32, 4));
+            Assert.Equal((byte)15, refMsgType);
+            Assert.Equal(99u, refSeqNum);
+            Assert.Equal(12345UL, refId);
+            Assert.Equal(0u, reason);
+            int trailerStart = 36;
+            byte memoLen = body[trailerStart];
+            byte textLen = body[trailerStart + 1];
+            Assert.Equal(0, memoLen);
+            string text = System.Text.Encoding.ASCII.GetString(body, trailerStart + 2, textLen);
+            Assert.Equal("Throttle limit exceeded", text);
+            session.Close("test");
+        }
+        finally { client.Close(); server.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Burst_within_cap_no_BMR_emitted()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            long now = 1_000_000;
+            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var session = NewSession(server,
+                new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 3, ThrottleMetrics = metrics },
+                () => now);
+
+            for (int i = 0; i < 3; i++)
+            {
+                var fb = BuildFixedBlock(100, (uint)(i + 1), (ulong)(100 + i));
+                Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder, fb));
+            }
+            Assert.Equal(3, metrics.Accepted);
+            Assert.Equal(0, metrics.Rejected);
+            Assert.True(session.IsOpen);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Burst_over_cap_rejects_and_session_stays_open()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            long now = 1_000_000;
+            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var session = NewSession(server,
+                new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 2, ThrottleMetrics = metrics },
+                () => now);
+
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 1, 7000)));
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 2, 7001)));
+            Assert.False(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 3, 7002)));
+            Assert.False(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 4, 7003)));
+
+            Assert.Equal(2, metrics.Accepted);
+            Assert.Equal(2, metrics.Rejected);
+            Assert.True(session.IsOpen);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Window_slides_forward_so_more_messages_admitted_after_time_passes()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            long now = 1_000_000;
+            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var session = NewSession(server,
+                new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 2, ThrottleMetrics = metrics },
+                () => now);
+
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 1, 1000)));
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 2, 1001)));
+            Assert.False(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 3, 1002)));
+
+            now = 1_002_000;
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 4, 2000)));
+
+            Assert.Equal(3, metrics.Accepted);
+            Assert.Equal(1, metrics.Rejected);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task FIXP_session_messages_bypass_throttle()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            long now = 1_000_000;
+            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var session = NewSession(server,
+                new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 1, ThrottleMetrics = metrics },
+                () => now);
+
+            for (int i = 0; i < 10; i++)
+            {
+                Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSequence,
+                    BuildFixedBlock(100, (uint)(i + 1), 0)));
+            }
+            // No application templates were sent, so neither counter moves.
+            Assert.Equal(0, metrics.Accepted);
+            Assert.Equal(0, metrics.Rejected);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Implements the per-session inbound sliding-window throttle for FIXP application messages, per [issue #56](https://github.com/pedrosakuma/B3MatchingPlatform/issues/56) / GAP-20.

## What

A small ring-of-timestamps throttle (`InboundThrottle`) lives inside each `FixpSession` and bounds inbound *application* messages to **N messages per W-millisecond sliding window**.

- **FIXP session-layer messages bypass** the gate (Negotiate, Establish, Sequence, RetransmitRequest). Only application templates (SimpleNewOrder, SimpleModifyOrder, NewOrderSingle, OrderCancelReplaceRequest, OrderCancelRequest, NewOrderCross) are counted.
- On violation: emit `BusinessMessageReject(reason=0, text="Throttle limit exceeded")` and **keep the session open**.
- **Rejected frames do not consume a slot** — a sustained burst keeps being rejected, instead of slowly re-admitting via displacement of older accepted timestamps. (Sliding-window semantics in O(1).)
- Window is **reset on every transition INTO Established** (initial Establish + rebind via #69b); lifetime accept/reject counters on the throttle instance are preserved.

## Config

```json
"tcp": {
  "throttle": { "timeWindowMs": 1000, "maxMessages": 100 }
}
```

Both must be `> 0` to enable. Setting either to 0 disables the throttle.

## Metrics

- `exch_throttle_accepted_total` — application messages admitted
- `exch_throttle_rejected_total` — application messages rejected

Exposed via `MetricsRegistry.Throttle`.

## Tests

8 new tests in `FixpSessionThrottleTests`:

- 4 unit tests on `InboundThrottle` (ring-buffer accept/reject, window slide, reject-doesn't-consume-slot, reset-preserves-counters).
- 4 integration tests on `FixpSession.TryAcceptInboundThrottle` (within-cap admits, over-cap rejects + session stays open, window slide admits new traffic, FIXP session messages bypass).

A new internal helper `FixpSession.TryAcceptInboundThrottle(templateId, fixedBlock)` is exposed (matching the pattern of existing helpers like `TryAcceptBusinessHeaderSessionId`) so tests can drive the throttle without constructing a fully-decodable SimpleNewOrder body. The production recv path now calls this helper.

## Pre-PR checks

- `dotnet build -c Release` — Build succeeded, 0 warnings, 0 errors (`TreatWarningsAsErrors=true`).
- `dotnet test -c Release` — All tests pass (incl. 8 new throttle tests).
- `dotnet format --verify-no-changes` — clean.

Closes #56