### PR TITLE
Trade-bust replay: operator endpoint + UMDF encoder helper (#15)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -135,6 +135,7 @@ when the bounded queue is full (`DropWrite`).
 | --- | --- | --- |
 | `/channel/{ch}/snapshot-now` | POST | Force the next snapshot rotation tick to fire. Useful for triggering a recovery-bootstrap window for a freshly connected MD consumer. |
 | `/channel/{ch}/bump-version` | POST | Advance the channel's `SessionVerId` (snapshot generation), forcing consumers to re-bootstrap. |
+| `/channel/{ch}/trade-bust/{tradeId}` | POST | Publish a `TradeBust_57` (trade reversal) on the incremental channel. Required query: `securityId`. Optional: `priceMantissa`, `size`, `tradeDate` (LocalMktDate; days since 1970-01-01, default = today UTC). The simulator does not retain a per-trade audit log — the operator supplies the echo fields the consumer audits. The bust frame is stamped with the engine's next `RptSeq` so the per-instrument sequence stays dense. |
 
 ### 2.5 Daily reset — `/admin/daily-reset`
 
@@ -266,6 +267,23 @@ curl -X POST http://127.0.0.1:8080/channel/84/bump-version
 
 Expected: `SessionVerId` on emitted frames increments; conformant
 consumers detect the version bump and replay snapshot → incremental.
+
+### 5.2.1 Replay a trade-bust (trade reversal)
+
+Goal: exercise the consumer's `TradeBust` handler end-to-end. The
+simulator does not record per-trade history, so the operator supplies
+the trade ID being busted plus the price/size echo fields.
+
+```bash
+# tradeId is in the path; securityId is required, the rest is optional.
+curl -X POST 'http://127.0.0.1:8080/channel/84/trade-bust/4242?securityId=900000000001&priceMantissa=2505000&size=100'
+```
+
+Expected: a single `TradeBust_57` frame on the incremental channel,
+stamped with the next available `RptSeq` (so the per-instrument
+sequence stays dense). The matching engine itself is not mutated — the
+bust is purely a market-data event the consumer's bust path must
+process by removing the matching trade from any aggregated counters.
 
 ### 5.3 EntryPoint Suspend → re-attach (FIXP)
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -193,6 +193,28 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         FlushPacket();
     }
 
+    /// <summary>
+    /// Operator-triggered trade-bust replay (issue #15). Synthesises a
+    /// <c>TradeBust_57</c> frame on the incremental channel using the
+    /// next available <see cref="MatchingEngine.AllocateNextRptSeq"/>.
+    /// The bust is flushed as a single-message packet under the current
+    /// SequenceVersion. No engine state is mutated — the matching engine
+    /// is unaware that a previously-emitted trade has been busted.
+    /// </summary>
+    private void ProcessTradeBust(OperatorTradeBust bust)
+    {
+        uint rptSeq = _engine.AllocateNextRptSeq();
+        _packetWritten = 0;
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.TradeBustBlockLength);
+        int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
+            bust.SecurityId, bust.PriceMantissa, bust.Size, bust.TradeId, bust.TradeDate,
+            _nowNanos(), rptSeq);
+        Commit(written);
+        FlushPacket();
+    }
+
     internal void ProcessOne(in WorkItem item)
     {
         if (item.Kind == WorkKind.SnapshotRotation || item.Kind == WorkKind.OperatorSnapshotNow)
@@ -207,6 +229,12 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         if (item.Kind == WorkKind.OperatorBumpVersion)
         {
             ProcessBumpVersion();
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorTradeBust)
+        {
+            ProcessTradeBust(item.TradeBust!);
             return;
         }
 
@@ -523,6 +551,23 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorBumpVersion, default, 0, false,
             0, 0, null, null, null, null));
 
