### PR TITLE
Add newsShock synthetic strategy (#117)

### DIFF
--- a/config/synthetic-trader.json
+++ b/config/synthetic-trader.json
@@ -50,6 +50,17 @@
         //   "triggerProbability": 0.02,  // per-tick fire probability [0,1]
         //   "sweepLots": 25,             // size = sweepLots * lotSize
         //   "crossTicks": 5              // ≥ levels-to-clear * mm.quoteSpacingTicks
+        // },
+        // {
+        //   "kind": "newsShock",
+        //   "name": "shock-petr4",
+        //   "meanIntervalMs": 60000,     // mean time between shocks
+        //   "jitterMs": 15000,           // ± uniform jitter, must be < mean
+        //   "shockDurationMs": 1500,     // burst window length
+        //   "fadeDurationMs": 3000,      // optional taper window (0 disables)
+        //   "levelsToSweep": 4,          // price offset = levelsToSweep × tickSize
+        //   "burstQtyLots": 5,           // size = burstQtyLots × lotSize per emit
+        //   "directionBias": 0.5         // 0 = always SELL, 1 = always BUY, 0.5 = symmetric
         // }
       ]
     }

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -209,6 +209,7 @@ ship today (per `SyntheticTraderConfig.cs`):
 | `meanReverting` | `alpha`, `entryThresholdTicks`, `crossTicks`, `lotsPerOrder` | Tracks an EWMA of the mid (`alpha` ∈ (0,1]); when the live mid deviates by ≥ `entryThresholdTicks`, sends a marketable IOC of `lotsPerOrder × lotSize` in the *contrarian* direction. |
 | `momentum` | `triggerTicks`, `crossTicks`, `lotsPerOrder` | Compares the mid to the previous tick; when the per-tick step is ≥ `triggerTicks`, sends a marketable IOC *in the direction of the move*. |
 | `sweeper` | `triggerProbability`, `sweepLots`, `crossTicks` | Per-tick fire (uniform side) of a large marketable IOC sized `sweepLots × lotSize`, priced `crossTicks` past the mid. Configure `crossTicks ≥ N × marketMaker.quoteSpacingTicks` to actually walk N levels. |
+| `newsShock` | `meanIntervalMs`, `jitterMs`, `shockDurationMs`, `fadeDurationMs`, `levelsToSweep`, `burstQtyLots`, `directionBias` | Stateful three-phase sequence (idle → shock → fade). After a randomised idle window (`meanIntervalMs ± jitterMs`), enters a `shockDurationMs` burst emitting one marketable IOC per tick on a side picked by `directionBias` (0 = SELL only, 1 = BUY only, 0.5 = symmetric). Optional `fadeDurationMs` linearly tapers the size to zero before returning to idle. All ms-windows are converted to tick counts using the runner's `tickIntervalMs`. |
 
 Tuning recipes:
 
@@ -226,6 +227,13 @@ Tuning recipes:
   and `crossTicks ≥ levelsPerSide × quoteSpacingTicks` so the sweep walks
   the full visible book — exercises consumer-side trade-through fills
   and snapshot recovery.
+* **News-shock simulation:** add a `newsShock` strategy alongside a
+  `marketMaker` so the shock has a resting book to walk through.
+  Defaults (`meanIntervalMs=60000`, `shockDurationMs=1500`,
+  `fadeDurationMs=3000`) reproduce a roughly-once-per-minute directional
+  burst suitable for stress-testing UMDF burst rates and consumer
+  snapshot-recovery paths. Set `directionBias=1.0` (or `0.0`) to force a
+  one-sided shock for repeatable scenarios.
 * **Burst load (throttle exercise):** raise the synthetic trader's
   `tickIntervalMs` down to `10–20` and bump `noiseTaker.orderProbability`
   to `0.9` — the per-session throttle (`exch_throttle_rejected_total`)

