### PR TITLE
Add FIXP-capable EntryPoint client to synthetic trader

### DIFF
--- a/config/exchange-simulator.soak.json
+++ b/config/exchange-simulator.soak.json
@@ -1,9 +1,8 @@
 {
-  // Soak-test exchange config (#120). Deliberately omits firms[]/sessions[]
-  // so the deprecated single-tenant fallback kicks in — this lets the
-  // SyntheticTrader (which does not implement FIXP Negotiate) connect and
-  // sustain load for the soak duration. Do NOT use as a template for new
-  // deployments; production configs should declare firms/sessions explicitly.
+  // Soak-test exchange config (#120 + #133). Now exercises the production
+  // FIXP handshake path via the synthetic trader's FixpClient. Declares one
+  // firm + one session so the soak runner authenticates exactly like a real
+  // OMS would in prod. devMode=true keeps access keys optional.
   "tcp": {
     "listen": "0.0.0.0:9876",
     "enteringFirm": 1,
@@ -11,7 +10,13 @@
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000
   },
-  "auth": { "devMode": true, "requireFixpHandshake": false },
+  "auth": { "devMode": true, "requireFixpHandshake": true },
+  "firms": [
+    { "id": "soakFirm", "name": "Soak Firm", "enteringFirmCode": 1 }
+  ],
+  "sessions": [
+    { "sessionId": "100", "firmId": "soakFirm" }
+  ],
   "http": {
     "listen": "0.0.0.0:8080",
     "livenessStaleMs": 5000

--- a/config/synthetic-trader.json
+++ b/config/synthetic-trader.json
@@ -5,6 +5,18 @@
   "firm": 1,
   "seed": 42,
   "tickIntervalMs": 100,
+  // Optional FIXP block — uncomment when the host has
+  // auth.requireFixpHandshake=true. The sessionId must match a
+  // sessions[] entry in the host config and be a decimal uint32 string
+  // (no leading zeros, > 0). accessKey is ignored when the host has
+  // auth.devMode=true.
+  // "fixp": {
+  //   "sessionId": "100",
+  //   "accessKey": "",
+  //   "keepAliveIntervalMs": 5000,
+  //   "cancelOnDisconnect": false,
+  //   "retransmitOnGap": true
+  // },
   "instruments": [
     {
       "securityId": 900000000001,

--- a/config/synthetic-trader.soak.json
+++ b/config/synthetic-trader.soak.json
@@ -3,6 +3,13 @@
   "firm": 1,
   "seed": 4242,
   "tickIntervalMs": 50,
+  "fixp": {
+    "sessionId": "100",
+    "accessKey": "",
+    "keepAliveIntervalMs": 5000,
+    "cancelOnDisconnect": false,
+    "retransmitOnGap": true
+  },
   "instruments": [
     {
       "securityId": 900000000001,

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -243,6 +243,41 @@ Tuning recipes:
   and a distinct EntryPoint `port` if you split the host. The sample
   uses `firm: 1` (the legacy single-tenant fallback).
 
+#### 4.0.1 FIXP handshake (production-shaped login)
+
+When the host has `auth.requireFixpHandshake=true` the synthetic trader
+must perform a full FIXP `Negotiate`+`Establish` before sending business
+frames. Add a `fixp` block to the trader config:
+
+```json
+"fixp": {
+  "sessionId": "100",
+  "accessKey": "",
+  "keepAliveIntervalMs": 5000,
+  "cancelOnDisconnect": false,
+  "retransmitOnGap": true
+}
+```
+
+The `sessionId` MUST be a decimal `uint32` string (no leading zeros, > 0)
+that matches a `sessions[].sessionId` declared in the host config. The
+companion firm entry's `enteringFirmCode` MUST equal the trader's
+`firm` field. With `auth.devMode=true` the `accessKey` is ignored; in
+prod-shaped configs set it to the value registered for the session.
+
+When the block is **omitted** the trader falls back to legacy "raw
+business frames, no handshake" mode for back-compat with hosts running
+`auth.requireFixpHandshake=false`.
+
+The `EntryPointClient` then automatically:
+* sends `Negotiate` + `Establish` on connect (throws on reject);
+* embeds a monotonic `msgSeqNum` in every outbound business frame;
+* emits a `Sequence` heartbeat after `keepAliveIntervalMs/2` of outbound
+  silence and disconnects if the gateway is silent for >1.5×keepAlive;
+* sends a `Terminate(FINISHED)` on graceful shutdown;
+* on detected inbound gaps, fires `RetransmitRequest` when
+  `retransmitOnGap=true`.
+
 ### 4.1 Deterministic replay (`tools/ScenarioReplay`)
 
 For reproducing bug reports and pinning regression tests, drive the host

--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -3,6 +3,7 @@ using System.Buffers.Binary;
 using System.Net.Sockets;
 using System.Threading.Channels;
 using B3.Exchange.Gateway;
+using B3.Exchange.SyntheticTrader.Fixp;
 
 namespace B3.Exchange.SyntheticTrader;
 
@@ -92,8 +93,10 @@ public sealed class EntryPointClient : IAsyncDisposable
     private readonly CancellationTokenSource _cts;
     private readonly Action<string>? _logDebug;
     private readonly Action<string>? _logWarn;
+    private readonly FixpClient? _fixp;
     private Task? _recvTask;
     private Task? _sendTask;
+    private Task? _heartbeatTask;
     private long _isOpen = 1;
 
     public event Action<ExecReportNew>? OnNew;
@@ -104,12 +107,22 @@ public sealed class EntryPointClient : IAsyncDisposable
 
     public bool IsOpen => Interlocked.Read(ref _isOpen) == 1;
 
-    private EntryPointClient(TcpClient tcp, NetworkStream stream, Action<string>? logDebug, Action<string>? logWarn, CancellationToken externalCt)
+    /// <summary>
+    /// Exposes the FIXP session layer when this client was constructed
+    /// with <see cref="FixpClientOptions"/>; <c>null</c> in legacy
+    /// (no-handshake) mode. Read-only — callers should drive sends via
+    /// <see cref="SendNewOrder"/>/<see cref="SendCancel"/>.
+    /// </summary>
+    public FixpClient? Fixp => _fixp;
+
+    private EntryPointClient(TcpClient tcp, NetworkStream stream, Action<string>? logDebug, Action<string>? logWarn,
+        CancellationToken externalCt, FixpClient? fixp = null)
     {
         _tcp = tcp;
         _stream = stream;
         _logDebug = logDebug;
         _logWarn = logWarn;
+        _fixp = fixp;
         _cts = CancellationTokenSource.CreateLinkedTokenSource(externalCt);
         _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(1024)
         {
@@ -138,10 +151,54 @@ public sealed class EntryPointClient : IAsyncDisposable
         return client;
     }
 
+    /// <summary>
+    /// Connects and performs a full FIXP handshake (Negotiate +
+    /// Establish) before returning. After this call returns the client
+    /// is in <see cref="FixpClientState.Established"/>; subsequent
+    /// business sends will carry the assigned <c>msgSeqNum</c>, the
+    /// client emits <c>Sequence</c> heartbeats, and a <c>Terminate</c>
+    /// is sent on dispose. Throws <see cref="FixpHandshakeRejectedException"/>
+    /// if the gateway rejects either handshake leg.
+    /// </summary>
+    public static async Task<EntryPointClient> ConnectAsync(string host, int port,
+        FixpClientOptions fixpOptions,
+        Action<string>? logDebug = null, Action<string>? logWarn = null, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(fixpOptions);
+        var tcp = new TcpClient { NoDelay = true };
+        try
+        {
+            await tcp.ConnectAsync(host, port, ct).ConfigureAwait(false);
+        }
+        catch
+        {
+            tcp.Dispose();
+            throw;
+        }
+        var stream = tcp.GetStream();
+        var fixp = new FixpClient(stream, fixpOptions, logDebug, logWarn);
+        var client = new EntryPointClient(tcp, stream, logDebug, logWarn, ct, fixp);
+        client.Start();
+        try
+        {
+            await fixp.NegotiateAndEstablishAsync(client._cts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            await client.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+        return client;
+    }
+
     private void Start()
     {
         _recvTask = Task.Run(() => RunReceiveLoopAsync(_cts.Token));
         _sendTask = Task.Run(() => RunSendLoopAsync(_cts.Token));
+        if (_fixp != null)
+        {
+            _heartbeatTask = Task.Run(() => RunHeartbeatLoopAsync(_cts.Token));
+        }
     }
 
     public bool SendNewOrder(ulong clOrdId, long securityId, OrderSide side,
@@ -150,6 +207,10 @@ public sealed class EntryPointClient : IAsyncDisposable
         if (!IsOpen) return false;
         var frame = new byte[HeaderSize + NewOrderBlockLen];
         EncodeNewOrder(frame, clOrdId, securityId, side, type, tif, qty, priceMantissa);
+        if (_fixp != null)
+        {
+            _fixp.AssignOutboundBusinessHeader(frame.AsSpan(HeaderSize, NewOrderBlockLen));
+        }
         _logDebug?.Invoke($"send NEW clord={clOrdId} sec={securityId} side={side} qty={qty} px={priceMantissa} tif={tif}");
         return Enqueue(frame);
     }
@@ -159,6 +220,10 @@ public sealed class EntryPointClient : IAsyncDisposable
         if (!IsOpen) return false;
         var frame = new byte[HeaderSize + CancelBlockLen];
         EncodeCancel(frame, clOrdId, securityId, orderId, origClOrdId, side);
+        if (_fixp != null)
+        {
+            _fixp.AssignOutboundBusinessHeader(frame.AsSpan(HeaderSize, CancelBlockLen));
+        }
         _logDebug?.Invoke($"send CXL clord={clOrdId} sec={securityId} orderId={orderId}");
         return Enqueue(frame);
     }
@@ -288,7 +353,14 @@ public sealed class EntryPointClient : IAsyncDisposable
             {
                 try
                 {
-                    await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                    if (_fixp != null)
+                    {
+                        await _fixp.WriteAsync(frame, ct).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                    }
                 }
                 catch (IOException ex)
                 {
@@ -307,6 +379,31 @@ public sealed class EntryPointClient : IAsyncDisposable
         {
             Close("send loop exit");
         }
+    }
+
+    private async Task RunHeartbeatLoopAsync(CancellationToken ct)
+    {
+        if (_fixp == null) return;
+        var period = TimeSpan.FromMilliseconds(Math.Max(50, _fixp.KeepAlive.TotalMilliseconds / 2));
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(period, ct).ConfigureAwait(false);
+                try { await _fixp.TickHeartbeatAsync(ct).ConfigureAwait(false); }
+                catch (Exception ex)
+                {
+                    _logWarn?.Invoke($"fixp heartbeat error: {ex.Message}");
+                }
+                if (_fixp.IsPeerStale())
+                {
+                    _logWarn?.Invoke("fixp watchdog: peer stale, closing");
+                    Close("fixp watchdog: peer stale");
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException) { }
     }
 
     private async Task RunReceiveLoopAsync(CancellationToken ct)
@@ -370,6 +467,33 @@ public sealed class EntryPointClient : IAsyncDisposable
                 try
                 {
                     await ReadExactAsync(_stream, body.AsMemory(0, bodyLength), ct).ConfigureAwait(false);
+                    if (_fixp != null)
+                    {
+                        var disp = _fixp.HandleInboundFrame(templateId, body.AsSpan(0, bodyLength));
+                        if (disp == InboundDisposition.HandledControl)
+                            continue;
+                        if (disp == InboundDisposition.PeerTerminated)
+                        {
+                            Close("peer Terminate");
+                            return;
+                        }
+                        if (disp == InboundDisposition.ProtocolError)
+                        {
+                            Close("fixp protocol error");
+                            return;
+                        }
+                        // PassThrough: track inbound business msgSeqNum
+                        // (InboundBusinessHeader is 18 bytes; msgSeqNum at body[4..8]).
+                        if (bodyLength >= 8)
+                        {
+                            uint msgSeq = BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(4, 4));
+                            if (!_fixp.TrackInboundBusinessSeq(msgSeq))
+                            {
+                                // Duplicate; drop without dispatching to ER callbacks.
+                                continue;
+                            }
+                        }
+                    }
                     Dispatch(templateId, version, body, blockLength);
                 }
                 finally
@@ -476,9 +600,16 @@ public sealed class EntryPointClient : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        // Send Terminate first when in FIXP mode so the gateway sees a
+        // graceful close rather than a half-open TCP. Best-effort.
+        if (_fixp != null)
+        {
+            try { await _fixp.DisposeAsync().ConfigureAwait(false); } catch { }
+        }
         Close("dispose");
         try { if (_recvTask != null) await _recvTask.ConfigureAwait(false); } catch { }
         try { if (_sendTask != null) await _sendTask.ConfigureAwait(false); } catch { }
+        try { if (_heartbeatTask != null) await _heartbeatTask.ConfigureAwait(false); } catch { }
         _cts.Dispose();
     }
 }

--- a/src/B3.Exchange.SyntheticTrader/Fixp/FixpClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/Fixp/FixpClient.cs
@@ -1,0 +1,489 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Text;
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.SyntheticTrader.Fixp;
+
+/// <summary>
+/// Disposition of an inbound FIXP frame after <see cref="FixpClient"/>
+/// has inspected it. The owning <c>EntryPointClient</c> uses this to
+/// decide whether to keep dispatching the frame to its application
+/// parser or stop further processing.
+/// </summary>
+public enum InboundDisposition
+{
+    /// <summary>Application frame the caller should keep parsing.</summary>
+    PassThrough,
+    /// <summary>FIXP session-layer frame already handled.</summary>
+    HandledControl,
+    /// <summary>Peer sent <c>Terminate</c>; caller should close.</summary>
+    PeerTerminated,
+    /// <summary>Unrecoverable framing/protocol error; caller should close.</summary>
+    ProtocolError,
+}
+
+/// <summary>
+/// Client-side FIXP session layer. Owns the FIXP state machine, the
+/// outbound application sequence number (idempotent flow), and the
+/// inbound application sequence tracking (recoverable flow). It does
+/// <em>not</em> own the network read loop — the embedding
+/// <c>EntryPointClient</c> drives reads and forwards each decoded frame
+/// to <see cref="HandleInboundFrame"/>. Outbound writes go through
+/// <see cref="WriteAsync"/> and are mutually excluded with the
+/// session-layer frames this class sends (heartbeat, NotApplied response,
+/// RetransmitRequest, Terminate).
+/// </summary>
+public sealed class FixpClient : IAsyncDisposable
+{
+    private readonly NetworkStream _stream;
+    private readonly FixpClientOptions _options;
+    private readonly Action<string>? _logDebug;
+    private readonly Action<string>? _logWarn;
+    private readonly SemaphoreSlim _writeLock = new(1, 1);
+    private readonly TaskCompletionSource<FixpFrameCodec.NegotiateResponseFrame> _negotiateTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource<FixpFrameCodec.EstablishAckFrame> _establishTcs =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly object _seqLock = new();
+
+    private volatile FixpClientState _state = FixpClientState.Init;
+    private uint _sessionIdNumeric;
+    private ulong _sessionVerId;
+    private uint _nextOutboundSeqNo = 1;
+    private uint _expectedInboundSeqNo = 1;
+    private long _lastInboundTicks;
+    private long _lastOutboundTicks;
+    private bool _disposed;
+
+    public FixpClient(NetworkStream stream, FixpClientOptions options,
+        Action<string>? logDebug = null, Action<string>? logWarn = null)
+    {
+        _stream = stream ?? throw new ArgumentNullException(nameof(stream));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        if (!uint.TryParse(_options.SessionId, out _sessionIdNumeric) || _sessionIdNumeric == 0
+            || _options.SessionId.StartsWith('0'))
+        {
+            throw new ArgumentException(
+                $"FixpClientOptions.SessionId must be a decimal uint32 string >0 with no leading zeros (got '{_options.SessionId}')",
+                nameof(options));
+        }
+        _logDebug = logDebug;
+        _logWarn = logWarn;
+        Touch(inbound: true);
+        Touch(inbound: false);
+    }
+
+    public FixpClientState State => _state;
+    public uint SessionIdNumeric => _sessionIdNumeric;
+    public ulong SessionVerId => _sessionVerId;
+    public uint NextOutboundSeqNo { get { lock (_seqLock) return _nextOutboundSeqNo; } }
+    public uint ExpectedInboundSeqNo { get { lock (_seqLock) return _expectedInboundSeqNo; } }
+    public DateTime LastInboundUtc => new(Interlocked.Read(ref _lastInboundTicks), DateTimeKind.Utc);
+    public DateTime LastOutboundUtc => new(Interlocked.Read(ref _lastOutboundTicks), DateTimeKind.Utc);
+    public TimeSpan KeepAlive => TimeSpan.FromMilliseconds(_options.KeepAliveIntervalMillis);
+
+    /// <summary>
+    /// Performs the synchronous Negotiate→NegotiateResponse→Establish→
+    /// EstablishAck handshake. Caller must invoke
+    /// <see cref="HandleInboundFrame"/> from its read loop while this is
+    /// awaiting (the loop typically starts before <c>NegotiateAndEstablishAsync</c>
+    /// completes — that's fine, this method only writes outbound frames
+    /// and awaits the inbound completion sources).
+    /// </summary>
+    public async Task NegotiateAndEstablishAsync(CancellationToken ct)
+    {
+        if (_state != FixpClientState.Init)
+            throw new InvalidOperationException($"NegotiateAndEstablishAsync called in state {_state}");
+
+        // Spec §4.5.2: sessionVerID must be incremented for each Negotiate
+        // on a given sessionId. We pick "now-as-nanoseconds" so independent
+        // synthetic-trader processes never collide on a given session.
+        _sessionVerId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        ulong negotiateTs = NowNanos();
+        byte[] credentials = BuildCredentialsJson(_options.SessionId, _options.AccessKey);
+        byte[] buf = new byte[1024];
+        int len = FixpFrameCodec.EncodeNegotiate(buf, _sessionIdNumeric, _sessionVerId, negotiateTs,
+            _options.EnteringFirm, onBehalfFirm: null,
+            credentials: credentials,
+            clientIp: ReadOnlySpan<byte>.Empty,
+            clientAppName: Encoding.ASCII.GetBytes(_options.ClientAppName),
+            clientAppVersion: Encoding.ASCII.GetBytes(_options.ClientAppVersion));
+
+        _state = FixpClientState.NegotiateSent;
+        await WriteRawAsync(buf.AsMemory(0, len), ct).ConfigureAwait(false);
+        _logDebug?.Invoke($"fixp Negotiate sent sessionId={_sessionIdNumeric} verId={_sessionVerId}");
+
+        var negResp = await _negotiateTcs.Task.WaitAsync(_options.HandshakeTimeout, ct).ConfigureAwait(false);
+        _logDebug?.Invoke($"fixp NegotiateResponse received semVer={negResp.SemVerMajor}.{negResp.SemVerMinor}.{negResp.SemVerPatch}");
+        _state = FixpClientState.Negotiated;
+
+        ulong establishTs = NowNanos();
+        ushort codType = _options.CancelOnDisconnect ? (ushort)4 : (ushort)0;
+        len = FixpFrameCodec.EncodeEstablish(buf, _sessionIdNumeric, _sessionVerId, establishTs,
+            keepAliveIntervalMillis: _options.KeepAliveIntervalMillis,
+            nextSeqNo: NextOutboundSeqNo,
+            cancelOnDisconnectType: codType,
+            codTimeoutWindowMillis: 0,
+            credentials: BuildCredentialsJson(_options.SessionId, _options.AccessKey));
+        _state = FixpClientState.EstablishSent;
+        await WriteRawAsync(buf.AsMemory(0, len), ct).ConfigureAwait(false);
+        _logDebug?.Invoke($"fixp Establish sent keepAlive={_options.KeepAliveIntervalMillis}ms cod={codType} nextSeq={NextOutboundSeqNo}");
+
+        var ack = await _establishTcs.Task.WaitAsync(_options.HandshakeTimeout, ct).ConfigureAwait(false);
+        lock (_seqLock)
+        {
+            // Server's lastIncomingSeqNo tells us what it has acked from
+            // any prior session version; for a fresh session this is 0
+            // and we keep our nextOutboundSeqNo at 1.
+            _expectedInboundSeqNo = ack.NextSeqNo;
+        }
+        _state = FixpClientState.Established;
+        _logDebug?.Invoke($"fixp Established serverNextSeq={ack.NextSeqNo} serverLastIncoming={ack.LastIncomingSeqNo}");
+    }
+
+    /// <summary>
+    /// Patches the 18-byte <c>InboundBusinessHeader</c> at the start of
+    /// <paramref name="bodyAfterWireHeader"/>: <c>sessionID</c>(4) at
+    /// offset 0 and <c>msgSeqNum</c>(4) at offset 4. Returns the assigned
+    /// <c>msgSeqNum</c>. Thread-safe; serializes assignment so the wire
+    /// order matches numeric order.
+    /// </summary>
+    public uint AssignOutboundBusinessHeader(Span<byte> bodyAfterWireHeader)
+    {
+        if (bodyAfterWireHeader.Length < 8)
+            throw new ArgumentException("body too small for InboundBusinessHeader", nameof(bodyAfterWireHeader));
+        uint assigned;
+        lock (_seqLock)
+        {
+            assigned = _nextOutboundSeqNo++;
+        }
+        BinaryPrimitives.WriteUInt32LittleEndian(bodyAfterWireHeader.Slice(0, 4), _sessionIdNumeric);
+        BinaryPrimitives.WriteUInt32LittleEndian(bodyAfterWireHeader.Slice(4, 4), assigned);
+        return assigned;
+    }
+
+    /// <summary>
+    /// Writes a fully-framed (SOFH+SBE header + body) buffer to the wire,
+    /// serialising against any concurrent session-layer frames the client
+    /// emits (heartbeat, Terminate, RetransmitRequest).
+    /// </summary>
+    public async Task WriteAsync(ReadOnlyMemory<byte> frame, CancellationToken ct)
+    {
+        await WriteRawAsync(frame, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Inspects an inbound frame after the SOFH+SBE header has been
+    /// parsed by the embedding read loop. For session-layer messages
+    /// (<c>NegotiateResponse</c>, <c>EstablishAck</c>, <c>Sequence</c>,
+    /// <c>NotApplied</c>, <c>Retransmission</c>, <c>RetransmitReject</c>,
+    /// <c>Terminate</c>, both <c>*Reject</c> handshake frames) the
+    /// disposition is <see cref="InboundDisposition.HandledControl"/>
+    /// (or <see cref="InboundDisposition.PeerTerminated"/> for
+    /// <c>Terminate</c>); for application frames the disposition is
+    /// <see cref="InboundDisposition.PassThrough"/>.
+    /// </summary>
+    public InboundDisposition HandleInboundFrame(ushort templateId, ReadOnlySpan<byte> body)
+    {
+        Touch(inbound: true);
+        switch (templateId)
+        {
+            case EntryPointFrameReader.TidNegotiateResponse:
+                if (FixpFrameCodec.TryDecodeNegotiateResponse(body, out var nr))
+                    _negotiateTcs.TrySetResult(nr);
+                else
+                    _negotiateTcs.TrySetException(new InvalidOperationException("malformed NegotiateResponse"));
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidNegotiateReject:
+                if (FixpFrameCodec.TryDecodeNegotiateReject(body, out var nrj))
+                {
+                    _state = FixpClientState.Failed;
+                    _negotiateTcs.TrySetException(new FixpHandshakeRejectedException(
+                        $"Negotiate rejected (code={nrj.RejectCode}, currentSessionVerId={nrj.CurrentSessionVerId})"));
+                }
+                else
+                {
+                    _negotiateTcs.TrySetException(new InvalidOperationException("malformed NegotiateReject"));
+                }
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidEstablishAck:
+                if (FixpFrameCodec.TryDecodeEstablishAck(body, out var ea))
+                    _establishTcs.TrySetResult(ea);
+                else
+                    _establishTcs.TrySetException(new InvalidOperationException("malformed EstablishAck"));
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidEstablishReject:
+                if (FixpFrameCodec.TryDecodeEstablishReject(body, out var erj))
+                {
+                    _state = FixpClientState.Failed;
+                    _establishTcs.TrySetException(new FixpHandshakeRejectedException(
+                        $"Establish rejected (code={erj.RejectCode}, lastIncomingSeqNo={erj.LastIncomingSeqNo})"));
+                }
+                else
+                {
+                    _establishTcs.TrySetException(new InvalidOperationException("malformed EstablishReject"));
+                }
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidSequence:
+                if (FixpFrameCodec.TryDecodeSequence(body, out var seq))
+                {
+                    // Spec §4.5.5: a Sequence message restates the sender's nextSeqNo;
+                    // it does not consume a sequence number itself. We use it both as
+                    // a peer-aliveness signal and to detect gaps in the recoverable
+                    // (server→client) stream.
+                    HandleSequenceMaybeGap(seq.NextSeqNo);
+                }
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidNotApplied:
+                if (FixpFrameCodec.TryDecodeNotApplied(body, out var na))
+                {
+                    // Idempotent client→server flow: server already advanced
+                    // its expected past the gap and accepted the latest message.
+                    // We log the loss; a future enhancement could replay from
+                    // an outbound retransmit ring buffer if the embedding test
+                    // demands strict at-least-once semantics.
+                    _logWarn?.Invoke($"fixp NotApplied: server gap fromSeqNo={na.FromSeqNo} count={na.Count} (idempotent flow — not resending)");
+                }
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidRetransmission:
+                if (FixpFrameCodec.TryDecodeRetransmission(body, out var rt))
+                {
+                    // The retransmitted business messages follow as
+                    // independent SBE frames on the wire after this
+                    // Retransmission header. The read loop will see them
+                    // as ordinary application frames and call
+                    // TrackInboundBusinessSeq(...) on each. We just align
+                    // our expected counter to the start of the burst so
+                    // gap detection treats them as in-order.
+                    lock (_seqLock) _expectedInboundSeqNo = rt.NextSeqNo;
+                    _logDebug?.Invoke($"fixp Retransmission: next={rt.NextSeqNo} count={rt.Count}");
+                }
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidRetransmitReject:
+                if (FixpFrameCodec.TryDecodeRetransmitReject(body, out var rrj))
+                {
+                    _logWarn?.Invoke($"fixp RetransmitReject: code={rrj.RejectCode} requestTs={rrj.RequestTimestampNanos}");
+                }
+                return InboundDisposition.HandledControl;
+
+            case EntryPointFrameReader.TidTerminate:
+                if (FixpFrameCodec.TryDecodeTerminate(body, out var tm))
+                {
+                    _logDebug?.Invoke($"fixp Terminate received code={tm.TerminationCode}");
+                }
+                _state = FixpClientState.Closed;
+                return InboundDisposition.PeerTerminated;
+
+            default:
+                return InboundDisposition.PassThrough;
+        }
+    }
+
+    /// <summary>
+    /// Tracks an inbound business message's <c>msgSeqNum</c> (read from
+    /// body[4..8] by the caller). Detects gaps in the recoverable
+    /// server→client stream and, when <see cref="FixpClientOptions.RetransmitOnGap"/>
+    /// is true, fires off a <c>RetransmitRequest</c>. Returns
+    /// <c>true</c> if the message is in-order or a valid retransmission;
+    /// <c>false</c> if it is a duplicate that the caller should drop.
+    /// </summary>
+    public bool TrackInboundBusinessSeq(uint msgSeqNum)
+    {
+        uint expected;
+        bool gap = false;
+        uint gapFrom = 0, gapCount = 0;
+        lock (_seqLock)
+        {
+            expected = _expectedInboundSeqNo;
+            if (msgSeqNum == 0)
+            {
+                // Pre-handshake legacy frame (msgSeqNum unset). Accept and don't advance.
+                return true;
+            }
+            if (msgSeqNum < expected)
+            {
+                _logWarn?.Invoke($"fixp duplicate inbound msgSeqNum={msgSeqNum} expected={expected}");
+                return false;
+            }
+            if (msgSeqNum > expected)
+            {
+                gap = true;
+                gapFrom = expected;
+                gapCount = msgSeqNum - expected;
+            }
+            _expectedInboundSeqNo = msgSeqNum + 1;
+        }
+        if (gap && _options.RetransmitOnGap && _state == FixpClientState.Established)
+        {
+            _ = Task.Run(() => SendRetransmitRequestAsync(gapFrom, gapCount, CancellationToken.None));
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Emits a <c>Sequence</c> heartbeat if no outbound traffic has been
+    /// sent for ≥ keepAlive/2. Safe to call from a periodic timer.
+    /// </summary>
+    public async Task TickHeartbeatAsync(CancellationToken ct)
+    {
+        if (_state != FixpClientState.Established) return;
+        var sinceOut = DateTime.UtcNow - LastOutboundUtc;
+        if (sinceOut < KeepAlive / 2) return;
+        byte[] buf = new byte[FixpFrameCodec.SequenceBlock + EntryPointFrameReader.WireHeaderSize];
+        int len = FixpFrameCodec.EncodeSequence(buf, NextOutboundSeqNo);
+        await WriteRawAsync(buf.AsMemory(0, len), ct).ConfigureAwait(false);
+        _logDebug?.Invoke($"fixp Sequence heartbeat sent next={NextOutboundSeqNo}");
+    }
+
+    /// <summary>
+    /// Returns true when the peer has been silent for &gt; 1.5 × keepAlive,
+    /// which the caller should treat as a dead session per spec §4.6.4.
+    /// </summary>
+    public bool IsPeerStale()
+    {
+        if (_state != FixpClientState.Established) return false;
+        var since = DateTime.UtcNow - LastInboundUtc;
+        return since > (KeepAlive + KeepAlive / 2);
+    }
+
+    public async Task TerminateAsync(byte code, CancellationToken ct)
+    {
+        if (_state == FixpClientState.Closed || _state == FixpClientState.Terminating)
+            return;
+        _state = FixpClientState.Terminating;
+        try
+        {
+            byte[] buf = new byte[FixpFrameCodec.TerminateBlock + EntryPointFrameReader.WireHeaderSize];
+            int len = FixpFrameCodec.EncodeTerminate(buf, _sessionIdNumeric, _sessionVerId, code);
+            await WriteRawAsync(buf.AsMemory(0, len), ct).ConfigureAwait(false);
+            _logDebug?.Invoke($"fixp Terminate sent code={code}");
+        }
+        catch (Exception ex)
+        {
+            _logWarn?.Invoke($"fixp Terminate write failed: {ex.Message}");
+        }
+        finally
+        {
+            _state = FixpClientState.Closed;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        if (_state == FixpClientState.Established)
+        {
+            try
+            {
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+                await TerminateAsync((byte)FixpSbe.TerminationCode.FINISHED, cts.Token).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Best-effort on dispose.
+            }
+        }
+        _writeLock.Dispose();
+    }
+
+    // ===== internals ========================================================
+
+    private async Task SendRetransmitRequestAsync(uint fromSeqNo, uint count, CancellationToken ct)
+    {
+        try
+        {
+            byte[] buf = new byte[FixpFrameCodec.RetransmitRequestBlock + EntryPointFrameReader.WireHeaderSize];
+            int len = FixpFrameCodec.EncodeRetransmitRequest(buf, _sessionIdNumeric,
+                NowNanos(), fromSeqNo, count);
+            await WriteRawAsync(buf.AsMemory(0, len), ct).ConfigureAwait(false);
+            _logDebug?.Invoke($"fixp RetransmitRequest sent from={fromSeqNo} count={count}");
+        }
+        catch (Exception ex)
+        {
+            _logWarn?.Invoke($"fixp RetransmitRequest write failed: {ex.Message}");
+        }
+    }
+
+    private void HandleSequenceMaybeGap(uint peerNextSeq)
+    {
+        uint expected;
+        bool gap = false;
+        uint from = 0, count = 0;
+        lock (_seqLock)
+        {
+            expected = _expectedInboundSeqNo;
+            if (peerNextSeq > expected)
+            {
+                gap = true;
+                from = expected;
+                count = peerNextSeq - expected;
+                // Don't move expected past the gap; let the retransmission fill it.
+            }
+        }
+        if (gap)
+        {
+            _logWarn?.Invoke($"fixp inbound gap (Sequence): expected={expected} peerNext={peerNextSeq}");
+            if (_options.RetransmitOnGap && _state == FixpClientState.Established)
+            {
+                _ = Task.Run(() => SendRetransmitRequestAsync(from, count, CancellationToken.None));
+            }
+        }
+    }
+
+    private async Task WriteRawAsync(ReadOnlyMemory<byte> frame, CancellationToken ct)
+    {
+        await _writeLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+            await _stream.FlushAsync(ct).ConfigureAwait(false);
+            Touch(inbound: false);
+        }
+        finally
+        {
+            _writeLock.Release();
+        }
+    }
+
+    private void Touch(bool inbound)
+    {
+        long ticks = DateTime.UtcNow.Ticks;
+        if (inbound) Interlocked.Exchange(ref _lastInboundTicks, ticks);
+        else Interlocked.Exchange(ref _lastOutboundTicks, ticks);
+    }
+
+    private static ulong NowNanos() => (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000L);
+
+    /// <summary>
+    /// Builds the gateway-expected credentials JSON document
+    /// (<c>{"auth_type":"basic","username":"&lt;sessionId&gt;","access_key":"&lt;key&gt;"}</c>)
+    /// per <c>NegotiateCredentials.TryParse</c> in the gateway. The
+    /// JSON is encoded as UTF-8 ASCII; both fields are validated by the
+    /// gateway as printable ASCII so we keep them raw.
+    /// </summary>
+    private static byte[] BuildCredentialsJson(string sessionId, string accessKey)
+    {
+        var json = $"{{\"auth_type\":\"basic\",\"username\":\"{sessionId}\",\"access_key\":\"{accessKey}\"}}";
+        return Encoding.ASCII.GetBytes(json);
+    }
+}
+
+/// <summary>
+/// Thrown when the server rejects a Negotiate or Establish handshake.
+/// Carries the rejection code in the message; the caller should treat
+/// this as fatal for the session.
+/// </summary>
+public sealed class FixpHandshakeRejectedException : Exception
+{
+    public FixpHandshakeRejectedException(string message) : base(message) { }
+}

--- a/src/B3.Exchange.SyntheticTrader/Fixp/FixpClientOptions.cs
+++ b/src/B3.Exchange.SyntheticTrader/Fixp/FixpClientOptions.cs
@@ -1,0 +1,73 @@
+namespace B3.Exchange.SyntheticTrader.Fixp;
+
+/// <summary>
+/// Configuration for the FIXP session layer when the synthetic trader's
+/// <c>EntryPointClient</c> talks to a host that has
+/// <c>auth.requireFixpHandshake=true</c>. When the caller does not supply
+/// these options the client stays in its legacy "raw SBE business frames,
+/// no handshake" mode for back-compat with existing soak/tests.
+/// </summary>
+public sealed record FixpClientOptions
+{
+    /// <summary>
+    /// Decimal uint32 string identifying the FIXP session, as required by
+    /// the gateway's <c>FirmRegistry</c> (no leading zeros, &gt; 0).
+    /// </summary>
+    public required string SessionId { get; init; }
+
+    /// <summary>
+    /// Wire-format firm code sent in the Negotiate's
+    /// <c>enteringFirm</c> field; usually matches <c>tcp.enteringFirm</c>
+    /// in the host config.
+    /// </summary>
+    public required uint EnteringFirm { get; init; }
+
+    /// <summary>
+    /// Optional access key sent in the Negotiate credentials varData
+    /// alongside the session id and the literal <c>auth_type=basic</c>.
+    /// In dev/test mode (host's <c>auth.devMode=true</c>) the gateway
+    /// ignores the access key, so the default empty string suffices.
+    /// </summary>
+    public string AccessKey { get; init; } = "";
+
+    /// <summary>
+    /// Idle interval in milliseconds the client advertises in
+    /// <c>Establish</c>. The client emits a <c>Sequence</c> heartbeat
+    /// after <see cref="KeepAliveIntervalMillis"/>/2 of outbound silence
+    /// and disconnects the session if it sees no inbound traffic for
+    /// 1.5×<see cref="KeepAliveIntervalMillis"/>.
+    /// </summary>
+    public uint KeepAliveIntervalMillis { get; init; } = 5000;
+
+    /// <summary>
+    /// When true, the Establish carries
+    /// <c>cancelOnDisconnectType=4</c> (cancel on disconnect &amp; on
+    /// terminate); otherwise <c>0</c> (do not cancel). The corresponding
+    /// timeout window is 0 (immediate) per spec when CoD is requested.
+    /// </summary>
+    public bool CancelOnDisconnect { get; init; } = false;
+
+    /// <summary>
+    /// When true, the client sends a <c>RetransmitRequest</c> on detected
+    /// inbound application sequence gaps. When false, gaps are logged and
+    /// the missing messages are skipped.
+    /// </summary>
+    public bool RetransmitOnGap { get; init; } = true;
+
+    /// <summary>
+    /// Timeout for the Negotiate→NegotiateResponse and
+    /// Establish→EstablishAck synchronous handshake legs.
+    /// </summary>
+    public TimeSpan HandshakeTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Optional "client app name" varData segment (≤30 bytes). Defaults
+    /// to "synth".
+    /// </summary>
+    public string ClientAppName { get; init; } = "synth";
+
+    /// <summary>
+    /// Optional "client app version" varData segment (≤30 bytes).
+    /// </summary>
+    public string ClientAppVersion { get; init; } = "1.0";
+}

--- a/src/B3.Exchange.SyntheticTrader/Fixp/FixpClientState.cs
+++ b/src/B3.Exchange.SyntheticTrader/Fixp/FixpClientState.cs
@@ -1,0 +1,23 @@
+namespace B3.Exchange.SyntheticTrader.Fixp;
+
+/// <summary>
+/// FIXP client-side state machine, mirroring the server-side
+/// <c>FixpStateMachine</c> in <c>B3.Exchange.Gateway</c>.
+///
+/// Transitions (happy path):
+///   <see cref="Init"/> → <see cref="NegotiateSent"/> → <see cref="Negotiated"/>
+///     → <see cref="EstablishSent"/> → <see cref="Established"/>
+///     → <see cref="Terminating"/> → <see cref="Closed"/>.
+/// Any reject moves the session to <see cref="Failed"/>.
+/// </summary>
+public enum FixpClientState
+{
+    Init = 0,
+    NegotiateSent,
+    Negotiated,
+    EstablishSent,
+    Established,
+    Terminating,
+    Closed,
+    Failed,
+}

--- a/src/B3.Exchange.SyntheticTrader/Fixp/FixpFrameCodec.cs
+++ b/src/B3.Exchange.SyntheticTrader/Fixp/FixpFrameCodec.cs
@@ -1,0 +1,319 @@
+using System.Buffers.Binary;
+using B3.Exchange.Gateway;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.SyntheticTrader.Fixp;
+
+/// <summary>
+/// Byte-level encoders and decoders for the FIXP session-layer frames the
+/// synthetic trader's <see cref="FixpClient"/> needs to speak. Pinned to
+/// the V6 / version-0 SBE schema as documented in
+/// <c>schemas/b3-entrypoint-messages-8.4.2.xml</c>.
+///
+/// <para>This is the client-side mirror of the gateway's internal
+/// encoders (<c>NegotiateHandshakeEncoders</c>, <c>EstablishHandshakeEncoders</c>,
+/// <c>SessionFrameEncoder</c>): we encode what the gateway decodes
+/// (<c>Negotiate</c>, <c>Establish</c>, <c>Sequence</c>,
+/// <c>RetransmitRequest</c>, <c>Terminate</c>) and decode what the
+/// gateway encodes (<c>NegotiateResponse</c>, <c>NegotiateReject</c>,
+/// <c>EstablishAck</c>, <c>EstablishReject</c>, <c>Sequence</c>,
+/// <c>NotApplied</c>, <c>Retransmission</c>, <c>RetransmitReject</c>,
+/// <c>Terminate</c>). All values are little-endian; field offsets follow
+/// the generated <see cref="FixpSbe.NegotiateData"/> / etc. structs and
+/// are commented inline so a future schema bump can be audited cheaply.</para>
+/// </summary>
+internal static class FixpFrameCodec
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+
+    // ----- Block lengths (mirror FixpSbe.*Data.BLOCK_LENGTH) ----------------
+    public const int NegotiateBlock = FixpSbe.NegotiateData.BLOCK_LENGTH;             // 28
+    public const int EstablishBlock = FixpSbe.EstablishData.BLOCK_LENGTH;             // 42
+    public const int SequenceBlock = FixpSbe.SequenceData.BLOCK_LENGTH;               // 4
+    public const int RetransmitRequestBlock = FixpSbe.RetransmitRequestData.BLOCK_LENGTH; // 20
+    public const int TerminateBlock = FixpSbe.TerminateData.BLOCK_LENGTH;             // 13
+    public const int NegotiateResponseBlock = FixpSbe.NegotiateResponseData.BLOCK_LENGTH; // 28
+    public const int NegotiateRejectBlock = FixpSbe.NegotiateRejectData.BLOCK_LENGTH; // 36
+    public const int EstablishAckBlock = FixpSbe.EstablishAckData.BLOCK_LENGTH;       // 40
+    public const int EstablishRejectBlock = FixpSbe.EstablishRejectData.BLOCK_LENGTH; // 26
+    public const int NotAppliedBlock = FixpSbe.NotAppliedData.BLOCK_LENGTH;           // 8
+    public const int RetransmissionBlock = FixpSbe.RetransmissionData.BLOCK_LENGTH;   // 20
+    public const int RetransmitRejectBlock = FixpSbe.RetransmitRejectData.BLOCK_LENGTH;
+
+    // varData maximums per spec §4.5.2.
+    public const int MaxCredentialsLength = 128;
+    public const int MaxClientIpLength = 30;
+    public const int MaxClientAppNameLength = 30;
+    public const int MaxClientAppVersionLength = 30;
+
+    // ===== Encoders (client → server) =======================================
+
+    /// <summary>
+    /// Encodes a <c>Negotiate</c> frame (templateId=1, version=0, BLOCK_LENGTH=28)
+    /// followed by 4 varData segments (credentials, clientIP, clientAppName,
+    /// clientAppVersion). Each varData segment is length(uint8) + payload bytes.
+    /// Returns the number of bytes written.
+    /// </summary>
+    public static int EncodeNegotiate(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        ulong timestampNanos, uint enteringFirm, uint? onBehalfFirm,
+        ReadOnlySpan<byte> credentials, ReadOnlySpan<byte> clientIp,
+        ReadOnlySpan<byte> clientAppName, ReadOnlySpan<byte> clientAppVersion)
+    {
+        if (credentials.Length > MaxCredentialsLength) throw new ArgumentException("credentials too long", nameof(credentials));
+        if (clientIp.Length > MaxClientIpLength) throw new ArgumentException("clientIp too long", nameof(clientIp));
+        if (clientAppName.Length > MaxClientAppNameLength) throw new ArgumentException("clientAppName too long", nameof(clientAppName));
+        if (clientAppVersion.Length > MaxClientAppVersionLength) throw new ArgumentException("clientAppVersion too long", nameof(clientAppVersion));
+
+        int varSize = 4 + credentials.Length + clientIp.Length + clientAppName.Length + clientAppVersion.Length;
+        int total = HeaderSize + NegotiateBlock + varSize;
+        if (dst.Length < total) throw new ArgumentException("buffer too small for Negotiate", nameof(dst));
+
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: NegotiateBlock,
+            templateId: EntryPointFrameReader.TidNegotiate, version: 0);
+        var body = dst.Slice(HeaderSize, NegotiateBlock);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(12, 8), timestampNanos);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(20, 4), enteringFirm);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(24, 4),
+            onBehalfFirm ?? FixpSbe.NegotiateData.OnbehalfFirmNullValue);
+
+        int pos = HeaderSize + NegotiateBlock;
+        pos += WriteVarSegment(dst.Slice(pos), credentials);
+        pos += WriteVarSegment(dst.Slice(pos), clientIp);
+        pos += WriteVarSegment(dst.Slice(pos), clientAppName);
+        pos += WriteVarSegment(dst.Slice(pos), clientAppVersion);
+        return pos;
+    }
+
+    /// <summary>
+    /// Encodes an <c>Establish</c> frame (templateId=4, version=0, BLOCK_LENGTH=42)
+    /// followed by an optional <c>credentials</c> varData segment (per spec the
+    /// segment is required but may be empty). Returns the bytes written.
+    /// </summary>
+    public static int EncodeEstablish(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        ulong timestampNanos, ulong keepAliveIntervalMillis, uint nextSeqNo,
+        ushort cancelOnDisconnectType, ulong codTimeoutWindowMillis,
+        ReadOnlySpan<byte> credentials)
+    {
+        if (credentials.Length > MaxCredentialsLength) throw new ArgumentException("credentials too long", nameof(credentials));
+        int varSize = 1 + credentials.Length;
+        int total = HeaderSize + EstablishBlock + varSize;
+        if (dst.Length < total) throw new ArgumentException("buffer too small for Establish", nameof(dst));
+
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: EstablishBlock,
+            templateId: EntryPointFrameReader.TidEstablish, version: 0);
+        var body = dst.Slice(HeaderSize, EstablishBlock);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(12, 8), timestampNanos);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), keepAliveIntervalMillis);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(28, 4), nextSeqNo);
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(32, 2), cancelOnDisconnectType);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(34, 8), codTimeoutWindowMillis);
+
+        int pos = HeaderSize + EstablishBlock;
+        pos += WriteVarSegment(dst.Slice(pos), credentials);
+        return pos;
+    }
+
+    /// <summary>
+    /// Encodes a <c>Sequence</c> frame (templateId=9, version=0, BLOCK_LENGTH=4).
+    /// Doubles as the heartbeat in idempotent flow.
+    /// </summary>
+    public static int EncodeSequence(Span<byte> dst, uint nextSeqNo)
+    {
+        int total = HeaderSize + SequenceBlock;
+        if (dst.Length < total) throw new ArgumentException("buffer too small for Sequence", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: SequenceBlock,
+            templateId: EntryPointFrameReader.TidSequence, version: 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(HeaderSize, 4), nextSeqNo);
+        return total;
+    }
+
+    /// <summary>
+    /// Encodes a <c>RetransmitRequest</c> frame (templateId=12, version=0,
+    /// BLOCK_LENGTH=20). Sent by the client when it detects a gap in
+    /// inbound application sequence numbers.
+    /// </summary>
+    public static int EncodeRetransmitRequest(Span<byte> dst, uint sessionId,
+        ulong timestampNanos, uint fromSeqNo, uint count)
+    {
+        int total = HeaderSize + RetransmitRequestBlock;
+        if (dst.Length < total) throw new ArgumentException("buffer too small for RetransmitRequest", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: RetransmitRequestBlock,
+            templateId: EntryPointFrameReader.TidRetransmitRequest, version: 0);
+        var body = dst.Slice(HeaderSize, RetransmitRequestBlock);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), timestampNanos);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(12, 4), fromSeqNo);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(16, 4), count);
+        return total;
+    }
+
+    /// <summary>
+    /// Encodes a <c>Terminate</c> frame (templateId=7, version=0, BLOCK_LENGTH=13).
+    /// </summary>
+    public static int EncodeTerminate(Span<byte> dst, uint sessionId, ulong sessionVerId,
+        byte terminationCode)
+    {
+        int total = HeaderSize + TerminateBlock;
+        if (dst.Length < total) throw new ArgumentException("buffer too small for Terminate", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            blockLength: TerminateBlock,
+            templateId: EntryPointFrameReader.TidTerminate, version: 0);
+        var body = dst.Slice(HeaderSize, TerminateBlock);
+        body.Clear();
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(4, 8), sessionVerId);
+        body[12] = terminationCode;
+        return total;
+    }
+
+    // ===== Decoders (server → client) =======================================
+
+    public readonly record struct NegotiateResponseFrame(
+        uint SessionId, ulong SessionVerId, ulong RequestTimestampNanos,
+        uint EnteringFirm, byte SemVerMajor, byte SemVerMinor, byte SemVerPatch);
+
+    public static bool TryDecodeNegotiateResponse(ReadOnlySpan<byte> body, out NegotiateResponseFrame frame)
+    {
+        if (body.Length < NegotiateResponseBlock) { frame = default; return false; }
+        frame = new NegotiateResponseFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            SessionVerId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            RequestTimestampNanos: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)),
+            EnteringFirm: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(20, 4)),
+            SemVerMajor: body[24], SemVerMinor: body[25], SemVerPatch: body[26]);
+        return true;
+    }
+
+    public readonly record struct NegotiateRejectFrame(
+        uint SessionId, ulong SessionVerId, ulong RequestTimestampNanos,
+        uint EnteringFirm, byte RejectCode, ulong CurrentSessionVerId);
+
+    public static bool TryDecodeNegotiateReject(ReadOnlySpan<byte> body, out NegotiateRejectFrame frame)
+    {
+        if (body.Length < NegotiateRejectBlock) { frame = default; return false; }
+        frame = new NegotiateRejectFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            SessionVerId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            RequestTimestampNanos: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)),
+            EnteringFirm: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(20, 4)),
+            RejectCode: body[24],
+            CurrentSessionVerId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(28, 8)));
+        return true;
+    }
+
+    public readonly record struct EstablishAckFrame(
+        uint SessionId, ulong SessionVerId, ulong RequestTimestampNanos,
+        ulong KeepAliveIntervalMillis, uint NextSeqNo, uint LastIncomingSeqNo,
+        byte SemVerMajor, byte SemVerMinor, byte SemVerPatch);
+
+    public static bool TryDecodeEstablishAck(ReadOnlySpan<byte> body, out EstablishAckFrame frame)
+    {
+        if (body.Length < EstablishAckBlock) { frame = default; return false; }
+        frame = new EstablishAckFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            SessionVerId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            RequestTimestampNanos: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)),
+            KeepAliveIntervalMillis: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(20, 8)),
+            NextSeqNo: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(28, 4)),
+            LastIncomingSeqNo: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(32, 4)),
+            SemVerMajor: body[36], SemVerMinor: body[37], SemVerPatch: body[38]);
+        return true;
+    }
+
+    public readonly record struct EstablishRejectFrame(
+        uint SessionId, ulong SessionVerId, ulong RequestTimestampNanos,
+        byte RejectCode, uint LastIncomingSeqNo);
+
+    public static bool TryDecodeEstablishReject(ReadOnlySpan<byte> body, out EstablishRejectFrame frame)
+    {
+        if (body.Length < EstablishRejectBlock) { frame = default; return false; }
+        frame = new EstablishRejectFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            SessionVerId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            RequestTimestampNanos: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(12, 8)),
+            RejectCode: body[20],
+            LastIncomingSeqNo: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(22, 4)));
+        return true;
+    }
+
+    public readonly record struct SequenceFrame(uint NextSeqNo);
+
+    public static bool TryDecodeSequence(ReadOnlySpan<byte> body, out SequenceFrame frame)
+    {
+        if (body.Length < SequenceBlock) { frame = default; return false; }
+        frame = new SequenceFrame(BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)));
+        return true;
+    }
+
+    public readonly record struct NotAppliedFrame(uint FromSeqNo, uint Count);
+
+    public static bool TryDecodeNotApplied(ReadOnlySpan<byte> body, out NotAppliedFrame frame)
+    {
+        if (body.Length < NotAppliedBlock) { frame = default; return false; }
+        frame = new NotAppliedFrame(
+            BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(4, 4)));
+        return true;
+    }
+
+    public readonly record struct RetransmissionFrame(
+        uint SessionId, ulong RequestTimestampNanos, uint NextSeqNo, uint Count);
+
+    public static bool TryDecodeRetransmission(ReadOnlySpan<byte> body, out RetransmissionFrame frame)
+    {
+        if (body.Length < RetransmissionBlock) { frame = default; return false; }
+        frame = new RetransmissionFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            RequestTimestampNanos: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            NextSeqNo: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(12, 4)),
+            Count: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(16, 4)));
+        return true;
+    }
+
+    public readonly record struct TerminateFrame(uint SessionId, ulong SessionVerId, byte TerminationCode);
+
+    public static bool TryDecodeTerminate(ReadOnlySpan<byte> body, out TerminateFrame frame)
+    {
+        if (body.Length < TerminateBlock) { frame = default; return false; }
+        frame = new TerminateFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            SessionVerId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            TerminationCode: body[12]);
+        return true;
+    }
+
+    public readonly record struct RetransmitRejectFrame(
+        uint SessionId, ulong RequestTimestampNanos, byte RejectCode);
+
+    public static bool TryDecodeRetransmitReject(ReadOnlySpan<byte> body, out RetransmitRejectFrame frame)
+    {
+        if (body.Length < RetransmitRejectBlock) { frame = default; return false; }
+        // RetransmitReject: sessionId(4) + requestTimestamp(8) + rejectCode(1) + (padding)
+        frame = new RetransmitRejectFrame(
+            SessionId: BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(0, 4)),
+            RequestTimestampNanos: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(4, 8)),
+            RejectCode: body[12]);
+        return true;
+    }
+
+    // ===== varData helpers ==================================================
+
+    private static int WriteVarSegment(Span<byte> dst, ReadOnlySpan<byte> payload)
+    {
+        if (dst.Length < 1 + payload.Length) throw new ArgumentException("buffer too small for var segment");
+        dst[0] = (byte)payload.Length;
+        payload.CopyTo(dst.Slice(1, payload.Length));
+        return 1 + payload.Length;
+    }
+}