+    /// <summary>
+    /// Operator command (issue #15): publishes a <c>TradeBust_57</c> frame
+    /// for a previously-emitted trade identified by
+    /// (<paramref name="securityId"/>, <paramref name="tradeId"/>). The
+    /// price/size/date echo fields are caller-supplied — the simulator
+    /// does not retain a per-trade audit log. The bust frame is stamped
+    /// with the next available <c>RptSeq</c> from the channel's matching
+    /// engine and emitted under the current <c>SequenceVersion</c>.
+    /// Returns <c>false</c> if the inbound queue is full. Safe to call
+    /// from any thread.
+    /// </summary>
+    public bool EnqueueOperatorTradeBust(long securityId, long priceMantissa, long size,
+        uint tradeId, ushort tradeDate)
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorTradeBust, default, 0, false,
+            0, 0, null, null, null, null,
+            TradeBust: new OperatorTradeBust(securityId, priceMantissa, size, tradeId, tradeDate)));
+
     // ====== IMatchingEventSink ======
 
     public void OnOrderAccepted(in OrderAcceptedEvent e)
@@ -655,7 +700,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _cts.Dispose();
     }
 
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust }
 
     internal sealed record WorkItem(
         WorkKind Kind,
@@ -668,7 +713,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         CancelOrderCommand? Cancel,
         ReplaceOrderCommand? Replace,
         CrossOrderCommand? Cross,
-        ResolvedMassCancel? MassCancel = null);
+        ResolvedMassCancel? MassCancel = null,
+        OperatorTradeBust? TradeBust = null);
 
     /// <summary>
     /// Per-channel mass-cancel payload after gateway-side resolution: a
@@ -676,6 +722,18 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// inbound timestamp.
     /// </summary>
     internal sealed record ResolvedMassCancel(IReadOnlyList<long> OrderIds, ulong EnteredAtNanos);
+
+    /// <summary>
+    /// Operator-triggered trade-bust payload (issue #15): identifies a
+    /// previously-published trade by (SecurityId, TradeId) and carries the
+    /// echo fields (price/size/date) the consumer audits.
+    /// </summary>
+    internal sealed record OperatorTradeBust(
+        long SecurityId,
+        long PriceMantissa,
+        long Size,
+        uint TradeId,
+        ushort TradeDate);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -148,6 +148,15 @@ public sealed class HttpServer : IAsyncDisposable
         app.MapPost("/channel/{ch:int}/bump-version", (int ch, HttpContext ctx) =>
             HandleOperatorEnqueue(ctx, ch, d => d.EnqueueOperatorBumpVersion(), "bump-version"));
 
+        // Operator endpoint (issue #15): trade-bust replay. tradeId is in
+        // the path; the echo fields the consumer audits (securityId, price,
+        // size, tradeDate) come as query-string parameters so the call is
+        // shell-friendly. priceMantissa/size default to 0; tradeDate
+        // defaults to today's UTC date encoded as LocalMktDate (days since
+        // 1970-01-01) when omitted. Returns 400 for malformed input.
+        app.MapPost("/channel/{ch:int}/trade-bust/{tradeId:long}", (int ch, long tradeId, HttpContext ctx) =>
+            HandleTradeBust(ctx, ch, tradeId));
+
         // #GAP-09 (#47): on-demand trading-day rollover. Terminates every
         // live FIXP session so clients reconnect with Negotiate +
         // Establish(nextSeqNo=1). The scheduled timer (HostConfig.dailyReset)
@@ -296,6 +305,69 @@ public sealed class HttpServer : IAsyncDisposable
         }
         ctx.Response.StatusCode = StatusCodes.Status202Accepted;
         return Results.Text($"accepted {opName} channel={channelNumber}\n", "text/plain");
