### PR TITLE
Add BenchmarkDotNet baseline + nightly workflow (#118)

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -1,0 +1,71 @@
+name: Bench (nightly)
+
+on:
+  schedule:
+    # 02:00 UTC daily — off-peak, low risk of clashing with feature work.
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'BenchmarkDotNet --filter pattern (default: all)'
+        required: false
+        default: '*'
+
+concurrency:
+  group: bench-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    name: BenchmarkDotNet
+    runs-on: ubuntu-latest
+    # Full suite is ~minutes today but allow head-room for future additions.
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Packages.props', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj
+
+      - name: Build (Release)
+        run: dotnet build bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj --no-restore -c Release
+
+      - name: Run benchmarks
+        env:
+          # GitHub-hosted runners are noisy; loosen tolerances slightly so a
+          # single noisy iteration does not turn the whole job red. We are
+          # tracking trends, not enforcing hard thresholds (yet).
+          DOTNET_TieredPGO: '1'
+        run: >
+          dotnet run --no-build -c Release
+          --project bench/B3.Exchange.Bench
+          --
+          --filter '${{ github.event.inputs.filter || ''*'' }}'
+          --exporters github
+
+      - name: Upload BenchmarkDotNet artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-results-${{ github.run_number }}
+          path: BenchmarkDotNet.Artifacts/**/*
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'global.json') }}
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Packages.props', 'global.json') }}
           restore-keys: |
             ${{ runner.os }}-nuget-
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="SbeSourceGenerator" Version="1.6.1" />

--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -14,6 +14,9 @@
   <Folder Name="/tools/">
     <Project Path="tools/ScenarioReplay/ScenarioReplay.csproj" />
   </Folder>
+  <Folder Name="/bench/">
+    <Project Path="bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj" />
+  </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/B3.Umdf.WireEncoder.Tests/B3.Umdf.WireEncoder.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj" />

--- a/bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj
+++ b/bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>B3.Exchange.Bench</RootNamespace>
+    <AssemblyName>B3.Exchange.Bench</AssemblyName>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <!-- BenchmarkDotNet emits some warnings (e.g. about ReadyToRun) we don't care about. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
+    <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/bench/B3.Exchange.Bench/BenchInstruments.cs
+++ b/bench/B3.Exchange.Bench/BenchInstruments.cs
@@ -1,0 +1,24 @@
+using B3.Exchange.Instruments;
+
+namespace B3.Exchange.Bench;
+
+internal static class BenchInstruments
+{
+    public const long PetrSecId = 900_000_000_001L;
+
+    public static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = PetrSecId,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000.00m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    /// <summary>10000 mantissa per 1.00 BRL.</summary>
+    public static long Px(decimal p) => (long)(p * 10_000m);
+}

