### PR TITLE
Add long-haul soak workflow with RSS / FD / thread leak assertions (#120)

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,0 +1,197 @@
+name: Soak (long-haul)
+
+# Long-running stability test for the exchange host. Runs an exchange host
+# under a sustained synthetic-trader load and samples process metrics every
+# 30s. Issue #120.
+#
+# - Schedule: 03:00 UTC nightly, default 60min runtime.
+# - Manual dispatch: defaults to 5min for fast iteration.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      duration_minutes:
+        description: 'Soak runtime in minutes (1–360).'
+        required: false
+        default: '10'
+      synth_clients:
+        description: 'Number of synthetic-trader processes to launch.'
+        required: false
+        default: '2'
+
+concurrency:
+  group: soak-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  soak:
+    name: Soak host + ${{ github.event.inputs.synth_clients || '2' }} synth traders
+    runs-on: ubuntu-latest
+    # 60min default schedule + ~10min for build/start/teardown/analysis.
+    # Manual dispatch up to 360min still fits within the 6h GitHub-hosted cap.
+    timeout-minutes: 380
+
+    env:
+      DURATION_MINUTES: ${{ github.event.inputs.duration_minutes || (github.event_name == 'schedule' && '60') || '10' }}
+      SYNTH_CLIENTS: ${{ github.event.inputs.synth_clients || '2' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Packages.props', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore + build (Release)
+        run: |
+          dotnet restore SbeB3Exchange.slnx
+          dotnet build SbeB3Exchange.slnx --no-restore -c Release
+
+      - name: Prepare artifact dir
+        run: mkdir -p artifacts/soak
+
+      - name: Start exchange host
+        id: start_host
+        run: |
+          set -euo pipefail
+          # Detach so subsequent steps can run; redirect logs to artifact.
+          # Run the published DLL directly (not `dotnet run --project`) so
+          # the working directory stays at the repo root and the relative
+          # `instruments` path inside the JSON resolves correctly.
+          # The soak config omits firms[]/sessions[] to use the legacy
+          # single-tenant fallback so SyntheticTrader (no FIXP Negotiate)
+          # can connect and drive sustained load.
+          nohup dotnet src/B3.Exchange.Host/bin/Release/net10.0/B3.Exchange.Host.dll \
+            config/exchange-simulator.soak.json \
+            > artifacts/soak/host.log 2>&1 &
+          echo "HOST_PID=$!" >> "$GITHUB_ENV"
+          echo "Host PID: $!"
+
+      - name: Wait for host readiness (/health/ready)
+        run: |
+          set -euo pipefail
+          for i in {1..60}; do
+            if curl -fs --max-time 2 http://127.0.0.1:8080/health/ready >/dev/null; then
+              echo "host ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "host did not become ready within 60s" >&2
+          tail -200 artifacts/soak/host.log >&2 || true
+          exit 1
+
+      - name: Start synthetic traders (best-effort)
+        # KNOWN LIMITATION: SyntheticTrader does not yet implement the FIXP
+        # Negotiate/Establish handshake required by the modern Gateway.
+        # Each connection is rejected with `app-message-before-negotiate`
+        # within milliseconds and the trader process exits without retry.
+        # Tracked as a follow-up to #120; for now this step provides only a
+        # brief burst of TCP-accept activity at start-of-soak. The host's
+        # snapshot rotator + instrument-definition publisher continue to
+        # generate steady UDP multicast traffic for the full soak duration,
+        # which exercises the publishers, timers, and HTTP server even with
+        # zero sustained client load.
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/soak/traders
+          for i in $(seq 1 "${SYNTH_CLIENTS}"); do
+            nohup dotnet src/B3.Exchange.SyntheticTrader/bin/Release/net10.0/B3.Exchange.SyntheticTrader.dll \
+              config/synthetic-trader.soak.json \
+              > "artifacts/soak/traders/trader-${i}.log" 2>&1 &
+            pid=$!
+            echo "trader ${i} PID: ${pid}"
+            echo "${pid}" >> artifacts/soak/trader-pids.txt
+          done
+          sleep 5
+
+      - name: Run sampler for ${{ env.DURATION_MINUTES }}min
+        env:
+          OUTPUT_CSV: artifacts/soak/samples.csv
+          METRICS_URL: http://127.0.0.1:8080/metrics
+          SAMPLE_INTERVAL_SECONDS: 30
+        run: |
+          set -euo pipefail
+          chmod +x tools/soak/sample.sh
+          DURATION_SECONDS=$(( DURATION_MINUTES * 60 )) \
+            bash tools/soak/sample.sh
+
+      - name: Stop synthetic traders
+        if: always()
+        run: |
+          set +e
+          if [[ -f artifacts/soak/trader-pids.txt ]]; then
+            while read -r pid; do
+              [[ -n "$pid" ]] && kill "$pid" 2>/dev/null
+            done < artifacts/soak/trader-pids.txt
+          fi
+          # Give them a moment to flush logs.
+          sleep 3
+          true
+
+      - name: Stop host
+        if: always()
+        run: |
+          set +e
+          if [[ -n "${HOST_PID:-}" ]]; then
+            kill "${HOST_PID}" 2>/dev/null
+            for i in {1..15}; do
+              kill -0 "${HOST_PID}" 2>/dev/null || break
+              sleep 1
+            done
+            kill -9 "${HOST_PID}" 2>/dev/null
+          fi
+          true
+
+      - name: Analyze samples
+        id: analyze
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ ! -s artifacts/soak/samples.csv ]]; then
+            echo "no samples collected — failing" >&2
+            exit 1
+          fi
+          python3 tools/soak/analyze.py artifacts/soak/samples.csv \
+            | tee artifacts/soak/summary.md
+          # Mirror the summary into the workflow run page.
+          {
+            echo "## Soak summary"
+            echo
+            cat artifacts/soak/summary.md
+            echo
+            echo "<details><summary>First 10 + last 10 samples</summary>"
+            echo
+            echo '```'
+            head -1 artifacts/soak/samples.csv
+            tail -n +2 artifacts/soak/samples.csv | head -10
+            echo "..."
+            tail -10 artifacts/soak/samples.csv
+            echo '```'
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload soak artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: soak-${{ github.run_number }}
+          path: artifacts/soak/**/*
+          if-no-files-found: warn
+          retention-days: 30

--- a/config/exchange-simulator.soak.json
+++ b/config/exchange-simulator.soak.json
@@ -1,0 +1,43 @@
+{
+  // Soak-test exchange config (#120). Deliberately omits firms[]/sessions[]
+  // so the deprecated single-tenant fallback kicks in — this lets the
+  // SyntheticTrader (which does not implement FIXP Negotiate) connect and
+  // sustain load for the soak duration. Do NOT use as a template for new
+  // deployments; production configs should declare firms/sessions explicitly.
+  "tcp": {
+    "listen": "0.0.0.0:9876",
+    "enteringFirm": 1,
+    "heartbeatIntervalMs": 30000,
+    "idleTimeoutMs": 30000,
+    "testRequestGraceMs": 5000
+  },
+  "auth": { "devMode": true },
+  "http": {
+    "listen": "0.0.0.0:8080",
+    "livenessStaleMs": 5000
+  },
+  "channels": [
+    {
+      "channelNumber": 84,
+      "incrementalGroup": "224.0.20.84",
+      "incrementalPort": 30084,
+      "ttl": 1,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-eqt.json",
+      "snapshot": {
+        "group": "224.0.20.184",
+        "port": 30184,
+        "ttl": 1,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 184,
+        "group": "224.0.21.84",
+        "port": 31084,
+        "ttl": 1,
+        "cadenceMs": 5000
+      }
+    }
+  ]
+}

--- a/config/synthetic-trader.soak.json
+++ b/config/synthetic-trader.soak.json
@@ -1,0 +1,20 @@
+{
+  "host": { "host": "127.0.0.1", "port": 9876 },
+  "firm": 1,
+  "seed": 4242,
+  "tickIntervalMs": 50,
+  "instruments": [
+    {
+      "securityId": 900000000001,
+      "tickSize": 100,
+      "lotSize": 100,
+      "initialMidMantissa": 123400,
+      "midDriftProbability": 0.1,
+      "strategies": [
+        { "kind": "marketMaker", "name": "mm-soak", "levelsPerSide": 3, "quoteSpacingTicks": 1, "replaceDistanceTicks": 5, "quantity": 100 },
+        { "kind": "noiseTaker", "name": "noise-soak", "orderProbability": 0.4, "maxLotMultiple": 2, "crossTicks": 2 },
+        { "kind": "meanReverting", "name": "meanrev-soak", "alpha": 0.1, "entryThresholdTicks": 5, "crossTicks": 2, "lotsPerOrder": 1 }
+      ]
+    }
+  ]
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -438,6 +438,58 @@ Notes:
   later packet so it appears later in the wire stream. Held packets are
   flushed on host shutdown.
 
+### 5.8 Long-haul soak (≥1h) — `.github/workflows/soak.yml`
+
+Detects slow leaks (RSS slope, FD growth, thread growth) that would not
+surface in the few-minute smoke soak from issue #4. Issue #120.
+
+Runs nightly at 03:00 UTC with `duration_minutes=60`; can also be
+dispatched manually with a custom `duration_minutes` (1–360) and
+`synth_clients` count.
+
+Tooling:
+
+- `tools/soak/sample.sh` — bash sampler that appends one CSV row every
+  `SAMPLE_INTERVAL_SECONDS` (default 30), capturing process RSS, VmSize,
+  thread count, FD count, and a few `/metrics` counters.
+- `tools/soak/analyze.py` — computes RSS slope (MB/h, OLS) and asserts
+  three thresholds (override via env):
+  - `RSS_SLOPE_MAX_MB_PER_H` (default 50)
+  - `FD_GROWTH_MAX` (default 100, last vs first)
+  - `THREAD_GROWTH_MAX` (default 20, last vs first)
+- Final summary is mirrored into `$GITHUB_STEP_SUMMARY`; the full sample
+  CSV + host/trader logs are uploaded as `soak-<run_number>` artifact
+  (30-day retention).
+
+Manual run:
+
+```bash
+gh workflow run soak.yml -f duration_minutes=15 -f synth_clients=2
+```
+
+Local equivalent (uses the published Release DLL so the relative
+`instruments` path resolves from the repo root):
+
+```bash
+dotnet build -c Release SbeB3Exchange.slnx
+dotnet src/B3.Exchange.Host/bin/Release/net10.0/B3.Exchange.Host.dll \
+  config/exchange-simulator.soak.json &
+HOST_PID=$!
+HOST_PID=$HOST_PID OUTPUT_CSV=/tmp/samples.csv DURATION_SECONDS=900 \
+  METRICS_URL=http://127.0.0.1:8080/metrics \
+  bash tools/soak/sample.sh
+python3 tools/soak/analyze.py /tmp/samples.csv
+```
+
+**Known limitation:** `SyntheticTrader` does not yet implement the FIXP
+Negotiate/Establish handshake required by the modern Gateway, so its
+connections are rejected within milliseconds of accept. The host's
+snapshot rotator + instrument-definition publisher continue to drive
+steady UDP multicast traffic for the full soak duration, exercising the
+publishers, timers, and HTTP surface; full client-side load coverage is
+gated on adding FIXP support to the synth trader (tracked as a #120
+follow-up).
+
 ---
 
 ## 6. Common tuning + debugging

--- a/tools/soak/analyze.py
+++ b/tools/soak/analyze.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Soak analyzer: read the CSV produced by sample.sh and emit a markdown summary
+to stdout. Exits non-zero if any threshold assertion fails.
+
+Thresholds are intentionally lax for the first run — issue #120 explicitly
+calls for establishing a baseline before tightening. They can be overridden
+via env vars to make the workflow easy to tune without code changes.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import statistics
+import sys
+from pathlib import Path
+
+
+def linear_slope(xs: list[float], ys: list[float]) -> float:
+    """Ordinary least squares slope of ys vs xs. Returns 0 if degenerate."""
+    n = len(xs)
+    if n < 2:
+        return 0.0
+    mean_x = sum(xs) / n
+    mean_y = sum(ys) / n
+    num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+    den = sum((x - mean_x) ** 2 for x in xs)
+    if den == 0:
+        return 0.0
+    return num / den
+
+
+def main(csv_path: str) -> int:
+    rss_slope_max_mb_per_h = float(os.environ.get("RSS_SLOPE_MAX_MB_PER_H", "50"))
+    fd_growth_max = int(os.environ.get("FD_GROWTH_MAX", "100"))
+    thread_growth_max = int(os.environ.get("THREAD_GROWTH_MAX", "20"))
+    min_samples = int(os.environ.get("MIN_SAMPLES", "5"))
+    # Discard the first WARMUP_SAMPLES rows from the slope calculation —
+    # JIT compilation, tier-PGO, and initial multicast-socket setup cause a
+    # large RSS jump in the first ~30s that would otherwise dominate the
+    # slope of any short soak.
+    warmup_samples = int(os.environ.get("WARMUP_SAMPLES", "4"))
+
+    rows = list(csv.DictReader(Path(csv_path).open()))
+    if len(rows) < min_samples:
+        print(f"### Soak summary\n\n**FAIL** — only {len(rows)} samples (need ≥{min_samples}).")
+        return 1
+
+    times = [float(r["uptime_s"]) for r in rows]
+    rss_mb = [float(r["rss_kb"]) / 1024.0 for r in rows]
+    fds = [int(r["fd_count"]) for r in rows]
+    threads = [int(r["threads"]) for r in rows]
+
+    # For slope assertions, drop warmup window. Last/peak/first stats
+    # still report on the whole run for visibility.
+    slope_start = min(warmup_samples, max(0, len(rows) - min_samples))
+    slope_times = times[slope_start:]
+    slope_rss = rss_mb[slope_start:]
+    slope_fds = [float(x) for x in fds[slope_start:]]
+    slope_thr = [float(x) for x in threads[slope_start:]]
+
+    duration_h = (times[-1] - times[0]) / 3600.0 if times[-1] > times[0] else 0
+    rss_slope_mb_per_s = linear_slope(slope_times, slope_rss)
+    rss_slope_mb_per_h = rss_slope_mb_per_s * 3600.0
+    rss_first, rss_last = rss_mb[0], rss_mb[-1]
+    rss_peak = max(rss_mb)
+    fd_first, fd_last = fds[0], fds[-1]
+    fd_peak = max(fds)
+    thr_first, thr_last = threads[0], threads[-1]
+    thr_peak = max(threads)
+
+    failures: list[str] = []
+
+    if rss_slope_mb_per_h > rss_slope_max_mb_per_h:
+        failures.append(
+            f"RSS slope {rss_slope_mb_per_h:.2f} MB/h exceeds threshold {rss_slope_max_mb_per_h} MB/h"
+        )
+    if (fd_last - fd_first) > fd_growth_max:
+        failures.append(
+            f"FD count grew by {fd_last - fd_first} (first={fd_first}, last={fd_last}) — exceeds {fd_growth_max}"
+        )
+    if (thr_last - thr_first) > thread_growth_max:
+        failures.append(
+            f"Thread count grew by {thr_last - thr_first} (first={thr_first}, last={thr_last}) — exceeds {thread_growth_max}"
+        )
+
+    status = "PASS" if not failures else "FAIL"
+    print(f"### Soak summary — **{status}**\n")
+    print(f"- Samples: **{len(rows)}** (warmup discarded from slope: {slope_start})")
+    print(f"- Duration: **{duration_h*60:.1f} min** ({duration_h:.2f} h)")
+    print()
+    print("| metric | first | last | peak | mean | slope (post-warmup) |")
+    print("|---|---|---|---|---|---|")
+    print(
+        f"| RSS (MB) | {rss_first:.1f} | {rss_last:.1f} | {rss_peak:.1f} | "
+        f"{statistics.mean(rss_mb):.1f} | **{rss_slope_mb_per_h:+.2f} MB/h** |"
+    )
+    print(
+        f"| FD count | {fd_first} | {fd_last} | {fd_peak} | "
+        f"{statistics.mean(fds):.1f} | {linear_slope(slope_times, slope_fds) * 3600:+.2f}/h |"
+    )
+    print(
+        f"| Threads | {thr_first} | {thr_last} | {thr_peak} | "
+        f"{statistics.mean(threads):.1f} | {linear_slope(slope_times, slope_thr) * 3600:+.2f}/h |"
+    )
+
+    print()
+    print("### Thresholds (override with env vars)")
+    print(f"- `RSS_SLOPE_MAX_MB_PER_H` = {rss_slope_max_mb_per_h}")
+    print(f"- `FD_GROWTH_MAX` = {fd_growth_max}")
+    print(f"- `THREAD_GROWTH_MAX` = {thread_growth_max}")
+
+    if failures:
+        print()
+        print("### Failures")
+        for f in failures:
+            print(f"- ❌ {f}")
+        return 1
+
+    print()
+    print("All thresholds satisfied.")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: analyze.py <samples.csv>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/tools/soak/sample.sh
+++ b/tools/soak/sample.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Soak sampler: every SAMPLE_INTERVAL_SECONDS, append one row to OUTPUT_CSV
+# describing the host process. Designed to be cheap (~milliseconds per sample)
+# so it doesn't perturb what it's measuring.
+#
+# Required env:
+#   HOST_PID              PID of the B3.Exchange.Host process under load
+#   OUTPUT_CSV            Path where samples are appended
+#   DURATION_SECONDS      Total runtime of the sampler loop
+# Optional env:
+#   SAMPLE_INTERVAL_SECONDS  Default 30
+#   METRICS_URL              If set, scrape this Prometheus endpoint and
+#                            extract a few interesting counters per sample.
+set -euo pipefail
+
+: "${HOST_PID:?HOST_PID required}"
+: "${OUTPUT_CSV:?OUTPUT_CSV required}"
+: "${DURATION_SECONDS:?DURATION_SECONDS required}"
+SAMPLE_INTERVAL_SECONDS="${SAMPLE_INTERVAL_SECONDS:-30}"
+METRICS_URL="${METRICS_URL:-}"
+
+mkdir -p "$(dirname "$OUTPUT_CSV")"
+echo "ts_unix,uptime_s,rss_kb,vm_kb,threads,fd_count,established_total,suspended_total,reaped_total,throttle_accepted_total,throttle_rejected_total" > "$OUTPUT_CSV"
+
+start_ts="$(date +%s)"
+end_ts=$((start_ts + DURATION_SECONDS))
+
+scrape_counter() {
+    # $1: prom name; emit value or 0 if missing.
+    local name="$1"
+    if [[ -z "$METRICS_URL" ]]; then echo 0; return; fi
+    curl -fs --max-time 2 "$METRICS_URL" 2>/dev/null \
+        | awk -v n="$name" '$1 == n { print $2; found=1; exit } END { if (!found) print 0 }'
+}
+
+while true; do
+    now="$(date +%s)"
+    if (( now >= end_ts )); then break; fi
+    if ! kill -0 "$HOST_PID" 2>/dev/null; then
+        echo "host PID $HOST_PID is gone — aborting sampler" >&2
+        exit 2
+    fi
+
+    uptime_s=$(( now - start_ts ))
+
+    rss_kb=$(awk '/^VmRSS:/ {print $2}' "/proc/$HOST_PID/status" 2>/dev/null || echo 0)
+    vm_kb=$(awk '/^VmSize:/ {print $2}' "/proc/$HOST_PID/status" 2>/dev/null || echo 0)
+    threads=$(awk '/^Threads:/ {print $2}' "/proc/$HOST_PID/status" 2>/dev/null || echo 0)
+    fd_count=$(ls "/proc/$HOST_PID/fd" 2>/dev/null | wc -l)
+
+    est=$(scrape_counter exch_session_established_total)
+    sus=$(scrape_counter exch_session_suspended_total)
+    rea=$(scrape_counter exch_session_reaped_total)
+    thr_a=$(scrape_counter exch_throttle_accepted_total)
+    thr_r=$(scrape_counter exch_throttle_rejected_total)
+
+    echo "${now},${uptime_s},${rss_kb},${vm_kb},${threads},${fd_count},${est},${sus},${rea},${thr_a},${thr_r}" >> "$OUTPUT_CSV"
+
+    sleep "$SAMPLE_INTERVAL_SECONDS"
+done
+
+echo "sampler finished after ${DURATION_SECONDS}s ($(wc -l < "$OUTPUT_CSV") lines including header)"


### PR DESCRIPTION
Delivers the soak NFR infrastructure from #120: nightly workflow + sampler + analyzer + configs + runbook. Does NOT close #120 — see "Known limitation" below — but unblocks all future leak detection.

## Components

- **`.github/workflows/soak.yml`** — nightly cron at 03:00 UTC (`duration_minutes=60` default) plus `workflow_dispatch` with configurable duration (1–360min) and synth-client count.
- **`tools/soak/sample.sh`** — bash sampler, 30s interval default. Captures process RSS, VmSize, threads, FD count, plus 4 `/metrics` counters.
- **`tools/soak/analyze.py`** — OLS slope on the post-warmup window. Asserts on `RSS_SLOPE_MAX_MB_PER_H` (50), `FD_GROWTH_MAX` (100), `THREAD_GROWTH_MAX` (20). All env-tunable.
- **`config/exchange-simulator.soak.json`** + **`config/synthetic-trader.soak.json`** — minimal soak configs.
- **`docs/RUNBOOK.md` §5.8** — operator docs + local-equivalent recipe.

## Workflow flow

1. Restore + Release build.
2. Start host (run the published DLL directly so the relative `instruments` path resolves from repo root).
3. Wait ≤60s for `/health/ready`.
4. Best-effort start N synth traders.
5. Run sampler for `DURATION_MINUTES`.
6. Stop processes (SIGTERM → SIGKILL).
7. Analyzer → `$GITHUB_STEP_SUMMARY`.
8. Upload CSV + logs as `soak-<run_number>` artifact (30-day retention).

## Known limitation — why this PR does NOT close #120

`SyntheticTrader` does not implement the FIXP Negotiate/Establish handshake required by the modern Gateway, so its connections are rejected with `app-message-before-negotiate` within milliseconds of accept. Discovered while smoke-testing this PR.

What works regardless: the host's snapshot rotator + instrument-definition publisher drive steady UDP multicast traffic for the entire soak duration, exercising the publishers, timers, multicast sockets, and HTTP surface — these are the most likely sources of leaks anyway.

What does NOT work: client-side load coverage (matching engine, FIXP retransmit buffer growth under sustained traffic). A follow-up issue will add FIXP support to SyntheticTrader; once that lands, the synth-trader steps already wired here become fully effective with no workflow change.

## Verification

- Local end-to-end smoke (60s sample window, 10s interval) ran cleanly: host starts, `/health/ready` returns OK, sampler writes CSV with all 11 columns, analyzer produces both PASS and FAIL outputs on hand-crafted no-leak / leak datasets.
- 595/595 tests pass.
- `dotnet format --verify-no-changes` clean.

Refs #120.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>