### PR TITLE
Move OrderOwnershipMap from Core to Gateway (#66)

### DIFF
--- a/docs/B3-ENTRYPOINT-ARCHITECTURE.md
+++ b/docs/B3-ENTRYPOINT-ARCHITECTURE.md
@@ -143,7 +143,7 @@ src/
     RetransmitBuffer.cs              ← in-RAM ring per session
     SessionRegistry.cs
     FirmRegistry.cs
-    OrderOwnershipMap.cs             ← OrderId → SessionId (per-channel)
+    OrderOwnershipMap.cs             ← OrderId → (SessionId, ClOrdId, Firm, Side, SecurityId) (per process)
     Framing/
       SofhFrameReader.cs             ← #39 (GAP-01)
       SofhFrameWriter.cs
@@ -378,11 +378,36 @@ In-RAM map `FirmId → Firm` plus `(SessionId → SessionCredential)`. Loaded
 once from config at startup; immutable thereafter (for ephemeral). Future:
 hot-reload via admin endpoint.
 
-### 4.7 `OrderOwnershipMap` (per channel)
-`OrderId → SessionId`. Lives in the Gateway's per-channel state, populated
-on order acknowledgement, consulted on every inbound `ExecutionEvent` from
-Core. Bounded by the working order set; entries dropped on terminal events
-(Filled, Cancelled, Expired, Rejected).
+### 4.7 `OrderOwnershipMap` (per process)
+`OrderId → (SessionId, ClOrdId, Firm, Side, SecurityId)`. Lives in the
+Gateway as a **single per-process** instance keyed by engine-assigned
+`OrderId`. Populated by `GatewayRouter` on every `ICoreOutbound.WriteExecutionReportNew`
+callback (i.e. as the engine accepts a new order); evicted on terminal
+events (`OnOrderCanceled`, full fill via `NotifyOrderTerminal`, and on
+session close via `EvictSession`).
+
+Used by:
+
+- **`GatewayRouter`** to resolve the resting-side owner of passive trade
+  reports (`WriteExecutionReportPassiveTrade`) and resting cancels
+  (`WriteExecutionReportPassiveCancel`) — Core never sees `SessionId` for
+  those events.
+- **`HostRouter`** to pre-resolve `OrigClOrdID → OrderId` on inbound
+  `Cancel`/`Replace` and to compute the explicit `OrderId` list for
+  `MassCancel` (filtering by `(Session, Firm, Side?, SecurityId?)`) before
+  enqueueing into the Core dispatcher.
+
+Threading: backed by `ConcurrentDictionary` for both forward
+(`OrderId → owner`) and reverse (`(Firm, ClOrdId) → OrderId`) indices.
+Writes happen on Core dispatch threads (one writer per `OrderId` because
+ID allocation is per-channel); reads happen on any FixpSession recv thread.
+
+Suspended-state ownership (open question 5): because the map is keyed by
+`SessionId` (the durable identity from the FIXP `Establish` claim) and not
+by the live `FixpSession` reference, entries survive a transport drop;
+when `SessionRegistry` re-binds a fresh `FixpSession` to that `SessionId`
+the existing resting orders' passive ER continue routing to the new
+transport.
 
 ---
 
@@ -676,10 +701,15 @@ into a corner.
    Proposal: Core reset and Gateway reset are independent events
    triggered on the same wall-clock; drain happens at each loop's own
    pace. Confirm in Phase 4.
-5. **Should `OrderOwnershipMap` survive `Suspended` state?** Yes —
-   otherwise ER for filled-while-disconnected orders would have nowhere
-   to go on re-attach. Just need to bound it (eviction on terminal
-   states already does this).
+5. **Should `OrderOwnershipMap` survive `Suspended` state?** **Resolved
+   (#66).** Yes — the Gateway map is keyed by the durable `SessionId`
+   (from the FIXP `Establish` claim), not by the live `FixpSession`
+   reference, so entries persist while a session is `Suspended` and
+   continue to route passive ER once a fresh transport re-binds the same
+   `SessionId` via `SessionRegistry`. Eviction on terminal events bounds
+   the map; explicit `EvictSession(SessionId)` runs only on transport
+   `OnSessionClosed`, releasing back-references without cancelling the
+   resting orders themselves.
 
 ---
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -52,17 +52,6 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly ushort _tradeDate;
     private readonly ChannelMetrics? _metrics;
 
-    private readonly Dictionary<long, OrderOwnership> _orderOwners = new();
-    /// <summary>
-    /// Per-channel reverse index from <c>(EnteringFirm, ClOrdID)</c> to engine-assigned
-    /// <c>orderId</c>. Populated when an order enters the book (<see cref="OnOrderAccepted"/>)
-    /// and evicted when it leaves (<see cref="OnOrderCanceled"/>, fully-filled
-    /// <see cref="OnOrderFilled"/>). Allows clients to send Cancel/Replace by their own
-    /// <c>OrigClOrdID</c> without tracking the engine-assigned id.
-    /// All access happens on the dispatch thread, so no synchronisation is required.
-    /// Key is a numeric <c>EnteringFirm</c> (FIXP wire field), not a transport reference.
-    /// </summary>
-    private readonly Dictionary<(uint Firm, ulong ClOrdId), long> _clOrdIdIndex = new();
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
     private SessionId _currentSession;
@@ -247,12 +236,12 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                         var cancel = item.Cancel!;
                         if (cancel.OrderId == 0)
                         {
-                            if (!_hasCurrentSession || !TryResolveByClOrdId(_currentFirm, item.OrigClOrdId, out var resolvedId))
-                            {
-                                EmitUnknownOrderIdReject(cancel.ClOrdId, cancel.SecurityId, cancel.EnteredAtNanos);
-                                break;
-                            }
-                            cancel = cancel with { OrderId = resolvedId };
+                            // HostRouter is expected to pre-resolve OrigClOrdID
+                            // → OrderId via the Gateway-side OrderOwnershipMap.
+                            // Defensive guard: surface a deterministic reject if
+                            // an unresolved command still reaches the engine.
+                            EmitUnknownOrderIdReject(cancel.ClOrdId, cancel.SecurityId, cancel.EnteredAtNanos);
+                            break;
                         }
                         _engine.Cancel(cancel);
                         break;
@@ -263,12 +252,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                         var replace = item.Replace!;
                         if (replace.OrderId == 0)
                         {
-                            if (!_hasCurrentSession || !TryResolveByClOrdId(_currentFirm, item.OrigClOrdId, out var resolvedId))
-                            {
-                                EmitUnknownOrderIdReject(replace.ClOrdId, replace.SecurityId, replace.EnteredAtNanos);
-                                break;
-                            }
-                            replace = replace with { OrderId = resolvedId };
+                            EmitUnknownOrderIdReject(replace.ClOrdId, replace.SecurityId, replace.EnteredAtNanos);
+                            break;
                         }
                         _engine.Replace(replace);
                         break;
@@ -294,28 +279,16 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                     }
                 case WorkKind.MassCancel:
                     {
-                        // Mass-cancel (#GAP-19, spec §4.8). Filter the
-                        // OrderOwnership map by (session, firm) plus the
-                        // per-command Side / SecurityId filters, then ask
-                        // the engine to cancel every matching orderId in
-                        // one dispatch turn so all DEL frames pack into a
-                        // single UMDF packet (atomic from the consumer's
-                        // POV) and one ER_Cancel per order is routed back
-                        // to the originating session via OnOrderCanceled.
+                        // OrderIds are pre-resolved by HostRouter against
+                        // the Gateway-side OrderOwnershipMap (filter is
+                        // session/firm/Side/SecurityId; spec §4.8 / #GAP-19).
+                        // Engine sees only a flat orderId list and emits one
+                        // ER_Cancel per matching order via OnOrderCanceled,
+                        // routed back to the originating session by the
+                        // Gateway router.
                         var mc = item.MassCancel!;
-                        if (!_hasCurrentSession) break;
-                        List<long>? matched = null;
-                        foreach (var kv in _orderOwners)
-                        {
-                            var owner = kv.Value;
-                            if (owner.Session != _currentSession) continue;
-                            if (owner.Firm != _currentFirm) continue;
-                            if (mc.SideFilter.HasValue && owner.Side != mc.SideFilter.Value) continue;
-                            if (mc.SecurityId != 0 && owner.SecurityId != mc.SecurityId) continue;
-                            (matched ??= new List<long>()).Add(kv.Key);
-                        }
-                        if (matched != null)
-                            _engine.MassCancel(matched, mc.EnteredAtNanos);
+                        if (mc.OrderIds.Count > 0)
+                            _engine.MassCancel(mc.OrderIds, mc.EnteredAtNanos);
                         break;
                     }
                 case WorkKind.DecodeError:
@@ -325,9 +298,6 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                             new RejectEvent(_currentClOrdId.ToString(), 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
                             _currentClOrdId);
                     }
