### PR TITLE
Refactor: extract FixpRetransmitController (#121, step 2/4)

### DIFF
--- a/src/B3.Exchange.Gateway/FixpRetransmitController.cs
+++ b/src/B3.Exchange.Gateway/FixpRetransmitController.cs
@@ -1,0 +1,214 @@
+using System.Buffers.Binary;
+using B3.Entrypoint.Fixp.Sbe.V6;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Owns the FIXP retransmission control plane for a <see cref="FixpSession"/>:
+/// the periodic <c>Sequence</c> heartbeat (spec §4.5.5) and the
+/// <c>RetransmitRequest → Retransmission/Sequence</c> replay block
+/// (spec §4.5.6, issue #46).
+///
+/// <para>Extracted from <see cref="FixpSession"/> as part of issue #121,
+/// step 2/4. Shares mutable state with the owning session
+/// (<c>_transport</c>, <c>_outboundLock</c>, <c>_retxBuffer</c>, message-seq
+/// peek) via constructor-injected accessors so behavior is identical to the
+/// pre-refactor inline implementation.</para>
+/// </summary>
+internal sealed class FixpRetransmitController
+{
+    private readonly Func<uint> _sessionId;
+    private readonly Func<TcpTransport> _transport;
+    private readonly RetransmitBuffer _retxBuffer;
+    private readonly object _outboundLock;
+    private readonly int _sendQueueCapacity;
+    private readonly Func<bool> _isOpen;
+    private readonly Func<uint> _peekNextMsgSeqNum;
+    private readonly Func<FixpEvent, FixpAction> _applyTransition;
+    private readonly Func<FixpState> _getState;
+    private readonly ILogger _logger;
+    private readonly long _connectionId;
+
+    /// <summary>One-outstanding-request gate. 0 = idle, 1 = a replay block
+    /// is mid-enqueue. CAS-guarded so a concurrent request can be rejected
+    /// with <c>RETRANSMIT_IN_PROGRESS</c> rather than allowed to interleave.</summary>
+    private int _retxInProgress;
+
+    public FixpRetransmitController(
+        Func<uint> sessionId,
+        Func<TcpTransport> transport,
+        RetransmitBuffer retxBuffer,
+        object outboundLock,
+        int sendQueueCapacity,
+        Func<bool> isOpen,
+        Func<uint> peekNextMsgSeqNum,
+        Func<FixpEvent, FixpAction> applyTransition,
+        Func<FixpState> getState,
+        ILogger logger,
+        long connectionId)
+    {
+        _sessionId = sessionId;
+        _transport = transport;
+        _retxBuffer = retxBuffer;
+        _outboundLock = outboundLock;
+        _sendQueueCapacity = sendQueueCapacity;
+        _isOpen = isOpen;
+        _peekNextMsgSeqNum = peekNextMsgSeqNum;
+        _applyTransition = applyTransition;
+        _getState = getState;
+        _logger = logger;
+        _connectionId = connectionId;
+    }
+
+    /// <summary>
+    /// Enqueues a FIXP <c>Sequence</c> heartbeat frame announcing
+    /// <see cref="FixpSession.PeekNextMsgSeqNum"/>. Spec §4.5.5: this
+    /// message announces the *next* MsgSeqNum we intend to send and
+    /// does not consume a sequence number itself, so we peek instead
+    /// of incrementing — otherwise an idle heartbeat before Establish
+    /// would cause the EstablishAck.nextSeqNo to be off by one.
+    ///
+    /// <para>Outbound lock: serializes against the replay block in
+    /// <see cref="ProcessAndEnqueueRetransmitRequest"/> so a watchdog-driven
+    /// heartbeat cannot land inside the Retransmission/replay/Sequence
+    /// burst on the wire (gpt-5.5 review #1).</para>
+    /// </summary>
+    public void EnqueueSequence()
+    {
+        if (!_isOpen()) return;
+        var frame = new byte[SessionFrameEncoder.SequenceTotal];
+        lock (_outboundLock)
+        {
+            SessionFrameEncoder.EncodeSequence(frame, _peekNextMsgSeqNum());
+            _transport().TryEnqueueFrame(frame);
+        }
+    }
+
+    /// <summary>
+    /// Decodes and processes a FIXP <c>RetransmitRequest</c> (template
+    /// id 12), per spec §4.5.6 and issue #46. Runs on the dispatch
+    /// (recv-loop) thread.
+    ///
+    /// <para>State machine routing (already encoded in
+    /// <see cref="FixpStateMachine"/>): <c>Established → Replay</c>;
+    /// <c>Suspended → DeferredToReestablish</c> (silently drop); other
+    /// states → <c>DropSilently</c>. Validation order before replay:
+    /// <c>SessionID</c> match, timestamp non-zero, count bounds, in-flight
+    /// gate (CAS), then the buffer's window check (<c>OUT_OF_RANGE</c>
+    /// vs <c>INVALID_FROMSEQNO</c>).</para>
+    ///
+    /// <para>On accept: encodes a <c>Retransmission</c> header with
+    /// <c>nextSeqNo = request.fromSeqNo</c> and <c>count = actual</c>,
+    /// enqueues all replay clones (each carrying the
+    /// <c>PossResend</c> bit), and finally enqueues a <c>Sequence</c>
+    /// frame whose <c>nextSeqNo</c> is the next live business seq
+    /// (i.e. <see cref="FixpSession.PeekNextMsgSeqNum"/>). The entire
+    /// block is enqueued under <see cref="_outboundLock"/> so live
+    /// business writes cannot interleave it on the wire and so the
+    /// trailing Sequence's seq matches what the peer will see next.</para>
+    /// </summary>
+    public void ProcessAndEnqueueRetransmitRequest(ReadOnlySpan<byte> fixedBlock)
+    {
+        // Layout (BLOCK_LENGTH=20): SessionID(4) | Timestamp(8 ulong) |
+        // FromSeqNo(4 uint) | Count(4 uint).
+        if (fixedBlock.Length < 20) return; // header validator already enforced this; defensive
+        uint reqSessionId = BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(0, 4));
+        ulong reqTimestamp = BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(4, 8));
+        uint fromSeq = BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(12, 4));
+        uint count = BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(16, 4));
+
+        var action = _applyTransition(FixpEvent.RetransmitRequest);
+        if (action != FixpAction.Replay)
+        {
+            // DropSilently / DeferredToReestablish / Terminal: per spec,
+            // emit nothing. Suspended sessions have no live transport
+            // anyway; a request that arrives in any pre-Established state
+            // is simply ignored and the peer is expected to drive the
+            // handshake before requesting recovery.
+            _logger.LogDebug("session {ConnectionId} retransmit-request action={Action} state={State} dropped",
+                _connectionId, action, _getState());
+            return;
+        }
+
+        // Spec validations BEFORE single-in-flight gate so a malformed
+        // request doesn't leave the gate held.
+        if (reqSessionId != _sessionId())
+        {
+            EnqueueRetransmitReject(reqTimestamp, RetransmitRejectCode.INVALID_SESSION);
+            return;
+        }
+        if (reqTimestamp == 0UL)
+        {
+            EnqueueRetransmitReject(reqTimestamp, RetransmitRejectCode.INVALID_TIMESTAMP);
+            return;
+        }
+
+        // One-outstanding-request gate. Cleared in the finally below
+        // after the entire replay block is enqueued under _outboundLock,
+        // so a subsequent request can never see partial state.
+        if (Interlocked.CompareExchange(ref _retxInProgress, 1, 0) != 0)
+        {
+            EnqueueRetransmitReject(reqTimestamp, RetransmitRejectCode.RETRANSMIT_IN_PROGRESS);
+            return;
+        }
+        try
+        {
+            // Buffer combines count-bounds + window check under one lock
+            // (no TOCTOU between FirstAvailable read and clone copy).
+            var snap = _retxBuffer.TryGet(fromSeq, count);
+            if (snap.RejectCode is { } code)
+            {
+                EnqueueRetransmitReject(reqTimestamp, code);
+                return;
+            }
+
+            // Hold the outbound lock for the entire block so (a) no live
+            // business frame interleaves on the wire and (b) the
+            // trailing Sequence's nextSeqNo matches the next live seq
+            // the peer will see (gpt-5.5 critique #1, #2).
+            lock (_outboundLock)
+            {
+                // Backpressure: TcpTransport's bounded send queue can
+                // drop frames if it overflows mid-replay (gpt-5.5 review
+                // #2). Reserve capacity for the FULL block (header +
+                // clones + trailer) under the outbound lock; if the
+                // queue cannot accept the burst, reject with SYSTEM_BUSY
+                // rather than advertise an exact count we can't deliver.
+                int needed = 2 + snap.Frames.Length;
+                var transport = _transport();
+                if (transport.SendQueueDepth + needed > _sendQueueCapacity)
+                {
+                    EnqueueRetransmitReject(reqTimestamp, RetransmitRejectCode.SYSTEM_BUSY);
+                    return;
+                }
+
+                var headerFrame = new byte[RetransmissionEncoder.RetransmissionTotal];
+                RetransmissionEncoder.EncodeRetransmission(headerFrame,
+                    _sessionId(), reqTimestamp,
+                    firstRetransmittedSeqNo: snap.FirstSeq, count: snap.ActualCount);
+                transport.TryEnqueueFrame(headerFrame);
+
+                for (int i = 0; i < snap.Frames.Length; i++)
+                    transport.TryEnqueueFrame(snap.Frames[i]);
+
+                var trailer = new byte[SessionFrameEncoder.SequenceTotal];
+                SessionFrameEncoder.EncodeSequence(trailer, _peekNextMsgSeqNum());
+                transport.TryEnqueueFrame(trailer);
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref _retxInProgress, 0);
+        }
+    }
+
+    private void EnqueueRetransmitReject(ulong requestTimestampNanos, RetransmitRejectCode code)
+    {
+        var frame = new byte[RetransmissionEncoder.RetransmitRejectTotal];
+        RetransmissionEncoder.EncodeRetransmitReject(frame, _sessionId(), requestTimestampNanos, code);
+        _transport().TryEnqueueFrame(frame);
+        _logger.LogInformation("session {ConnectionId} retransmit-reject code={Code}",
+            _connectionId, code);
+    }
+}

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -76,12 +76,7 @@ public sealed class FixpSession : IAsyncDisposable
     /// </summary>
     private readonly RetransmitBuffer _retxBuffer;
     private readonly FixpOutboundEncoder _outboundEncoder;