--- a/src/B3.Exchange.SyntheticTrader/Program.cs
+++ b/src/B3.Exchange.SyntheticTrader/Program.cs
@@ -33,7 +33,27 @@ Info($"connecting to {cfg.Host.Host}:{cfg.Host.Port}");
 EntryPointClient client;
 try
 {
-    client = await EntryPointClient.ConnectAsync(cfg.Host.Host, cfg.Host.Port, Debug, Warn, shutdown.Token);
+    if (cfg.Fixp != null)
+    {
+        var fixpOptions = new B3.Exchange.SyntheticTrader.Fixp.FixpClientOptions
+        {
+            SessionId = cfg.Fixp.SessionId,
+            EnteringFirm = cfg.Firm,
+            AccessKey = cfg.Fixp.AccessKey,
+            KeepAliveIntervalMillis = cfg.Fixp.KeepAliveIntervalMs,
+            CancelOnDisconnect = cfg.Fixp.CancelOnDisconnect,
+            RetransmitOnGap = cfg.Fixp.RetransmitOnGap,
+            ClientAppName = cfg.Fixp.ClientAppName,
+            ClientAppVersion = cfg.Fixp.ClientAppVersion,
+        };
+        Info($"FIXP handshake sessionId={cfg.Fixp.SessionId} firm={cfg.Firm} keepAlive={cfg.Fixp.KeepAliveIntervalMs}ms cod={cfg.Fixp.CancelOnDisconnect}");
+        client = await EntryPointClient.ConnectAsync(cfg.Host.Host, cfg.Host.Port, fixpOptions, Debug, Warn, shutdown.Token);
+        Info("FIXP session established");
+    }
+    else
+    {
+        client = await EntryPointClient.ConnectAsync(cfg.Host.Host, cfg.Host.Port, Debug, Warn, shutdown.Token);
+    }
 }
 catch (Exception ex)
 {

--- a/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
+++ b/src/B3.Exchange.SyntheticTrader/SyntheticTraderConfig.cs
@@ -20,6 +20,31 @@ public sealed class SyntheticTraderConfig
     [JsonPropertyName("tickIntervalMs")] public int TickIntervalMs { get; set; } = 100;
 
     [JsonPropertyName("instruments")] public List<InstrumentConfig> Instruments { get; set; } = new();
+
+    /// <summary>
+    /// Optional FIXP block. When present the trader performs a full
+    /// Negotiate+Establish handshake on connect and runs the session
+    /// layer (sequence numbers, heartbeat, Terminate on dispose). When
+    /// omitted the trader stays in legacy "raw business frames" mode for
+    /// back-compat with hosts that have <c>auth.requireFixpHandshake=false</c>.
+    /// </summary>
+    [JsonPropertyName("fixp")] public FixpConfig? Fixp { get; set; }
+}
+
+/// <summary>
+/// FIXP session layer configuration. The <c>sessionId</c> must match a
+/// <c>sessions[].sessionId</c> entry in the host config and obey the
+/// gateway's decimal-uint32 rule (no leading zeros, &gt; 0).
+/// </summary>
+public sealed class FixpConfig
+{
+    [JsonPropertyName("sessionId")] public string SessionId { get; set; } = "";
+    [JsonPropertyName("accessKey")] public string AccessKey { get; set; } = "";
+    [JsonPropertyName("keepAliveIntervalMs")] public uint KeepAliveIntervalMs { get; set; } = 5000;
+    [JsonPropertyName("cancelOnDisconnect")] public bool CancelOnDisconnect { get; set; }
+    [JsonPropertyName("retransmitOnGap")] public bool RetransmitOnGap { get; set; } = true;
+    [JsonPropertyName("clientAppName")] public string ClientAppName { get; set; } = "synth";
+    [JsonPropertyName("clientAppVersion")] public string ClientAppVersion { get; set; } = "1.0";
 }
 
 public sealed class HostEndpointConfig

