### PR TITLE
Additional synthetic strategies: meanReverting / momentum / sweeper (#13)

### DIFF
--- a/config/synthetic-trader.json
+++ b/config/synthetic-trader.json
@@ -28,6 +28,29 @@
           "maxLotMultiple": 3,
           "crossTicks": 2
         }
+        // Additional taker strategies are available — uncomment to enable:
+        // ,{
+        //   "kind": "meanReverting",
+        //   "name": "meanrev-petr4",
+        //   "alpha": 0.1,                // EWMA smoothing factor (0,1]
+        //   "entryThresholdTicks": 5,    // ticks of mid deviation before firing
+        //   "crossTicks": 2,             // marketable offset on entry
+        //   "lotsPerOrder": 2            // size = lotsPerOrder * lotSize
+        // },
+        // {
+        //   "kind": "momentum",
+        //   "name": "momo-petr4",
+        //   "triggerTicks": 3,           // per-tick mid-step before firing
+        //   "crossTicks": 1,
+        //   "lotsPerOrder": 1
+        // },
+        // {
+        //   "kind": "sweeper",
+        //   "name": "sweep-petr4",
+        //   "triggerProbability": 0.02,  // per-tick fire probability [0,1]
+        //   "sweepLots": 25,             // size = sweepLots * lotSize
+        //   "crossTicks": 5              // ≥ levels-to-clear * mm.quoteSpacingTicks
+        // }
       ]
     }
   ]

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -198,13 +198,16 @@ once at startup so the inbound recv thread has a fixed identity table).
 
 ## 4. Synthetic trader recipes
 
-`config/synthetic-trader.json` is the bundled sample. Two strategies
+`config/synthetic-trader.json` is the bundled sample. Five strategies
 ship today (per `SyntheticTraderConfig.cs`):
 
 | Strategy `kind` | Knobs | Behaviour |
 | --- | --- | --- |
 | `marketMaker` | `levelsPerSide`, `quoteSpacingTicks`, `replaceDistanceTicks`, `quantity` | Posts `levelsPerSide` resting quotes either side of the mid; replaces when the mid drifts more than `replaceDistanceTicks`. |
 | `noiseTaker` | `orderProbability`, `maxLotMultiple`, `crossTicks` | On each tick, with `orderProbability`, sends an aggressive marketable order up to `maxLotMultiple` × lot, priced `crossTicks` past the touch. |
+| `meanReverting` | `alpha`, `entryThresholdTicks`, `crossTicks`, `lotsPerOrder` | Tracks an EWMA of the mid (`alpha` ∈ (0,1]); when the live mid deviates by ≥ `entryThresholdTicks`, sends a marketable IOC of `lotsPerOrder × lotSize` in the *contrarian* direction. |
+| `momentum` | `triggerTicks`, `crossTicks`, `lotsPerOrder` | Compares the mid to the previous tick; when the per-tick step is ≥ `triggerTicks`, sends a marketable IOC *in the direction of the move*. |
+| `sweeper` | `triggerProbability`, `sweepLots`, `crossTicks` | Per-tick fire (uniform side) of a large marketable IOC sized `sweepLots × lotSize`, priced `crossTicks` past the mid. Configure `crossTicks ≥ N × marketMaker.quoteSpacingTicks` to actually walk N levels. |
 
 Tuning recipes:
 
@@ -212,6 +215,16 @@ Tuning recipes:
   `quoteSpacingTicks=1`, `quantity=100`. Drop the `noiseTaker`.
 * **Continuous trade flow:** `marketMaker` with `levelsPerSide=3` plus
   one `noiseTaker` at `orderProbability=0.3`. (This is the default.)