-    /// <summary>0 / 1 — set via <see cref="Interlocked.CompareExchange"/>
-    /// for the duration of a single retransmission replay (per spec
-    /// §4.5.6: "one outstanding request at a time"). Cleared after the
-    /// last frame of the replay block is enqueued under
-    /// <see cref="_outboundLock"/>.</summary>
-    private int _retxInProgress;
+    private readonly FixpRetransmitController _retransmitController;
     /// <summary>The wire SessionID currently claimed in <see cref="_claims"/>,
     /// or 0 if no claim is held. Tracked so <see cref="Close"/> can
     /// release the claim using the value from the moment the claim was
@@ -338,6 +333,18 @@ public sealed class FixpSession : IAsyncDisposable
             nowNanos: () => _nowNanos(),
             isOpen: () => IsOpen,
             close: Close);
+        _retransmitController = new FixpRetransmitController(
+            sessionId: () => SessionId,
+            transport: () => _transport!,
+            retxBuffer: _retxBuffer,
+            outboundLock: _outboundLock,
+            sendQueueCapacity: _sendQueueCapacity,
+            isOpen: () => IsOpen,
+            peekNextMsgSeqNum: PeekNextMsgSeqNum,
+            applyTransition: ApplyTransition,
+            getState: () => State,
+            logger: _logger,
+            connectionId: ConnectionId);
         if (_options.ThrottleMaxMessages > 0 && _options.ThrottleTimeWindowMs > 0)
         {
             _throttle = new InboundThrottle(
@@ -1398,26 +1405,7 @@ public sealed class FixpSession : IAsyncDisposable
         }
     }
 