+    }
+
+    private IResult HandleTradeBust(HttpContext ctx, int channelNumber, long tradeId)
+    {
+        if (channelNumber < 0 || channelNumber > 255 ||
+            !_dispatchers.TryGetValue((byte)channelNumber, out var disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown channel {channelNumber}\n", "text/plain");
+        }
+        if (tradeId <= 0 || tradeId > uint.MaxValue)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"tradeId must be in (0, {uint.MaxValue}]\n", "text/plain");
+        }
+        var q = ctx.Request.Query;
+        if (!TryParseLong(q["securityId"], out long securityId) || securityId <= 0)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("missing or invalid 'securityId' query parameter\n", "text/plain");
+        }
+        if (!TryParseLong(q["priceMantissa"], out long priceMantissa, allowMissing: true))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("invalid 'priceMantissa' query parameter\n", "text/plain");
+        }
+        if (!TryParseLong(q["size"], out long size, allowMissing: true) || size < 0)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("invalid 'size' query parameter\n", "text/plain");
+        }
+        ushort tradeDate;
+        if (q.ContainsKey("tradeDate"))
+        {
+            if (!TryParseLong(q["tradeDate"], out long td) || td < 0 || td > ushort.MaxValue)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return Results.Text($"invalid 'tradeDate' (LocalMktDate; days since 1970-01-01, 0..{ushort.MaxValue})\n", "text/plain");
+            }
+            tradeDate = (ushort)td;
+        }
+        else
+        {
+            tradeDate = (ushort)(DateTimeOffset.UtcNow.Date - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalDays;
+        }
+
+        if (!disp.EnqueueOperatorTradeBust(securityId, priceMantissa, size, (uint)tradeId, tradeDate))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {channelNumber} inbound queue full\n", "text/plain");
+        }
+        ctx.Response.StatusCode = StatusCodes.Status202Accepted;
+        return Results.Text(
+            $"accepted trade-bust channel={channelNumber} tradeId={tradeId} securityId={securityId}\n",
+            "text/plain");
+    }
+
+    private static bool TryParseLong(Microsoft.Extensions.Primitives.StringValues values, out long value, bool allowMissing = false)
+    {
+        value = 0;
+        var s = values.ToString();
+        if (string.IsNullOrEmpty(s)) return allowMissing;
+        return long.TryParse(s, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value);
     }
 
     private static IPEndPoint ParseEndpoint(string s)

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -66,6 +66,22 @@ public sealed class MatchingEngine
     public SelfTradePrevention SelfTradePrevention => _stp;
 
     /// <summary>
+    /// Allocates and returns the next <c>RptSeq</c> value without emitting
+    /// any matching event. Designed for the operator-triggered trade-bust
+    /// replay path (issue #15) where the dispatcher synthesises a
+    /// <c>TradeBust_57</c> frame outside the engine but must keep the
+    /// channel's <c>RptSeq</c> sequence dense. May only be invoked from the
+    /// dispatch thread; throws if called while the engine is mid-dispatch
+    /// (i.e. from inside a sink callback).
+    /// </summary>
+    public uint AllocateNextRptSeq()
+    {
+        if (_dispatching)
+            throw new InvalidOperationException("AllocateNextRptSeq called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
+        return ++_rptSeq;
+    }
+
+    /// <summary>
     /// Hard reset of every per-instrument book and the engine's
     /// <c>RptSeq</c> counter. Designed for the operator-initiated
     /// channel-reset path (issue #6): the dispatcher invokes this on

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -358,6 +358,47 @@ public static class UmdfWireEncoder
         return total;
     }
 
