### PR TITLE
GAP-19 (#55): OrderMassActionRequest 701 / Report 702

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -232,6 +232,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             WorkKind.Cancel => item.Cancel?.EnteredAtNanos ?? ulong.MaxValue,
             WorkKind.Replace => item.Replace?.EnteredAtNanos ?? ulong.MaxValue,
             WorkKind.Cross => item.Cross?.Buy.EnteredAtNanos ?? ulong.MaxValue,
+            WorkKind.MassCancel => item.MassCancel?.EnteredAtNanos ?? ulong.MaxValue,
             _ => ulong.MaxValue,
         };
         _packetWritten = 0;
@@ -289,6 +290,32 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                         _metrics?.IncOrdersIn();
                         _currentClOrdId = cross.SellClOrdIdValue;
                         _engine.Submit(cross.Sell);
+                        break;
+                    }
+                case WorkKind.MassCancel:
+                    {
+                        // Mass-cancel (#GAP-19, spec §4.8). Filter the
+                        // OrderOwnership map by (session, firm) plus the
+                        // per-command Side / SecurityId filters, then ask
+                        // the engine to cancel every matching orderId in
+                        // one dispatch turn so all DEL frames pack into a
+                        // single UMDF packet (atomic from the consumer's
+                        // POV) and one ER_Cancel per order is routed back
+                        // to the originating session via OnOrderCanceled.
+                        var mc = item.MassCancel!;
+                        if (!_hasCurrentSession) break;
+                        List<long>? matched = null;
+                        foreach (var kv in _orderOwners)
+                        {
+                            var owner = kv.Value;
+                            if (owner.Session != _currentSession) continue;
+                            if (owner.Firm != _currentFirm) continue;
+                            if (mc.SideFilter.HasValue && owner.Side != mc.SideFilter.Value) continue;
+                            if (mc.SecurityId != 0 && owner.SecurityId != mc.SecurityId) continue;
+                            (matched ??= new List<long>()).Add(kv.Key);
+                        }
+                        if (matched != null)
+                            _engine.MassCancel(matched, mc.EnteredAtNanos);
                         break;
                     }
                 case WorkKind.DecodeError:
@@ -459,6 +486,13 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             LogQueueFull(ChannelNumber, WorkKind.Cross);
     }
 
+    public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
+    {
+        if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
+            0, 0, null, null, null, null, cmd)))
+            LogQueueFull(ChannelNumber, WorkKind.MassCancel);
+    }
+
     public void OnDecodeError(SessionId session, string error)
     {
         _logger.LogWarning("channel {ChannelNumber} inbound decode error: {Error}", ChannelNumber, error);
@@ -528,7 +562,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_hasCurrentSession)
         {
-            _orderOwners[e.OrderId] = new OrderOwnership(_currentSession, _currentClOrdId, _currentFirm);
+            _orderOwners[e.OrderId] = new OrderOwnership(_currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId);
             if (_currentClOrdId != 0)
                 _clOrdIdIndex[(_currentFirm, _currentClOrdId)] = e.OrderId;
         }
@@ -669,9 +703,15 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _cts.Dispose();
     }
 
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, DecodeError, SnapshotRotation, ReleaseOwner, OperatorSnapshotNow, OperatorBumpVersion }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, ReleaseOwner, OperatorSnapshotNow, OperatorBumpVersion }
 
-    internal readonly record struct OrderOwnership(SessionId Session, ulong ClOrdId, uint Firm);
+    /// <summary>
+    /// Per-resting-order routing context. <see cref="Side"/> +
+    /// <see cref="SecurityId"/> are stamped at <see cref="OnOrderAccepted"/>
+    /// so the mass-cancel filter (#GAP-19, spec §4.8) can decide which
+    /// orders match without a round-trip into the engine.
+    /// </summary>
+    internal readonly record struct OrderOwnership(SessionId Session, ulong ClOrdId, uint Firm, Side Side, long SecurityId);
 
     internal sealed record WorkItem(
         WorkKind Kind,
@@ -683,7 +723,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         NewOrderCommand? NewOrder,
         CancelOrderCommand? Cancel,
         ReplaceOrderCommand? Replace,
-        CrossOrderCommand? Cross);
+        CrossOrderCommand? Cross,
+        MassCancelCommand? MassCancel = null);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Core/CoreOutbound.cs
+++ b/src/B3.Exchange.Core/CoreOutbound.cs
@@ -88,6 +88,23 @@ public interface IInboundCommandSink
     /// </summary>
     void EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm);
 
+    /// <summary>
+    /// Enqueues a mass-cancel command (OrderMassActionRequest template 701,
+    /// spec §4.8 / #GAP-19). The dispatcher walks its
+    /// <c>OrderOwnership</c> map for every resting order owned by the
+    /// originating <paramref name="session"/> + <paramref name="enteringFirm"/>
+    /// that matches the optional Side / SecurityId filters and cancels
+    /// each (one <c>ExecutionReport_Cancel</c> per order back to the
+    /// originating session). The caller (gateway) is responsible for
+    /// emitting the matching <c>OrderMassActionReport</c> (template 702)
+    /// acknowledgement on the same wire.
+    ///
+    /// <para>A <c>SecurityId == 0</c> on the command means "any
+    /// instrument"; the host router fans the command out to every
+    /// dispatcher in that case.</para>
+    /// </summary>
+    void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm);
+
     /// <summary>Called when a frame fails decoding. Logging hook only — the
     /// Gateway-side <c>FixpSession</c> is responsible for the actual
     /// SessionReject (Terminate) / BusinessMessageReject + close-of-stream

