### PR TITLE
Soak: enable real client load via requireFixpHandshake=false (closes #120)

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -73,9 +73,9 @@ jobs:
           # Run the published DLL directly (not `dotnet run --project`) so
           # the working directory stays at the repo root and the relative
           # `instruments` path inside the JSON resolves correctly.
-          # The soak config omits firms[]/sessions[] to use the legacy
-          # single-tenant fallback so SyntheticTrader (no FIXP Negotiate)
-          # can connect and drive sustained load.
+          # The soak config sets `auth.requireFixpHandshake=false` so the
+          # SyntheticTrader (which speaks the SBE business protocol but not
+          # FIXP Negotiate/Establish) can sustain a connection.
           nohup dotnet src/B3.Exchange.Host/bin/Release/net10.0/B3.Exchange.Host.dll \
             config/exchange-simulator.soak.json \
             > artifacts/soak/host.log 2>&1 &
@@ -96,18 +96,11 @@ jobs:
           tail -200 artifacts/soak/host.log >&2 || true
           exit 1
 
-      - name: Start synthetic traders (best-effort)
-        # KNOWN LIMITATION: SyntheticTrader does not yet implement the FIXP
-        # Negotiate/Establish handshake required by the modern Gateway.
-        # Each connection is rejected with `app-message-before-negotiate`
-        # within milliseconds and the trader process exits without retry.
-        # Tracked as a follow-up to #120; for now this step provides only a
-        # brief burst of TCP-accept activity at start-of-soak. The host's
-        # snapshot rotator + instrument-definition publisher continue to
-        # generate steady UDP multicast traffic for the full soak duration,
-        # which exercises the publishers, timers, and HTTP server even with
-        # zero sustained client load.
-        continue-on-error: true
+      - name: Start synthetic traders
+        # The soak host config sets `auth.requireFixpHandshake = false` so
+        # SyntheticTrader can drive sustained load over its existing SBE
+        # send loop without implementing the FIXP Negotiate/Establish
+        # handshake. Production hosts leave the flag at its default (true).
         run: |
           set -euo pipefail
           mkdir -p artifacts/soak/traders

--- a/config/exchange-simulator.soak.json
+++ b/config/exchange-simulator.soak.json
@@ -11,7 +11,7 @@
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000
   },
-  "auth": { "devMode": true },
+  "auth": { "devMode": true, "requireFixpHandshake": false },
   "http": {
     "listen": "0.0.0.0:8080",
     "livenessStaleMs": 5000

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -481,14 +481,10 @@ HOST_PID=$HOST_PID OUTPUT_CSV=/tmp/samples.csv DURATION_SECONDS=900 \
 python3 tools/soak/analyze.py /tmp/samples.csv
 ```
 
-**Known limitation:** `SyntheticTrader` does not yet implement the FIXP
-Negotiate/Establish handshake required by the modern Gateway, so its
-connections are rejected within milliseconds of accept. The host's
-snapshot rotator + instrument-definition publisher continue to drive
-steady UDP multicast traffic for the full soak duration, exercising the
-publishers, timers, and HTTP surface; full client-side load coverage is
-gated on adding FIXP support to the synth trader (tracked as a #120
-follow-up).
+**Note on the soak config:** `config/exchange-simulator.soak.json` sets
+`auth.requireFixpHandshake = false` so the SyntheticTrader's plain-SBE
+business protocol can drive sustained client load. Production hosts
+must keep the flag at its default (`true`).
 
 ---
 


### PR DESCRIPTION
Follow-up to #129. The previous PR landed the soak infrastructure but documented a known limitation: SyntheticTrader connections were rejected within ms with `app-message-before-negotiate` because the trader doesn't speak FIXP.

Investigating further turned up `AuthConfig.RequireFixpHandshake` (already used by `EndToEndReplayTests`): a host-side flag that, when false, lets clients skip FIXP and go straight to the SBE business protocol. Setting it on the soak config eliminates the limitation.

## Changes

- `config/exchange-simulator.soak.json`: `auth.requireFixpHandshake = false`.
- `.github/workflows/soak.yml`: dropped `continue-on-error` and the long limitation comment from the synth-trader step.
- `docs/RUNBOOK.md` §5.8: replaced the limitation paragraph with a brief note about the `requireFixpHandshake` setting.

## Verification

Local smoke confirms the trader connection now lasts the full soak duration: host log shows `recv-eof` on shutdown SIGTERM rather than `app-message-before-negotiate` on the first frame.

Closes #120. Issue #130 (opened a few minutes ago to track adding FIXP to the synth trader) already closed as obsolete.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>