+    /// <summary>
+    /// Writes <c>TradeBust_57</c> (V16). Used by the operator-triggered
+    /// trade-bust replay path (issue #15) to surface a trade reversal on
+    /// the incremental channel without going through the matching engine.
+    /// </summary>
+    public static int WriteTradeBustFrame(
+        Span<byte> dst,
+        long securityId,
+        long priceMantissa,
+        long size,
+        uint tradeId,
+        ushort tradeDate,
+        ulong transactTimeNanos,
+        uint rptSeq)
+    {
+        const int total = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.TradeBustBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.TradeBust_57Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.TradeBustBlockLength);
+        body.Clear();
+
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodySecurityIdOffset, 8), in securityId);
+        // MatchEventIndicator: bit 7 (EndOfEvent, 0x80). Single-message bust
+        // packets are self-contained events, so flag end-of-event here.
+        body[WireOffsets.TradeBustBodyMatchEventIndicatorOffset] = 0x80;
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodyMdEntryPxOffset, 8), in priceMantissa);
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodyMdEntrySizeOffset, 8), in size);
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodyTradeIdOffset, 4), in tradeId);
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodyTradeDateOffset, 2), in tradeDate);
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodyTransactTimeOffset, 8), in transactTimeNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.TradeBustBodyRptSeqOffset, 4), in rptSeq);
+
+        return total;
+    }
+
     private static void WriteFramingHeader(Span<byte> dst, int totalFrameLength)
     {
         ushort messageLength = checked((ushort)totalFrameLength);

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -80,6 +80,24 @@ public static class WireOffsets
     public const int SnapOrdersGroupSizeEncodingSize = 3;      // BlockLength(ushort) + NumInGroup(byte)
     public const int SnapOrdersEntrySize = 42;                 // per-entry (V16 layout)
 
+    // ---- TradeBust_57 (V16) ----
+    // Body layout (BLOCK_LENGTH=48): securityID@0 (long), securityExchange@8
+    // shares offset with matchEventIndicator@8 (byte) — encoder writes the
+    // MEI and leaves securityExchange/tradingSessionID as 0; tradingSessionID@9
+    // (byte); mDEntryPx@12 (long mantissa); mDEntrySize@20 (long); tradeID@28
+    // (uint); tradeDate@32 (ushort); transactTime@36 (ulong nanos); rptSeq@44
+    // (uint, 0 = NULL).
+    public const int TradeBustBlockLength = 48;
+    public const int TradeBustBodySecurityIdOffset = 0;
+    public const int TradeBustBodyMatchEventIndicatorOffset = 8;
+    public const int TradeBustBodyTradingSessionIdOffset = 9;
+    public const int TradeBustBodyMdEntryPxOffset = 12;
+    public const int TradeBustBodyMdEntrySizeOffset = 20;
+    public const int TradeBustBodyTradeIdOffset = 28;
+    public const int TradeBustBodyTradeDateOffset = 32;
+    public const int TradeBustBodyTransactTimeOffset = 36;
+    public const int TradeBustBodyRptSeqOffset = 44;
+
     // ---- ChannelReset_11 (V16) ----
     // Body: MatchEventIndicator @0 (4 bytes — UMDF wire treats the bitset as
     // a 4-byte block, see schema offset="4" on MDEntryTimestamp), then

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -289,6 +289,60 @@ public class ChannelDispatcherTests
     }
 
     [Fact]