--- a/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
@@ -55,6 +55,7 @@ internal static class BusinessMessageRejectEncoder
         EntryPointFrameReader.TidOrderCancelReplaceRequest => 18, // MessageType.OrderCancelReplaceRequest
         EntryPointFrameReader.TidOrderCancelRequest => 19,// MessageType.OrderCancelRequest
         EntryPointFrameReader.TidNewOrderCross => 20,     // MessageType.NewOrderCross
+        EntryPointFrameReader.TidOrderMassActionRequest => 29, // MessageType.OrderMassActionRequest
         _ => 0,
     };
 

--- a/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
+++ b/src/B3.Exchange.Gateway/EntryPointFrameReader.cs
@@ -60,6 +60,10 @@ public static class EntryPointFrameReader
     public const ushort TidOrderCancelReplaceRequest = 104;
     /// <summary>Inbound: OrderCancelRequest (V6 base, no version variants).</summary>
     public const ushort TidOrderCancelRequest = 105;
+    /// <summary>Inbound: OrderMassActionRequest (V6 base, spec §4.8 / #GAP-19).</summary>
+    public const ushort TidOrderMassActionRequest = 701;
+    /// <summary>Outbound: OrderMassActionReport (V6 base, spec §4.8 / #GAP-19).</summary>
+    public const ushort TidOrderMassActionReport = 702;
     /// <summary>Session: Sequence (FIXP, also used as heartbeat). Bidirectional.</summary>
     public const ushort TidSequence = 9;
     /// <summary>Session: Negotiate (FIXP, inbound only). See spec §4.5.2.</summary>
@@ -103,6 +107,7 @@ public static class EntryPointFrameReader
         (TidNewOrderCross, 6) => 84,             // NewOrderCross.MESSAGE_SIZE (root V6, group + varData follow)
         (TidOrderCancelReplaceRequest, 2) => 142, // OrderCancelReplaceRequestV2.MESSAGE_SIZE
         (TidOrderCancelRequest, 0) => 76,        // OrderCancelRequest.MESSAGE_SIZE (V6 base)