-    private void EnqueueSequence()
-    {
-        if (!IsOpen) return;
-        var frame = new byte[SessionFrameEncoder.SequenceTotal];
-        // FIXP §4.5.5: the Sequence message announces the *next* MsgSeqNum
-        // we intend to send. It does not consume a sequence number itself,
-        // so we must peek instead of incrementing — otherwise the Establish
-        // handshake would observe a phantom gap (e.g. an idle heartbeat
-        // before Establish would push EstablishAck.nextSeqNo off by one).
-        //
-        // Outbound lock: serializes against the replay block in
-        // ProcessAndEnqueueRetransmitRequest so a watchdog-driven
-        // heartbeat cannot land inside the Retransmission/replay/Sequence
-        // sequence on the wire (gpt-5.5 review #1).
-        lock (_outboundLock)
-        {
-            SessionFrameEncoder.EncodeSequence(frame, PeekNextMsgSeqNum());
-            _transport.TryEnqueueFrame(frame);
-        }
-    }
+    private void EnqueueSequence() => _retransmitController.EnqueueSequence();
 
     private static async Task ReadExactlyAsync(Stream s, byte[] buf, CancellationToken ct)
         => await ReadExactlyAsync(s, buf.AsMemory(), ct).ConfigureAwait(false);
@@ -1464,109 +1452,7 @@ public sealed class FixpSession : IAsyncDisposable
     /// Sequence's seq matches what the peer will see next.</para>
     /// </summary>
     private void ProcessAndEnqueueRetransmitRequest(ReadOnlySpan<byte> fixedBlock)
