### PR TITLE
Multicast chaos injection (#119)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -374,6 +374,70 @@ Goal: trigger the per-session sliding-window throttle (#56 / GAP-20).
 3. Stop the burst; the rejection counter freezes and the accept counter
    resumes growing.
 
+### 5.7 Multicast chaos injection (controlled drop / dup / reorder)
+
+To exercise a consumer's gap-detection and snapshot-bootstrap paths without
+bringing in `tc`/`netem` or a real flaky network, the host can wrap any
+incremental UDP sink with a chaos decorator (issue #119). All probabilities
+default to 0 — chaos is opt-in per channel.
+
+Add a `chaos` block to one or more `channels[]` entries in
+`config/exchange-simulator.json`:
+
+```jsonc
+{
+  "channelNumber": 1,
+  "incrementalGroup": "239.1.1.1",
+  "incrementalPort": 30001,
+  "instrumentsFile": "config/instruments.json",
+  // ... existing fields ...
+  "chaos": {
+    "dropProbability": 0.01,        // 1% packet loss
+    "duplicateProbability": 0.005,  // 0.5% duplicates
+    "reorderProbability": 0.01,     // 1% reordered
+    "reorderMaxLagPackets": 3,      // hold reordered packets up to 3 slots
+    "seed": 42                      // deterministic across restarts
+  }
+}
+```
+
+Verify the decorator is active (host log line at startup):
+
+```
+chaos decorator active: drop=1.00 % dup=0.50 % reorder=1.00 % maxLag=3 seed=42
+```
+
+Watch the counters in `/metrics`:
+
+```
+umdf_chaos_dropped_total{channel="1"}     <n>
+umdf_chaos_duplicated_total{channel="1"}  <n>
+umdf_chaos_reordered_total{channel="1"}   <n>
+```
+
+Recovery scenario (companion `SbeB3UmdfConsumer`):
+
+1. Start the host with `dropProbability: 0.01` on a channel of interest.
+2. Drive load with a synthetic trader.
+3. The consumer should observe gaps in `MsgSeqNum`, request a snapshot
+   from the snapshot multicast group, and resume processing without losing
+   book state.
+4. Set `dropProbability: 0` and restart — the channel returns to lossless
+   behavior; counters stop incrementing.
+
+Notes:
+
+- Chaos lives **only on the incremental sink** wired in `ExchangeHost`.
+  Snapshot and InstrumentDef sinks are unaffected so the consumer always has
+  a clean recovery channel to bootstrap from.
+- The decorator is **not thread-safe** (matches the contract of the
+  underlying sinks): it is invoked exclusively from the channel's
+  `ChannelDispatcher` thread.
+- Reorder semantics: a reordered packet is held back by a random lag in
+  `[1, reorderMaxLagPackets]` Publish-calls, then released **after** a
+  later packet so it appears later in the wire stream. Held packets are
+  flushed on host shutdown.
+
 ---
 
 ## 6. Common tuning + debugging

--- a/src/B3.Exchange.Core/ChaosConfig.cs
+++ b/src/B3.Exchange.Core/ChaosConfig.cs
@@ -1,0 +1,46 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Configuration for <see cref="ChaosUdpPacketSinkDecorator"/>. Probabilities
+/// are independent and evaluated in order: drop &gt; duplicate &gt; reorder.
+/// All probabilities default to 0 (no chaos). When all are 0 the decorator
+/// degenerates to a pass-through.
+///
+/// <para>Reorder semantics: when a packet is selected for reorder it is
+/// placed into a small in-memory queue with a random release-lag in the
+/// range <c>[1, ReorderMaxLagPackets]</c>. Subsequent calls to
+/// <see cref="ChaosUdpPacketSinkDecorator.Publish"/> decrement the lag of
+/// every queued packet and release those whose lag has reached 0 — emitted
+/// after the current packet so they appear later in the wire stream.</para>
+///
+/// <para>The seeded <see cref="System.Random"/> makes runs deterministic for
+/// regression tests. Operator runs typically pass a non-zero seed too so
+/// drop patterns are reproducible across host restarts.</para>
+/// </summary>
+public sealed class ChaosConfig
+{
+    public double DropProbability { get; init; }
+    public double DuplicateProbability { get; init; }
+    public double ReorderProbability { get; init; }
+    public int ReorderMaxLagPackets { get; init; } = 3;
+    public int Seed { get; init; }
+
+    public bool IsActive =>
+        DropProbability > 0 || DuplicateProbability > 0 || ReorderProbability > 0;
+
+    /// <summary>Throws <see cref="ArgumentException"/> if any probability is
+    /// outside [0,1] or <c>ReorderMaxLagPackets</c> is non-positive while
+    /// reorder is enabled.</summary>
+    public void Validate()
+    {
+        if (DropProbability < 0 || DropProbability > 1)
+            throw new ArgumentException("DropProbability must be in [0, 1]", nameof(DropProbability));
+        if (DuplicateProbability < 0 || DuplicateProbability > 1)
+            throw new ArgumentException("DuplicateProbability must be in [0, 1]", nameof(DuplicateProbability));
+        if (ReorderProbability < 0 || ReorderProbability > 1)
+            throw new ArgumentException("ReorderProbability must be in [0, 1]", nameof(ReorderProbability));
+        if (ReorderProbability > 0 && ReorderMaxLagPackets <= 0)
+            throw new ArgumentException("ReorderMaxLagPackets must be > 0 when reorder is enabled",
+                nameof(ReorderMaxLagPackets));
+    }
+}

--- a/src/B3.Exchange.Core/ChaosUdpPacketSinkDecorator.cs
+++ b/src/B3.Exchange.Core/ChaosUdpPacketSinkDecorator.cs
@@ -1,0 +1,124 @@
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// <see cref="IUmdfPacketSink"/> decorator that injects controlled packet loss,
+/// duplication, and reordering into an inner sink. Designed for testing the
+/// companion <c>SbeB3UmdfConsumer</c>'s recovery paths (snapshot bootstrap,
+/// gap detection) without external network-shaping tools.
+///
+/// <para>NOT thread-safe; like the inner sinks it expects to be called from a
+/// single channel-thread caller (one <see cref="ChannelDispatcher"/> per sink
+/// instance). Counters are exposed via <see cref="ChannelMetrics.IncChaosDropped"/>
+/// etc.</para>
+/// </summary>
+public sealed class ChaosUdpPacketSinkDecorator : IUmdfPacketSink, IDisposable
+{
+    private readonly IUmdfPacketSink _inner;
+    private readonly ChaosConfig _config;
+    private readonly ChannelMetrics? _metrics;
+    private readonly ILogger<ChaosUdpPacketSinkDecorator> _logger;
+    private readonly Random _rng;
+    // Tiny FIFO of (countdown, payload) for reordered packets. Capacity is
+    // bounded by ReorderMaxLagPackets so memory stays trivial.
+    private readonly List<DelayedPacket> _delayed;
+
+    public ChaosUdpPacketSinkDecorator(
+        IUmdfPacketSink inner,
+        ChaosConfig config,
+        ILogger<ChaosUdpPacketSinkDecorator> logger,
+        ChannelMetrics? metrics = null)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(logger);
+        config.Validate();
+        _inner = inner;
+        _config = config;
+        _metrics = metrics;
+        _logger = logger;
+        _rng = new Random(config.Seed);
+        _delayed = new List<DelayedPacket>(capacity: Math.Max(1, config.ReorderMaxLagPackets));
+        _logger.LogInformation(
+            "chaos decorator active: drop={Drop:P2} dup={Dup:P2} reorder={Reorder:P2} maxLag={MaxLag} seed={Seed}",
+            config.DropProbability, config.DuplicateProbability, config.ReorderProbability,
+            config.ReorderMaxLagPackets, config.Seed);
+    }
+
+    public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+    {
+        // Drop: decide first; a dropped packet still counts for reorder lag
+        // bookkeeping (i.e. it occupies a slot in the wire stream we just
+        // chose not to fill). Drained reordered packets that were due before
+        // this slot are still emitted so dropping a packet does not freeze
+        // the reorder queue.
+        if (_config.DropProbability > 0 && _rng.NextDouble() < _config.DropProbability)
+        {
+            _metrics?.IncChaosDropped();
+            DrainDueDelayed(channelNumber);
+            return;
+        }
+
+        // Reorder: hold this packet aside; emit later. Drain any other
+        // delayed packets whose lag has expired before this one.
+        if (_config.ReorderProbability > 0 && _rng.NextDouble() < _config.ReorderProbability)
+        {
+            int lag = 1 + _rng.Next(_config.ReorderMaxLagPackets);
+            _delayed.Add(new DelayedPacket(channelNumber, packet.ToArray(), lag));
+            _metrics?.IncChaosReordered();
+            DrainDueDelayed(channelNumber);
+            return;
+        }
+
+        // Send + maybe duplicate.
+        _inner.Publish(channelNumber, packet);
+        if (_config.DuplicateProbability > 0 && _rng.NextDouble() < _config.DuplicateProbability)
+        {
+            _inner.Publish(channelNumber, packet);
+            _metrics?.IncChaosDuplicated();
+        }
+
+        DrainDueDelayed(channelNumber);
+    }
+
+    private void DrainDueDelayed(byte currentChannel)
+    {
+        if (_delayed.Count == 0) return;
+        // Decrement every entry; emit those that hit 0. We iterate by index
+        // so removal does not invalidate subsequent indices.
+        for (int i = 0; i < _delayed.Count;)
+        {
+            var d = _delayed[i];
+            d.Lag--;
+            if (d.Lag <= 0)
+            {
+                _inner.Publish(d.ChannelNumber, d.Payload);
+                _delayed.RemoveAt(i);
+            }
+            else
+            {
+                _delayed[i] = d;
+                i++;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        // Flush any remaining delayed packets so we don't silently lose them
+        // on shutdown. The inner sink's Dispose still happens via host
+        // wiring (decorator does not own the inner socket).
+        for (int i = 0; i < _delayed.Count; i++)
+            _inner.Publish(_delayed[i].ChannelNumber, _delayed[i].Payload);
+        _delayed.Clear();
+    }
+
+    private struct DelayedPacket
+    {
+        public byte ChannelNumber;
+        public byte[] Payload;
+        public int Lag;
+        public DelayedPacket(byte ch, byte[] payload, int lag) { ChannelNumber = ch; Payload = payload; Lag = lag; }
+    }
+}

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -18,6 +18,9 @@ public sealed class ChannelMetrics
     private long _snapshotsEmitted;
     private long _instrumentDefsEmitted;
     private long _lastTickUnixMs;
+    private long _chaosDropped;
+    private long _chaosDuplicated;
+    private long _chaosReordered;
 
     public ChannelMetrics(byte channelNumber)
     {
@@ -29,11 +32,17 @@ public sealed class ChannelMetrics
     public long SnapshotsEmitted => Interlocked.Read(ref _snapshotsEmitted);
     public long InstrumentDefsEmitted => Interlocked.Read(ref _instrumentDefsEmitted);
     public long LastTickUnixMs => Interlocked.Read(ref _lastTickUnixMs);
+    public long ChaosDropped => Interlocked.Read(ref _chaosDropped);
+    public long ChaosDuplicated => Interlocked.Read(ref _chaosDuplicated);
+    public long ChaosReordered => Interlocked.Read(ref _chaosReordered);
 
     public void IncOrdersIn() => Interlocked.Increment(ref _ordersIn);
     public void IncPacketsOut() => Interlocked.Increment(ref _packetsOut);
     public void IncSnapshotsEmitted() => Interlocked.Increment(ref _snapshotsEmitted);
     public void IncInstrumentDefsEmitted() => Interlocked.Increment(ref _instrumentDefsEmitted);
+    public void IncChaosDropped() => Interlocked.Increment(ref _chaosDropped);
+    public void IncChaosDuplicated() => Interlocked.Increment(ref _chaosDuplicated);
+    public void IncChaosReordered() => Interlocked.Increment(ref _chaosReordered);
 
     /// <summary>
     /// Heartbeat. Called from the dispatch thread on every loop wakeup so
@@ -198,6 +207,15 @@ public sealed class MetricsRegistry
         EmitGauge(sb, "exch_dispatch_loop_last_tick_unixms",
             "Unix time (milliseconds) of the dispatcher loop's last heartbeat.",
             channels, c => c.LastTickUnixMs);
+        EmitCounter(sb, "umdf_chaos_dropped_total",
+            "Total UMDF packets dropped by the chaos decorator (issue #119). 0 unless chaos is enabled in HostConfig.",
+            channels, c => c.ChaosDropped);
+        EmitCounter(sb, "umdf_chaos_duplicated_total",
+            "Total UMDF packets duplicated by the chaos decorator (issue #119).",
+            channels, c => c.ChaosDuplicated);
+        EmitCounter(sb, "umdf_chaos_reordered_total",
+            "Total UMDF packets held back for reorder by the chaos decorator (issue #119).",
+            channels, c => c.ChaosReordered);
 
         sb.Append("# HELP exch_send_queue_depth Per-session ExecutionReport send-queue depth (channel=\"all\" because the session queue is shared).\n");
         sb.Append("# TYPE exch_send_queue_depth gauge\n");

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -123,6 +123,22 @@ public sealed class ExchangeHost : IAsyncDisposable
             var engineLogger = _loggerFactory.CreateLogger<MatchingEngine>();
             var channelMetrics = _metrics.RegisterChannel(ch.ChannelNumber);
 
+            // Wrap with chaos decorator if configured (issue #119). Off by
+            // default; only activates when the operator opts in via config.
+            if (ch.Chaos is { } chaosCfg)
+            {
+                var coreCfg = chaosCfg.ToCore();
+                if (coreCfg.IsActive)
+                {
+                    var chaos = new ChaosUdpPacketSinkDecorator(
+                        sink, coreCfg,
+                        _loggerFactory.CreateLogger<ChaosUdpPacketSinkDecorator>(),
+                        channelMetrics);
+                    _ownedSinks.Add(chaos);
+                    sink = chaos;
+                }
+            }
+
             // Capture the engine via a side-channel so we can build a snapshot
             // source that reads through the live book on the dispatcher thread.
             MatchingEngine? capturedEngine = null;

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -204,6 +204,37 @@ public sealed class ChannelConfig
     /// instrument definitions are published for this channel.
     /// </summary>
     [JsonPropertyName("instrumentDefinition")] public InstrumentDefinitionConfig? InstrumentDefinition { get; set; }
+
+    /// <summary>
+    /// Optional chaos injection on the incremental UDP sink (issue #119).
+    /// When omitted or all probabilities are 0, the sink is unmodified.
+    /// Used to exercise the consumer's recovery paths (snapshot bootstrap,
+    /// gap detection) without external network-shaping tools.
+    /// </summary>
+    [JsonPropertyName("chaos")] public ChaosConfigJson? Chaos { get; set; }
+}
+
+/// <summary>
+/// JSON projection of <see cref="B3.Exchange.Core.ChaosConfig"/>. Lives here
+/// (rather than re-using the Core type directly) so the JSON shape is owned
+/// by the host config layer and the Core decorator stays POCO-free.
+/// </summary>
+public sealed class ChaosConfigJson
+{
+    [JsonPropertyName("dropProbability")] public double DropProbability { get; set; }
+    [JsonPropertyName("duplicateProbability")] public double DuplicateProbability { get; set; }
+    [JsonPropertyName("reorderProbability")] public double ReorderProbability { get; set; }
+    [JsonPropertyName("reorderMaxLagPackets")] public int ReorderMaxLagPackets { get; set; } = 3;
+    [JsonPropertyName("seed")] public int Seed { get; set; }
+
+    public B3.Exchange.Core.ChaosConfig ToCore() => new()
+    {
+        DropProbability = DropProbability,
+        DuplicateProbability = DuplicateProbability,
+        ReorderProbability = ReorderProbability,
+        ReorderMaxLagPackets = ReorderMaxLagPackets,
+        Seed = Seed,
+    };
 }
 
 public enum UmdfTransport

--- a/tests/B3.Exchange.Core.Tests/ChaosUdpPacketSinkDecoratorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChaosUdpPacketSinkDecoratorTests.cs
@@ -1,0 +1,158 @@
+namespace B3.Exchange.Core.Tests;
+
+public class ChaosUdpPacketSinkDecoratorTests
+{
+    private sealed class RecordingSink : IUmdfPacketSink
+    {
+        public List<(byte Channel, byte[] Bytes)> Sent { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+            => Sent.Add((channelNumber, packet.ToArray()));
+    }
+
+    private static byte[] Pkt(byte tag) => new[] { tag, (byte)0xAA, (byte)0xBB };
+
+    [Fact]
+    public void DropProbabilityOne_NoPacketsLeaveSink()
+    {
+        var inner = new RecordingSink();
+        using var chaos = new ChaosUdpPacketSinkDecorator(
+            inner,
+            new ChaosConfig { DropProbability = 1.0, Seed = 1 },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ChaosUdpPacketSinkDecorator>.Instance);
+
+        for (int i = 0; i < 10; i++)
+            chaos.Publish(1, Pkt((byte)i));
+
+        Assert.Empty(inner.Sent);
+    }
+
+    [Fact]
+    public void DuplicateProbabilityOne_EmitsTwoCopies()
+    {
+        var inner = new RecordingSink();
+        using var chaos = new ChaosUdpPacketSinkDecorator(
+            inner,
+            new ChaosConfig { DuplicateProbability = 1.0, Seed = 2 },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ChaosUdpPacketSinkDecorator>.Instance);
+
+        chaos.Publish(1, Pkt(0xCC));
+        chaos.Publish(1, Pkt(0xDD));
+
+        Assert.Equal(4, inner.Sent.Count);
+        Assert.Equal(0xCC, inner.Sent[0].Bytes[0]);
+        Assert.Equal(0xCC, inner.Sent[1].Bytes[0]);
+        Assert.Equal(0xDD, inner.Sent[2].Bytes[0]);
+        Assert.Equal(0xDD, inner.Sent[3].Bytes[0]);
+    }
+
+    [Fact]
+    public void NoChaos_ActsAsPassthrough()
+    {
+        var inner = new RecordingSink();
+        using var chaos = new ChaosUdpPacketSinkDecorator(
+            inner,
+            new ChaosConfig(), // all probabilities 0
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ChaosUdpPacketSinkDecorator>.Instance);
+
+        for (int i = 0; i < 5; i++) chaos.Publish(7, Pkt((byte)i));
+
+        Assert.Equal(5, inner.Sent.Count);
+        Assert.All(inner.Sent, p => Assert.Equal(7, p.Channel));
+    }
+
+    [Fact]
+    public void ReorderProbabilityOne_DefersPacketByAtMostMaxLag()
+    {
+        // With probability 1 and maxLag = 2, every packet enters the delay queue
+        // at lag in [1,2]. Sequence of 6 inputs should still produce 6 outputs
+        // (no loss), but order is shuffled and order-of-emission is bounded
+        // by the maxLag window.
+        var inner = new RecordingSink();
+        using var chaos = new ChaosUdpPacketSinkDecorator(
+            inner,
+            new ChaosConfig { ReorderProbability = 1.0, ReorderMaxLagPackets = 2, Seed = 42 },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ChaosUdpPacketSinkDecorator>.Instance);
+
+        for (int i = 0; i < 6; i++) chaos.Publish(1, Pkt((byte)i));
+
+        // After 6 publishes, some may still be pending; flush via Dispose.
+        // Capture count before flush + after to sanity-check.
+        int before = inner.Sent.Count;
+        // Re-dispose explicitly via a using-scope to flush.
+        chaos.Dispose();
+        int after = inner.Sent.Count;
+
+        Assert.Equal(6, after);
+        Assert.True(after >= before);
+
+        // Order: a packet emitted at index k must have been queued at most
+        // maxLag (=2) Publish-calls before its emission. Verify no packet
+        // index advances more than maxLag positions backward.
+        // Simpler: each emitted index must be within ±maxLag of its arrival.
+        for (int k = 0; k < after; k++)
+        {
+            int arrived = inner.Sent[k].Bytes[0];
+            int diff = arrived - k;
+            Assert.True(Math.Abs(diff) <= 2,
+                $"packet {arrived} emitted at slot {k} (diff={diff}) exceeds maxLag=2");
+        }
+    }
+
+    [Fact]
+    public void DroppedPacket_DoesNotFreezeReorderQueue()
+    {
+        // Mix drop=0.5 + reorder=0.5 with a fixed seed; assert reorder queue
+        // drains by Dispose-time so no packet is "stuck" forever.
+        var inner = new RecordingSink();
+        using (var chaos = new ChaosUdpPacketSinkDecorator(
+            inner,
+            new ChaosConfig
+            {
+                DropProbability = 0.5,
+                ReorderProbability = 0.5,
+                ReorderMaxLagPackets = 2,
+                Seed = 7,
+            },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ChaosUdpPacketSinkDecorator>.Instance))
+        {
+            for (int i = 0; i < 20; i++) chaos.Publish(1, Pkt((byte)i));
+        }
+        // Dispose flushes any pending delayed packets — assert >0 emitted (the seed
+        // shouldn't drop everything).
+        Assert.True(inner.Sent.Count > 0);
+    }
+
+    [Fact]
+    public void IncrementsMetricsCounters()
+    {
+        var inner = new RecordingSink();
+        var metrics = new ChannelMetrics(channelNumber: 9);
+        using var chaos = new ChaosUdpPacketSinkDecorator(
+            inner,
+            new ChaosConfig { DropProbability = 1.0, Seed = 1 },
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<ChaosUdpPacketSinkDecorator>.Instance,
+            metrics);
+
+        for (int i = 0; i < 4; i++) chaos.Publish(9, Pkt((byte)i));
+
+        Assert.Equal(4, metrics.ChaosDropped);
+        Assert.Equal(0, metrics.ChaosDuplicated);
+        Assert.Equal(0, metrics.ChaosReordered);
+    }
+
+    [Theory]
+    [InlineData(-0.1)]
+    [InlineData(1.1)]
+    public void Validate_RejectsOutOfRangeProbability(double p)
+    {
+        var cfg = new ChaosConfig { DropProbability = p };
+        Assert.Throws<ArgumentException>(cfg.Validate);
+    }
+
+    [Fact]
+    public void Validate_ReorderRequiresPositiveMaxLag()
+    {
+        var cfg = new ChaosConfig { ReorderProbability = 0.5, ReorderMaxLagPackets = 0 };
+        Assert.Throws<ArgumentException>(cfg.Validate);
+    }
+}


### PR DESCRIPTION
Closes #119.

Adds an opt-in `IUmdfPacketSink` decorator that injects controlled drop / duplicate / reorder into the incremental UDP sink, with deterministic seeding, per-channel metrics, and host config plumbing.

## What

- **`ChaosConfig` + `ChaosUdpPacketSinkDecorator`** in `B3.Exchange.Core`.
  - Probabilities default to 0 → pass-through.
  - Reorder uses bounded `[1, ReorderMaxLagPackets]` lag; held packets flushed on dispose.
  - Not thread-safe (matches the existing sink contract — single dispatcher thread per sink).
- **Metrics**: `ChannelMetrics` gains `ChaosDropped`/`Duplicated`/`Reordered` counters; Prometheus exposes `umdf_chaos_dropped_total`, `umdf_chaos_duplicated_total`, `umdf_chaos_reordered_total`.
- **Host config**: per-channel `chaos` block (`HostConfig.ChannelConfig.Chaos`); `ExchangeHost` wraps only the incremental sink so snapshot + instrument-definition channels stay clean for recovery.
- **Tests** (`B3.Exchange.Core.Tests`): pass-through, drop=1, dup=1, reorder lag bound, drained-on-dispose, metrics increment, validation errors.
- **Runbook** §5.7: recovery scenario walkthrough + metrics reference.

## Verification

```
dotnet build -c Release      → OK, 0 warnings
dotnet test  -c Release      → all suites green (Core 41/41, Gateway 376/376, Host 33/33)
dotnet format --verify-no-changes → clean
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>