+        (TidOrderMassActionRequest, 6) => 52,    // OrderMassActionRequestData.MESSAGE_SIZE (V6 base, no varData)
         (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.
         (TidNegotiate, 0) => 28,                 // NegotiateData.BLOCK_LENGTH (V6 schema, root version 0)
         (TidEstablish, 0) => 42,                 // EstablishData.BLOCK_LENGTH

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -652,6 +652,48 @@ public sealed class FixpSession : IAsyncDisposable
                 _sink.OnDecodeError(Identity, cnErr ?? "decode error: OrderCancelRequest");
                 await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:OrderCancelRequest").ConfigureAwait(false);
                 return false;
+            case EntryPointFrameReader.TidOrderMassActionRequest:
+                {
+                    var mcOutcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+                        fixedBlock, now, out var mcCmd, out var mcClOrd, out var mcMsg);
+                    if (mcOutcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
+                    {
+                        // Spec §4.8 — acknowledge synchronously with
+                        // OrderMassActionReport(ACCEPTED) ahead of the
+                        // per-order ER_Cancel frames the engine will emit
+                        // asynchronously when it processes EnqueueMassCancel.
+                        byte? sideByte = mcCmd.SideFilter switch
+                        {
+                            Matching.Side.Buy => (byte)'1',
+                            Matching.Side.Sell => (byte)'2',
+                            _ => null,
+                        };
+                        WriteOrderMassActionReport(mcClOrd,
+                            OrderMassActionReportEncoder.MassActionResponseAccepted,
+                            massActionRejectReason: null,
+                            side: sideByte, securityId: mcCmd.SecurityId,
+                            transactTimeNanos: now);
+                        _sink.EnqueueMassCancel(mcCmd, Identity, EnteringFirm);
+                        return true;
+                    }
+                    if (mcOutcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
+                    {
+                        // Template 702 IS the reject mechanism for 701 —
+                        // emit OrderMassActionReport(REJECTED) rather than
+                        // a generic BusinessMessageReject so the peer's
+                        // FIX-side state machine sees the expected ack
+                        // family (spec §4.8).
+                        WriteOrderMassActionReport(mcClOrd,
+                            OrderMassActionReportEncoder.MassActionResponseRejected,
+                            massActionRejectReason: OrderMassActionReportEncoder.RejectReasonMassActionNotSupported,
+                            side: null, securityId: 0, transactTimeNanos: now,
+                            text: mcMsg);
+                        return true;
+                    }
+                    _sink.OnDecodeError(Identity, mcMsg ?? "decode error: OrderMassActionRequest");
+                    await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:OrderMassActionRequest").ConfigureAwait(false);
+                    return false;
+                }
             default:
                 // Unreachable: TryParseInboundHeader has already screened out
                 // unknown templates and returned UnsupportedTemplate.
@@ -842,7 +884,8 @@ public sealed class FixpSession : IAsyncDisposable
         || templateId == EntryPointFrameReader.TidNewOrderSingle
         || templateId == EntryPointFrameReader.TidOrderCancelReplaceRequest
         || templateId == EntryPointFrameReader.TidOrderCancelRequest
-        || templateId == EntryPointFrameReader.TidNewOrderCross;
+        || templateId == EntryPointFrameReader.TidNewOrderCross
+        || templateId == EntryPointFrameReader.TidOrderMassActionRequest;
 
     /// <summary>
     /// Emits a <c>BusinessMessageReject(33003)</c> for an application
@@ -1458,6 +1501,40 @@ public sealed class FixpSession : IAsyncDisposable
                 securityId, orderId, (ulong)rptSeq, transactTimeNanos,
                 leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa,
                 receivedTimeNanos: receivedTimeNanos);
+            return AppendAndEnqueueLocked(exact);
+        }
+    }
+
+    /// <summary>
+    /// Per-session monotonic counter sourcing
+    /// <c>OrderMassActionReport.MassActionReportID</c> (template 702).
+    /// Spec requires an engine-assigned unique id; deriving it from a
+    /// per-session counter is sufficient because the (sessionId, id)
+    /// pair is globally unique.
+    /// </summary>
+    private long _massActionReportSeq;
+
+    /// <summary>
+    /// Encodes and enqueues an <c>OrderMassActionReport</c> (template 702,
+    /// spec §4.8 / #GAP-19) acknowledging — or rejecting — an inbound
+    /// <c>OrderMassActionRequest</c>. The report is sent ahead of the
+    /// per-order <c>ExecutionReport_Cancel</c> messages that the engine
+    /// emits asynchronously for the matching resting orders.
+    /// </summary>
+    public bool WriteOrderMassActionReport(ulong clOrdIdValue, byte massActionResponse,
+        byte? massActionRejectReason, byte? side, long securityId, ulong transactTimeNanos,
+        string? text = null)
+    {
+        if (!IsOpen) return false;
+        ulong reportId = (ulong)Interlocked.Increment(ref _massActionReportSeq);
+        int textLen = string.IsNullOrEmpty(text) ? 0 : Math.Min(text!.Length, OrderMassActionReportEncoder.MaxTextLength);
+        var exact = new byte[OrderMassActionReportEncoder.TotalSize(textLen)];
+        lock (_outboundLock)
+        {
+            OrderMassActionReportEncoder.EncodeOrderMassActionReportWithText(exact,
+                SessionId, NextMsgSeqNum(), transactTimeNanos,
+                clOrdIdValue, reportId, transactTimeNanos,
+                massActionResponse, massActionRejectReason, side, securityId, text);
             return AppendAndEnqueueLocked(exact);
         }
     }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -692,6 +692,127 @@ internal static class InboundMessageDecoder
         return InboundDecodeOutcome.Success;
     }
 