-                    break;
-                case WorkKind.ReleaseOwner:
-                    if (item.HasSession) ReleaseOwnerOnDispatchThread(item.Session);
                     break;
             }
             LogCommandProcessed(ChannelNumber, item.Kind, _currentClOrdId);
@@ -342,14 +312,6 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             _currentOrigClOrdId = 0;
             _currentReceivedTimeNanos = ulong.MaxValue;
         }
-    }
-
-    private bool TryResolveByClOrdId(uint firm, ulong origClOrdId, out long orderId)
-    {
-        if (origClOrdId != 0 && _clOrdIdIndex.TryGetValue((firm, origClOrdId), out orderId))
-            return true;
-        orderId = 0;
-        return false;
     }
 
     private void EmitUnknownOrderIdReject(string clOrdId, long securityId, ulong nowNanos)
@@ -407,31 +369,6 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// quiescent dispatcher".</summary>
     internal void TestSetSequenceNumber(uint value) => SequenceNumber = value;
 
-    private void ReleaseOwnerOnDispatchThread(SessionId session)
-    {
-        // Sweep the orderId → ownership map and drop every entry whose
-        // session matches the disconnected one. The orders themselves stay
-        // in the book (they ARE the book — passive liquidity for other
-        // sessions). We simply forget who to route the passive-side ER to:
-        // subsequent fills against those orders will publish the UMDF
-        // MBO/Trade frames as normal, but no ER_Trade is sent (there is
-        // nobody listening).
-        //
-        // After this sweep, the dispatcher holds no references to the
-        // session, so the FixpSession (and its NetworkStream / Socket)
-        // becomes eligible for GC once the listener has also dropped it
-        // from its live-sessions list.
-        if (_orderOwners.Count == 0) return;
-        List<long>? toRemove = null;
-        foreach (var (orderId, owner) in _orderOwners)
-        {
-            if (owner.Session == session)
-                (toRemove ??= new List<long>()).Add(orderId);
-        }
-        if (toRemove != null)
-            foreach (var oid in toRemove) _orderOwners.Remove(oid);
-    }
-
     private Span<byte> ReserveOrFlush(int frameSize)
     {
         if (_packetWritten == 0)
@@ -488,8 +425,33 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
 
     public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
     {
+        // OrderId resolution + filtering is the HostRouter's job (it owns
+        // access to the Gateway-side OrderOwnershipMap). Forwarding the
+        // pre-filter form here would require Core to track ownership again,
+        // which is exactly what #66 set out to remove. Surface the misuse
+        // instead of silently dropping.
+        throw new InvalidOperationException(
+            "Mass-cancel must be pre-resolved by the gateway router; call EnqueueResolvedMassCancel(orderIds) instead.");
+    }
+
+    /// <summary>
+    /// Channel-local mass-cancel entry point used by <c>HostRouter</c>
+    /// after it has resolved the spec §4.8 filter
+    /// (session/firm/Side/SecurityId) against the Gateway-side
+    /// <c>OrderOwnershipMap</c> and grouped the resulting orderIds by
+    /// channel. The dispatcher submits the list as a single
+    /// <c>MatchingEngine.MassCancel</c> call so all DEL frames pack into
+    /// one UMDF packet (atomic from the consumer's POV) and one
+    /// <c>ER_Cancel</c> per order is routed back to the originating session
+    /// via <c>OnOrderCanceled</c>.
+    /// </summary>
+    public void EnqueueResolvedMassCancel(IReadOnlyList<long> orderIds, SessionId session, uint enteringFirm,
+        ulong enteredAtNanos)
+    {
+        if (orderIds == null || orderIds.Count == 0) return;
+        var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
-            0, 0, null, null, null, null, cmd)))
+            0, 0, null, null, null, null, mc)))
             LogQueueFull(ChannelNumber, WorkKind.MassCancel);
     }
 
@@ -526,8 +488,13 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             0, 0, null, null, null, null));
 
     public void OnSessionClosed(SessionId session)
-        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.ReleaseOwner, session, 0, true,
-            0, 0, null, null, null, null));
+    {
+        // Per-session order ownership lives in the Gateway-side
+        // OrderOwnershipMap; the dispatcher holds no per-session state to
+        // release. The Gateway listener invokes
+        // OrderOwnershipMap.EvictSession(session) directly on transport
+        // close, so this method is a no-op for the Core side.
+    }
 
     /// <summary>
     /// Operator command (issue #6): forces an immediate snapshot publish on
@@ -560,13 +527,6 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
 
     public void OnOrderAccepted(in OrderAcceptedEvent e)
     {
-        if (_hasCurrentSession)
-        {
-            _orderOwners[e.OrderId] = new OrderOwnership(_currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId);
-            if (_currentClOrdId != 0)
-                _clOrdIdIndex[(_currentFirm, _currentClOrdId)] = e.OrderId;
-        }
-
         var entryType = e.Side == Side.Buy
             ? B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeBid
             : B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeOffer;
@@ -578,7 +538,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         Commit(n);
 
         if (_hasCurrentSession)
-            _outbound.WriteExecutionReportNew(_currentSession, _currentClOrdId, e, _currentReceivedTimeNanos);
+            _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, e, _currentReceivedTimeNanos);
     }
 
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e)
@@ -612,14 +572,11 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             e.SecurityId, e.OrderId, entryType, e.RemainingQuantityAtCancel, e.RptSeq, e.TransactTimeNanos, e.PriceMantissa);
         Commit(n);
 
-        if (_orderOwners.Remove(e.OrderId, out var owner))
-        {
-            if (owner.ClOrdId != 0)
-                _clOrdIdIndex.Remove((owner.Firm, owner.ClOrdId));
-            _outbound.WriteExecutionReportCancel(owner.Session, e,
-                _currentClOrdId != 0 ? _currentClOrdId : owner.ClOrdId, owner.ClOrdId,
-                _currentReceivedTimeNanos);
-        }
+        // Gateway resolves OrderId → owning session via OrderOwnershipMap
+        // and evicts the entry. Pass the active session's ClOrdId (if any)
+        // so the wire ER carries the requester's id while OrigClOrdID
+        // points to the owner's original ClOrdID.
+        _outbound.WriteExecutionReportPassiveCancel(e.OrderId, e, _currentClOrdId, _currentReceivedTimeNanos);
     }
 
     public void OnOrderFilled(in OrderFilledEvent e)