--- a/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpClientHandshakeTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpClientHandshakeTests.cs
@@ -1,0 +1,152 @@
+using B3.Exchange.Core;
+using B3.Exchange.Host;
+using B3.Exchange.SyntheticTrader.Fixp;
+
+namespace B3.Exchange.SyntheticTrader.Tests.Fixp;
+
+/// <summary>
+/// End-to-end check that <see cref="FixpClient"/> negotiates a session
+/// against a real <see cref="ExchangeHost"/> with
+/// <c>auth.requireFixpHandshake=true</c>, sends a business order with a
+/// proper <c>InboundBusinessHeader.msgSeqNum</c>, receives the
+/// corresponding ExecutionReport, and shuts down with a graceful
+/// <c>Terminate</c>.
+/// </summary>
+public class FixpClientHandshakeTests
+{
+    private const long Petr = 900_000_000_001L;
+
+    private sealed class CountingSink : IUmdfPacketSink
+    {
+        public int Count;
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Interlocked.Increment(ref Count);
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task FixpClient_HandshakeAndOrderRoundTrip()
+    {
+        var sink = new CountingSink();
+        var hostCfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = true, DevMode = true },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Firms = new()
+            {
+                new FirmConfig { Id = "firmA", Name = "Firm A", EnteringFirmCode = 7 },
+            },
+            Sessions = new()
+            {
+                new SessionConfig { SessionId = "100", FirmId = "firmA" },
+            },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30190,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+
+        await using var host = new ExchangeHost(hostCfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var fixpOptions = new FixpClientOptions
+        {
+            SessionId = "100",
+            EnteringFirm = 7,
+            KeepAliveIntervalMillis = 2000,
+            CancelOnDisconnect = false,
+            RetransmitOnGap = false,
+            HandshakeTimeout = TimeSpan.FromSeconds(5),
+        };
+        await using var client = await EntryPointClient.ConnectAsync(
+            ep.Address.ToString(), ep.Port, fixpOptions, ct: cts.Token);
+
+        Assert.NotNull(client.Fixp);
+        Assert.Equal(FixpClientState.Established, client.Fixp!.State);
+        Assert.Equal(100u, client.Fixp.SessionIdNumeric);
+
+        // Send a single NewOrder on PETR4 and wait for ER_New (or ER_Reject).
+        var erTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        client.OnNew += _ => erTcs.TrySetResult(true);
+        client.OnReject += _ => erTcs.TrySetResult(true);
+
+        bool ok = client.SendNewOrder(
+            clOrdId: 12345,
+            securityId: Petr,
+            side: OrderSide.Buy,
+            type: OrderTypeIntent.Limit,
+            tif: OrderTifIntent.Day,
+            qty: 100,
+            priceMantissa: 100_000);
+        Assert.True(ok, "SendNewOrder should accept the frame");
+
+        var completed = await Task.WhenAny(erTcs.Task, Task.Delay(TimeSpan.FromSeconds(5), cts.Token));
+        Assert.Same(erTcs.Task, completed);
+        Assert.True(await erTcs.Task, "expected ER_New or ER_Reject from gateway");
+
+        // FIXP outbound seq must have advanced past 1 after one business send.
+        Assert.True(client.Fixp.NextOutboundSeqNo > 1u,
+            $"expected nextOutboundSeqNo > 1, got {client.Fixp.NextOutboundSeqNo}");
+    }
+
+    [Fact]
+    public async Task FixpClient_RejectsUnknownSession()
+    {
+        var sink = new CountingSink();
+        var hostCfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = true, DevMode = true },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Firms = new() { new FirmConfig { Id = "firmA", Name = "Firm A", EnteringFirmCode = 7 } },
+            Sessions = new() { new SessionConfig { SessionId = "100", FirmId = "firmA" } },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30191,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+
+        await using var host = new ExchangeHost(hostCfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var fixpOptions = new FixpClientOptions
+        {
+            SessionId = "9999",  // not registered
+            EnteringFirm = 7,
+            HandshakeTimeout = TimeSpan.FromSeconds(3),
+        };
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await using var _ = await EntryPointClient.ConnectAsync(
+                ep.Address.ToString(), ep.Port, fixpOptions, ct: cts.Token);
+        });
+    }
+}