+    /// <summary>
+    /// Field offsets inside the OrderMassActionRequest (template 701)
+    /// SBE root block. Offsets are taken from the generated SBE struct.
+    /// </summary>
+    private static class OrderMassActionRequestOffsets
+    {
+        public const int MassActionType = 18;          // byte
+        public const int ClOrdID = 20;                 // ulong
+        public const int OrdTagID = 29;                // byte (0 == null)
+        public const int Side = 30;                    // char (0 == null)
+        public const int Asset = 32;                   // 6 bytes, all-zero == null
+        public const int SecurityID = 38;              // ulong (0 == null)
+        public const int InvestorID = 46;              // 6 bytes (V2 only); zeros == null (overlaps SecurityExchange in V1 base)
+    }
+
+    private const byte MassActionTypeCancelOrders = 3;
+
+    /// <summary>
+    /// Decodes an <c>OrderMassActionRequest</c> body (template 701, spec
+    /// §4.8 / #GAP-19) into a <see cref="MassCancelCommand"/>. Returns
+    /// <see cref="InboundDecodeOutcome.Success"/> when the request maps
+    /// onto the engine's supported subset (cancel-orders, optional Side
+    /// + SecurityID filters). Returns
+    /// <see cref="InboundDecodeOutcome.UnsupportedFeature"/> for
+    /// schema-valid but unimplemented variants. Returns
+    /// <see cref="InboundDecodeOutcome.DecodeError"/> for wire values
+    /// that violate the SBE schema.
+    /// </summary>
+    public static InboundDecodeOutcome TryDecodeOrderMassActionRequest(
+        ReadOnlySpan<byte> body, ulong enteredAtNanos,
+        out MassCancelCommand cmd, out ulong clOrdIdValue, out string? message)
+    {
+        cmd = null!;
+        clOrdIdValue = 0;
+        message = null;
+
+        byte massActionType = body[OrderMassActionRequestOffsets.MassActionType];
+        byte sideByte = body[OrderMassActionRequestOffsets.Side];
+        byte ordTagId = body[OrderMassActionRequestOffsets.OrdTagID];
+        ulong securityIdRaw = MemoryMarshal.Read<ulong>(body.Slice(OrderMassActionRequestOffsets.SecurityID, 8));
+        clOrdIdValue = MemoryMarshal.Read<ulong>(body.Slice(OrderMassActionRequestOffsets.ClOrdID, 8));
+
+        if (massActionType != MassActionTypeCancelOrders)
+        {
+            if (massActionType == 2 || massActionType == 4)
+            {
+                message = $"MassActionType={massActionType} not supported (only CANCEL_ORDERS=3)";
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
+            message = $"invalid MassActionType={massActionType}";
+            return InboundDecodeOutcome.DecodeError;
+        }
+
+        if (ordTagId != 0)
+        {
+            message = "OrdTagID filter not supported (engine does not track ordTagID per order)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+
+        var assetSpan = body.Slice(OrderMassActionRequestOffsets.Asset, 6);
+        if (!IsAllZero(assetSpan))
+        {
+            message = "Asset filter not supported (engine does not track per-instrument asset)";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+
+        var investorSpan = body.Slice(OrderMassActionRequestOffsets.InvestorID, 6);
+        if (!IsMassActionInvestorEmpty(investorSpan))
+        {
+            message = "InvestorID (mass cancel on behalf) not supported";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+
+        Side? sideFilter = null;
+        if (sideByte != 0)
+        {
+            if (!TryMapSide(sideByte, out var side))
+            {
+                message = $"invalid Side={sideByte}";
+                return InboundDecodeOutcome.DecodeError;
+            }
+            sideFilter = side;
+        }
+
+        long securityId = securityIdRaw == 0 ? 0L : (long)securityIdRaw;
+
+        cmd = new MassCancelCommand(
+            SecurityId: securityId,
+            SideFilter: sideFilter,
+            EnteredAtNanos: enteredAtNanos);
+        return InboundDecodeOutcome.Success;
+    }
+
+    private static bool IsAllZero(ReadOnlySpan<byte> span)
+    {
+        for (int i = 0; i < span.Length; i++)
+            if (span[i] != 0) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// In the OrderMassActionRequest V1 base layout the bytes at offset
+    /// 46 hold the constant <c>SecurityExchange</c> = "BVMF" (4 chars,
+    /// padded to 6); in V2 the same offset holds <c>InvestorID</c>.
+    /// Treat the slot as "no InvestorID" when zeros, "BVMF" (with
+    /// trailing zeros/spaces), all-zero, or all-space.
+    /// </summary>
+    private static bool IsMassActionInvestorEmpty(ReadOnlySpan<byte> span)
+    {
+        if (IsAllZero(span)) return true;
+        if (span.Length >= 4 && span[0] == 'B' && span[1] == 'V' && span[2] == 'M' && span[3] == 'F')
+        {
+            for (int i = 4; i < span.Length; i++)
+                if (span[i] != 0 && span[i] != (byte)' ') return false;
+            return true;
+        }
+        for (int i = 0; i < span.Length; i++)
+            if (span[i] != (byte)' ') return false;
+        return true;
+    }
+
     private static bool TryMapSide(byte b, out Side side)
     {
         switch (b)

--- a/src/B3.Exchange.Gateway/OrderMassActionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/OrderMassActionReportEncoder.cs
@@ -1,0 +1,126 @@
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Byte-level encoder for the EntryPoint <c>OrderMassActionReport</c>
+/// (templateId=702, schema V6). Used to acknowledge — or reject — an
+/// inbound <c>OrderMassActionRequest</c> (template 701, spec §4.8 /
+/// #GAP-19) on the same TCP session, ahead of the per-order
+/// <c>ExecutionReport_Cancel</c> messages that the engine emits for the
+/// matching resting orders.
+///
+/// Layout (V6, BlockLength=70):
+///   header(12) | OutboundBusinessHeader(18 @0)
+///            | MassActionType(uint8 @18)
+///            | MassActionScope(uint8 nullable @19, null=255)
+///            | ClOrdID(ulong @20)
+///            | MassActionReportID(ulong @28)
+///            | TransactTime(ulong @36)
+///            | MassActionResponse(uint8 @44)
+///            | MassActionRejectReason(uint8 nullable @45, null=255)
+///            | ExecRestatementReason(uint8 nullable @46, null=255)
+///            | OrdTagID(uint8 nullable @47, null=0)
+///            | Side(char nullable @48, null=0)
+///            | (pad @49)
+///            | Asset(6 bytes @50, all-zero == null)
+///            | SecurityID(ulong nullable @56, null=0)
+///            | SecurityExchange(4 bytes constant "BVMF" @64) — overlaps
+///              InvestorID@64 (V2 Prefix(2)@64 + Document(4)@66)
+///   varData: text (uint8 length + bytes)
+/// </summary>
+internal static class OrderMassActionReportEncoder
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+    public const int BlockLength = 70;
+
+    /// <summary>Maximum text varData length (schema cap).</summary>
+    public const int MaxTextLength = 250;
+
+    public const byte MassActionTypeCancelOrders = 3;
+    public const byte MassActionResponseRejected = (byte)'0';
+    public const byte MassActionResponseAccepted = (byte)'1';
+    public const byte RejectReasonMassActionNotSupported = 0;
+    public const byte RejectReasonInvalidOrUnknownMarketSegment = 8;
+    public const byte RejectReasonOther = 99;
+
+    /// <summary>Total wire size with <paramref name="textLen"/> bytes of text varData.</summary>
+    public static int TotalSize(int textLen) => HeaderSize + BlockLength + 1 /*text len*/ + textLen;
+
+    public static int EncodeOrderMassActionReport(Span<byte> dst,
+        uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
+        ulong clOrdIdValue, ulong massActionReportId, ulong transactTimeNanos,
+        byte massActionResponse, byte? massActionRejectReason,
+        byte? side, long securityId,
+        ReadOnlySpan<byte> textAscii)
+    {
+        if (textAscii.Length > MaxTextLength)
+            throw new ArgumentException($"text exceeds {MaxTextLength} bytes", nameof(textAscii));
+
+        int total = TotalSize(textAscii.Length);
+        if (dst.Length < total)
+            throw new ArgumentException("buffer too small for OrderMassActionReport", nameof(dst));
+
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: BlockLength,
+            EntryPointFrameReader.TidOrderMassActionReport, version: 6);
+
+        var body = dst.Slice(HeaderSize, BlockLength);
+        body.Clear();
+
+        // OutboundBusinessHeader
+        MemoryMarshal.Write(body.Slice(0, 4), in sessionId);
+        MemoryMarshal.Write(body.Slice(4, 4), in msgSeqNum);
+        MemoryMarshal.Write(body.Slice(8, 8), in sendingTimeNanos);
+        body[16] = 0;     // EventIndicator
+        body[17] = 255;   // MarketSegmentID null
+
+        body[18] = MassActionTypeCancelOrders;
+        body[19] = 255;   // MassActionScope null
+        MemoryMarshal.Write(body.Slice(20, 8), in clOrdIdValue);
+        MemoryMarshal.Write(body.Slice(28, 8), in massActionReportId);
+        MemoryMarshal.Write(body.Slice(36, 8), in transactTimeNanos);
+        body[44] = massActionResponse;
+        body[45] = massActionRejectReason ?? (byte)255;
+        body[46] = 255;   // ExecRestatementReason null
+        body[47] = 0;     // OrdTagID null
+        body[48] = side ?? (byte)0;
+        // body[49] padding
+        // body[50..56] Asset null (zeros)
+        ulong securityIdRaw = securityId == 0 ? 0UL : (ulong)securityId;
+        MemoryMarshal.Write(body.Slice(56, 8), in securityIdRaw);
+        // SecurityExchange "BVMF" at offset 64 (V1 base) — overlaps
+        // InvestorID@64 in V2; we always write the constant.
+        body[64] = (byte)'B';
+        body[65] = (byte)'V';
+        body[66] = (byte)'M';
+        body[67] = (byte)'F';
+        // body[68..70] padding (overlaps remainder of InvestorID.Document)
+
+        // varData: text
+        var trailer = dst.Slice(HeaderSize + BlockLength, total - HeaderSize - BlockLength);
+        trailer[0] = (byte)textAscii.Length;
+        if (textAscii.Length > 0) textAscii.CopyTo(trailer.Slice(1));
+        return total;
+    }
+
+    public static int EncodeOrderMassActionReportWithText(Span<byte> dst,
+        uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
+        ulong clOrdIdValue, ulong massActionReportId, ulong transactTimeNanos,
+        byte massActionResponse, byte? massActionRejectReason,
+        byte? side, long securityId, string? text)
+    {
+        if (string.IsNullOrEmpty(text))
+        {
+            return EncodeOrderMassActionReport(dst, sessionId, msgSeqNum, sendingTimeNanos,
+                clOrdIdValue, massActionReportId, transactTimeNanos,
+                massActionResponse, massActionRejectReason, side, securityId, ReadOnlySpan<byte>.Empty);
+        }
+        Span<byte> tmp = stackalloc byte[MaxTextLength];
+        int len = Encoding.ASCII.GetBytes(text.AsSpan(0, Math.Min(text.Length, MaxTextLength)), tmp);
+        return EncodeOrderMassActionReport(dst, sessionId, msgSeqNum, sendingTimeNanos,
+            clOrdIdValue, massActionReportId, transactTimeNanos,
+            massActionResponse, massActionRejectReason, side, securityId, tmp.Slice(0, len));
+    }
+}

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -75,6 +75,26 @@ public sealed class HostRouter : IInboundCommandSink
             RejectUnknownInstrument(cmd.Buy.SecurityId, session, cmd.BuyClOrdIdValue);
     }
 
+    public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
+    {
+        // Spec §4.8 / #GAP-19 — when SecurityId is supplied we route to
+        // exactly one dispatcher (unknown SecurityId → no-op: the gateway
+        // has already emitted an OrderMassActionReport(ACCEPTED) for the
+        // request, and there is nothing to cancel). When SecurityId is
+        // null/zero the request can target ANY of the firm's resting
+        // orders, so we fan it out to every dispatcher; each one filters
+        // its OrderOwnership map and emits one ER_Cancel per matching
+        // resting order owned by this session.
+        if (cmd.SecurityId != 0)
+        {
+            if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
+                disp.EnqueueMassCancel(cmd, session, enteringFirm);
+            return;
+        }
+        foreach (var disp in _allDispatchers)
+            disp.EnqueueMassCancel(cmd, session, enteringFirm);
+    }
+
     public void OnDecodeError(SessionId session, string error)
     {
         // Logging hook only. The FixpSession itself emits the

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -70,6 +70,9 @@ public enum CancelReason : byte
     /// policy because an incoming aggressor from the same firm would have
     /// crossed against it.</summary>
     SelfTradePrevention,
+    /// <summary>Resting order cancelled by an OrderMassActionRequest
+    /// (template 701 → ER_Cancel; spec §4.8 / #GAP-19).</summary>
+    MassCancel,
 }
 
 /// <summary>
@@ -126,3 +129,18 @@ public sealed record CrossOrderCommand(
     ulong BuyClOrdIdValue,
     ulong SellClOrdIdValue,
     ulong CrossId);
+
+/// <summary>
+/// Mass-cancel command (OrderMassActionRequest template 701, spec §4.8 /
+/// #GAP-19). The engine itself only ever sees a flat list of orderIds —
+/// the channel dispatcher resolves the (session, firm, optional Side,
+/// optional SecurityId) filter set against its <c>OrderOwnership</c> map
+/// before invoking <see cref="MatchingEngine.MassCancel"/>. A
+/// <c>SecurityId</c> of zero (the schema's null sentinel) means "any
+/// instrument in this dispatcher's books"; the host router fans the
+/// inbound command out to every channel when no security id is set.
+/// </summary>
+public sealed record MassCancelCommand(
+    long SecurityId,
+    Side? SideFilter,
+    ulong EnteredAtNanos);

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -178,6 +178,45 @@ public sealed class MatchingEngine
         finally { ExitDispatch(); }
     }
 
+    /// <summary>
+    /// Mass-cancel the supplied resting orderIds (spec §4.8 / #GAP-19).
+    /// Each resolved order emits one <see cref="OrderCanceledEvent"/> with
+    /// <see cref="CancelReason.MassCancel"/>; orderIds that no longer
+    /// resolve (already filled / cancelled in the same dispatch turn)
+    /// are skipped silently. Returns the number of orders actually
+    /// cancelled. Caller (the channel dispatcher) is expected to have
+    /// already filtered by session / firm / side / asset using its
+    /// <c>OrderOwnership</c> map, so the engine sees only orderIds.
+    /// </summary>
+    public int MassCancel(IReadOnlyCollection<long> orderIds, ulong enteredAtNanos)
+    {
+        ArgumentNullException.ThrowIfNull(orderIds);
+        if (orderIds.Count == 0) return 0;
+        EnterDispatch();
+        try
+        {
+            int cancelled = 0;
+            foreach (var orderId in orderIds)
+            {
+                // Locate the book that owns this orderId. Mass-cancel runs
+                // in O(books × orderIds) which is acceptable since a typical
+                // mass-cancel touches a small number of resting orders
+                // within one channel.
+                foreach (var book in _booksById.Values)
+                {
+                    if (book.TryGet(orderId, out var resting))
+                    {
+                        EmitCanceled(book, resting, enteredAtNanos, CancelReason.MassCancel);
+                        cancelled++;
+                        break;
+                    }
+                }
+            }
+            return cancelled;
+        }
+        finally { ExitDispatch(); }
+    }
+
     public void Replace(ReplaceOrderCommand cmd)
     {
         EnterDispatch();

--- a/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
@@ -23,6 +23,7 @@ public class BusinessHeaderSessionIdValidationTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -20,6 +20,7 @@ public class EntryPointHeartbeatTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
@@ -23,6 +23,7 @@ public class EntryPointListenerDailyResetTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
@@ -25,6 +25,7 @@ public class EntryPointListenerReaperTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
@@ -23,6 +23,7 @@ public class EntryPointStrictGatingTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
@@ -21,6 +21,7 @@ public class EntryPointTerminateOnErrorTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
@@ -22,6 +22,7 @@ public class FixpSessionReattachTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
@@ -21,6 +21,7 @@ public class FixpSessionRetransmitTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
@@ -25,6 +25,7 @@ public class FixpSessionSuspendTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
     }

--- a/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
@@ -23,6 +23,7 @@ public class InboundMsgSeqNumGapTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/OrderMassActionRequestDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/OrderMassActionRequestDecoderTests.cs
@@ -1,0 +1,158 @@
+using System.Runtime.InteropServices;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Body-only decoder tests for OrderMassActionRequest (template 701,
+/// spec §4.8 / #GAP-19). Wire framing (SOFH+SBE) is exercised by the
+/// E2E suite — this file pins field offsets and the
+/// Success/UnsupportedFeature/DecodeError mapping in isolation.
+/// </summary>
+public class OrderMassActionRequestDecoderTests
+{
+    private const int BlockLength = 52;
+
+    private static byte[] BuildRequest(byte massActionType = 3, byte side = 0,
+        ulong securityId = 0, byte ordTagId = 0, byte[]? asset = null, byte[]? investorId = null,
+        ulong clOrdId = 4242UL)
+    {
+        var body = new byte[BlockLength];
+        body[18] = massActionType;
+        MemoryMarshal.Write(body.AsSpan(20, 8), in clOrdId);
+        body[29] = ordTagId;
+        body[30] = side;
+        if (asset != null) asset.CopyTo(body.AsSpan(32, 6));
+        MemoryMarshal.Write(body.AsSpan(38, 8), in securityId);
+        if (investorId != null) investorId.CopyTo(body.AsSpan(46, 6));
+        return body;
+    }
+
+    [Fact]
+    public void Success_NoFilters()
+    {
+        var body = BuildRequest();
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, enteredAtNanos: 100UL, out var cmd, out var clOrd, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(4242UL, clOrd);
+        Assert.Equal(0L, cmd.SecurityId);
+        Assert.Null(cmd.SideFilter);
+        Assert.Equal(100UL, cmd.EnteredAtNanos);
+    }
+
+    [Fact]
+    public void Success_SideFilter_Buy()
+    {
+        var body = BuildRequest(side: (byte)'1');
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out var cmd, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(Side.Buy, cmd.SideFilter);
+    }
+
+    [Fact]
+    public void Success_SideFilter_Sell()
+    {
+        var body = BuildRequest(side: (byte)'2');
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out var cmd, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(Side.Sell, cmd.SideFilter);
+    }
+
+    [Fact]
+    public void Success_SecurityIdFilter()
+    {
+        var body = BuildRequest(securityId: 900_000_000_001UL);
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out var cmd, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(900_000_000_001L, cmd.SecurityId);
+    }
+
+    [Fact]
+    public void UnsupportedFeature_ReleaseFromSuspension()
+    {
+        var body = BuildRequest(massActionType: 2);
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("MassActionType", msg);
+    }
+
+    [Fact]
+    public void UnsupportedFeature_CancelAndSuspend()
+    {
+        var body = BuildRequest(massActionType: 4);
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+    }
+
+    [Fact]
+    public void UnsupportedFeature_OrdTagIdSet()
+    {
+        var body = BuildRequest(ordTagId: 7);
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("OrdTagID", msg);
+    }
+
+    [Fact]
+    public void UnsupportedFeature_AssetSet()
+    {
+        var body = BuildRequest(asset: new byte[] { (byte)'D', (byte)'O', (byte)'L', 0, 0, 0 });
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("Asset", msg);
+    }
+
+    [Fact]
+    public void UnsupportedFeature_InvestorIdSet()
+    {
+        // Non-"BVMF" bytes at offset 46 indicate V2 InvestorID is populated.
+        var body = BuildRequest(investorId: new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC });
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("InvestorID", msg);
+    }
+
+    [Fact]
+    public void Success_SecurityExchangeBVMFTreatedAsNoInvestorId()
+    {
+        // V1 base layout writes the constant SecurityExchange "BVMF" at
+        // offset 46; the decoder must NOT treat that as a populated
+        // InvestorID.
+        var body = BuildRequest(investorId: new byte[] { (byte)'B', (byte)'V', (byte)'M', (byte)'F', 0, 0 });
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+    }
+
+    [Fact]
+    public void DecodeError_InvalidMassActionType()
+    {
+        var body = BuildRequest(massActionType: 99);
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("invalid MassActionType", msg);
+    }
+
+    [Fact]
+    public void DecodeError_InvalidSide()
+    {
+        var body = BuildRequest(side: (byte)'9');
+        var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
+            body, 0UL, out _, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.DecodeError, outcome);
+        Assert.Contains("Side", msg);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
@@ -21,6 +21,7 @@ public class SessionLifecycleMetricsWiringTests
         public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
         public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -336,6 +336,106 @@ public class ExchangeHostE2ETests
             $"missing symbols: {string.Join(",", expectedSymbols.Except(seenSymbols))}");
     }
 
+    [Fact]
+    public async Task OrderMassActionRequest_CancelsAllRestingOrdersForSession()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        // Place two resting BUY orders.
+        await stream.WriteAsync(BuildSimpleNewOrder(clOrdId: 7001, secId: Petr,
+            side: '1', ordType: '2', tif: '0', qty: 100, priceMantissa: 100_000));
+        var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+        await stream.WriteAsync(BuildSimpleNewOrder(clOrdId: 7002, secId: Petr,
+            side: '1', ordType: '2', tif: '0', qty: 200, priceMantissa: 99_000));
+        var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er2.TemplateId);
+
+        // Mass-cancel all orders on this security (no Side filter).
+        await stream.WriteAsync(BuildOrderMassActionRequest(clOrdId: 7100, secId: Petr));
+
+        // Expect: OrderMassActionReport(ACCEPTED) first, then 2 ER_Cancel
+        // frames (one per resting order) — order between the two cancels
+        // is FIFO-by-orderId and not part of the assertion.
+        var report = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidOrderMassActionReport, report.TemplateId);
+        Assert.Equal((byte)'1', report.Body[44]); // MassActionResponse = ACCEPTED
+        ulong reportClOrd = BinaryPrimitives.ReadUInt64LittleEndian(report.Body.AsSpan(20, 8));
+        Assert.Equal(7100UL, reportClOrd);
+
+        var cancel1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, cancel1.TemplateId);
+        var cancel2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, cancel2.TemplateId);
+    }
+
+    [Fact]
+    public async Task OrderMassActionRequest_SideFilter_OnlyCancelsMatchingSide()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        // One BUY @ 100 and one SELL @ 200 — they don't cross.
+        await stream.WriteAsync(BuildSimpleNewOrder(clOrdId: 8001, secId: Petr,
+            side: '1', ordType: '2', tif: '0', qty: 100, priceMantissa: 100_000));
+        var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+        await stream.WriteAsync(BuildSimpleNewOrder(clOrdId: 8002, secId: Petr,
+            side: '2', ordType: '2', tif: '0', qty: 100, priceMantissa: 200_000));
+        var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er2.TemplateId);
+
+        // Mass-cancel only BUY side.
+        await stream.WriteAsync(BuildOrderMassActionRequest(clOrdId: 8100, secId: Petr, side: '1'));
+
+        var report = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidOrderMassActionReport, report.TemplateId);
+        Assert.Equal((byte)'1', report.Body[48]); // Side filter echoed = Buy
+
+        var cancel = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, cancel.TemplateId);
+        // Verify it cancelled the BUY (ER_Cancel.Side @ body[18] = '1')
+        Assert.Equal((byte)'1', cancel.Body[18]);
+    }
+
+    [Fact]
+    public async Task OrderMassActionRequest_OrdTagIdFilter_RejectedAsUnsupportedFeature()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        // Build a request with OrdTagID set (unsupported feature).
+        var frame = BuildOrderMassActionRequest(clOrdId: 9100, secId: Petr);
+        frame[EntryPointFrameReader.WireHeaderSize + 29] = 7; // OrdTagID
+        await stream.WriteAsync(frame);
+
+        var report = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidOrderMassActionReport, report.TemplateId);
+        Assert.Equal((byte)'0', report.Body[44]); // MassActionResponse = REJECTED
+        Assert.Equal((byte)0, report.Body[45]);   // RejectReason = MASS_ACTION_NOT_SUPPORTED
+    }
+
     private static byte[] BuildOrderCancelRequest(ulong clOrdId, long secId, ulong orderId, ulong origClOrdId, char side)
     {
         // 12-byte composite header (SOFH+SBE) + 76-byte OrderCancelRequest (V6) body.
@@ -438,6 +538,32 @@ public class ExchangeHostE2ETests
         body[58] = (byte)tif;
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        return frame;
+    }
+
+    private static byte[] BuildOrderMassActionRequest(ulong clOrdId, char? side = null, long? secId = null)
+    {
+        // 12-byte composite header (SOFH+SBE) + 52-byte OrderMassActionRequest (V6) body.
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 52];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: 52, templateId: EntryPointFrameReader.TidOrderMassActionRequest, version: 6);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        body[18] = 3;                  // MassActionType = CANCEL_ORDERS
+        body[19] = 255;                // MassActionScope null
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        body[28] = 255;                // ExecRestatementReason null
+        body[29] = 0;                  // OrdTagID null
+        body[30] = side.HasValue ? (byte)side.Value : (byte)0;
+        // body[31] padding; body[32..38] Asset null (zeros)
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(38, 8),
+            secId.HasValue ? (ulong)secId.Value : 0UL);
+        // body[46..52] InvestorID/SecurityExchange — leave as constant "BVMF"
+        body[46] = (byte)'B';
+        body[47] = (byte)'V';
+        body[48] = (byte)'M';
+        body[49] = (byte)'F';
         return frame;
     }
 