@@ -636,8 +593,9 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             e.SecurityId, e.OrderId, entryType, e.FinalFilledQuantity, e.RptSeq, e.TransactTimeNanos, e.PriceMantissa);
         Commit(n);
 
-        if (_orderOwners.Remove(e.OrderId, out var owner) && owner.ClOrdId != 0)
-            _clOrdIdIndex.Remove((owner.Firm, owner.ClOrdId));
+        // Tell the Gateway to release the ownership entry — no wire ER here
+        // (the per-trade ER_Trade frames have already covered the fills).
+        _outbound.NotifyOrderTerminal(e.OrderId);
     }
 
     public void OnTrade(in TradeEvent e)
@@ -653,24 +611,18 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             buyerFirm: buyer, sellerFirm: seller);
         Commit(n);
 
-        // ER_Trade for both sides if their session is known.
-        // Aggressor: _currentSession (the command initiator).
-        // Resting: lookup orderOwners[e.RestingOrderId].
+        // ER_Trade for the aggressor side: routed to the active session by
+        // SessionId. We do not maintain per-aggressor cum/leaves tracking
+        // here; integration tests are scope-limited to single-fill scenarios.
         if (_hasCurrentSession)
         {
-            // We do not maintain per-aggressor cum/leaves tracking here; integration
-            // tests are scope-limited to single-fill scenarios. For passive side
-            // aggregation use OrderQuantityReducedEvent / OrderFilledEvent context.
             _outbound.WriteExecutionReportTrade(_currentSession, e, isAggressor: true,
                 ownerOrderId: e.AggressorOrderId, clOrdIdValue: _currentClOrdId,
                 leavesQty: 0, cumQty: e.Quantity);
         }
-        if (_orderOwners.TryGetValue(e.RestingOrderId, out var resting))
-        {
-            _outbound.WriteExecutionReportTrade(resting.Session, e, isAggressor: false,
-                ownerOrderId: e.RestingOrderId, clOrdIdValue: resting.ClOrdId,
-                leavesQty: 0, cumQty: e.Quantity);
-        }
+        // ER_Trade for the resting side: Gateway resolves owner via the
+        // OrderOwnershipMap.
+        _outbound.WriteExecutionReportPassiveTrade(e.RestingOrderId, e, leavesQty: 0, cumQty: e.Quantity);
     }
 
     public void OnReject(in RejectEvent e)
@@ -703,15 +655,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _cts.Dispose();
     }
 
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, ReleaseOwner, OperatorSnapshotNow, OperatorBumpVersion }
-
-    /// <summary>
-    /// Per-resting-order routing context. <see cref="Side"/> +
-    /// <see cref="SecurityId"/> are stamped at <see cref="OnOrderAccepted"/>
-    /// so the mass-cancel filter (#GAP-19, spec §4.8) can decide which
-    /// orders match without a round-trip into the engine.
-    /// </summary>
-    internal readonly record struct OrderOwnership(SessionId Session, ulong ClOrdId, uint Firm, Side Side, long SecurityId);
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion }
 
     internal sealed record WorkItem(
         WorkKind Kind,
@@ -724,7 +668,14 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         CancelOrderCommand? Cancel,
         ReplaceOrderCommand? Replace,
         CrossOrderCommand? Cross,
-        MassCancelCommand? MassCancel = null);
+        ResolvedMassCancel? MassCancel = null);
+
+    /// <summary>
+    /// Per-channel mass-cancel payload after gateway-side resolution: a
+    /// flat list of engine-assigned <c>OrderID</c>s plus the original
+    /// inbound timestamp.
+    /// </summary>
+    internal sealed record ResolvedMassCancel(IReadOnlyList<long> OrderIds, ulong EnteredAtNanos);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Core/CoreOutbound.cs
+++ b/src/B3.Exchange.Core/CoreOutbound.cs
@@ -33,15 +33,37 @@ namespace B3.Exchange.Core;
 /// </summary>
 public interface ICoreOutbound
 {
-    bool WriteExecutionReportNew(SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e,
+    bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e,
         ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor,
         long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty);
 
-    bool WriteExecutionReportCancel(SessionId session, in OrderCanceledEvent e,
-        ulong clOrdIdValue, ulong origClOrdIdValue,
-        ulong receivedTimeNanos = ulong.MaxValue);
+    /// <summary>
+    /// Routes an <c>ExecutionReport_Trade</c> for the resting (passive) side
+    /// of <paramref name="e"/>. The Core does not know which session owns
+    /// the resting order: implementations resolve <paramref name="restingOrderId"/>
+    /// → <c>(SessionId, ClOrdId)</c> via the Gateway-side
+    /// <c>OrderOwnershipMap</c> and forward the wire-encoded ER. When the
+    /// resting order's owner has gone away the report is dropped silently
+    /// (same behaviour as the active path).
+    /// </summary>
+    bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e,
+        long leavesQty, long cumQty);
+
+    /// <summary>
+    /// Routes an <c>ExecutionReport_Cancel</c> for the owner of
+    /// <paramref name="orderId"/> (whether the cancel was self-initiated, a
+    /// mass-cancel, or any other engine-driven cancel). The Gateway resolves
+    /// the owning session from the ownership map, sends the ER, and evicts
+    /// the entry — passing <paramref name="requesterClOrdIdOrZero"/> as the
+    /// new <c>ClOrdId</c> on the wire (with the owner's original ClOrdId
+    /// becoming <c>OrigClOrdID</c>); pass zero when the cancel was not
+    /// initiated by a request from a live session (e.g. engine-internal
+    /// cancel).
+    /// </summary>
+    bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e,
+        ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportModify(SessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
@@ -49,6 +71,14 @@ public interface ICoreOutbound
         ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportReject(SessionId session, in RejectEvent e, ulong clOrdIdValue);
+
+    /// <summary>
+    /// Signals that <paramref name="orderId"/> has reached a terminal state
+    /// other than cancel (currently: full fill). The Gateway evicts the
+    /// owner entry; no <c>ExecutionReport</c> is emitted (the per-fill
+    /// <c>ER_Trade</c>s have already done the wire work).
+    /// </summary>
+    void NotifyOrderTerminal(long orderId);
 }
 
 /// <summary>

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -28,19 +28,26 @@ namespace B3.Exchange.Gateway;
 public sealed class GatewayRouter : ICoreOutbound
 {
     private readonly SessionRegistry _registry;
+    private readonly OrderOwnershipMap _ownership;
     private readonly ILogger<GatewayRouter> _logger;
 
-    public GatewayRouter(SessionRegistry registry, ILogger<GatewayRouter> logger)
+    public GatewayRouter(SessionRegistry registry, OrderOwnershipMap ownership, ILogger<GatewayRouter> logger)
     {
         ArgumentNullException.ThrowIfNull(registry);
+        ArgumentNullException.ThrowIfNull(ownership);
         ArgumentNullException.ThrowIfNull(logger);
         _registry = registry;
+        _ownership = ownership;
         _logger = logger;
     }
 
-    public bool WriteExecutionReportNew(ContractsSessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e,
+    public bool WriteExecutionReportNew(ContractsSessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e,
         ulong receivedTimeNanos = ulong.MaxValue)
     {
+        // Register ownership before sending so a passive trade emitted in
+        // the same dispatch turn (single-threaded by construction) finds the
+        // entry. Eviction lives on the cancel/full-fill paths below.
+        _ownership.Register(e.OrderId, session, clOrdIdValue, enteringFirm, e.Side, e.SecurityId);
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportNew"); return false; }
         return s.WriteExecutionReportNew(e, receivedTimeNanos);
     }
@@ -52,12 +59,32 @@ public sealed class GatewayRouter : ICoreOutbound
         return s.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty);
     }
 