--- a/bench/B3.Exchange.Bench/MatchingBenchmarks.cs
+++ b/bench/B3.Exchange.Bench/MatchingBenchmarks.cs
@@ -1,0 +1,134 @@
+using BenchmarkDotNet.Attributes;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Bench;
+
+/// <summary>
+/// Hot-path matching engine benchmarks.
+///
+/// Scenarios:
+/// - <see cref="NewOrder_NoCross"/>     — single LIMIT order rests on an empty book.
+/// - <see cref="NewOrder_FullCross"/>   — aggressor sweeps a pre-built book of N levels.
+/// - <see cref="Cancel_RestingOrder"/>  — cancel an already-resting order by orderId.
+///
+/// All benchmarks reset the engine in <see cref="IterationSetupAttribute"/> so the JIT
+/// sees a steady-state input. Runs against the host runtime (net10.0) by default.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5, invocationCount: 1)]
+public class MatchingBenchmarks
+{
+    private MatchingEngine _engine = null!;
+    private NoOpSink _sink = null!;
+    private long _prebuiltCancelOrderId;
+
+    [Params(10, 100)]
+    public int CrossLevels;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _sink = new NoOpSink();
+        _engine = new MatchingEngine(new[] { BenchInstruments.Petr4 }, _sink, NullLogger<MatchingEngine>.Instance);
+    }
+
+    // ---------- NewOrder_NoCross ----------
+
+    [IterationSetup(Target = nameof(NewOrder_NoCross))]
+    public void Setup_NoCross()
+    {
+        _engine.ResetForChannelReset();
+        _sink.Reset();
+    }
+
+    [Benchmark]
+    public void NewOrder_NoCross()
+    {
+        var cmd = new NewOrderCommand(
+            ClOrdId: "C1",
+            SecurityId: BenchInstruments.PetrSecId,
+            Side: Side.Buy,
+            Type: OrderType.Limit,
+            Tif: TimeInForce.Day,
+            PriceMantissa: BenchInstruments.Px(32.00m),
+            Quantity: 100,
+            EnteringFirm: 7,
+            EnteredAtNanos: 0);
+        _engine.Submit(cmd);
+    }
+
+    // ---------- NewOrder_FullCross ----------
+
+    [IterationSetup(Target = nameof(NewOrder_FullCross))]
+    public void Setup_FullCross()
+    {
+        _engine.ResetForChannelReset();
+        _sink.Reset();
+
+        // Build N resting bids descending from 32.00 by 1 tick. Aggressor (sell, market IOC)
+        // will sweep all of them in a single Submit().
+        long basePx = BenchInstruments.Px(32.00m);
+        for (int i = 0; i < CrossLevels; i++)
+        {
+            _engine.Submit(new NewOrderCommand(
+                ClOrdId: $"M{i}",
+                SecurityId: BenchInstruments.PetrSecId,
+                Side: Side.Buy,
+                Type: OrderType.Limit,
+                Tif: TimeInForce.Day,
+                PriceMantissa: basePx - i * 1, // 1 mantissa = 1 tick (0.0001) — we use Px so /10000.
+                Quantity: 100,
+                EnteringFirm: 8,
+                EnteredAtNanos: 0));
+        }
+    }
+
+    [Benchmark]
+    public void NewOrder_FullCross()
+    {
+        var aggressor = new NewOrderCommand(
+            ClOrdId: "AGG",
+            SecurityId: BenchInstruments.PetrSecId,
+            Side: Side.Sell,
+            Type: OrderType.Market,
+            Tif: TimeInForce.IOC,
+            PriceMantissa: 0,
+            Quantity: 100L * CrossLevels,
+            EnteringFirm: 7,
+            EnteredAtNanos: 0);
+        _engine.Submit(aggressor);
+    }
+
+    // ---------- Cancel_RestingOrder ----------
+
+    [IterationSetup(Target = nameof(Cancel_RestingOrder))]
+    public void Setup_Cancel()
+    {
+        _engine.ResetForChannelReset();
+        _sink.Reset();
+        // Submit one resting order and remember its id (NoOpSink discards events,
+        // so we use the engine's own sequential allocator: first order = 1).
+        _engine.Submit(new NewOrderCommand(
+            ClOrdId: "R1",
+            SecurityId: BenchInstruments.PetrSecId,
+            Side: Side.Buy,
+            Type: OrderType.Limit,
+            Tif: TimeInForce.Day,
+            PriceMantissa: BenchInstruments.Px(32.00m),
+            Quantity: 100,
+            EnteringFirm: 7,
+            EnteredAtNanos: 0));
+        _prebuiltCancelOrderId = _engine.PeekNextOrderId - 1;
+    }
+
+    [Benchmark]
+    public void Cancel_RestingOrder()
+    {
+        _engine.Cancel(new CancelOrderCommand(
+            ClOrdId: "X1",
+            SecurityId: BenchInstruments.PetrSecId,
+            OrderId: _prebuiltCancelOrderId,
+            EnteredAtNanos: 0));
+    }
+}

--- a/bench/B3.Exchange.Bench/NoOpSink.cs
+++ b/bench/B3.Exchange.Bench/NoOpSink.cs
@@ -1,0 +1,29 @@
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Bench;
+
+/// <summary>
+/// Zero-allocation matching event sink used by benchmarks. Records nothing;
+/// counters are kept only so the JIT cannot dead-code-eliminate sink calls.
+/// </summary>
+internal sealed class NoOpSink : IMatchingEventSink
+{
+    public long Accepted;
+    public long QuantityReduced;
+    public long Canceled;
+    public long Filled;
+    public long Trades;
+    public long Rejects;
+
+    public void OnOrderAccepted(in OrderAcceptedEvent e) => Accepted++;
+    public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => QuantityReduced++;
+    public void OnOrderCanceled(in OrderCanceledEvent e) => Canceled++;
+    public void OnOrderFilled(in OrderFilledEvent e) => Filled++;
+    public void OnTrade(in TradeEvent e) => Trades++;
+    public void OnReject(in RejectEvent e) => Rejects++;
+
+    public void Reset()
+    {
+        Accepted = QuantityReduced = Canceled = Filled = Trades = Rejects = 0;
+    }
+}