--- a/src/B3.Exchange.SyntheticTrader/NewsShockStrategy.cs
+++ b/src/B3.Exchange.SyntheticTrader/NewsShockStrategy.cs
@@ -1,0 +1,185 @@
+namespace B3.Exchange.SyntheticTrader;
+
+/// <summary>
+/// Stateful news-shock strategy (issue #117). Cycles through three phases:
+///
+/// <list type="number">
+///   <item><b>Idle</b>: emits no orders. Waits a random number of ticks
+///   (<c>meanIntervalTicks</c> ± <c>jitterTicks</c>) until the next
+///   trigger fires.</item>
+///   <item><b>Shock</b>: lasts <c>shockDurationTicks</c> ticks. On each
+///   tick, picks a side (biased by <see cref="DirectionBias"/>) and
+///   emits one marketable IOC limit sized
+///   <c>burstLots × lotSize</c> at <c>levelsToSweep × tickSize</c>
+///   through the mid, designed to walk several resting levels.</item>
+///   <item><b>Fade</b>: lasts <c>fadeDurationTicks</c> ticks. Burst
+///   quantity decays linearly from full to zero over the window so the
+///   shock tapers rather than ending abruptly. Side is unchanged.</item>
+/// </list>
+///
+/// <para>The strategy is deterministic for a given (RNG, tick-sequence)
+/// pair — no wall-clock dependency. All ms-based config is converted to
+/// tick counts using the <c>tickIntervalMs</c> from the runner so the
+/// strategy can advance its phase machine purely on tick-count math.</para>
+///
+/// <para>The shock-side draw uses <see cref="Random.NextDouble"/> against
+/// <see cref="DirectionBias"/>: a value &lt; bias means BUY (positive
+/// shock), otherwise SELL. <c>directionBias = 0.5</c> ⇒ symmetric.</para>
+///
+/// <para>Pairs naturally with a <see cref="MarketMakerStrategy"/> on the
+/// same instrument: the maker provides the resting book that the shock
+/// then walks through. Without a maker, the shock orders will simply
+/// rest as aggressive limits and exercise the cancel/expiry path.</para>
+/// </summary>
+public sealed class NewsShockStrategy : IStrategy
+{
+    public enum Phase { Idle, Shock, Fade }
+
+    private readonly int _meanIntervalTicks;
+    private readonly int _jitterTicks;
+    private readonly int _shockDurationTicks;
+    private readonly int _fadeDurationTicks;
+
+    private Phase _phase;
+    private int _phaseTicksRemaining;
+    private int _shockDurationActual;
+    private int _fadeDurationActual;
+    private OrderSide _shockSide;
+    private long _seq;
+
+    public string Name { get; }
+    public int LevelsToSweep { get; }
+    public long BurstLots { get; }
+    public double DirectionBias { get; }
+
+    /// <summary>
+    /// Read-only view of the current phase, for tests and logging.
+    /// </summary>
+    public Phase CurrentPhase => _phase;
+
+    public NewsShockStrategy(
+        string name,
+        int tickIntervalMs,
+        int meanIntervalMs,
+        int jitterMs,
+        int shockDurationMs,
+        int fadeDurationMs,
+        int levelsToSweep,
+        long burstLots,
+        double directionBias)
+    {
+        if (string.IsNullOrEmpty(name)) throw new ArgumentException("name required", nameof(name));
+        if (tickIntervalMs <= 0) throw new ArgumentOutOfRangeException(nameof(tickIntervalMs));
+        if (meanIntervalMs <= 0) throw new ArgumentOutOfRangeException(nameof(meanIntervalMs));
+        if (jitterMs < 0) throw new ArgumentOutOfRangeException(nameof(jitterMs));
+        if (jitterMs >= meanIntervalMs) throw new ArgumentOutOfRangeException(nameof(jitterMs),
+            "jitterMs must be < meanIntervalMs so the trigger interval stays positive");
+        if (shockDurationMs <= 0) throw new ArgumentOutOfRangeException(nameof(shockDurationMs));
+        if (fadeDurationMs < 0) throw new ArgumentOutOfRangeException(nameof(fadeDurationMs));
+        if (levelsToSweep <= 0) throw new ArgumentOutOfRangeException(nameof(levelsToSweep));
+        if (burstLots <= 0) throw new ArgumentOutOfRangeException(nameof(burstLots));
+        if (directionBias < 0 || directionBias > 1) throw new ArgumentOutOfRangeException(nameof(directionBias));
+
+        Name = name;
+        LevelsToSweep = levelsToSweep;
+        BurstLots = burstLots;
+        DirectionBias = directionBias;
+
+        // Convert ms to tick counts; floor to >= 1 tick for non-zero windows.
+        _meanIntervalTicks = Math.Max(1, meanIntervalMs / tickIntervalMs);
+        _jitterTicks = jitterMs / tickIntervalMs;
+        _shockDurationTicks = Math.Max(1, shockDurationMs / tickIntervalMs);
+        _fadeDurationTicks = fadeDurationMs == 0 ? 0 : Math.Max(1, fadeDurationMs / tickIntervalMs);
+
+        _phase = Phase.Idle;
+        _phaseTicksRemaining = -1; // first tick will roll an interval
+    }
+
+    public IEnumerable<OrderIntent> Tick(in MarketState state, Random rng)
+    {
+        switch (_phase)
+        {
+            case Phase.Idle:
+                if (_phaseTicksRemaining < 0)
+                    _phaseTicksRemaining = RollIdleTicks(rng);
+                if (_phaseTicksRemaining > 1)
+                {
+                    _phaseTicksRemaining--;
+                    return Array.Empty<OrderIntent>();
+                }
+                // Trigger fires this tick: choose side, transition to Shock.
+                _shockSide = rng.NextDouble() < DirectionBias ? OrderSide.Buy : OrderSide.Sell;
+                _shockDurationActual = _shockDurationTicks;
+                _fadeDurationActual = _fadeDurationTicks;
+                _phase = Phase.Shock;
+                _phaseTicksRemaining = _shockDurationTicks - 1; // current tick counts as one
+                if (_phaseTicksRemaining <= 0)
+                    EnterFadeOrIdle(rng);
+                return EmitBurst(state, fadeFraction: 1.0);
+
+            case Phase.Shock:
+                {
+                    var burst = EmitBurst(state, fadeFraction: 1.0);
+                    _phaseTicksRemaining--;
+                    if (_phaseTicksRemaining <= 0)
+                        EnterFadeOrIdle(rng);
+                    return burst;
+                }
+
+            case Phase.Fade:
+                {
+                    double fraction = _fadeDurationActual <= 0 ? 0
+                        : (double)(_phaseTicksRemaining + 1) / _fadeDurationActual;
+                    var burst = EmitBurst(state, fadeFraction: fraction);
+                    _phaseTicksRemaining--;
+                    if (_phaseTicksRemaining < 0)
+                        BackToIdle(rng);
+                    return burst;
+                }
+        }
+        return Array.Empty<OrderIntent>();
+    }
+
+    private void EnterFadeOrIdle(Random rng)
+    {
+        if (_fadeDurationTicks == 0)
+        {
+            BackToIdle(rng);
+        }
+        else
+        {
+            _phase = Phase.Fade;
+            _phaseTicksRemaining = _fadeDurationTicks - 1;
+        }
+    }
+
+    private int RollIdleTicks(Random rng)
+    {
+        if (_jitterTicks == 0) return _meanIntervalTicks;
+        // Uniform in [mean - jitter, mean + jitter], floored at 1.
+        int span = 2 * _jitterTicks + 1;
+        int n = _meanIntervalTicks - _jitterTicks + rng.Next(span);
+        return Math.Max(1, n);
+    }
+
+    private void BackToIdle(Random rng)
+    {
+        _phase = Phase.Idle;
+        _phaseTicksRemaining = RollIdleTicks(rng);
+    }
+
+    private IEnumerable<OrderIntent> EmitBurst(in MarketState state, double fadeFraction)
+    {
+        long tick = state.TickSize <= 0 ? 1 : state.TickSize;
+        long lot = state.LotSize <= 0 ? 1 : state.LotSize;
+        long fullQty = BurstLots * lot;
+        long qty = fadeFraction >= 1.0 ? fullQty : (long)Math.Round(fullQty * fadeFraction);
+        if (qty < lot) return Array.Empty<OrderIntent>();
+        long offset = (long)LevelsToSweep * tick;
+        long px = _shockSide == OrderSide.Buy ? state.MidMantissa + offset : state.MidMantissa - offset;
+        if (px <= 0) return Array.Empty<OrderIntent>();
+        string sideTag = _shockSide == OrderSide.Buy ? "B" : "S";
+        string tag = $"{Name}-{state.SecurityId}-{sideTag}-{++_seq}";
+        return new[] { OrderIntent.NewMarketableLimit(state.SecurityId, _shockSide, qty, px, tag) };
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/Program.cs
+++ b/src/B3.Exchange.SyntheticTrader/Program.cs
@@ -43,7 +43,7 @@ catch (Exception ex)
 
 var instruments = cfg.Instruments.Select(ic =>
     (cfg: ic, strategies: (IReadOnlyList<IStrategy>)ic.Strategies
-        .Select(SyntheticTraderConfigLoader.BuildStrategy).ToList()));
+        .Select(s => SyntheticTraderConfigLoader.BuildStrategy(s, cfg.TickIntervalMs)).ToList()));
 
 var seed = cfg.Seed != 0 ? cfg.Seed : Environment.TickCount;
 var rng = new Random(seed);

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
@@ -49,7 +49,8 @@ public sealed class InstrumentConfig
 public sealed class StrategyConfig
 {
     /// <summary>One of: <c>marketMaker</c>, <c>noiseTaker</c>,
-    /// <c>meanReverting</c>, <c>momentum</c>, <c>sweeper</c>.</summary>
+    /// <c>meanReverting</c>, <c>momentum</c>, <c>sweeper</c>,
+    /// <c>newsShock</c>.</summary>
     [JsonPropertyName("kind")] public string Kind { get; set; } = "";
     [JsonPropertyName("name")] public string Name { get; set; } = "";
 
@@ -77,6 +78,17 @@ public sealed class StrategyConfig
     [JsonPropertyName("triggerProbability")] public double TriggerProbability { get; set; } = 0.05;
     /// <summary>Lots per sweep order; size <c>sweepLots * lotSize</c>.</summary>
     [JsonPropertyName("sweepLots")] public long SweepLots { get; set; } = 10;
+
+    // NewsShock (issue #117)
+    /// <summary>Mean ticks-between-shocks (used directly when configured in
+    /// ticks); when <see cref="MeanIntervalMs"/> is set, takes precedence.</summary>
+    [JsonPropertyName("meanIntervalMs")] public int MeanIntervalMs { get; set; } = 60000;
+    [JsonPropertyName("jitterMs")] public int JitterMs { get; set; }
+    [JsonPropertyName("shockDurationMs")] public int ShockDurationMs { get; set; } = 1500;
+    [JsonPropertyName("fadeDurationMs")] public int FadeDurationMs { get; set; } = 3000;
+    [JsonPropertyName("levelsToSweep")] public int LevelsToSweep { get; set; } = 3;
+    [JsonPropertyName("burstQtyLots")] public long BurstQtyLots { get; set; } = 5;
+    [JsonPropertyName("directionBias")] public double DirectionBias { get; set; } = 0.5;
 }
 
 public static class SyntheticTraderConfigLoader