+* **Trend / mean-reversion mix:** add a `momentum` strategy
+  (`triggerTicks=2`, `lotsPerOrder=1`) plus a `meanReverting`
+  (`alpha=0.1`, `entryThresholdTicks=5`) — momentum amplifies short
+  mid-drift bursts and mean-revert fades extended drifts; together they
+  produce more interesting trade prints than `noiseTaker` alone.
+* **Trade-through / sweep exercise:** add a `sweeper` with
+  `triggerProbability=0.02`, `sweepLots` ≥ 5×`marketMaker.quantity`/`lotSize`,
+  and `crossTicks ≥ levelsPerSide × quoteSpacingTicks` so the sweep walks
+  the full visible book — exercises consumer-side trade-through fills
+  and snapshot recovery.
 * **Burst load (throttle exercise):** raise the synthetic trader's
   `tickIntervalMs` down to `10–20` and bump `noiseTaker.orderProbability`
   to `0.9` — the per-session throttle (`exch_throttle_rejected_total`)

--- a/src/B3.Exchange.SyntheticTrader/MeanRevertingStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/MeanRevertingStrategy.cs
@@ -1,0 +1,81 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Mean-reverting marketable taker. Maintains an exponentially-weighted
+/// moving average (EWMA) of the observed midprice and, when the live mid
+/// deviates from the EWMA by at least <see cref="EntryThresholdTicks"/>
+/// ticks, sends a marketable IOC limit in the *contrarian* direction
+/// (sell when above the EWMA, buy when below) sized at
+/// <see cref="LotsPerOrder"/> × the instrument's lot size.
+///
+/// <para>The EWMA uses <see cref="Alpha"/> as the smoothing factor:
+/// <c>ema = alpha*mid + (1 - alpha)*ema</c>. The first observed tick
+/// seeds the EWMA verbatim — until then, no orders are produced.</para>
+///
+/// <para>State (<c>_ema</c>, <c>_seeded</c>) is mutated only inside
+/// <see cref="Tick"/>, which the runner contract guarantees is invoked
+/// serially on the runner's tick task. The strategy holds no RNG of its
+/// own; all randomness flows through the supplied seeded
+/// <see cref="Random"/>.</para>
+/// </summary>
+public sealed class MeanRevertingStrategy : IStrategy
+{
+    private double _ema;
+    private bool _seeded;
+    private long _seq;
+
+    public string Name { get; }
+    public double Alpha { get; }
+    public int EntryThresholdTicks { get; }
+    public int CrossTicks { get; }
+    public long LotsPerOrder { get; }
+
+    public MeanRevertingStrategy(string name, double alpha, int entryThresholdTicks, int crossTicks, long lotsPerOrder)
+    {
+        if (alpha <= 0 || alpha > 1) throw new ArgumentOutOfRangeException(nameof(alpha));
+        if (entryThresholdTicks <= 0) throw new ArgumentOutOfRangeException(nameof(entryThresholdTicks));
+        if (crossTicks <= 0) throw new ArgumentOutOfRangeException(nameof(crossTicks));
+        if (lotsPerOrder <= 0) throw new ArgumentOutOfRangeException(nameof(lotsPerOrder));
+        Name = name;
+        Alpha = alpha;
+        EntryThresholdTicks = entryThresholdTicks;
+        CrossTicks = crossTicks;
+        LotsPerOrder = lotsPerOrder;
+    }
+
+    public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng)
+    {
+        long mid = state.MidMantissa;
+        long tick = state.TickSize <= 0 ? 1 : state.TickSize;
+        long lot = state.LotSize <= 0 ? 1 : state.LotSize;
+
+        if (!_seeded)
+        {
+            _ema = mid;
+            _seeded = true;
+            return Array.Empty<OrderIntent>();
+        }
+
+        double prevEma = _ema;
+        _ema = Alpha * mid + (1 - Alpha) * prevEma;
+
+        long thresholdMantissa = (long)EntryThresholdTicks * tick;
+        long deviation = mid - (long)prevEma;
+        if (deviation >= thresholdMantissa)
+        {
+            // Mid is rich vs EWMA → fade the rally with a SELL.
+            long px = mid - (long)CrossTicks * tick;
+            if (px <= 0) return Array.Empty<OrderIntent>();
+            string tag = $"{Name}-{state.SecurityId}-S-{++_seq}";
+            return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, OrderSide.Sell, LotsPerOrder * lot, px, tag) };
+        }
+        if (deviation <= -thresholdMantissa)
+        {
+            // Mid is cheap vs EWMA → fade the dip with a BUY.
+            long px = mid + (long)CrossTicks * tick;
+            string tag = $"{Name}-{state.SecurityId}-B-{++_seq}";
+            return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, OrderSide.Buy, LotsPerOrder * lot, px, tag) };
+        }
+        return Array.Empty<OrderIntent>();
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/MomentumStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/MomentumStrategy.cs
@@ -1,0 +1,73 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Momentum marketable taker. Compares the live mid against the mid
+/// observed on the previous <see cref="Tick"/> call; when the per-tick
+/// step is at least <see cref="TriggerTicks"/> ticks, sends a marketable
+/// IOC limit *in the direction of the move* (buy on up-tick, sell on
+/// down-tick) sized at <see cref="LotsPerOrder"/> × the instrument's lot
+/// size.
+///
+/// <para>The first observed tick seeds the previous-mid reference; no
+/// orders are produced until the second tick. State is mutated only
+/// inside <see cref="Tick"/>, which the runner invokes serially.</para>
+///
+/// <para>Pairs naturally with <see cref="MeanRevertingStrategy"/> on the
+/// same instrument: momentum amplifies short bursts, mean-revert fades
+/// extended drifts. The mid random walk in the runner
+/// (<c>midDriftProbability</c>) provides the trigger flow.</para>
+/// </summary>
+public sealed class MomentumStrategy : IStrategy
+{
+    private long _prevMid;
+    private bool _seeded;
+    private long _seq;
+
+    public string Name { get; }
+    public int TriggerTicks { get; }
+    public int CrossTicks { get; }
+    public long LotsPerOrder { get; }
+
+    public MomentumStrategy(string name, int triggerTicks, int crossTicks, long lotsPerOrder)
+    {
+        if (triggerTicks <= 0) throw new ArgumentOutOfRangeException(nameof(triggerTicks));
+        if (crossTicks <= 0) throw new ArgumentOutOfRangeException(nameof(crossTicks));
+        if (lotsPerOrder <= 0) throw new ArgumentOutOfRangeException(nameof(lotsPerOrder));
+        Name = name;
+        TriggerTicks = triggerTicks;
+        CrossTicks = crossTicks;
+        LotsPerOrder = lotsPerOrder;
+    }
+
+    public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng)
+    {
+        long mid = state.MidMantissa;
+        long tick = state.TickSize <= 0 ? 1 : state.TickSize;
+        long lot = state.LotSize <= 0 ? 1 : state.LotSize;
+
+        if (!_seeded)
+        {
+            _prevMid = mid;
+            _seeded = true;
+            return Array.Empty<OrderIntent>();
+        }
+
+        long step = mid - _prevMid;
+        _prevMid = mid;
+        long thresholdMantissa = (long)TriggerTicks * tick;
+        if (step >= thresholdMantissa)
+        {
+            long px = mid + (long)CrossTicks * tick;
+            string tag = $"{Name}-{state.SecurityId}-B-{++_seq}";
+            return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, OrderSide.Buy, LotsPerOrder * lot, px, tag) };
+        }
+        if (step <= -thresholdMantissa)
+        {
+            long px = mid - (long)CrossTicks * tick;
+            if (px <= 0) return Array.Empty<OrderIntent>();
+            string tag = $"{Name}-{state.SecurityId}-S-{++_seq}";
+            return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, OrderSide.Sell, LotsPerOrder * lot, px, tag) };
+        }
+        return Array.Empty<OrderIntent>();
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/SweeperStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/SweeperStrategy.cs
@@ -1,0 +1,62 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Periodic large marketable order designed to clear several levels of
+/// the resting book in one shot — useful for exercising trade-through
+/// fills, partial-fill bookkeeping, and the snapshot/incremental
+/// recovery path on the consumer side.
+///
+/// <para>On each tick, with probability <see cref="TriggerProbability"/>,
+/// emits a single marketable IOC limit:</para>
+/// <list type="bullet">
+///   <item>Side is uniform-random (RNG-driven).</item>
+///   <item>Quantity is <see cref="SweepLots"/> × the instrument's lot
+///   size. Set this several times larger than a typical
+///   market-maker level so the sweep actually walks the book.</item>
+///   <item>Price is the live mid offset by <see cref="CrossTicks"/>
+///   ticks in the aggressor's direction; for a true "clear N levels"
+///   sweep, configure <c>crossTicks ≥ N × marketMaker.quoteSpacingTicks</c>.</item>
+/// </list>
+///
+/// <para>Holds no internal state across ticks beyond a per-instance
+/// monotonic <c>_seq</c> for tag uniqueness. RNG is the runner-supplied
+/// seeded <see cref="Random"/>; the strategy is fully deterministic for a
+/// given (state, rng-state) sequence.</para>
+/// </summary>
+public sealed class SweeperStrategy : IStrategy
+{
+    private long _seq;
+
+    public string Name { get; }
+    public double TriggerProbability { get; }
+    public long SweepLots { get; }
+    public int CrossTicks { get; }
+
+    public SweeperStrategy(string name, double triggerProbability, long sweepLots, int crossTicks)
+    {
+        if (triggerProbability < 0 || triggerProbability > 1) throw new ArgumentOutOfRangeException(nameof(triggerProbability));
+        if (sweepLots <= 0) throw new ArgumentOutOfRangeException(nameof(sweepLots));
+        if (crossTicks <= 0) throw new ArgumentOutOfRangeException(nameof(crossTicks));
+        Name = name;
+        TriggerProbability = triggerProbability;
+        SweepLots = sweepLots;
+        CrossTicks = crossTicks;
+    }
+
+    public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng)
+    {
+        if (rng.NextDouble() >= TriggerProbability)
+            return Array.Empty<OrderIntent>();
+
+        long tick = state.TickSize <= 0 ? 1 : state.TickSize;
+        long lot = state.LotSize <= 0 ? 1 : state.LotSize;
+        var side = rng.Next(2) == 0 ? OrderSide.Buy : OrderSide.Sell;
+        long qty = SweepLots * lot;
+        long px = side == OrderSide.Buy
+            ? state.MidMantissa + (long)CrossTicks * tick
+            : state.MidMantissa - (long)CrossTicks * tick;
+        if (px <= 0) return Array.Empty<OrderIntent>();
+        string tag = $"{Name}-{state.SecurityId}-{(side == OrderSide.Buy ? "B" : "S")}-{++_seq}";
+        return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, side, qty, px, tag) };
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
@@ -48,7 +48,8 @@ public sealed class InstrumentConfig
 
 public sealed class StrategyConfig
 {
-    /// <summary>One of: <c>marketMaker</c>, <c>noiseTaker</c>.</summary>
+    /// <summary>One of: <c>marketMaker</c>, <c>noiseTaker</c>,
+    /// <c>meanReverting</c>, <c>momentum</c>, <c>sweeper</c>.</summary>
     [JsonPropertyName("kind")] public string Kind { get; set; } = "";
     [JsonPropertyName("name")] public string Name { get; set; } = "";
 
@@ -62,6 +63,20 @@ public sealed class StrategyConfig
     [JsonPropertyName("orderProbability")] public double OrderProbability { get; set; } = 0.2;
     [JsonPropertyName("maxLotMultiple")] public int MaxLotMultiple { get; set; } = 3;
     [JsonPropertyName("crossTicks")] public int CrossTicks { get; set; } = 1;
+
+    // MeanReverting / Momentum / Sweeper
+    /// <summary>EWMA smoothing factor for <c>meanReverting</c> (0,1].</summary>
+    [JsonPropertyName("alpha")] public double Alpha { get; set; } = 0.1;
+    /// <summary>Tick-distance from the EWMA at which <c>meanReverting</c> fires.</summary>
+    [JsonPropertyName("entryThresholdTicks")] public int EntryThresholdTicks { get; set; } = 3;
+    /// <summary>Per-tick mid-step (in ticks) at which <c>momentum</c> fires.</summary>
+    [JsonPropertyName("triggerTicks")] public int TriggerTicks { get; set; } = 2;
+    /// <summary>Lots per order for <c>meanReverting</c> / <c>momentum</c>.</summary>
+    [JsonPropertyName("lotsPerOrder")] public long LotsPerOrder { get; set; } = 1;
+    /// <summary>Per-tick fire probability for <c>sweeper</c> [0,1].</summary>
+    [JsonPropertyName("triggerProbability")] public double TriggerProbability { get; set; } = 0.05;
+    /// <summary>Lots per sweep order; size <c>sweepLots * lotSize</c>.</summary>
+    [JsonPropertyName("sweepLots")] public long SweepLots { get; set; } = 10;
 }
 
 public static class SyntheticTraderConfigLoader