--- a/bench/B3.Exchange.Bench/Program.cs
+++ b/bench/B3.Exchange.Bench/Program.cs
@@ -1,0 +1,9 @@
+using BenchmarkDotNet.Running;
+
+// Use BenchmarkSwitcher so the binary supports `--filter`, `--list`, etc.
+// Examples:
+//   dotnet run -c Release --project bench/B3.Exchange.Bench -- --filter '*Matching*'
+//   dotnet run -c Release --project bench/B3.Exchange.Bench -- --list flat
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+internal sealed partial class Program;

--- a/bench/B3.Exchange.Bench/README.md
+++ b/bench/B3.Exchange.Bench/README.md
@@ -1,0 +1,48 @@
+# B3.Exchange.Bench — performance baselines
+
+BenchmarkDotNet harness for the simulator's hot paths. See issue #118.
+
+## Scope
+
+| Class | What it measures |
+|---|---|
+| `MatchingBenchmarks` | `MatchingEngine.Submit` (NewOrder no-cross + full sweep across N levels) and `Cancel` by orderId. |
+| `UmdfEncoderBenchmarks` | Single-frame UMDF encode (PacketHeader, OrderAdded, OrderDeleted, Trade). |
+
+The matching benchmarks use a `NoOpSink` to keep the measurement focused on
+engine work, and `IterationSetup` to give each invocation a clean book.
+
+## Run locally
+
+```bash
+# all benchmarks
+dotnet run -c Release --project bench/B3.Exchange.Bench -- --filter '*'
+
+# one class
+dotnet run -c Release --project bench/B3.Exchange.Bench -- --filter '*Matching*'
+
+# list available
+dotnet run -c Release --project bench/B3.Exchange.Bench -- --list flat
+```
+
+Reports are written under `BenchmarkDotNet.Artifacts/results/` (markdown +
+CSV + GitHub-flavoured md).
+
+## CI
+
+`.github/workflows/bench-nightly.yml` runs the full suite on a schedule
+(02:00 UTC) and uploads `BenchmarkDotNet.Artifacts/` as a build artifact for
+trend-tracking. The job is also dispatchable manually
+(`workflow_dispatch`) with an optional `filter` input.
+
+This is **baseline-only** today: no failure gate. Once a few nightly runs
+have established stable numbers, a regression threshold can be added in a
+follow-up.
+
+## Out of scope (for now)
+
+- E2E `ChannelDispatcher` loopback throughput (deferred — needs a stand-alone
+  no-op packet sink and synthetic command generator without TCP).
+- SBE *decode* benchmarks for inbound EntryPoint frames (deferred — requires
+  a representative pre-encoded byte corpus).
+- GC profiling beyond what `MemoryDiagnoser` reports.