@@ -98,7 +110,7 @@ public static class SyntheticTraderConfigLoader
         return cfg;
     }
 
-    public static IStrategy BuildStrategy(StrategyConfig sc) => sc.Kind switch
+    public static IStrategy BuildStrategy(StrategyConfig sc, int tickIntervalMs) => sc.Kind switch
     {
         "marketMaker" => new MarketMakerStrategy(
             string.IsNullOrEmpty(sc.Name) ? "mm" : sc.Name,
@@ -115,6 +127,12 @@ public static class SyntheticTraderConfigLoader
         "sweeper" => new SweeperStrategy(
             string.IsNullOrEmpty(sc.Name) ? "sweep" : sc.Name,
             sc.TriggerProbability, sc.SweepLots, sc.CrossTicks),
+        "newsShock" => new NewsShockStrategy(
+            string.IsNullOrEmpty(sc.Name) ? "shock" : sc.Name,
+            tickIntervalMs,
+            sc.MeanIntervalMs, sc.JitterMs,
+            sc.ShockDurationMs, sc.FadeDurationMs,
+            sc.LevelsToSweep, sc.BurstQtyLots, sc.DirectionBias),
         _ => throw new InvalidOperationException($"unknown strategy kind '{sc.Kind}'"),
     };
 }

--- a/tests/B3.Exchange.SyntheticTrader.Tests/AdditionalStrategyTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/AdditionalStrategyTests.cs
@@ -204,20 +204,31 @@ public class AdditionalStrategyTests
             EntryThresholdTicks = 4,
             CrossTicks = 2,
             LotsPerOrder = 3,