### PR DESCRIPTION
Implements EntryPoint **OrderMassActionRequest** (template 701) and
**OrderMassActionReport** (template 702) so a TCP session can cancel
its own resting orders in bulk.

## Wire format

- 701 decoder (V6, BlockLength=52) in `InboundMessageDecoder` with a
  3-state outcome (`Success` / `DecodeError` / `UnsupportedFeature`).
- 702 encoder (V6, BlockLength=70) in new
  `OrderMassActionReportEncoder`.
- `BusinessMessageReject` mapping for `refMsgType=29`.
- `FixpSession` dispatches 701, sends 702 (ACCEPTED) **synchronously**
  on receipt, then enqueues the `MassCancel` work item; per-order
  ER_Cancel frames flow asynchronously after the engine cancels each
  resting order.

## Routing

- `ChannelDispatcher.OrderOwnership` now stamps `Side` and `SecurityId`
  on every accepted order so it can resolve the
  `(firm, sessionId, side, securityId)` filter without bouncing through
  the engine.
- `HostRouter.EnqueueMassCancel` fans out to every dispatcher when
  `SecurityID` is null, otherwise routes to the single owning
  dispatcher.

## Engine

- `MatchingEngine.MassCancel(IReadOnlyCollection<long>, ulong)` cancels
  each resolved orderId atomically on the dispatch thread, emitting
  `CancelReason.MassCancel` on every cancel.

## Unsupported features

The engine doesn't track the following per-order today, so requests
containing these filters are rejected with
`702(REJECTED, MASS_ACTION_NOT_SUPPORTED=0)` — that's the FIX-spec
reject mechanism for 701, not a generic BMR:

- `Asset` filter
- `OrdTagID` filter
- `InvestorID` filter (mass-cancel on behalf of an investor)

## Tests

- 13 decoder unit tests covering the Success / UnsupportedFeature /
  DecodeError matrix.
- 3 E2E tests through the host: cancel-all, side-filtered cancel,
  unsupported-feature rejection. Total suite: 493 passing.
- `dotnet format --verify-no-changes` clean.

Closes #55.