--- a/bench/B3.Exchange.Bench/UmdfEncoderBenchmarks.cs
+++ b/bench/B3.Exchange.Bench/UmdfEncoderBenchmarks.cs
@@ -1,0 +1,73 @@
+using BenchmarkDotNet.Attributes;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Bench;
+
+/// <summary>
+/// UMDF wire-encoder hot-path benchmarks. Each benchmark writes one frame
+/// into a pre-allocated buffer, so timings reflect pure SBE/byte-layout cost
+/// (no allocations expected; verified via <see cref="MemoryDiagnoserAttribute"/>).
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5)]
+public class UmdfEncoderBenchmarks
+{
+    private byte[] _buf = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // 1500 bytes is more than enough for any single UMDF frame we emit.
+        _buf = new byte[1500];
+    }
+
+    [Benchmark]
+    public int PacketHeader()
+    {
+        return UmdfWireEncoder.WritePacketHeader(_buf, 1, 1, 12345, 1_700_000_000_000_000_000UL);
+    }
+
+    [Benchmark]
+    public int OrderAdded_BidLevel()
+    {
+        return UmdfWireEncoder.WriteOrderAddedFrame(
+            _buf,
+            securityId: BenchInstruments.PetrSecId,
+            secondaryOrderId: 1234,
+            mdEntryType: UmdfWireEncoder.MdEntryTypeBid,
+            priceMantissa: BenchInstruments.Px(32.00m),
+            size: 100,
+            rptSeq: 42,
+            insertTimestampNanos: 1_700_000_000_000_000_000UL);
+    }
+
+    [Benchmark]
+    public int OrderDeleted()
+    {
+        return UmdfWireEncoder.WriteOrderDeletedFrame(
+            _buf,
+            securityId: BenchInstruments.PetrSecId,
+            secondaryOrderId: 1234,
+            mdEntryType: UmdfWireEncoder.MdEntryTypeBid,
+            size: 100,
+            rptSeq: 43,
+            transactTimeNanos: 1_700_000_000_000_000_000UL,
+            priceMantissa: BenchInstruments.Px(32.00m));
+    }
+
+    [Benchmark]
+    public int Trade_FullyTagged()
+    {
+        return UmdfWireEncoder.WriteTradeFrame(
+            _buf,
+            securityId: BenchInstruments.PetrSecId,
+            priceMantissa: BenchInstruments.Px(32.00m),
+            size: 100,
+            tradeId: 99,
+            tradeDate: 9234,
+            transactTimeNanos: 1_700_000_000_000_000_000UL,
+            rptSeq: 44,
+            buyerFirm: 7,
+            sellerFirm: 8);
+    }
+}


### PR DESCRIPTION
Closes #118.

Establish a performance baseline so future PRs (notably the FixpSession refactor in #121) can detect regressions in the simulator's hot paths.

## What

**New project `bench/B3.Exchange.Bench`** (net10.0 Exe, BenchmarkDotNet 0.15.4) using `BenchmarkSwitcher` so the binary supports `--filter` / `--list` / `--exporters`.

`MatchingBenchmarks` (3 scenarios):
- **NewOrder_NoCross** — single LIMIT rests on empty book.
- **NewOrder_FullCross** — aggressor sweeps N pre-built levels (`[Params(10, 100)]`).
- **Cancel_RestingOrder** — cancel by orderId.

Uses a `NoOpSink` to keep measurement focused on engine work; `IterationSetup` resets the book before each invocation.

`UmdfEncoderBenchmarks` (4 scenarios): `PacketHeader`, `OrderAdded_BidLevel`, `OrderDeleted`, `Trade_FullyTagged`. Pre-allocated 1500-byte buffer; expected **0 alloc/op** (verified by `MemoryDiagnoser`).

`bench/B3.Exchange.Bench/README.md` documents how to run locally.

## CI

New workflow `.github/workflows/bench-nightly.yml`:
- Runs the full suite at **02:00 UTC** daily.
- Uploads `BenchmarkDotNet.Artifacts/` as a 90-day build artifact for trend tracking.
- Manually dispatchable with optional `filter` input.
- **Baseline-only** today: no failure gate. Once trends stabilise (a few nightly runs), a regression threshold can be added in a follow-up.

## Other

- BenchmarkDotNet 0.15.4 added to `Directory.Packages.props`.
- `bench/` folder added to `SbeB3Exchange.slnx`.
- `ci.yml` NuGet cache key now also includes `Directory.Packages.props` so CPM-file changes correctly invalidate the cache.

## Verification

- `dotnet build SbeB3Exchange.slnx -c Release` → 0 warnings, 0 errors
- `dotnet test SbeB3Exchange.slnx -c Release --no-build` → **586/586 pass**
- `dotnet format SbeB3Exchange.slnx --verify-no-changes --severity warn` → clean
- `dotnet run -c Release --project bench/B3.Exchange.Bench -- --list flat` → 7 benchmarks listed
- Smoke run of `*PacketHeader*` executed successfully (BDN reports clean)

## Why now

Tier A (Foundation) of the post-feature-completeness roadmap. Lands before #121 (FixpSession refactor) so we have measurements to compare against.