### PR TITLE
Enable Central Package Management (#122)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="SbeSourceGenerator" Version="1.6.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /src
 
-COPY Directory.Build.props global.json SbeB3Exchange.slnx ./
+COPY Directory.Build.props Directory.Packages.props global.json SbeB3Exchange.slnx ./
 COPY schemas/ schemas/
 COPY src/ src/
 

--- a/Dockerfile.synthtrader
+++ b/Dockerfile.synthtrader
@@ -7,7 +7,7 @@ FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 
 WORKDIR /src
 
-COPY Directory.Build.props global.json SbeB3Exchange.slnx ./
+COPY Directory.Build.props Directory.Packages.props global.json SbeB3Exchange.slnx ./
 COPY schemas/ schemas/
 COPY src/ src/
 

--- a/src/B3.EntryPoint.Sbe/B3.EntryPoint.Sbe.csproj
+++ b/src/B3.EntryPoint.Sbe/B3.EntryPoint.Sbe.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SbeSourceGenerator" Version="1.6.1" />
+    <PackageReference Include="SbeSourceGenerator" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Core/B3.Exchange.Core.csproj
+++ b/src/B3.Exchange.Core/B3.Exchange.Core.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
+++ b/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.Exchange.Matching/B3.Exchange.Matching.csproj
+++ b/src/B3.Exchange.Matching/B3.Exchange.Matching.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/B3.Umdf.Sbe/B3.Umdf.Sbe.csproj
+++ b/src/B3.Umdf.Sbe/B3.Umdf.Sbe.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SbeSourceGenerator" Version="1.6.1" />
+    <PackageReference Include="SbeSourceGenerator" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
+++ b/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj
+++ b/tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj
+++ b/tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Matching.Tests/B3.Exchange.Matching.Tests.csproj
+++ b/tests/B3.Exchange.Matching.Tests/B3.Exchange.Matching.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Umdf.WireEncoder.Tests/B3.Umdf.WireEncoder.Tests.csproj
+++ b/tests/B3.Umdf.WireEncoder.Tests/B3.Umdf.WireEncoder.Tests.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/ScenarioReplay.Tests/ScenarioReplay.Tests.csproj
+++ b/tests/ScenarioReplay.Tests/ScenarioReplay.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #122.

Adopt NuGet Central Package Management to eliminate version drift across the 18+ csproj files in the solution.

## Changes

- Add `Directory.Packages.props` at repo root with `ManagePackageVersionsCentrally=true` and `CentralPackageTransitivePinningEnabled=true`.
- Strip `Version=` attributes from every `<PackageReference>` in csprojs (mechanical `sed`).
- Unify pre-existing version drift to the highest version in use:

| Package | Before | After |
|---|---|---|
| coverlet.collector | 6.0.4 + 10.0.0 | **10.0.0** |
| Microsoft.NET.Test.Sdk | 17.14.1 + 18.5.1 | **18.5.1** |
| xunit.runner.visualstudio | 3.1.4 + 3.1.5 | **3.1.5** |

Other packages (`Microsoft.Extensions.Logging.Abstractions` 10.0.0, `SbeSourceGenerator` 1.6.1, `xunit` 2.9.3) were already aligned.

## Verification

- `dotnet build SbeB3Exchange.slnx -c Release` → 0 warnings, 0 errors
- `dotnet test SbeB3Exchange.slnx -c Release --no-build` → **586/586 pass**
- `dotnet format SbeB3Exchange.slnx --verify-no-changes --severity warn` → clean

## Why now

This is part of the post-feature-completeness roadmap (Tier A — Foundation). It lands first because it is risk-free and centralises versioning before later PRs (#118 Benchmarks introduces a new project, #121 FixpSession refactor, etc.) start adding dependencies.

No behavioural changes.