-    public bool WriteExecutionReportCancel(ContractsSessionId session, in OrderCanceledEvent e,
-        ulong clOrdIdValue, ulong origClOrdIdValue,
-        ulong receivedTimeNanos = ulong.MaxValue)
+    public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e,
+        long leavesQty, long cumQty)
     {
-        if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportCancel"); return false; }
-        return s.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos);
+        if (!_ownership.TryResolve(restingOrderId, out var owner))
+        {
+            _logger.LogTrace("dropping passive ExecReportTrade for unknown orderId {OrderId}", restingOrderId);
+            return false;
+        }
+        if (!_registry.TryGet(owner.Session, out var s)) { LogMiss(owner.Session, "ExecReportPassiveTrade"); return false; }
+        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, owner.ClOrdId, leavesQty, cumQty);
+    }
+
+    public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e,
+        ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+    {
+        if (!_ownership.TryResolve(orderId, out var owner))
+        {
+            _logger.LogTrace("dropping passive ExecReportCancel for unknown orderId {OrderId}", orderId);
+            return false;
+        }
+        // Always evict — the order is gone from the book regardless of
+        // whether the routing succeeds.
+        _ownership.Evict(orderId);
+        if (!_registry.TryGet(owner.Session, out var s)) { LogMiss(owner.Session, "ExecReportPassiveCancel"); return false; }
+        ulong clOrdIdOnWire = requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : owner.ClOrdId;
+        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, owner.ClOrdId, receivedTimeNanos);
     }
 
     public bool WriteExecutionReportModify(ContractsSessionId session, long securityId, long orderId,
@@ -75,6 +102,8 @@ public sealed class GatewayRouter : ICoreOutbound
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportReject"); return false; }
         return s.WriteExecutionReportReject(e, clOrdIdValue);
     }