@@ -91,6 +106,15 @@ public static class SyntheticTraderConfigLoader
         "noiseTaker" => new NoiseTakerStrategy(
             string.IsNullOrEmpty(sc.Name) ? "noise" : sc.Name,
             sc.OrderProbability, sc.MaxLotMultiple, sc.CrossTicks),
+        "meanReverting" => new MeanRevertingStrategy(
+            string.IsNullOrEmpty(sc.Name) ? "meanrev" : sc.Name,
+            sc.Alpha, sc.EntryThresholdTicks, sc.CrossTicks, sc.LotsPerOrder),
+        "momentum" => new MomentumStrategy(
+            string.IsNullOrEmpty(sc.Name) ? "momo" : sc.Name,
+            sc.TriggerTicks, sc.CrossTicks, sc.LotsPerOrder),
+        "sweeper" => new SweeperStrategy(
+            string.IsNullOrEmpty(sc.Name) ? "sweep" : sc.Name,
+            sc.TriggerProbability, sc.SweepLots, sc.CrossTicks),
         _ => throw new InvalidOperationException($"unknown strategy kind '{sc.Kind}'"),
     };
 }

--- a/tests/B3.Exchange.SyntheticTrader.Tests/AdditionalStrategyTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/AdditionalStrategyTests.cs
@@ -1,0 +1,223 @@
+namespace B3.Exchange.SyntheticTrader.Tests;
+
+/// <summary>
+/// Unit tests for the additional taker strategies added with issue #13:
+/// MeanReverting, Momentum, Sweeper. Same fixed-RNG / hand-built
+/// MarketState approach as <see cref="StrategyTests"/>.
+/// </summary>
+public class AdditionalStrategyTests
+{
+    private static MarketState State(long mid = 100_0000, long tick = 100, long lot = 100)
+        => new(SecurityId: 1, MidMantissa: mid, TickSize: tick, LotSize: lot,
+            LastTradePxMantissa: mid, LastTradeQty: 0,
+            MyLiveOrders: Array.Empty<LiveOrder>());
+
+    // ---- MeanReverting --------------------------------------------------
+
+    [Fact]
+    public void MeanReverting_FirstTick_SeedsAndEmitsNothing()
+    {
+        var mr = new MeanRevertingStrategy("mr", alpha: 0.1, entryThresholdTicks: 3, crossTicks: 2, lotsPerOrder: 1);
+        Assert.Empty(mr.Tick(State(), new Random(1)));
+    }
+
+    [Fact]
+    public void MeanReverting_MidWellAboveEwma_SellsMarketable()
+    {
+        var mr = new MeanRevertingStrategy("mr", alpha: 0.1, entryThresholdTicks: 3, crossTicks: 2, lotsPerOrder: 2);
+        var rng = new Random(1);
+        // Seed at 100_0000 (EMA = 100_0000).
+        Assert.Empty(mr.Tick(State(mid: 100_0000), rng));
+        // Jump up to 100_1000 → deviation = +1000 mantissa = 10 ticks (>3) → SELL.
+        var intents = mr.Tick(State(mid: 100_1000), rng).ToList();
+        Assert.Single(intents);
+        var ord = intents[0];
+        Assert.Equal(OrderSide.Sell, ord.Side);
+        Assert.Equal(OrderTifIntent.IOC, ord.Tif);
+        Assert.Equal(100_1000 - 200, ord.PriceMantissa); // mid - crossTicks*tick
+        Assert.Equal(2 * 100, ord.Quantity);             // lotsPerOrder * lotSize
+    }
+
+    [Fact]
+    public void MeanReverting_MidWellBelowEwma_BuysMarketable()
+    {
+        var mr = new MeanRevertingStrategy("mr", alpha: 0.1, entryThresholdTicks: 3, crossTicks: 2, lotsPerOrder: 1);
+        var rng = new Random(1);
+        Assert.Empty(mr.Tick(State(mid: 100_0000), rng));
+        var intents = mr.Tick(State(mid: 99_9000), rng).ToList();
+        Assert.Single(intents);
+        var ord = intents[0];
+        Assert.Equal(OrderSide.Buy, ord.Side);
+        Assert.Equal(99_9000 + 200, ord.PriceMantissa);
+    }
+
+    [Fact]
+    public void MeanReverting_SmallMove_NoOrder()
+    {
+        var mr = new MeanRevertingStrategy("mr", alpha: 0.1, entryThresholdTicks: 5, crossTicks: 2, lotsPerOrder: 1);
+        var rng = new Random(1);
+        Assert.Empty(mr.Tick(State(mid: 100_0000), rng));
+        // 2-tick move (< threshold of 5).
+        Assert.Empty(mr.Tick(State(mid: 100_0200), rng));
+    }
+
+    [Fact]
+    public void MeanReverting_InvalidArgs_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MeanRevertingStrategy("x", alpha: 0, entryThresholdTicks: 1, crossTicks: 1, lotsPerOrder: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MeanRevertingStrategy("x", alpha: 1.5, entryThresholdTicks: 1, crossTicks: 1, lotsPerOrder: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MeanRevertingStrategy("x", alpha: 0.1, entryThresholdTicks: 0, crossTicks: 1, lotsPerOrder: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MeanRevertingStrategy("x", alpha: 0.1, entryThresholdTicks: 1, crossTicks: 0, lotsPerOrder: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new MeanRevertingStrategy("x", alpha: 0.1, entryThresholdTicks: 1, crossTicks: 1, lotsPerOrder: 0));
+    }
+
+    // ---- Momentum -------------------------------------------------------
+
+    [Fact]
+    public void Momentum_FirstTick_SeedsAndEmitsNothing()
+    {
+        var m = new MomentumStrategy("mo", triggerTicks: 2, crossTicks: 1, lotsPerOrder: 1);
+        Assert.Empty(m.Tick(State(), new Random(1)));
+    }
+
+    [Fact]
+    public void Momentum_UpTickAboveThreshold_BuysWithMid()
+    {
+        var m = new MomentumStrategy("mo", triggerTicks: 2, crossTicks: 1, lotsPerOrder: 3);
+        var rng = new Random(1);
+        Assert.Empty(m.Tick(State(mid: 100_0000), rng));
+        var intents = m.Tick(State(mid: 100_0300), rng).ToList(); // +3 ticks
+        Assert.Single(intents);
+        var ord = intents[0];
+        Assert.Equal(OrderSide.Buy, ord.Side);
+        Assert.Equal(OrderTifIntent.IOC, ord.Tif);
+        Assert.Equal(100_0300 + 100, ord.PriceMantissa); // mid + 1 tick
+        Assert.Equal(3 * 100, ord.Quantity);
+    }
+
+    [Fact]
+    public void Momentum_DownTickAboveThreshold_Sells()
+    {
+        var m = new MomentumStrategy("mo", triggerTicks: 2, crossTicks: 1, lotsPerOrder: 1);
+        var rng = new Random(1);
+        Assert.Empty(m.Tick(State(mid: 100_0000), rng));
+        var intents = m.Tick(State(mid: 99_9700), rng).ToList(); // -3 ticks
+        Assert.Single(intents);
+        Assert.Equal(OrderSide.Sell, intents[0].Side);
+        Assert.Equal(99_9700 - 100, intents[0].PriceMantissa);
+    }
+
+    [Fact]
+    public void Momentum_SubThresholdStep_NoOrder()
+    {
+        var m = new MomentumStrategy("mo", triggerTicks: 5, crossTicks: 1, lotsPerOrder: 1);
+        var rng = new Random(1);
+        Assert.Empty(m.Tick(State(mid: 100_0000), rng));
+        Assert.Empty(m.Tick(State(mid: 100_0200), rng)); // +2 ticks < 5
+    }
+
+    [Fact]
+    public void Momentum_PrevMidUpdatesEachTick()
+    {
+        var m = new MomentumStrategy("mo", triggerTicks: 2, crossTicks: 1, lotsPerOrder: 1);
+        var rng = new Random(1);
+        Assert.Empty(m.Tick(State(mid: 100_0000), rng));
+        // Step 1: +2 ticks → BUY. Prev becomes 100_0200.
+        Assert.Single(m.Tick(State(mid: 100_0200), rng));
+        // Step 2: same mid → 0 step → no order. Prev stays 100_0200.
+        Assert.Empty(m.Tick(State(mid: 100_0200), rng));
+        // Step 3: another +2 ticks vs prev → BUY again.
+        Assert.Single(m.Tick(State(mid: 100_0400), rng));
+    }
+
+    // ---- Sweeper --------------------------------------------------------
+
+    [Fact]
+    public void Sweeper_NeverFiresWhenProbabilityZero()
+    {
+        var sw = new SweeperStrategy("sw", triggerProbability: 0.0, sweepLots: 10, crossTicks: 5);
+        var rng = new Random(1);
+        for (int i = 0; i < 100; i++)
+            Assert.Empty(sw.Tick(State(), rng));
+    }
+
+    [Fact]
+    public void Sweeper_AlwaysFiresWhenProbabilityOne_AndSizesCorrectly()
+    {
+        var sw = new SweeperStrategy("sw", triggerProbability: 1.0, sweepLots: 7, crossTicks: 4);
+        var rng = new Random(1);
+        for (int i = 0; i < 20; i++)
+        {
+            var intents = sw.Tick(State(mid: 100_0000), rng).ToList();
+            Assert.Single(intents);
+            var ord = intents[0];
+            Assert.Equal(OrderTifIntent.IOC, ord.Tif);
+            Assert.Equal(7 * 100, ord.Quantity); // sweepLots * lot
+            long expectedPx = ord.Side == OrderSide.Buy ? 100_0400 : 99_9600;
+            Assert.Equal(expectedPx, ord.PriceMantissa);
+        }
+    }
+
+    [Fact]
+    public void Sweeper_DeterministicForSeededRng()
+    {
+        var s = State();
+        var a = new SweeperStrategy("sw", triggerProbability: 0.4, sweepLots: 5, crossTicks: 3);
+        var b = new SweeperStrategy("sw", triggerProbability: 0.4, sweepLots: 5, crossTicks: 3);
+        var ra = new Random(123);
+        var rb = new Random(123);
+        var seqA = new List<OrderIntent>();
+        var seqB = new List<OrderIntent>();
+        for (int i = 0; i < 200; i++)
+        {
+            seqA.AddRange(a.Tick(s, ra));
+            seqB.AddRange(b.Tick(s, rb));
+        }
+        Assert.NotEmpty(seqA);
+        Assert.Equal(seqA.Count, seqB.Count);
+        for (int i = 0; i < seqA.Count; i++)
+        {
+            Assert.Equal(seqA[i].Side, seqB[i].Side);
+            Assert.Equal(seqA[i].PriceMantissa, seqB[i].PriceMantissa);
+            Assert.Equal(seqA[i].Quantity, seqB[i].Quantity);
+        }
+    }
+
+    [Fact]
+    public void Sweeper_InvalidArgs_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SweeperStrategy("x", triggerProbability: -0.1, sweepLots: 1, crossTicks: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SweeperStrategy("x", triggerProbability: 1.1, sweepLots: 1, crossTicks: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SweeperStrategy("x", triggerProbability: 0.5, sweepLots: 0, crossTicks: 1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new SweeperStrategy("x", triggerProbability: 0.5, sweepLots: 1, crossTicks: 0));
+    }
+
+    // ---- Config wiring --------------------------------------------------
+
+    [Fact]
+    public void BuildStrategy_KnownKinds_BuildsAllNewStrategies()
+    {
+        Assert.IsType<MeanRevertingStrategy>(SyntheticTraderConfigLoader.BuildStrategy(new StrategyConfig
+        {
+            Kind = "meanReverting",
+            Alpha = 0.2,
+            EntryThresholdTicks = 4,
+            CrossTicks = 2,
+            LotsPerOrder = 3,
+        }));
+        Assert.IsType<MomentumStrategy>(SyntheticTraderConfigLoader.BuildStrategy(new StrategyConfig
+        {
+            Kind = "momentum",
+            TriggerTicks = 2,
+            CrossTicks = 1,
+            LotsPerOrder = 1,
+        }));
+        Assert.IsType<SweeperStrategy>(SyntheticTraderConfigLoader.BuildStrategy(new StrategyConfig
+        {
+            Kind = "sweeper",
+            TriggerProbability = 0.05,
+            SweepLots = 25,
+            CrossTicks = 5,
+        }));
+    }
+}


### PR DESCRIPTION
Closes #13.

Adds three new `IStrategy` implementations to `B3.Exchange.SyntheticTrader`, the most common 'taker' archetypes called out in the issue. News-shock is intentionally deferred — it can be approximated today by a high-prob `sweeper` window driven externally; a dedicated stateful version can land separately.

## What's new

| `kind` | Knobs | Behaviour |
| --- | --- | --- |
| `meanReverting` | `alpha`, `entryThresholdTicks`, `crossTicks`, `lotsPerOrder` | EWMA of mid; on deviation ≥ threshold, marketable IOC in the **contrarian** direction. |
| `momentum` | `triggerTicks`, `crossTicks`, `lotsPerOrder` | Per-tick mid step ≥ `triggerTicks` → marketable IOC **with** the move. |
| `sweeper` | `triggerProbability`, `sweepLots`, `crossTicks` | Per-tick fire (uniform side) of `sweepLots × lotSize` priced `crossTicks` past the mid; configure `crossTicks ≥ levelsPerSide × quoteSpacingTicks` to walk the visible book. |

All three follow the existing `NoiseTakerStrategy` template:
- Deterministic for a given (state, rng-state) sequence.
- No internal RNG — randomness flows from the runner's seeded `Random`.
- `ArgumentOutOfRangeException` on invalid knobs.
- Per-instance `Tick`-only state (EWMA / previous mid) — safe under the runner contract (`Tick` invoked serially on the runner's tick task).

## Wiring

- `StrategyConfig` gains: `alpha`, `entryThresholdTicks`, `triggerTicks`, `lotsPerOrder`, `triggerProbability`, `sweepLots`. Existing knobs untouched; defaults unchanged.
- `SyntheticTraderConfigLoader.BuildStrategy` switch gets three new arms.
- `config/synthetic-trader.json` has commented `,{...}` examples for each new kind (defaults still match the prior MM + noise pair).
- `docs/RUNBOOK.md` §4 updated with the knob table and two new recipes ('trend / mean-reversion mix', 'trade-through / sweep exercise').

## Tests

`tests/B3.Exchange.SyntheticTrader.Tests/AdditionalStrategyTests.cs` (15 cases): happy-path side/qty/price assertions, sub-threshold no-fire, RNG determinism (sweeper), invalid-knob guards, `BuildStrategy` round-trip per kind.

Full repo: `dotnet build -c Release` + `dotnet test --no-build -c Release` — **569 / 569 pass**, format check clean.

## Out of scope (carried)

- News-shock strategy (stateful directional burst). Deferable; a separate small PR can add it on top of this skeleton without churn.
- `MarketState` does **not** carry a price history series; momentum / mean-revert keep their own minimal state. Kept this way to limit blast radius — a richer `MarketState` would touch every strategy and the runner.