-    {
-        // Layout (BLOCK_LENGTH=20): SessionID(4) | Timestamp(8 ulong) |
-        // FromSeqNo(4 uint) | Count(4 uint).
-        if (fixedBlock.Length < 20) return; // header validator already enforced this; defensive
-        uint reqSessionId = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(0, 4));
-        ulong reqTimestamp = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(4, 8));
-        uint fromSeq = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(12, 4));
-        uint count = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(16, 4));
-
-        var action = ApplyTransition(FixpEvent.RetransmitRequest);
-        if (action != FixpAction.Replay)
-        {
-            // DropSilently / DeferredToReestablish / Terminal: per spec,
-            // emit nothing. Suspended sessions have no live transport
-            // anyway; a request that arrives in any pre-Established state
-            // is simply ignored and the peer is expected to drive the
-            // handshake before requesting recovery.
-            _logger.LogDebug("session {ConnectionId} retransmit-request action={Action} state={State} dropped",
-                ConnectionId, action, State);
-            return;
-        }
-
-        // Spec validations BEFORE single-in-flight gate so a malformed
-        // request doesn't leave the gate held.
-        if (reqSessionId != SessionId)
-        {
-            EnqueueRetransmitReject(reqTimestamp, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_SESSION);
-            return;
-        }
-        if (reqTimestamp == 0UL)
-        {
-            EnqueueRetransmitReject(reqTimestamp, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_TIMESTAMP);
-            return;
-        }
-
-        // One-outstanding-request gate. Cleared in the finally below
-        // after the entire replay block is enqueued under _outboundLock,
-        // so a subsequent request can never see partial state.
-        if (Interlocked.CompareExchange(ref _retxInProgress, 1, 0) != 0)
-        {
-            EnqueueRetransmitReject(reqTimestamp, B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.RETRANSMIT_IN_PROGRESS);
-            return;
-        }
-        try
-        {
-            // Buffer combines count-bounds + window check under one lock
-            // (no TOCTOU between FirstAvailable read and clone copy).
-            var snap = _retxBuffer.TryGet(fromSeq, count);
-            if (snap.RejectCode is { } code)
-            {
-                EnqueueRetransmitReject(reqTimestamp, code);
-                return;
-            }
-
-            // Hold the outbound lock for the entire block so (a) no live
-            // business frame interleaves on the wire and (b) the
-            // trailing Sequence's nextSeqNo matches the next live seq
-            // the peer will see (gpt-5.5 critique #1, #2).
-            lock (_outboundLock)
-            {
-                // Backpressure: TcpTransport's bounded send queue can
-                // drop frames if it overflows mid-replay (gpt-5.5 review
-                // #2). Reserve capacity for the FULL block (header +
-                // clones + trailer) under the outbound lock; if the
-                // queue cannot accept the burst, reject with SYSTEM_BUSY
-                // rather than advertise an exact count we can't deliver.
-                int needed = 2 + snap.Frames.Length;
-                if (_transport.SendQueueDepth + needed > _sendQueueCapacity)
-                {
-                    EnqueueRetransmitReject(reqTimestamp,
-                        B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.SYSTEM_BUSY);
-                    return;
-                }
-
-                var headerFrame = new byte[RetransmissionEncoder.RetransmissionTotal];
-                RetransmissionEncoder.EncodeRetransmission(headerFrame,
-                    SessionId, reqTimestamp,
-                    firstRetransmittedSeqNo: snap.FirstSeq, count: snap.ActualCount);
-                _transport.TryEnqueueFrame(headerFrame);
-
-                for (int i = 0; i < snap.Frames.Length; i++)
-                    _transport.TryEnqueueFrame(snap.Frames[i]);
-
-                var trailer = new byte[SessionFrameEncoder.SequenceTotal];
-                SessionFrameEncoder.EncodeSequence(trailer, PeekNextMsgSeqNum());
-                _transport.TryEnqueueFrame(trailer);
-            }
-        }
-        finally
-        {
-            Volatile.Write(ref _retxInProgress, 0);
-        }
-    }
-
-    private void EnqueueRetransmitReject(ulong requestTimestampNanos,
-        B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode code)
-    {
-        var frame = new byte[RetransmissionEncoder.RetransmitRejectTotal];
-        RetransmissionEncoder.EncodeRetransmitReject(frame, SessionId, requestTimestampNanos, code);
-        _transport.TryEnqueueFrame(frame);
-        _logger.LogInformation("session {ConnectionId} retransmit-reject code={Code}",
-            ConnectionId, code);
-    }
+        => _retransmitController.ProcessAndEnqueueRetransmitRequest(fixedBlock);
 
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
         => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos);