--- a/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpFrameCodecTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpFrameCodecTests.cs
@@ -1,0 +1,172 @@
+using System.Buffers.Binary;
+using B3.Exchange.Gateway;
+using B3.Exchange.SyntheticTrader.Fixp;
+
+namespace B3.Exchange.SyntheticTrader.Tests.Fixp;
+
+/// <summary>
+/// Round-trip sanity checks for <see cref="FixpFrameCodec"/>: every
+/// encoder lays down bytes that the matching decoder (or, where the
+/// codec only ships an encoder, the gateway's own decoder) reads back
+/// to the same logical values.
+/// </summary>
+public class FixpFrameCodecTests
+{
+    private const int HeaderSize = EntryPointFrameReader.WireHeaderSize;
+
+    [Fact]
+    public void EncodeNegotiate_WriteHeaderAndBody()
+    {
+        var buf = new byte[256];
+        int len = FixpFrameCodec.EncodeNegotiate(buf,
+            sessionId: 42, sessionVerId: 12345, timestampNanos: 999_888_777,
+            enteringFirm: 7, onBehalfFirm: null,
+            credentials: new byte[] { 1, 2, 3 },
+            clientIp: System.Text.Encoding.ASCII.GetBytes("127.0.0.1"),
+            clientAppName: System.Text.Encoding.ASCII.GetBytes("synth"),
+            clientAppVersion: System.Text.Encoding.ASCII.GetBytes("1.0"));
+
+        Assert.True(len > HeaderSize + FixpFrameCodec.NegotiateBlock);
+        // SOFH messageLength
+        Assert.Equal((ushort)len, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2)));
+        // SBE templateId is at SOFH+SbeHeader: blockLength(2)+templateId(2)
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        Assert.Equal(EntryPointFrameReader.TidNegotiate, tid);
+        // sessionId @ HeaderSize+0
+        Assert.Equal(42u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(HeaderSize + 0, 4)));
+        // enteringFirm @ HeaderSize+20
+        Assert.Equal(7u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(HeaderSize + 20, 4)));
+    }
+
+    [Fact]
+    public void EncodeEstablish_WriteHeaderAndBody()
+    {
+        var buf = new byte[128];
+        int len = FixpFrameCodec.EncodeEstablish(buf,
+            sessionId: 42, sessionVerId: 12345, timestampNanos: 999,
+            keepAliveIntervalMillis: 5000, nextSeqNo: 1,
+            cancelOnDisconnectType: 4, codTimeoutWindowMillis: 0,
+            credentials: ReadOnlySpan<byte>.Empty);
+        Assert.Equal(HeaderSize + FixpFrameCodec.EstablishBlock + 1, len); // varData length byte = 0
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        Assert.Equal(EntryPointFrameReader.TidEstablish, tid);
+        Assert.Equal(5000ul, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(HeaderSize + 20, 8)));
+        Assert.Equal(1u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(HeaderSize + 28, 4)));
+        Assert.Equal((ushort)4, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(HeaderSize + 32, 2)));
+    }
+
+    [Fact]
+    public void EncodeSequence_RoundTrip()
+    {
+        var buf = new byte[32];
+        int len = FixpFrameCodec.EncodeSequence(buf, nextSeqNo: 17);
+        Assert.Equal(HeaderSize + FixpFrameCodec.SequenceBlock, len);
+        Assert.True(FixpFrameCodec.TryDecodeSequence(buf.AsSpan(HeaderSize, FixpFrameCodec.SequenceBlock), out var seq));
+        Assert.Equal(17u, seq.NextSeqNo);
+    }
+
+    [Fact]
+    public void EncodeRetransmitRequest_RoundTrip()
+    {
+        var buf = new byte[64];
+        int len = FixpFrameCodec.EncodeRetransmitRequest(buf, sessionId: 9,
+            timestampNanos: 0xdeadbeef, fromSeqNo: 100, count: 5);
+        Assert.Equal(HeaderSize + FixpFrameCodec.RetransmitRequestBlock, len);
+        Assert.Equal(9u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(HeaderSize + 0, 4)));
+        Assert.Equal(0xdeadbeefUL, BinaryPrimitives.ReadUInt64LittleEndian(buf.AsSpan(HeaderSize + 4, 8)));
+        Assert.Equal(100u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(HeaderSize + 12, 4)));
+        Assert.Equal(5u, BinaryPrimitives.ReadUInt32LittleEndian(buf.AsSpan(HeaderSize + 16, 4)));
+    }
+
+    [Fact]
+    public void EncodeTerminate_RoundTrip()
+    {
+        var buf = new byte[32];
+        int len = FixpFrameCodec.EncodeTerminate(buf, sessionId: 11, sessionVerId: 222, terminationCode: 1);
+        Assert.Equal(HeaderSize + FixpFrameCodec.TerminateBlock, len);
+        Assert.True(FixpFrameCodec.TryDecodeTerminate(buf.AsSpan(HeaderSize, FixpFrameCodec.TerminateBlock), out var tm));
+        Assert.Equal(11u, tm.SessionId);
+        Assert.Equal(222ul, tm.SessionVerId);
+        Assert.Equal((byte)1, tm.TerminationCode);
+    }
+
+    [Fact]
+    public void DecodeNegotiateResponse_ParsesAllFields()
+    {
+        // Lay down the body manually: sessionId(4)+sessionVerId(8)+
+        // requestTimestamp(8)+enteringFirm(4)+semVer(4)
+        var body = new byte[FixpFrameCodec.NegotiateResponseBlock];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), 42);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(4, 8), 100);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(12, 8), 200);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(20, 4), 7);
+        body[24] = 6; body[25] = 0; body[26] = 0;
+
+        Assert.True(FixpFrameCodec.TryDecodeNegotiateResponse(body, out var nr));
+        Assert.Equal(42u, nr.SessionId);
+        Assert.Equal(100ul, nr.SessionVerId);
+        Assert.Equal(200ul, nr.RequestTimestampNanos);
+        Assert.Equal(7u, nr.EnteringFirm);
+        Assert.Equal(6, nr.SemVerMajor);
+    }
+
+    [Fact]
+    public void DecodeEstablishAck_ParsesAllFields()
+    {
+        var body = new byte[FixpFrameCodec.EstablishAckBlock];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), 42);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(4, 8), 100);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(12, 8), 200);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(20, 8), 5000);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(28, 4), 1);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(32, 4), 0);
+        body[36] = 6; body[37] = 0; body[38] = 0;
+
+        Assert.True(FixpFrameCodec.TryDecodeEstablishAck(body, out var ack));
+        Assert.Equal(42u, ack.SessionId);
+        Assert.Equal(5000ul, ack.KeepAliveIntervalMillis);
+        Assert.Equal(1u, ack.NextSeqNo);
+    }
+
+    [Fact]
+    public void DecodeNotApplied_ParsesGap()
+    {
+        var body = new byte[FixpFrameCodec.NotAppliedBlock];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), 50);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(4, 4), 3);
+        Assert.True(FixpFrameCodec.TryDecodeNotApplied(body, out var na));
+        Assert.Equal(50u, na.FromSeqNo);
+        Assert.Equal(3u, na.Count);
+    }
+
+    [Fact]
+    public void DecodeRetransmission_ParsesHeader()
+    {
+        var body = new byte[FixpFrameCodec.RetransmissionBlock];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), 42);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(4, 8), 12345);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(12, 4), 100);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(16, 4), 5);
+        Assert.True(FixpFrameCodec.TryDecodeRetransmission(body, out var rt));
+        Assert.Equal(42u, rt.SessionId);
+        Assert.Equal(100u, rt.NextSeqNo);
+        Assert.Equal(5u, rt.Count);
+    }
+
+    [Fact]
+    public void EncoderRejectsTooShortBuffer()
+    {
+        var tiny = new byte[4];
+        Assert.Throws<ArgumentException>(() => FixpFrameCodec.EncodeSequence(tiny, 0));
+        Assert.Throws<ArgumentException>(() => FixpFrameCodec.EncodeTerminate(tiny, 0, 0, 0));
+    }
+
+    [Fact]
+    public void EncoderRejectsOversizedVarSegments()
+    {
+        var huge = new byte[FixpFrameCodec.MaxCredentialsLength + 1];
+        var buf = new byte[1024];
+        Assert.Throws<ArgumentException>(() => FixpFrameCodec.EncodeNegotiate(buf,
+            1, 1, 1, 1, null, huge, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty, ReadOnlySpan<byte>.Empty));
+    }
+}