+    public void OperatorTradeBust_EmitsSinglePacketWithBustFrame_AndAllocatesNextRptSeq()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        // Seed one resting order so the engine's RptSeq counter is non-zero.
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        uint rptBefore = GetEngine(disp).CurrentRptSeq;
+        Assert.True(rptBefore > 0);
+        pkt.Packets.Clear();
+        uint seqBefore = disp.SequenceNumber;
+        ushort versionBefore = disp.SequenceVersion;
+
+        Assert.True(disp.EnqueueOperatorTradeBust(securityId: Petr,
+            priceMantissa: Px(10m), size: 100, tradeId: 4242, tradeDate: 19_500));
+        DrainInbound(disp);
+
+        // Engine RptSeq was bumped exactly once by the bust.
+        Assert.Equal(rptBefore + 1, GetEngine(disp).CurrentRptSeq);
+
+        // Single bust packet emitted on the incremental channel.
+        Assert.Single(pkt.Packets);
+        var packet = pkt.Packets[0];
+        int expectedLen = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize + WireOffsets.TradeBustBlockLength;
+        Assert.Equal(expectedLen, packet.Length);
+
+        // Packet header: same SequenceVersion, monotonic SequenceNumber.
+        Assert.Equal(versionBefore, MemoryMarshal.Read<ushort>(packet.AsSpan(WireOffsets.PacketHeaderSequenceVersionOffset, 2)));
+        Assert.Equal(seqBefore + 1, MemoryMarshal.Read<uint>(packet.AsSpan(WireOffsets.PacketHeaderSequenceNumberOffset, 4)));
+
+        // SBE TemplateId == 57 (TradeBust).
+        int sbeHdrStart = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize;
+        ushort templateId = MemoryMarshal.Read<ushort>(packet.AsSpan(sbeHdrStart + 2, 2));
+        Assert.Equal((ushort)57, templateId);
+
+        // Body: SecurityId + tradeId + rptSeq match.
+        int bodyStart = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        Assert.Equal(Petr, MemoryMarshal.Read<long>(packet.AsSpan(bodyStart + WireOffsets.TradeBustBodySecurityIdOffset, 8)));
+        Assert.Equal(4242u, MemoryMarshal.Read<uint>(packet.AsSpan(bodyStart + WireOffsets.TradeBustBodyTradeIdOffset, 4)));
+        Assert.Equal(rptBefore + 1, MemoryMarshal.Read<uint>(packet.AsSpan(bodyStart + WireOffsets.TradeBustBodyRptSeqOffset, 4)));
+
+        // Engine state untouched: book still has the seeded order.
+        Assert.Equal(1, GetEngine(disp).OrderCount(Petr));
+
+        // No execution reports flowed back to the FakeSession — the bust is
+        // purely a market-data event.
+        Assert.Empty(reply.Trades);
+        Assert.Empty(reply.Cancels);
+    }
+
+    [Fact]
     public void OperatorBumpVersion_ClearsBook_BumpsVersions_EmitsChannelResetPacket()
     {
         var (disp, pkt, outbound) = NewDispatcher();

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -137,6 +137,53 @@ public class HttpServerTests
     }
 
     [Fact]