### PR DESCRIPTION
Refs #121 — second of four micro-PRs decomposing `FixpSession.cs`. Builds on PR #126 (OutboundEncoder).

## What this PR moves

Into the new `FixpRetransmitController`:
- `EnqueueSequence()` — idle/heartbeat Sequence frame (spec §4.5.5).
- `ProcessAndEnqueueRetransmitRequest()` — RetransmitRequest → Replay block (spec §4.5.6 / issue #46).
- `EnqueueRetransmitReject()` private helper.
- `_retxInProgress` single-in-flight gate.

Stays on `FixpSession`:
- `_msgSeqNum` + `NextMsgSeqNum`/`PeekNextMsgSeqNum` (still used by Establish/EstablishAck encoding paths).
- `ApplyTransition` state-machine entry point.
- All inbound dispatch routing — `ProcessAndEnqueueRetransmitRequest` and `EnqueueSequence` are kept as one-line delegates so existing call sites (DispatchInboundAsync, watchdog) are untouched.

## Wiring

Controller receives mutable state via constructor accessors:
- `Func<TcpTransport>` (re-bound on re-attach)
- `Func<bool> isOpen` (combined `_isOpen` + transport)
- `Func<uint>` for `SessionId` and `PeekNextMsgSeqNum`
- `Func<FixpEvent, FixpAction>` for the state machine
- `Func<FixpState>` for diagnostic logging

Behavior identical to the pre-refactor inline implementation.

## Verification

```
dotnet build -c Release      → OK, 0 warnings
dotnet test  -c Release      → 595/595 (Gateway 376/376)
dotnet format --verify-no-changes → clean
```

`FixpSession.cs`: 2015 → **1901 lines** (-114). Cumulative for #121: 2159 → 1901 (-258).

Two extractions to go: MassActionHandler (3/4), then InboundDispatcher (4/4) which is the largest piece.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>