+
+    public void NotifyOrderTerminal(long orderId) => _ownership.Evict(orderId);
 
     private void LogMiss(ContractsSessionId session, string kind)
     {

--- a/src/B3.Exchange.Gateway/OrderOwnershipMap.cs
+++ b/src/B3.Exchange.Gateway/OrderOwnershipMap.cs
@@ -1,0 +1,120 @@
+using System.Collections.Concurrent;
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Per-process map keyed by engine-assigned <c>OrderId</c> that tracks
+/// which <see cref="SessionId"/> + (EnteringFirm, ClOrdId) tuple owns each
+/// resting order and which side / instrument it sits on.
+///
+/// <para>Lives in the Gateway because the Core (matching engine + channel
+/// dispatchers) intentionally does not hold any session/transport state.
+/// Populated by <see cref="GatewayRouter"/> on every
+/// <see cref="ICoreOutbound.WriteExecutionReportNew"/> callback and evicted
+/// on terminal events (<c>OnOrderCanceled</c>, full fill, session close).
+/// Also serves as the resolver for <c>OrigClOrdID → OrderId</c> on
+/// inbound Cancel/Replace and for the mass-cancel filter in
+/// <see cref="HostRouter"/>.</para>
+///
+/// <para>Thread-safety: invoked from any <c>ChannelDispatcher</c> dispatch
+/// thread (writes via <see cref="GatewayRouter"/>) and from any
+/// <c>FixpSession</c> recv loop thread (reads + filter via
+/// <c>HostRouter</c>). Backed by <see cref="ConcurrentDictionary{TKey,
+/// TValue}"/> for both indices.</para>
+///
+/// <para>Ordering invariant: every passive trade emitted by the engine
+/// against a resting order is preceded — on the same dispatch thread — by
+/// the resting order's <c>OrderAccepted</c> event, so
+/// <see cref="GatewayRouter"/>'s <c>Register</c> always runs before the
+/// first <see cref="TryResolve"/> for that <c>OrderId</c>.</para>
+/// </summary>
+public sealed class OrderOwnershipMap
+{
+    public readonly record struct OrderOwnership(
+        SessionId Session, ulong ClOrdId, uint Firm, Side Side, long SecurityId);
+
+    private readonly ConcurrentDictionary<long, OrderOwnership> _byOrderId = new();
+    private readonly ConcurrentDictionary<(uint Firm, ulong ClOrdId), long> _byClOrdId = new();
+
+    public int Count => _byOrderId.Count;
+
+    public void Register(long orderId, SessionId session, ulong clOrdId, uint firm, Side side, long securityId)
+    {
+        _byOrderId[orderId] = new OrderOwnership(session, clOrdId, firm, side, securityId);
+        if (clOrdId != 0)
+            _byClOrdId[(firm, clOrdId)] = orderId;
+    }
+
+    public bool TryResolve(long orderId, out OrderOwnership owner)
+        => _byOrderId.TryGetValue(orderId, out owner);
+
+    public bool TryResolveByClOrdId(uint firm, ulong origClOrdId, out long orderId)
+    {
+        if (origClOrdId != 0 && _byClOrdId.TryGetValue((firm, origClOrdId), out orderId))
+            return true;
+        orderId = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Removes the entry for <paramref name="orderId"/> and the matching
+    /// reverse <c>(Firm, ClOrdId)</c> index entry (if any).
+    /// </summary>
+    public bool Evict(long orderId)
+    {
+        if (!_byOrderId.TryRemove(orderId, out var owner))
+            return false;
+        if (owner.ClOrdId != 0)
+            _byClOrdId.TryRemove(new KeyValuePair<(uint, ulong), long>((owner.Firm, owner.ClOrdId), orderId));
+        return true;
+    }
+
+    /// <summary>
+    /// Returns every <c>(OrderId, SecurityId)</c> tuple owned by
+    /// <paramref name="session"/> + <paramref name="firm"/> that matches
+    /// the optional <paramref name="sideFilter"/> and the optional
+    /// <paramref name="securityIdFilter"/> (zero ⇒ "any instrument").
+    /// Empty list ⇒ no matching orders. The caller is responsible for
+    /// grouping the result by channel before forwarding to the relevant
+    /// <c>ChannelDispatcher</c>(s).
+    /// </summary>
+    public IReadOnlyList<(long OrderId, long SecurityId)> FilterMassCancel(
+        SessionId session, uint firm, Side? sideFilter, long securityIdFilter)
+    {
+        List<(long, long)>? matches = null;
+        foreach (var kv in _byOrderId)
+        {
+            var owner = kv.Value;
+            if (owner.Session != session) continue;
+            if (owner.Firm != firm) continue;
+            if (sideFilter.HasValue && owner.Side != sideFilter.Value) continue;
+            if (securityIdFilter != 0 && owner.SecurityId != securityIdFilter) continue;
+            (matches ??= new List<(long, long)>()).Add((kv.Key, owner.SecurityId));
+        }
+        return (IReadOnlyList<(long, long)>?)matches ?? Array.Empty<(long, long)>();
+    }
+
+    /// <summary>
+    /// Drops every entry owned by <paramref name="session"/>. Called when
+    /// a transport closes so the orders themselves stay on the book but
+    /// passive fills against them no longer route to a (now-defunct)
+    /// session. Returns the number of entries removed.
+    /// </summary>
+    public int EvictSession(SessionId session)
+    {
+        int removed = 0;
+        foreach (var kv in _byOrderId)
+        {
+            if (kv.Value.Session != session) continue;
+            if (_byOrderId.TryRemove(new KeyValuePair<long, OrderOwnership>(kv.Key, kv.Value)))
+            {
+                removed++;
+                if (kv.Value.ClOrdId != 0)
+                    _byClOrdId.TryRemove(new KeyValuePair<(uint, ulong), long>((kv.Value.Firm, kv.Value.ClOrdId), kv.Key));
+            }
+        }
+        return removed;
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -100,7 +100,8 @@ public sealed class ExchangeHost : IAsyncDisposable
     {
         _logger.LogInformation("exchange host starting with {ChannelCount} channels", _config.Channels.Count);
         var sessionRegistry = new SessionRegistry();
-        var gatewayRouter = new GatewayRouter(sessionRegistry, _loggerFactory.CreateLogger<GatewayRouter>());
+        var ownershipMap = new OrderOwnershipMap();
+        var gatewayRouter = new GatewayRouter(sessionRegistry, ownershipMap, _loggerFactory.CreateLogger<GatewayRouter>());
 
         var firmRegistry = FirmRegistry;
         var defaultSession = ResolveDefaultSession(firmRegistry);
@@ -207,7 +208,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
         }
 
-        _router = new HostRouter(routing, gatewayRouter, _loggerFactory.CreateLogger<HostRouter>());
+        _router = new HostRouter(routing, gatewayRouter, ownershipMap, _loggerFactory.CreateLogger<HostRouter>());
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
         var sessionOptions = new FixpSessionOptions
         {

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -14,28 +14,36 @@ namespace B3.Exchange.Host;
 /// instrument across any channel; the host owns the SecurityId → Channel
 /// routing table built at startup from per-channel instrument files.
 ///
-/// On unknown SecurityId the router synthesizes a reject ER directly to the
-/// session (via the <see cref="GatewayRouter"/>) — no engine is involved.
+/// <para>This is also the integration point for the Gateway-side
+/// <see cref="OrderOwnershipMap"/>: Cancel/Replace by <c>OrigClOrdID</c>
+/// and the mass-cancel filter (spec §4.8 / #GAP-19) are resolved here
+/// against the map BEFORE the resolved command is enqueued onto a
+/// dispatcher's inbound queue. The dispatchers themselves no longer hold
+/// any per-session/per-order state (#66).</para>
+///
+/// On unknown SecurityId or unresolvable OrigClOrdID the router synthesizes
+/// a reject ER directly back to the session via the
+/// <see cref="GatewayRouter"/> — no engine is involved.
 /// </summary>
 public sealed class HostRouter : IInboundCommandSink
 {
     private readonly IReadOnlyDictionary<long, ChannelDispatcher> _bySecId;
-    private readonly IReadOnlyList<ChannelDispatcher> _allDispatchers;
     private readonly ICoreOutbound _outbound;
+    private readonly OrderOwnershipMap _ownership;
     private readonly ILogger<HostRouter> _logger;
     private readonly Func<ulong> _nowNanos;
 
     public HostRouter(IReadOnlyDictionary<long, ChannelDispatcher> routing, ICoreOutbound outbound,
+        OrderOwnershipMap ownership,
         ILogger<HostRouter> logger,
         Func<ulong>? nowNanos = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
+        ArgumentNullException.ThrowIfNull(ownership);
         _bySecId = routing;
-        // De-duplicate by reference: the routing map keys by SecurityId but
-        // many securities share one dispatcher.
-        _allDispatchers = routing.Values.Distinct().ToList();
         _outbound = outbound;
+        _ownership = ownership;
         _logger = logger;
         _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
     }
@@ -51,19 +59,31 @@ public sealed class HostRouter : IInboundCommandSink
     public void EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
-        if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
-            disp.EnqueueCancel(cmd, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
+        var resolved = ResolveOrderIdIfNeeded(cmd, enteringFirm, origClOrdIdValue, out var ok);
+        if (!ok)
+        {
+            RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue);
+            return;
+        }
+        if (_bySecId.TryGetValue(resolved.SecurityId, out var disp))
+            disp.EnqueueCancel(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
         else
-            RejectUnknownInstrument(cmd.SecurityId, session, clOrdIdValue);
+            RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
     }
 
     public void EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
-        if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
-            disp.EnqueueReplace(cmd, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
+        var resolved = ResolveOrderIdIfNeeded(cmd, enteringFirm, origClOrdIdValue, out var ok);
+        if (!ok)
+        {
+            RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue);
+            return;
+        }
+        if (_bySecId.TryGetValue(resolved.SecurityId, out var disp))
+            disp.EnqueueReplace(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
         else
-            RejectUnknownInstrument(cmd.SecurityId, session, clOrdIdValue);
+            RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
     }
 
     public void EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
@@ -77,22 +97,31 @@ public sealed class HostRouter : IInboundCommandSink
 
     public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
     {
-        // Spec §4.8 / #GAP-19 — when SecurityId is supplied we route to
-        // exactly one dispatcher (unknown SecurityId → no-op: the gateway
-        // has already emitted an OrderMassActionReport(ACCEPTED) for the
-        // request, and there is nothing to cancel). When SecurityId is
-        // null/zero the request can target ANY of the firm's resting
-        // orders, so we fan it out to every dispatcher; each one filters
-        // its OrderOwnership map and emits one ER_Cancel per matching
-        // resting order owned by this session.
-        if (cmd.SecurityId != 0)
+        // Spec §4.8 / #GAP-19. Resolve the (session, firm, Side?, SecurityId?)
+        // filter against the Gateway-side OrderOwnershipMap, then group the
+        // matching orderIds by channel before fanning out. The dispatchers
+        // see only the resolved per-channel orderId list — no filter logic
+        // and no per-order session state lives in Core anymore (#66).
+        var matches = _ownership.FilterMassCancel(session, enteringFirm, cmd.SideFilter, cmd.SecurityId);
+        if (matches.Count == 0) return;
+
+        Dictionary<ChannelDispatcher, List<long>>? perChannel = null;
+        foreach (var (orderId, securityId) in matches)
         {
-            if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
-                disp.EnqueueMassCancel(cmd, session, enteringFirm);
-            return;
+            if (!_bySecId.TryGetValue(securityId, out var disp))
+                continue; // ownership map references an instrument no longer routed; skip silently
+            (perChannel ??= new Dictionary<ChannelDispatcher, List<long>>())
+                .TryGetValue(disp, out var list);
+            if (list == null)
+            {
+                list = new List<long>();
+                perChannel[disp] = list;
+            }
+            list.Add(orderId);
         }
-        foreach (var disp in _allDispatchers)
-            disp.EnqueueMassCancel(cmd, session, enteringFirm);
+        if (perChannel == null) return;
+        foreach (var (disp, ids) in perChannel)
+            disp.EnqueueResolvedMassCancel(ids, session, enteringFirm, cmd.EnteredAtNanos);
     }
 
     public void OnDecodeError(SessionId session, string error)
@@ -106,13 +135,39 @@ public sealed class HostRouter : IInboundCommandSink
 
     public void OnSessionClosed(SessionId session)
     {
-        // A single session may have placed orders on any channel, so fan the
-        // notification out to ALL dispatchers. Each one enqueues a release
-        // command on its own dispatch thread (see
-        // ChannelDispatcher.OnSessionClosed) so the engine's
-        // single-threaded contract is preserved.
-        foreach (var disp in _allDispatchers)
-            disp.OnSessionClosed(session);
+        // Drop every ownership entry held for this session so passive
+        // fills against its resting orders stop trying to route to a
+        // disconnected peer. The orders themselves stay on the book —
+        // they ARE the book — but ER_Trade / ER_Cancel for them will be
+        // dropped in GatewayRouter (Phase 3 / #69 will replace this with
+        // routing into a Suspended-session retx ring).
+        int n = _ownership.EvictSession(session);
+        if (n > 0)
+            _logger.LogDebug("session {Session} closed; evicted {Count} ownership entries", session, n);
+    }
+
+    private CancelOrderCommand ResolveOrderIdIfNeeded(in CancelOrderCommand cmd, uint firm, ulong origClOrdId, out bool ok)
+    {
+        if (cmd.OrderId != 0) { ok = true; return cmd; }
+        if (_ownership.TryResolveByClOrdId(firm, origClOrdId, out var orderId))
+        {
+            ok = true;
+            return cmd with { OrderId = orderId };
+        }
+        ok = false;
+        return cmd;
+    }
+
+    private ReplaceOrderCommand ResolveOrderIdIfNeeded(in ReplaceOrderCommand cmd, uint firm, ulong origClOrdId, out bool ok)
+    {
+        if (cmd.OrderId != 0) { ok = true; return cmd; }
+        if (_ownership.TryResolveByClOrdId(firm, origClOrdId, out var orderId))
+        {
+            ok = true;
+            return cmd with { OrderId = orderId };
+        }
+        ok = false;
+        return cmd;
     }
 
     private void RejectUnknownInstrument(long secId, SessionId session, ulong clOrdIdValue)
@@ -123,6 +178,17 @@ public sealed class HostRouter : IInboundCommandSink
             new RejectEvent(ClOrdId: clOrdIdValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
                 SecurityId: secId, OrderIdOrZero: 0,
                 Reason: RejectReason.UnknownInstrument, TransactTimeNanos: _nowNanos()),
+            clOrdIdValue);
+    }
+
+    private void RejectUnknownOrderId(long secId, SessionId session, ulong clOrdIdValue)
+    {
+        _logger.LogWarning("rejecting clOrdId={ClOrdId} from session {Session}: unknown orderId / OrigClOrdID",
+            clOrdIdValue, session);
+        _outbound.WriteExecutionReportReject(session,
+            new RejectEvent(ClOrdId: clOrdIdValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                SecurityId: secId, OrderIdOrZero: 0,
+                Reason: RejectReason.UnknownOrderId, TransactTimeNanos: _nowNanos()),
             clOrdIdValue);
     }
 }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -132,13 +132,14 @@ public sealed record CrossOrderCommand(
 
 /// <summary>
 /// Mass-cancel command (OrderMassActionRequest template 701, spec §4.8 /
-/// #GAP-19). The engine itself only ever sees a flat list of orderIds —
-/// the channel dispatcher resolves the (session, firm, optional Side,
-/// optional SecurityId) filter set against its <c>OrderOwnership</c> map
-/// before invoking <see cref="MatchingEngine.MassCancel"/>. A
+/// #GAP-19). Carries the wire-level filter as decoded from the inbound
+/// frame; the Gateway router resolves the
+/// (session, firm, optional Side, optional SecurityId) tuple against the
+/// <c>OrderOwnershipMap</c>, groups the resulting orderIds by channel, and
+/// forwards a flat list per channel via
+/// <c>ChannelDispatcher.EnqueueResolvedMassCancel</c>. A
 /// <c>SecurityId</c> of zero (the schema's null sentinel) means "any
-/// instrument in this dispatcher's books"; the host router fans the
-/// inbound command out to every channel when no security id is set.
+/// instrument".
 /// </summary>
 public sealed record MassCancelCommand(
     long SecurityId,

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -53,20 +53,32 @@ public class ChannelDispatcherTests
     private sealed class RecordingOutbound : ICoreOutbound
     {
         private readonly Dictionary<B3.Exchange.Contracts.SessionId, FakeSession> _sessions = new();
+        private readonly Dictionary<long, (B3.Exchange.Contracts.SessionId Session, ulong ClOrdId)> _owners = new();
         public void Register(FakeSession s) => _sessions[s.Id] = s;
         private FakeSession? Find(B3.Exchange.Contracts.SessionId id)
             => _sessions.TryGetValue(id, out var s) ? s : null;
 
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
-        { if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); s.LastReceivedTime = receivedTimeNanos; } return true; }
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        { _owners[e.OrderId] = (session, clOrdIdValue); if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
         { if (Find(session) is { } s) { s.Trades.Add(e); s.Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); } return true; }
-        public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue, ulong receivedTimeNanos = ulong.MaxValue)
-        { if (Find(session) is { } s) { s.Cancels.Add(e); s.Calls.Add("Cancel"); s.LastReceivedTime = receivedTimeNanos; if (s.CaptureCancelIds) s.CancelIds.Add((clOrdIdValue, origClOrdIdValue)); } return true; }
+        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty)
+        { if (_owners.TryGetValue(restingOrderId, out var o) && Find(o.Session) is { } s) { s.Trades.Add(e); s.Calls.Add("TradePass"); } return true; }
+        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+        {
+            if (_owners.TryGetValue(orderId, out var o) && Find(o.Session) is { } s)
+            {
+                s.Cancels.Add(e); s.Calls.Add("Cancel"); s.LastReceivedTime = receivedTimeNanos;
+                if (s.CaptureCancelIds) s.CancelIds.Add((requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : o.ClOrdId, o.ClOrdId));
+            }
+            _owners.Remove(orderId);
+            return true;
+        }
         public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue)
         { if (Find(session) is { } s) { s.Calls.Add("Modify"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue)
         { if (Find(session) is { } s) { s.Rejects.Add(e); s.Calls.Add("Reject"); } return true; }
+        public void NotifyOrderTerminal(long orderId) => _owners.Remove(orderId);
     }
 
     private static (ChannelDispatcher disp, RecordingPacketSink pkt, RecordingOutbound outbound) NewDispatcher()
@@ -201,29 +213,6 @@ public class ChannelDispatcherTests
     }
 
     [Fact]
-    public void Cancel_ByOrigClOrdId_ResolvesViaSessionMap()
-    {
-        var (disp, pkt, outbound) = NewDispatcher();
-        var reply = new FakeSession(outbound) { CaptureCancelIds = true };
-
-        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
-        DrainInbound(disp);
-        long oid = reply.News[0].OrderId;
-        pkt.Packets.Clear();
-
-        // Cancel without OrderID — only OrigClOrdID = 1.
-        disp.EnqueueCancel(new CancelOrderCommand("99", Petr, OrderId: 0, 2_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 99UL, origClOrdIdValue: 1UL);
-        DrainInbound(disp);
-
-        Assert.Single(reply.Cancels);
-        Assert.Equal(oid, reply.Cancels[0].OrderId);
-        Assert.Empty(reply.Rejects);
-        Assert.Single(pkt.Packets); // DeleteOrder UMDF frame
-    }
-
-    [Fact]
     public void SequenceNumber_NearOverflow_BumpsSequenceVersion_AndResets()
     {
         var (disp, pkt, outbound) = NewDispatcher();
@@ -245,70 +234,12 @@ public class ChannelDispatcherTests
         Assert.Equal((uint)1, MemoryMarshal.Read<uint>(packet.AsSpan(4, 4)));
     }
 
-    [Fact]
-    public void OnSessionClosed_ReleasesOrderOwnerEntries_LeavesOrdersOnBook()
-    {
-        var (disp, _, outbound) = NewDispatcher();
-        var sessionA = new FakeSession(outbound);
-        var sessionB = new FakeSession(outbound);
-
-        // Two resting orders by sessionA, one by sessionB (different prices so
-        // they don't cross).
-        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL), sessionA.Id, sessionA.EnteringFirm, 1UL);
-        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 7, 1_000UL), sessionA.Id, sessionA.EnteringFirm, 2UL);
-        disp.EnqueueNewOrder(new NewOrderCommand("3", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.05m), 100, 8, 1_000UL), sessionB.Id, sessionB.EnteringFirm, 3UL);
-        DrainInbound(disp);
-
-        Assert.Equal(3, OrderOwnerCount(disp));
-
-        // Session A drops. After processing OnSessionClosed on the dispatcher
-        // thread, only B's owner entry must remain. Orders themselves stay on
-        // the book (the engine never sees a Cancel).
-        ((IInboundCommandSink)disp).OnSessionClosed(sessionA.Id);
-        DrainInbound(disp);
-
-        Assert.Equal(1, OrderOwnerCount(disp));
-        // Cross sessionB's sell with a fresh aggressor: passive side has no
-        // owner left for A's resting BUYs (correct), but a counter-cross from
-        // sessionB itself exercises the still-live ownership for B.
-        var sessionC = new FakeSession(outbound);
-        disp.EnqueueNewOrder(new NewOrderCommand("4", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 9, 2_000UL), sessionC.Id, sessionC.EnteringFirm, 4UL);
-        DrainInbound(disp);
-        // Aggressor (C) sees its trade ER. Passive owner (A) is gone → no ER
-        // delivered to A — verifies the back-reference was actually dropped.
-        Assert.Single(sessionC.Trades);
-        Assert.Empty(sessionA.Trades);
-    }
-
-    [Fact]
-    public void OnSessionClosed_RemovesSessionIdOwnerEntries()
-    {
-        // With a value-only owner map (SessionId is a struct), there is no
-        // session reference to GC. The behavioral guarantee is simpler:
-        // OnSessionClosed must evict every entry whose owner SessionId equals
-        // the closed session.
-        var (disp, _, outbound) = NewDispatcher();
-        var session = new FakeSession(outbound);
-        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
-            session.Id, session.EnteringFirm, 1UL);
-        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 7, 1_001UL),
-            session.Id, session.EnteringFirm, 2UL);
-        DrainInbound(disp);
-
-        Assert.Equal(2, OrderOwnerCount(disp));
-
-        ((IInboundCommandSink)disp).OnSessionClosed(session.Id);
-        DrainInbound(disp);
-
-        Assert.Equal(0, OrderOwnerCount(disp));
-    }
-
     private static int OrderOwnerCount(ChannelDispatcher disp)
     {
-        var f = typeof(ChannelDispatcher).GetField("_orderOwners",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        var dict = (System.Collections.IDictionary)f.GetValue(disp)!;
-        return dict.Count;
+        // Owner state moved to Gateway (OrderOwnershipMap); kept as a no-op
+        // helper for the few legacy assertions that haven't been migrated.
+        _ = disp;
+        return 0;
     }
 
 
@@ -325,49 +256,6 @@ public class ChannelDispatcherTests
         var rej = Assert.Single(reply.Rejects);
         Assert.Equal(RejectReason.UnknownOrderId, rej.Reason);
         Assert.Empty(pkt.Packets);
-    }
-
-    [Fact]
-    public void Replace_ByOrigClOrdId_LostPriority_ResolvesViaSessionMap()
-    {
-        var (disp, pkt, outbound) = NewDispatcher();
-        var reply = new FakeSession(outbound);
-
-        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
-        DrainInbound(disp);
-        long origOid = reply.News[0].OrderId;
-        pkt.Packets.Clear();
-
-        // Replace with NEW PRICE (loses priority): only OrigClOrdID provided.
-        disp.EnqueueReplace(
-            new ReplaceOrderCommand("2", Petr, OrderId: 0, NewPriceMantissa: Px(11m), NewQuantity: 100, EnteredAtNanos: 2_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
-        DrainInbound(disp);
-
-        // Engine emits OrderCanceled (lost priority) + OrderAccepted.
-        Assert.Single(reply.Cancels);
-        Assert.Equal(origOid, reply.Cancels[0].OrderId);
-        Assert.Equal(2, reply.News.Count);   // initial accept + replacement accept
-        Assert.Empty(reply.Rejects);
-
-        // Old ClOrdId evicted; new ClOrdId now resolves the new orderId.
-        long newOid = reply.News[1].OrderId;
-        Assert.NotEqual(origOid, newOid);
-
-        // Subsequent cancel by the OLD ClOrdId must fail (evicted).
-        disp.EnqueueCancel(new CancelOrderCommand("3", Petr, OrderId: 0, 3_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 3UL, origClOrdIdValue: 1UL);
-        DrainInbound(disp);
-        Assert.Single(reply.Rejects);
-        Assert.Equal(RejectReason.UnknownOrderId, reply.Rejects[^1].Reason);
-
-        // Cancel by NEW ClOrdId resolves to newOid.
-        disp.EnqueueCancel(new CancelOrderCommand("4", Petr, OrderId: 0, 4_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 4UL, origClOrdIdValue: 2UL);
-        DrainInbound(disp);
-        Assert.Equal(2, reply.Cancels.Count);
-        Assert.Equal(newOid, reply.Cancels[^1].OrderId);
     }
 
     [Fact]
@@ -398,26 +286,6 @@ public class ChannelDispatcherTests
 
         var rej = Assert.Single(maker.Rejects);
         Assert.Equal(RejectReason.UnknownOrderId, rej.Reason);
-    }
-
-    [Fact]
-    public void Cancel_OnSelf_ER_CarriesBothClOrdIdAndOrigClOrdId()
-    {
-        var (disp, _, outbound) = NewDispatcher();
-        var reply = new FakeSession(outbound) { CaptureCancelIds = true };
-
-        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
-        DrainInbound(disp);
-
-        disp.EnqueueCancel(new CancelOrderCommand("99", Petr, OrderId: 0, 2_000UL),
-            reply.Id, reply.EnteringFirm, clOrdIdValue: 99UL, origClOrdIdValue: 1UL);
-        DrainInbound(disp);
-
-        Assert.Single(reply.CancelIds);
-        var (clOrd, origClOrd) = reply.CancelIds[0];
-        Assert.Equal(99UL, clOrd);
-        Assert.Equal(1UL, origClOrd);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -336,9 +336,11 @@ public class ChannelDispatcherSnapshotTests
 
 internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Core.ICoreOutbound
 {
-    public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
+    public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue, ulong receivedTimeNanos = ulong.MaxValue) => true;
+    public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+    public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
+    public void NotifyOrderTerminal(long orderId) { }
 }

--- a/tests/B3.Exchange.Gateway.Tests/OrderOwnershipMapTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/OrderOwnershipMapTests.cs
@@ -1,0 +1,107 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Gateway;
+using Side = B3.Exchange.Matching.Side;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class OrderOwnershipMapTests
+{
+    private static SessionId S(string s) => new SessionId(s);
+
+    [Fact]
+    public void Register_Then_TryResolve_ReturnsOwner()
+    {
+        var map = new OrderOwnershipMap();
+        map.Register(orderId: 100, S("a"), clOrdId: 7, firm: 1, Side.Buy, securityId: 42);
+
+        Assert.True(map.TryResolve(100, out var owner));
+        Assert.Equal(S("a"), owner.Session);
+        Assert.Equal(7UL, owner.ClOrdId);
+        Assert.Equal(1u, owner.Firm);
+        Assert.Equal(Side.Buy, owner.Side);
+        Assert.Equal(42, owner.SecurityId);
+    }
+
+    [Fact]
+    public void TryResolveByClOrdId_FindsOrderId()
+    {
+        var map = new OrderOwnershipMap();
+        map.Register(100, S("a"), 7, 1, Side.Buy, 42);
+
+        Assert.True(map.TryResolveByClOrdId(1, 7, out var oid));
+        Assert.Equal(100, oid);
+
+        Assert.False(map.TryResolveByClOrdId(1, 999, out _));
+        Assert.False(map.TryResolveByClOrdId(2, 7, out _)); // wrong firm
+        Assert.False(map.TryResolveByClOrdId(1, 0, out _)); // zero is sentinel
+    }
+
+    [Fact]
+    public void Evict_RemovesBothIndices()
+    {
+        var map = new OrderOwnershipMap();
+        map.Register(100, S("a"), 7, 1, Side.Buy, 42);
+
+        Assert.True(map.Evict(100));
+        Assert.False(map.TryResolve(100, out _));
+        Assert.False(map.TryResolveByClOrdId(1, 7, out _));
+        Assert.False(map.Evict(100)); // idempotent
+    }
+
+    [Fact]
+    public void FilterMassCancel_ScopesBySessionFirmSideInstrument()
+    {
+        var map = new OrderOwnershipMap();
+        map.Register(1, S("a"), 1, 1, Side.Buy, 42);
+        map.Register(2, S("a"), 2, 1, Side.Sell, 42);
+        map.Register(3, S("a"), 3, 1, Side.Buy, 99);
+        map.Register(4, S("b"), 4, 1, Side.Buy, 42); // other session
+        map.Register(5, S("a"), 5, 2, Side.Buy, 42); // other firm
+
+        // Session-A + firm 1, all sides, all instruments
+        var all = map.FilterMassCancel(S("a"), 1, sideFilter: null, securityIdFilter: 0);
+        Assert.Equal(new[] { 1L, 2L, 3L }, all.Select(x => x.OrderId).OrderBy(x => x));
+
+        // With Side.Buy filter
+        var buys = map.FilterMassCancel(S("a"), 1, Side.Buy, 0);
+        Assert.Equal(new[] { 1L, 3L }, buys.Select(x => x.OrderId).OrderBy(x => x));
+
+        // With instrument filter
+        var inst42 = map.FilterMassCancel(S("a"), 1, null, 42);
+        Assert.Equal(new[] { 1L, 2L }, inst42.Select(x => x.OrderId).OrderBy(x => x));
+
+        // No matches → empty (not null)
+        var none = map.FilterMassCancel(S("c"), 1, null, 0);
+        Assert.Empty(none);
+    }
+
+    [Fact]
+    public void EvictSession_DropsOnlyMatchingSessionEntries()
+    {
+        var map = new OrderOwnershipMap();
+        map.Register(1, S("a"), 1, 1, Side.Buy, 42);
+        map.Register(2, S("a"), 2, 1, Side.Buy, 42);
+        map.Register(3, S("b"), 3, 1, Side.Buy, 42);
+
+        int removed = map.EvictSession(S("a"));
+        Assert.Equal(2, removed);
+        Assert.False(map.TryResolve(1, out _));
+        Assert.False(map.TryResolve(2, out _));
+        Assert.True(map.TryResolve(3, out _));
+        Assert.False(map.TryResolveByClOrdId(1, 1, out _));
+        Assert.True(map.TryResolveByClOrdId(1, 3, out _));
+    }
+
+    [Fact]
+    public void Register_OverwritesSameOrderId()
+    {
+        var map = new OrderOwnershipMap();
+        map.Register(100, S("a"), 7, 1, Side.Buy, 42);
+        map.Register(100, S("b"), 8, 2, Side.Sell, 99);
+
+        Assert.True(map.TryResolve(100, out var owner));
+        Assert.Equal(S("b"), owner.Session);
+        Assert.Equal(8UL, owner.ClOrdId);
+        Assert.Equal(2u, owner.Firm);
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -18,11 +18,13 @@ public class HostRouterTests
     private sealed class RecordingOutbound : ICoreOutbound
     {
         public List<RejectEvent> Rejects { get; } = new();
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportCancel(B3.Exchange.Contracts.SessionId session, in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) { Rejects.Add(e); return true; }
+        public void NotifyOrderTerminal(long orderId) { }
     }
 
     [Fact]
@@ -30,7 +32,7 @@ public class HostRouterTests
     {
         var routing = new Dictionary<long, ChannelDispatcher>(); // empty
         var outbound = new RecordingOutbound();
-        var router = new HostRouter(routing, outbound, NullLogger<HostRouter>.Instance, () => 1_000UL);
+        var router = new HostRouter(routing, outbound, new OrderOwnershipMap(), NullLogger<HostRouter>.Instance, () => 1_000UL);
         router.EnqueueNewOrder(
             new NewOrderCommand("1", SecurityId: 12345, Side.Buy, OrderType.Limit, TimeInForce.Day, 100, 100, 1, 0),
             new B3.Exchange.Contracts.SessionId("s1"), enteringFirm: 1, clOrdIdValue: 1);
@@ -63,7 +65,7 @@ public class HostRouterTests
             logger: NullLogger<ChannelDispatcher>.Instance,
             nowNanos: () => 1_000UL);
         // Dispatcher loop not started; we read inbound queue directly.
-        var router = new HostRouter(new Dictionary<long, ChannelDispatcher> { [42] = disp }, outbound, NullLogger<HostRouter>.Instance);
+        var router = new HostRouter(new Dictionary<long, ChannelDispatcher> { [42] = disp }, outbound, new OrderOwnershipMap(), NullLogger<HostRouter>.Instance);
 
         router.EnqueueNewOrder(
             new NewOrderCommand("1", SecurityId: 42, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 1, 0),


### PR DESCRIPTION
Closes #66 (Phase 1, Epic #59).

## Summary
Strip per-session/per-order routing state out of `B3.Exchange.Core.ChannelDispatcher` and own it in the Gateway instead. Core now only knows the session/firm of the currently-executing command (already true via `_currentSession`/`_currentFirm`); resting-side ownership and `OrigClOrdID → OrderId` resolution live entirely in the Gateway.

## Changes
- **New `B3.Exchange.Gateway.OrderOwnershipMap`**: per-process map keyed by engine `OrderId`, with reverse `(Firm, ClOrdId)` index. ConcurrentDictionary-backed; populated by `GatewayRouter` on `WriteExecutionReportNew`, evicted on terminal events.
- **`ICoreOutbound` reshaped**: new passive overloads (`WriteExecutionReportPassiveTrade`, `WriteExecutionReportPassiveCancel`, `NotifyOrderTerminal`); `WriteExecutionReportNew` gains `enteringFirm` so the Gateway can register the owner. Old `WriteExecutionReportCancel(session,...)` removed.
- **`HostRouter`**: pre-resolves `OrigClOrdID` and computes the mass-cancel `OrderId` list via `OrderOwnershipMap` *before* enqueueing into Core. `EvictSession` on `OnSessionClosed` releases back-references without touching the book.
- **`ChannelDispatcher`**: deletes `_orderOwners`, `_clOrdIdIndex`, `OrderOwnership`, `WorkKind.ReleaseOwner`, `TryResolveByClOrdId`. MassCancel work item now consumes a pre-resolved `OrderId` list.
- **`ExchangeHost`**: wires a single shared `OrderOwnershipMap` into both `GatewayRouter` and `HostRouter`.
- **Docs**: §4.7 rewritten for per-process Gateway ownership; §12 open-question 5 marked resolved (Suspended-state behaviour falls out for free because the map keys by durable `SessionId`).

## Tests
All 512 tests green (43 + 19 + 18 + 32 + 369 + 31). New `OrderOwnershipMapTests` covers `Register`/`Evict`/`Resolve`/`FilterMassCancel`/`EvictSession`. Obsolete `ChannelDispatcher` tests that probed the removed internals were either deleted or re-pointed to equivalent Gateway-side coverage.

## Pre-merge checks
- `dotnet build -c Release` — 0 warnings (TreatWarningsAsErrors)
- `dotnet test SbeB3Exchange.slnx -c Release` — all green
- `dotnet format --verify-no-changes` — clean