+    public async Task OperatorTradeBust_Returns202_AndEmitsTradeBustOnIncrementalSink()
+    {
+        var (cfg, _) = BuildConfig();
+        var incSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => incSink);
+        await host.StartAsync();
+        var http = host.HttpEndpoint!;
+
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{http}") };
+
+        // securityId 900_000_000_001 = PETR4 (matches config/instruments-eqt.json).
+        var url = "/channel/84/trade-bust/4242?securityId=900000000001&priceMantissa=2505000&size=100&tradeDate=19500";
+        var resp = await client.PostAsync(url, content: null);
+        Assert.Equal(System.Net.HttpStatusCode.Accepted, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("trade-bust", body);
+        Assert.Contains("4242", body);
+
+        // Wait for dispatcher to drain.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (incSink.Packets.Count == 0 && DateTime.UtcNow < deadline)
+            await Task.Delay(20);
+        Assert.True(incSink.Packets.Count >= 1, "expected TradeBust packet on incremental sink");
+
+        var packet = incSink.Packets[0];
+        // SBE TemplateId @ packet[16+4+2..+4] == 57.
+        ushort templateId = System.Runtime.InteropServices.MemoryMarshal.Read<ushort>(packet.AsSpan(16 + 4 + 2, 2));
+        Assert.Equal((ushort)57, templateId);
+
+        // Bad channel.
+        var unknown = await client.PostAsync("/channel/200/trade-bust/4242?securityId=1", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.NotFound, unknown.StatusCode);
+
+        // Missing securityId.
+        var missing = await client.PostAsync("/channel/84/trade-bust/4242", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, missing.StatusCode);
+
+        // Invalid securityId (zero).
+        var invalid = await client.PostAsync("/channel/84/trade-bust/4242?securityId=0", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, invalid.StatusCode);
+
+        // Invalid tradeDate (out of ushort range).
+        var badDate = await client.PostAsync("/channel/84/trade-bust/4242?securityId=900000000001&tradeDate=70000", content: null);
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, badDate.StatusCode);
+    }
+
+    [Fact]
     public async Task OperatorBumpVersion_Returns202_AndEmitsChannelResetOnIncrementalSink()
     {
         var (cfg, _) = BuildConfig();

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -121,6 +121,28 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void TradeBust_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WriteTradeBustFrame(buf, securityId: 900_000_000_001L,
+            priceMantissa: 250_5000L, size: 100L, tradeId: 7,
+            tradeDate: 9000, transactTimeNanos: 12345UL, rptSeq: 17);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.TradeBustBlockLength, n);
+
+        var msgLen = MemoryMarshal.Read<ushort>(buf.AsSpan(0, 2));
+        Assert.Equal((ushort)n, msgLen);
+
+        Assert.True(TradeBust_57Data.TryParse(buf.AsSpan(FrameOffset, WireOffsets.TradeBustBlockLength), out var rdr));
+        Assert.Equal(900_000_000_001L, (long)rdr.Data.SecurityID.Value);
+        Assert.Equal(250_5000L, rdr.Data.MDEntryPx.Mantissa);
+        Assert.Equal(100L, rdr.Data.MDEntrySize.Value);
+        Assert.Equal(7u, rdr.Data.TradeID.Value);
+        Assert.Equal(9000, (ushort)rdr.Data.TradeDate.Value);
+        Assert.Equal(12345UL, rdr.Data.TransactTime.Time);
+        Assert.Equal(17u, rdr.Data.RptSeq);
+    }
+
+    [Fact]
     public void Trade_NullableBuyerSeller_AreNull()
     {
         var buf = new byte[80];


### PR DESCRIPTION
Closes #15.

Adds an operator-triggered path to publish `TradeBust_57` (trade reversal) frames so the consumer's bust handling is exercisable end-to-end. The simulator previously had no way to surface a bust; the matching engine never naturally produces one.

## Surface

| Endpoint | Method | Notes |
| --- | --- | --- |
| `/channel/{ch}/trade-bust/{tradeId}` | POST | Required query: `securityId`. Optional: `priceMantissa`, `size`, `tradeDate` (LocalMktDate; default today UTC). 202 on enqueue, 400 on malformed input, 404 unknown channel, 503 if inbound queue full. |

## Implementation notes

- `UmdfWireEncoder.WriteTradeBustFrame` mirrors `WriteTradeFrame`. Body is the V16 `TradeBust_57` (BLOCK_LENGTH=48); MEI is set to 0x80 (EndOfEvent) since each bust ships as a self-contained packet.
- `MatchingEngine.AllocateNextRptSeq()` (new public helper) lets the dispatcher bump `RptSeq` without emitting a matching event, keeping per-instrument sequence dense across the externally-injected bust. Guarded against re-entry from sink callbacks.
- New `ChannelDispatcher.WorkKind.OperatorTradeBust` + `OperatorTradeBust` payload + `EnqueueOperatorTradeBust(...)`. `ProcessTradeBust` runs on the dispatch thread, allocates the next RptSeq, and flushes a single packet under the current `SequenceVersion`.
- The simulator does not retain a per-trade audit log; the operator supplies the price/size/date echo fields. Matching engine state is not mutated — the bust is a market-data event only.

## Tests (3 new + ~unchanged baseline)

- `UmdfWireEncoderTests.TradeBust_Roundtrip` — full field round-trip with the SBE-generated reader.
- `ChannelDispatcherTests.OperatorTradeBust_EmitsSinglePacketWithBustFrame_AndAllocatesNextRptSeq` — single packet, TemplateId 57, monotonic SequenceNumber, `RptSeq = prev + 1`, engine state unchanged, no ER flow back.
- `HttpServerTests.OperatorTradeBust_Returns202_AndEmitsTradeBustOnIncrementalSink` — POST → 202 → one packet; covers 404 / 400 cases (missing/invalid `securityId`, out-of-range `tradeDate`).

Full repo: 572 / 572 pass, format check clean.

`docs/RUNBOOK.md` §2.4 + §5.2.1 updated with the new endpoint and a recovery-scenario walkthrough.