-        }));
+        }, tickIntervalMs: 100));
         Assert.IsType<MomentumStrategy>(SyntheticTraderConfigLoader.BuildStrategy(new StrategyConfig
         {
             Kind = "momentum",
             TriggerTicks = 2,
             CrossTicks = 1,
             LotsPerOrder = 1,
-        }));
+        }, tickIntervalMs: 100));
         Assert.IsType<SweeperStrategy>(SyntheticTraderConfigLoader.BuildStrategy(new StrategyConfig
         {
             Kind = "sweeper",
             TriggerProbability = 0.05,
             SweepLots = 25,
             CrossTicks = 5,
-        }));
+        }, tickIntervalMs: 100));
+        Assert.IsType<NewsShockStrategy>(SyntheticTraderConfigLoader.BuildStrategy(new StrategyConfig
+        {
+            Kind = "newsShock",
+            MeanIntervalMs = 5000,
+            JitterMs = 1000,
+            ShockDurationMs = 1000,
+            FadeDurationMs = 2000,
+            LevelsToSweep = 3,
+            BurstQtyLots = 5,
+            DirectionBias = 0.5,
+        }, tickIntervalMs: 100));
     }
 }

--- a/tests/B3.Exchange.SyntheticTrader.Tests/NewsShockStrategyTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/NewsShockStrategyTests.cs
@@ -1,0 +1,205 @@
+namespace B3.Exchange.SyntheticTrader.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="NewsShockStrategy"/> (issue #117). Drives the
+/// idle → shock → fade → idle phase machine deterministically by counting
+/// ticks; uses a seeded <see cref="Random"/> for trigger jitter and side
+/// selection.
+/// </summary>
+public class NewsShockStrategyTests
+{
+    private static MarketState State(long mid = 100_0000, long tick = 100, long lot = 100)
+        => new(SecurityId: 1, MidMantissa: mid, TickSize: tick, LotSize: lot,
+            LastTradePxMantissa: mid, LastTradeQty: 0,
+            MyLiveOrders: Array.Empty<LiveOrder>());
+
+    [Fact]
+    public void Idle_NoOrdersUntilTrigger()
+    {
+        // tickIntervalMs=100, mean=500ms, no jitter → 5 idle ticks then shock.
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 500, jitterMs: 0,
+            shockDurationMs: 200, fadeDurationMs: 0,
+            levelsToSweep: 3, burstLots: 1, directionBias: 1.0); // always BUY
+        var rng = new Random(1);
+
+        // Ticks 1..4: idle (no emission)
+        for (int i = 0; i < 4; i++)
+        {
+            Assert.Empty(s.Tick(State(), rng));
+            Assert.Equal(NewsShockStrategy.Phase.Idle, s.CurrentPhase);
+        }
+        // Tick 5: trigger fires → shock burst.
+        var intents = s.Tick(State(), rng).ToList();
+        Assert.Single(intents);
+        Assert.Equal(OrderSide.Buy, intents[0].Side);
+        Assert.Equal(NewsShockStrategy.Phase.Shock, s.CurrentPhase);
+    }
+
+    [Fact]
+    public void Shock_EmitsBurstAtMidPlusOffset_BuySide()
+    {
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 100, jitterMs: 0,
+            shockDurationMs: 100, fadeDurationMs: 0,
+            levelsToSweep: 4, burstLots: 7, directionBias: 1.0);
+        var rng = new Random(1);
+        var intents = s.Tick(State(mid: 100_0000, tick: 100, lot: 50), rng).ToList();
+        Assert.Single(intents);
+        var o = intents[0];
+        Assert.Equal(OrderSide.Buy, o.Side);
+        Assert.Equal(OrderTifIntent.IOC, o.Tif);
+        Assert.Equal(100_0000 + 4 * 100, o.PriceMantissa);
+        Assert.Equal(7 * 50, o.Quantity);
+    }
+
+    [Fact]
+    public void Shock_SellSide_PriceBelowMid()
+    {
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 100, jitterMs: 0,
+            shockDurationMs: 100, fadeDurationMs: 0,
+            levelsToSweep: 2, burstLots: 1, directionBias: 0.0); // always SELL
+        var intents = s.Tick(State(mid: 100_0000, tick: 100), new Random(1)).ToList();
+        Assert.Single(intents);
+        Assert.Equal(OrderSide.Sell, intents[0].Side);
+        Assert.Equal(100_0000 - 2 * 100, intents[0].PriceMantissa);
+    }
+
+    [Fact]
+    public void FullCycle_IdleShockFadeIdle()
+    {
+        // mean=200ms (2 ticks), shock=300ms (3 ticks), fade=300ms (3 ticks).
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 200, jitterMs: 0,
+            shockDurationMs: 300, fadeDurationMs: 300,
+            levelsToSweep: 1, burstLots: 10, directionBias: 1.0);
+        var rng = new Random(1);
+
+        // Idle ticks (1)
+        Assert.Empty(s.Tick(State(), rng));
+        Assert.Equal(NewsShockStrategy.Phase.Idle, s.CurrentPhase);
+        // Tick 2: trigger → shock
+        Assert.Single(s.Tick(State(), rng));
+        Assert.Equal(NewsShockStrategy.Phase.Shock, s.CurrentPhase);
+        // Two more shock ticks
+        Assert.Single(s.Tick(State(), rng));
+        Assert.Equal(NewsShockStrategy.Phase.Shock, s.CurrentPhase);
+        Assert.Single(s.Tick(State(), rng));
+        // Now transitions to Fade for next 3 ticks.
+        Assert.Equal(NewsShockStrategy.Phase.Fade, s.CurrentPhase);
+        long firstFadeQty = s.Tick(State(), rng).Single().Quantity;
+        long secondFadeQty = s.Tick(State(), rng).Single().Quantity;
+        // Fade is monotonically non-increasing.
+        Assert.True(secondFadeQty <= firstFadeQty);
+        // Final fade tick consumes remaining; subsequent tick is back to Idle.
+        s.Tick(State(), rng).ToList();
+        Assert.Equal(NewsShockStrategy.Phase.Idle, s.CurrentPhase);
+    }
+
+    [Fact]
+    public void Fade_QuantityDecaysLinearlyToZero()
+    {
+        // shock=100ms (1 tick), fade=400ms (4 ticks). Burst=10 lots × lot=1.
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 100, jitterMs: 0,
+            shockDurationMs: 100, fadeDurationMs: 400,
+            levelsToSweep: 1, burstLots: 10, directionBias: 1.0);
+        var rng = new Random(1);
+        // Shock tick → full quantity 10.
+        Assert.Equal(10, s.Tick(State(lot: 1), rng).Single().Quantity);
+        Assert.Equal(NewsShockStrategy.Phase.Fade, s.CurrentPhase);
+        // 4 fade ticks: fractions 4/4, 3/4, 2/4, 1/4 → 10, 8 (rounded), 5, 3 (rounded).
+        var qtys = new List<long>();
+        for (int i = 0; i < 4; i++)
+            qtys.Add(s.Tick(State(lot: 1), rng).Single().Quantity);
+        Assert.Equal(NewsShockStrategy.Phase.Idle, s.CurrentPhase);
+        Assert.True(qtys[0] >= qtys[1]);
+        Assert.True(qtys[1] >= qtys[2]);
+        Assert.True(qtys[2] >= qtys[3]);
+        Assert.True(qtys[3] >= 0);
+    }
+
+    [Fact]
+    public void Jitter_TriggerIntervalStaysWithinBand()
+    {
+        // mean=10 ticks, jitter=4 ticks → idle phase length always in [6,14].
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 1000, jitterMs: 400,
+            shockDurationMs: 100, fadeDurationMs: 0,
+            levelsToSweep: 1, burstLots: 1, directionBias: 1.0);
+        var rng = new Random(42);
+        for (int cycle = 0; cycle < 10; cycle++)
+        {
+            int idleTicks = 0;
+            while (s.CurrentPhase == NewsShockStrategy.Phase.Idle)
+            {
+                var emitted = s.Tick(State(), rng).ToList();
+                idleTicks++;
+                if (emitted.Count > 0) break; // shock fired this tick
+            }
+            Assert.InRange(idleTicks, 6, 14);
+            // Now in Shock phase (1 tick), advance back to idle.
+            // shockDurationTicks=1 and fade=0 → next tick goes back to Idle.
+            // (Actually current Shock tick already happened above; advance once more.)
+            // Force back to idle:
+            while (s.CurrentPhase != NewsShockStrategy.Phase.Idle)
+                s.Tick(State(), rng).ToList();
+        }
+    }
+
+    [Fact]
+    public void DirectionBias_AllBuysWhenBiasIsOne()
+    {
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 100, jitterMs: 0,
+            shockDurationMs: 100, fadeDurationMs: 0,
+            levelsToSweep: 1, burstLots: 1, directionBias: 1.0);
+        var rng = new Random(99);
+        for (int i = 0; i < 50; i++)
+        {
+            var intents = s.Tick(State(), rng).ToList();
+            if (intents.Count > 0)
+                Assert.Equal(OrderSide.Buy, intents[0].Side);
+        }
+    }
+
+    [Fact]
+    public void DirectionBias_AllSellsWhenBiasIsZero()
+    {
+        var s = new NewsShockStrategy("ns",
+            tickIntervalMs: 100, meanIntervalMs: 100, jitterMs: 0,
+            shockDurationMs: 100, fadeDurationMs: 0,
+            levelsToSweep: 1, burstLots: 1, directionBias: 0.0);
+        var rng = new Random(99);
+        for (int i = 0; i < 50; i++)
+        {
+            var intents = s.Tick(State(), rng).ToList();
+            if (intents.Count > 0)
+                Assert.Equal(OrderSide.Sell, intents[0].Side);
+        }
+    }
+
+    [Fact]
+    public void Validation_RejectsBadConfigs()
+    {
+        Assert.Throws<ArgumentException>(() => new NewsShockStrategy("",
+            100, 100, 0, 100, 0, 1, 1, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            tickIntervalMs: 0, 100, 0, 100, 0, 1, 1, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, meanIntervalMs: 0, 0, 100, 0, 1, 1, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, 100, jitterMs: 200, 100, 0, 1, 1, 0.5)); // jitter >= mean
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, 100, 0, shockDurationMs: 0, 0, 1, 1, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, 100, 0, 100, fadeDurationMs: -1, 1, 1, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, 100, 0, 100, 0, levelsToSweep: 0, 1, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, 100, 0, 100, 0, 1, burstLots: 0, 0.5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new NewsShockStrategy("x",
+            100, 100, 0, 100, 0, 1, 1, directionBias: 1.5));
+    }
+}