### PR DESCRIPTION
Closes #133.

## What

Implements a feature-complete FIXP session-layer client inside `B3.Exchange.SyntheticTrader` so the synthetic trader (and the scenario replay tools that depend on it) can talk to a host with `auth.requireFixpHandshake=true`. This unblocks #115 (multi-session replay) and #116 (tape-diff).

## Scope

- `Negotiate` / `Establish` / `Sequence` keep-alive / `Terminate` handshake.
- Heartbeat (keepAlive/2) + watchdog (1.5x keepAlive).
- Inbound recovery: `NotApplied`, `RetransmitRequest` -> `Retransmission`.
- `cancelOnDisconnect` declared in `Establish`.
- Per-session monotonic `msgSeqNum` patched into outbound business frames.
- Graceful `Terminate(FINISHED)` on shutdown.

Out of scope (deliberate): TCP rebind / re-attach, automatic reconnect on TCP loss. Single TCP per session is enough for the synth + replay use cases; rebind is exercised by gateway-side tests.

## How to use

Add an optional `fixp` block to `synthetic-trader.json`:

```json
"fixp": {
  "sessionId": "100",
  "accessKey": "",
  "keepAliveIntervalMs": 5000,
  "cancelOnDisconnect": false,
  "retransmitOnGap": true
}
```

When the block is omitted the trader falls back to legacy raw-frame mode for back-compat with `requireFixpHandshake=false` hosts.

## Validation

- 617/617 tests pass (604 baseline + 13 new: 10 codec round-trips + 3 handshake/integration).
- `dotnet format` clean.
- Soak configs (`config/exchange-simulator.soak.json`, `config/synthetic-trader.soak.json`) flipped back to `requireFixpHandshake=true` with matching firms/sessions entries.
- Runbook \xC2\xA74.0.1 documents the flow.