### PR DESCRIPTION
Closes #117.

Adds a new stateful synthetic trader strategy that simulates news-driven directional shocks against the resting book.

## Behaviour

Three-phase state machine:

1. **Idle** — emits no orders. Waits a random number of ticks (`meanIntervalMs ± jitterMs`).
2. **Shock** — emits one marketable IOC per tick for `shockDurationMs`, on a side biased by `directionBias` (0 = SELL, 1 = BUY, 0.5 = symmetric), sized `burstQtyLots × lotSize`, priced `levelsToSweep × tickSize` past the mid so it walks several resting levels.
3. **Fade** (optional) — for `fadeDurationMs`, emits the same side but linearly tapers the size to zero before returning to Idle.

All ms-based windows are converted to tick counts using the runner's `tickIntervalMs` so the phase machine advances purely on tick-count math and stays deterministic for a given (RNG, tick-sequence) pair.

## Wiring

`SyntheticTraderConfigLoader.BuildStrategy` now takes `tickIntervalMs` as a second argument so the news-shock loader can convert ms knobs without leaking the runner clock into the strategy itself. The other strategies ignore it; `Program.cs` and the existing test were updated.

## Tests

9 new unit tests in `NewsShockStrategyTests` covering:
- idle period emits nothing until trigger;
- shock side / price / quantity arithmetic;
- full idle → shock → fade → idle cycle;
- linear fade taper;
- trigger jitter stays within configured band;
- direction bias 0 / 1 forces side;
- argument validation.

Plus a kind-registration assertion in `AdditionalStrategyTests`. Full suite: 595→604 tests, all green.

## Docs / config

- Runbook §4 strategy table gets a row for `newsShock`, plus a tuning recipe.
- `config/synthetic-trader.json` gains a commented-out example block.