### PR TITLE
Multi-session replay scripts in tools/ScenarioReplay

### DIFF
--- a/tests/ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -1,0 +1,186 @@
+using B3.Exchange.Core;
+using B3.Exchange.Host;
+using B3.Exchange.SyntheticTrader;
+using B3.Exchange.SyntheticTrader.Fixp;
+
+namespace B3.Exchange.ScenarioReplay.Tests;
+
+/// <summary>
+/// End-to-end test for multi-session replay (#115): boots an
+/// <see cref="ExchangeHost"/> with two firms / two sessions, opens one
+/// FIXP-handshaken <see cref="EntryPointClient"/> per session, drives a
+/// crossing script through <see cref="ReplayRunner"/>, and asserts both
+/// sides see ER_Trade tagged with their session name.
+/// </summary>
+public class MultiSessionReplayTests
+{
+    private const long Petr = 900_000_000_001L;
+
+    private sealed class CountingSink : IUmdfPacketSink
+    {
+        public int Count;
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Interlocked.Increment(ref Count);
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task TwoSessions_CrossingScript_LandsErTradesOnBothSides()
+    {
+        var sink = new CountingSink();
+        var hostCfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = true, DevMode = true },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Firms = new()
+            {
+                new FirmConfig { Id = "firmA", Name = "Firm A", EnteringFirmCode = 7 },
+                new FirmConfig { Id = "firmB", Name = "Firm B", EnteringFirmCode = 8 },
+            },
+            Sessions = new()
+            {
+                new SessionConfig { SessionId = "100", FirmId = "firmA" },
+                new SessionConfig { SessionId = "200", FirmId = "firmB" },
+            },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30192,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+
+        await using var host = new ExchangeHost(hostCfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        await using var clientA = await EntryPointClient.ConnectAsync(
+            ep.Address.ToString(), ep.Port,
+            new FixpClientOptions { SessionId = "100", EnteringFirm = 7, HandshakeTimeout = TimeSpan.FromSeconds(5) },
+            ct: cts.Token);
+        await using var clientB = await EntryPointClient.ConnectAsync(
+            ep.Address.ToString(), ep.Port,
+            new FixpClientOptions { SessionId = "200", EnteringFirm = 8, HandshakeTimeout = TimeSpan.FromSeconds(5) },
+            ct: cts.Token);
+
+        var sw = new StringWriter();
+        long t = 0;
+        using var capture = new CaptureWriter(sw, () => Interlocked.Increment(ref t));
+
+        var sessions = new Dictionary<string, EntryPointClient>
+        {
+            ["firmA"] = clientA,
+            ["firmB"] = clientB,
+        };
+        var runner = new ReplayRunner(sessions, "firmA", new SystemClock(speed: 10.0), capture);
+
+        // firmA posts a resting bid; firmB hits it with a marketable IOC sell.
+        // clOrdId reuse across sessions is allowed (issue note: the gateway
+        // namespaces orders by (firm, clOrdId)).
+        var script = new[]
+        {
+            new ScriptEvent(0,  ScriptEventKind.New, 1, Petr, Side.Buy,  OrderType.Limit, Tif.Day, 100, 320000, 0, 1, "firmA"),
+            new ScriptEvent(20, ScriptEventKind.New, 1, Petr, Side.Sell, OrderType.Limit, Tif.IOC, 100, 320000, 0, 2, "firmB"),
+        };
+
+        await runner.RunAsync(script, cts.Token);
+
+        // Wait for ER_Trade on both sessions.
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var snap = sw.ToString();
+            if (snap.Contains("\"session\":\"firmA\"") && snap.Contains("\"session\":\"firmB\"")
+                && snap.Contains("\"execType\":\"trade\""))
+                break;
+            await Task.Delay(50, cts.Token);
+        }
+
+        capture.Dispose();
+        var lines = sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+
+        Assert.Contains(lines, l => l.Contains("\"session\":\"firmA\"") && l.Contains("submit_new") && l.Contains("clOrdId=1"));
+        Assert.Contains(lines, l => l.Contains("\"session\":\"firmB\"") && l.Contains("submit_new") && l.Contains("clOrdId=1"));
+
+        // Each side must observe its own ER_Trade tagged with the right session.
+        Assert.Contains(lines, l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"trade\""));
+        Assert.Contains(lines, l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmB\"") && l.Contains("\"execType\":\"trade\""));
+
+        // ER_New for the resting bid must be tagged firmA, not firmB.
+        Assert.Contains(lines, l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"new\""));
+    }
+
+    [Fact]
+    public async Task EventWithoutSession_RoutesToDefault_BackCompat()
+    {
+        var sink = new CountingSink();
+        var hostCfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30193,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+
+        await using var host = new ExchangeHost(hostCfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await using var client = await EntryPointClient.ConnectAsync(ep.Address.ToString(), ep.Port);
+
+        var sw = new StringWriter();
+        long t = 0;
+        using var capture = new CaptureWriter(sw, () => Interlocked.Increment(ref t));
+
+        var sessions = new Dictionary<string, EntryPointClient> { ["only"] = client };
+        var runner = new ReplayRunner(sessions, "only", new SystemClock(speed: 10.0), capture);
+
+        var script = new[]
+        {
+            // No "session" field — should route to "only".
+            new ScriptEvent(0, ScriptEventKind.New, 99, Petr, Side.Buy, OrderType.Limit, Tif.Day, 100, 320000, 0, 1),
+        };
+
+        await runner.RunAsync(script, cts.Token);
+
+        var deadline = DateTime.UtcNow.AddSeconds(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (sw.ToString().Contains("\"execType\":\"new\""))
+                break;
+            await Task.Delay(50, cts.Token);
+        }
+
+        capture.Dispose();
+        var snapshot = sw.ToString();
+        Assert.Contains("\"session\":\"only\"", snapshot);
+        Assert.Contains("\"execType\":\"new\"", snapshot);
+    }
+}

--- a/tools/ScenarioReplay/CaptureWriter.cs
+++ b/tools/ScenarioReplay/CaptureWriter.cs
@@ -36,12 +36,13 @@ public sealed class CaptureWriter : IDisposable
 
     public void WriteEr(string execType, ulong clOrdId, long securityId, long orderId,
         long lastQty = 0, long lastPxMantissa = 0, long leavesQty = 0, long cumQty = 0,
-        ulong origClOrdId = 0, byte ordRejReason = 0, string side = "")
+        ulong origClOrdId = 0, byte ordRejReason = 0, string side = "", string? session = null)
     {
         var rec = new
         {
             t = _timestampFn(),
             src = "er",
+            session,
             execType,
             clOrdId,
             securityId,
@@ -73,9 +74,9 @@ public sealed class CaptureWriter : IDisposable
         WriteLine(rec);
     }
 
-    public void WriteEvent(string @event, string? detail = null)
+    public void WriteEvent(string @event, string? detail = null, string? session = null)
     {
-        var rec = new { t = _timestampFn(), src = "evt", @event, detail };
+        var rec = new { t = _timestampFn(), src = "evt", session, @event, detail };
         WriteLine(rec);
     }
 

--- a/tools/ScenarioReplay/Program.cs
+++ b/tools/ScenarioReplay/Program.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using B3.Exchange.ScenarioReplay;
 using B3.Exchange.SyntheticTrader;
+using B3.Exchange.SyntheticTrader.Fixp;
 
 if (args.Length == 1 && (args[0] == "-h" || args[0] == "--help"))
 {
@@ -39,21 +40,56 @@ await using var mcast = opts.MulticastGroup != null
 using var shutdown = new CancellationTokenSource();
 Console.CancelKeyPress += (_, e) => { e.Cancel = true; shutdown.Cancel(); };
 
-EntryPointClient client;
+// Resolve the session list. If --session was used we open one client per
+// declared session and require all events to address a known one (or use
+// the first declared session as the default for back-compat with scripts
+// that omit the field). Without --session we fall back to a single
+// implicit "default" session over the legacy raw frame protocol.
+var sessions = new Dictionary<string, EntryPointClient>();
+string defaultSession;
 try
 {
-    client = await EntryPointClient.ConnectAsync(opts.Host, opts.Port, logDebug: null, logWarn: Warn, shutdown.Token);
+    if (opts.Sessions.Count == 0)
+    {
+        var legacy = await EntryPointClient.ConnectAsync(opts.Host, opts.Port, logDebug: null, logWarn: Warn, shutdown.Token);
+        sessions["default"] = legacy;
+        defaultSession = "default";
+        Info($"connected legacy session to {opts.Host}:{opts.Port}");
+    }
+    else
+    {
+        foreach (var s in opts.Sessions)
+        {
+            var fixp = new FixpClientOptions
+            {
+                SessionId = s.SessionId,
+                EnteringFirm = s.EnteringFirm,
+                AccessKey = opts.AccessKeys.TryGetValue(s.Name, out var k) ? k : "",
+                CancelOnDisconnect = false,
+                RetransmitOnGap = true,
+            };
+            var client = await EntryPointClient.ConnectAsync(
+                s.Host, s.Port, fixp, logDebug: null, logWarn: Warn, shutdown.Token);
+            sessions[s.Name] = client;
+            Info($"connected session '{s.Name}' (sessionId={s.SessionId} firm={s.EnteringFirm}) to {s.Host}:{s.Port}");
+        }
+        defaultSession = opts.Sessions[0].Name;
+    }
 }
 catch (Exception ex)
 {
     Warn($"connect failed: {ex.Message}");
+    foreach (var c in sessions.Values)
+    {
+        try { await c.DisposeAsync(); } catch { }
+    }
     return 4;
 }
 
-await using (client)
+try
 {
     var clock = new SystemClock(opts.Speed);
-    var runner = new ReplayRunner(client, clock, capture, Info, Warn);
+    var runner = new ReplayRunner(sessions, defaultSession, clock, capture, Info, Warn);
     try
     {
         await runner.RunAsync(events, shutdown.Token);
@@ -76,8 +112,15 @@ await using (client)
         catch (OperationCanceledException) { }
     }
 }
+finally
+{
+    foreach (var c in sessions.Values)
+    {
+        try { await c.DisposeAsync(); } catch { }
+    }
+}
 
-Info($"done; submitted={(args.Length > 0 ? "<see capture>" : "0")}");
+Info("done");
 return 0;
 
 static void PrintUsage()
@@ -88,9 +131,19 @@ static void PrintUsage()
         required:
           --script <path>             JSONL replay script
 
-        connection:
+        single-session connection (legacy, no FIXP handshake):
           --host <ip|hostname>        EntryPoint host (default 127.0.0.1)
           --port <n>                  EntryPoint port (default 9876)
+
+        multi-session connection (FIXP handshake per session):
+          --session <spec>            Repeatable. Spec format:
+                                          name=sessionId:firm[@host:port]
+                                      e.g. firmA=100:1@127.0.0.1:9876
+                                      The first --session is the default
+                                      target for events that omit "session".
+          --access-key <name>=<key>   Repeatable. Access key for a named
+                                      session; default is empty (works in
+                                      auth.devMode=true hosts).
 
         capture:
           --out <path>                Tape file (JSONL); default: discard
@@ -105,6 +158,49 @@ static void PrintUsage()
         """);
 }
 
+internal sealed class SessionSpec
+{
+    public string Name { get; init; } = "";
+    public string SessionId { get; init; } = "";
+    public uint EnteringFirm { get; init; }
+    public string Host { get; init; } = "127.0.0.1";
+    public int Port { get; init; } = 9876;
+
+    /// <summary>
+    /// Parses <c>name=sessionId:firm[@host:port]</c>.
+    /// </summary>
+    public static SessionSpec Parse(string raw, string defaultHost, int defaultPort)
+    {
+        var eq = raw.IndexOf('=');
+        if (eq <= 0 || eq == raw.Length - 1)
+            throw new ArgumentException($"invalid --session '{raw}': expected name=sessionId:firm[@host:port]");
+        var name = raw.Substring(0, eq);
+        var rhs = raw.Substring(eq + 1);
+        string host = defaultHost;
+        int port = defaultPort;
+        var at = rhs.IndexOf('@');
+        if (at >= 0)
+        {
+            var hp = rhs.Substring(at + 1);
+            rhs = rhs.Substring(0, at);
+            var colon = hp.LastIndexOf(':');
+            if (colon < 0) throw new ArgumentException($"invalid --session '{raw}': host segment must be host:port");
+            host = hp.Substring(0, colon);
+            if (!int.TryParse(hp.AsSpan(colon + 1), out port))
+                throw new ArgumentException($"invalid --session '{raw}': port is not an integer");
+        }
+        var sc = rhs.IndexOf(':');
+        if (sc <= 0 || sc == rhs.Length - 1)
+            throw new ArgumentException($"invalid --session '{raw}': credentials must be sessionId:firm");
+        var sid = rhs.Substring(0, sc);
+        if (!uint.TryParse(rhs.AsSpan(sc + 1), out var firm) || firm == 0)
+            throw new ArgumentException($"invalid --session '{raw}': firm must be a positive uint32");
+        if (!uint.TryParse(sid, out var sidNum) || sidNum == 0)
+            throw new ArgumentException($"invalid --session '{raw}': sessionId must be a positive uint32 decimal string");
+        return new SessionSpec { Name = name, SessionId = sid, EnteringFirm = firm, Host = host, Port = port };
+    }
+}
+
 internal sealed class CliOptions
 {
     public string Host { get; private set; } = "127.0.0.1";
@@ -115,10 +211,13 @@ internal sealed class CliOptions
     public int MulticastPort { get; private set; }
     public double Speed { get; private set; } = 1.0;
     public int TrailingTimeoutMs { get; private set; } = 1000;
+    public List<SessionSpec> Sessions { get; } = new();
+    public Dictionary<string, string> AccessKeys { get; } = new(StringComparer.Ordinal);
 
     public static CliOptions? Parse(string[] args, out string? error)
     {
         var o = new CliOptions();
+        var rawSessions = new List<string>();
         for (int i = 0; i < args.Length; i++)
         {
             switch (args[i])
@@ -138,6 +237,15 @@ internal sealed class CliOptions
                     }
                 case "--speed": o.Speed = double.Parse(Need(args, ref i), System.Globalization.CultureInfo.InvariantCulture); break;
                 case "--timeout-ms": o.TrailingTimeoutMs = int.Parse(Need(args, ref i)); break;
+                case "--session": rawSessions.Add(Need(args, ref i)); break;
+                case "--access-key":
+                    {
+                        var v = Need(args, ref i);
+                        var idx = v.IndexOf('=');
+                        if (idx <= 0) { error = $"invalid --access-key '{v}', expected name=key"; return null; }
+                        o.AccessKeys[v.Substring(0, idx)] = v.Substring(idx + 1);
+                        break;
+                    }
                 default:
                     error = $"unknown argument '{args[i]}'";
                     return null;
@@ -146,6 +254,25 @@ internal sealed class CliOptions
         if (string.IsNullOrEmpty(o.ScriptPath)) { error = "--script is required"; return null; }
         if (o.Speed <= 0) { error = "--speed must be > 0"; return null; }
         if (!File.Exists(o.ScriptPath)) { error = $"script not found: {o.ScriptPath}"; return null; }
+        try
+        {
+            foreach (var raw in rawSessions)
+                o.Sessions.Add(SessionSpec.Parse(raw, o.Host, o.Port));
+        }
+        catch (ArgumentException ex)
+        {
+            error = ex.Message;
+            return null;
+        }
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var s in o.Sessions)
+        {
+            if (!seen.Add(s.Name))
+            {
+                error = $"duplicate --session name '{s.Name}'";
+                return null;
+            }
+        }
         error = null;
         return o;
     }

--- a/tools/ScenarioReplay/README.md
+++ b/tools/ScenarioReplay/README.md
@@ -28,9 +28,17 @@ dotnet run --project tools/ScenarioReplay -- \
 ```
 ScenarioReplay --script <path.jsonl> [options]
 
-connection:
+single-session connection (legacy, no FIXP handshake):
   --host <ip|hostname>      EntryPoint host (default 127.0.0.1)
   --port <n>                EntryPoint port (default 9876)
+
+multi-session connection (FIXP handshake per session):
+  --session <spec>          Repeatable. Spec: name=sessionId:firm[@host:port]
+                            e.g. firmA=100:1@127.0.0.1:9876
+                            The first --session is the default target for
+                            events that omit "session".
+  --access-key <name>=<key> Repeatable. Access key for a named session;
+                            default is empty (works in auth.devMode=true).
 
 capture:
   --out <path>              Tape file (JSONL); default: discard
@@ -72,6 +80,28 @@ break older scripts.
 | `type`        | `new` (optional)                 | `limit` (default) or `market`                                         |
 | `tif`         | `new` (optional)                 | `day` (default), `ioc`, or `fok`                                      |
 | `origClOrdId` | `cancel`                         | the resting order's original `clOrdId`                                |
+| `session`     | optional (multi-session only)    | session name (matches a `--session` `name=...` arg). When omitted, the event is routed to the first declared session (or the legacy single client). |
+
+## Multi-session example
+
+```bash
+# Host config: two firms (codes 1 + 2) and two FIXP sessions (100, 200)
+# under auth.requireFixpHandshake=true.
+dotnet run --project tools/ScenarioReplay -- \
+    --session firmA=100:1 --session firmB=200:2 \
+    --script crossing.jsonl \
+    --out tape.jsonl
+```
+
+```jsonl
+# crossing.jsonl: firmA posts a resting bid; firmB sweeps it.
+{"atMs": 0,  "session": "firmA", "kind": "new",  "clOrdId": 1, "securityId": 900000000001, "side": "buy",  "type": "limit", "tif": "day", "qty": 100, "px": 320000}
+{"atMs": 50, "session": "firmB", "kind": "new",  "clOrdId": 1, "securityId": 900000000001, "side": "sell", "type": "limit", "tif": "ioc", "qty": 100, "px": 320000}
+```
+
+clOrdId reuse across sessions is fine — the gateway namespaces resting
+orders by `(firm, clOrdId)` and the replay runner keeps a per-session
+`clOrdId → orderId` map for cancel resolution.
 
 ## Tape format (JSONL)
 
@@ -84,13 +114,13 @@ jq 'select(.src=="mcast") | {sequenceNumber, messageCount}' tape.jsonl
 
 Record types:
 
-- `{"src":"er", "execType":"new"|"trade"|"cancel"|"reject", ...}` — decoded
-  ExecutionReport fields.
+- `{"src":"er", "session":"<name>", "execType":"new"|"trade"|"cancel"|"reject", ...}` — decoded
+  ExecutionReport fields. `session` is the originating session name.
 - `{"src":"mcast", "channel", "sequenceVersion", "sequenceNumber",
   "messageCount", "bytes":"<hex>"}` — full UMDF packet bytes plus PacketHeader
   metadata (multicast capture only; requires `--multicast`).
-- `{"src":"evt", "event":"script_start"|"submit_new"|"submit_cancel"|"script_end"|"disconnect"|"aborted", ...}`
-  — runner lifecycle annotations.
+- `{"src":"evt", "session":"<name>", "event":"script_start"|"submit_new"|"submit_cancel"|"script_end"|"disconnect"|"aborted", ...}`
+  — runner lifecycle annotations. `session` is null on script-wide events.
 
 The `t` field is a unix-millisecond timestamp; mask it (or pipe through
 `jq 'del(.t)'`) when diffing across runs.
@@ -99,10 +129,9 @@ The `t` field is a unix-millisecond timestamp; mask it (or pipe through
 
 This MVP is intentionally narrow:
 
-- single TCP session (no multi-session scripts yet)
-- no "diff harness" subcommand (use plain `diff` / `jq` for now)
-- no FIXP authentication (host must be configured with
-  `auth.requireFixpHandshake=false`)
+- no "diff harness" subcommand (use plain `diff` / `jq` for now —
+  follow-up tracked in #116)
+- single TCP connection per session (no automatic reconnect on drop)
 
 Follow-ups will live as separate issues.
 

--- a/tools/ScenarioReplay/ReplayRunner.cs
+++ b/tools/ScenarioReplay/ReplayRunner.cs
@@ -3,90 +3,141 @@ using B3.Exchange.SyntheticTrader;
 namespace B3.Exchange.ScenarioReplay;
 
 /// <summary>
-/// Replays a parsed script against an <see cref="EntryPointClient"/>,
-/// translating each <see cref="ScriptEvent"/> into a NewOrder or Cancel
-/// frame and respecting per-event scheduling via the injected
-/// <see cref="IClock"/>. The runner is single-threaded — events are emitted
-/// in (atMs, file-order) sequence, never in parallel — so the resulting
-/// tape is deterministic for a given script.
+/// Replays a parsed script against one or more <see cref="EntryPointClient"/>
+/// instances keyed by session name, translating each <see cref="ScriptEvent"/>
+/// into a NewOrder or Cancel frame and respecting per-event scheduling via the
+/// injected <see cref="IClock"/>. The runner is single-threaded — events are
+/// emitted in (atMs, file-order) sequence, never in parallel — so the
+/// resulting tape is deterministic for a given script.
 ///
-/// Keeps a <c>clOrdId → orderId</c> map populated from inbound ER_New /
-/// ER_Trade so a script can target a resting order with
+/// Each session keeps its own <c>clOrdId → orderId</c> map populated from
+/// inbound ER_New / ER_Trade so a script can target a resting order with
 /// <c>{"kind":"cancel","clOrdId":...,"origClOrdId":...}</c> without the
-/// author having to know the engine-assigned <c>orderId</c>.
+/// author having to know the engine-assigned <c>orderId</c>. Order-id
+/// namespaces are kept per-session because the gateway already namespaces
+/// orders by <c>(firm, clOrdId)</c>: clOrdId reuse across sessions is fine
+/// and resolves to the right resting order on cancel.
 /// </summary>
 public sealed class ReplayRunner
 {
-    private readonly EntryPointClient _client;
+    private readonly IReadOnlyDictionary<string, EntryPointClient> _sessions;
+    private readonly string _defaultSession;
     private readonly IClock _clock;
     private readonly CaptureWriter _capture;
     private readonly Action<string>? _logInfo;
     private readonly Action<string>? _logWarn;
-    private readonly Dictionary<ulong, long> _clOrdToOrderId = new();
+    private readonly Dictionary<string, Dictionary<ulong, long>> _clOrdToOrderId = new();
     private readonly object _mapGate = new();
 
     public int EventsSubmitted { get; private set; }
 
+    /// <summary>
+    /// Single-session constructor (back-compat). Treats the client as the
+    /// implicit "default" session and ignores any <c>session</c> field on
+    /// script events.
+    /// </summary>
     public ReplayRunner(EntryPointClient client, IClock clock, CaptureWriter capture,
         Action<string>? logInfo = null, Action<string>? logWarn = null)
+        : this(
+            new Dictionary<string, EntryPointClient> { ["default"] = client ?? throw new ArgumentNullException(nameof(client)) },
+            "default", clock, capture, logInfo, logWarn)
     {
-        ArgumentNullException.ThrowIfNull(client);
+    }
+
+    /// <summary>
+    /// Multi-session constructor. <paramref name="defaultSession"/> must be
+    /// a key in <paramref name="sessions"/> and is used as the routing
+    /// target whenever a <see cref="ScriptEvent"/> omits <c>session</c>.
+    /// </summary>
+    public ReplayRunner(
+        IReadOnlyDictionary<string, EntryPointClient> sessions,
+        string defaultSession,
+        IClock clock,
+        CaptureWriter capture,
+        Action<string>? logInfo = null,
+        Action<string>? logWarn = null)
+    {
+        ArgumentNullException.ThrowIfNull(sessions);
+        ArgumentNullException.ThrowIfNull(defaultSession);
         ArgumentNullException.ThrowIfNull(clock);
         ArgumentNullException.ThrowIfNull(capture);
-        _client = client;
+        if (sessions.Count == 0)
+            throw new ArgumentException("at least one session required", nameof(sessions));
+        if (!sessions.ContainsKey(defaultSession))
+            throw new ArgumentException(
+                $"defaultSession '{defaultSession}' is not a registered session", nameof(defaultSession));
+        _sessions = sessions;
+        _defaultSession = defaultSession;
         _clock = clock;
         _capture = capture;
         _logInfo = logInfo;
         _logWarn = logWarn;
 
-        _client.OnNew += er =>
+        foreach (var (name, client) in sessions)
         {
-            lock (_mapGate) _clOrdToOrderId[er.ClOrdId] = er.OrderId;
-            _capture.WriteEr("new", er.ClOrdId, er.SecurityId, er.OrderId,
-                side: er.Side == OrderSide.Buy ? "buy" : "sell");
-        };
-        _client.OnTrade += er =>
-        {
-            lock (_mapGate) _clOrdToOrderId[er.ClOrdId] = er.OrderId;
-            _capture.WriteEr("trade", er.ClOrdId, er.SecurityId, er.OrderId,
-                lastQty: er.LastQty, lastPxMantissa: er.LastPxMantissa,
-                leavesQty: er.LeavesQty, cumQty: er.CumQty,
-                side: er.Side == OrderSide.Buy ? "buy" : "sell");
-        };
-        _client.OnCancel += er =>
-        {
-            _capture.WriteEr("cancel", er.ClOrdId, er.SecurityId, er.OrderId,
-                side: er.Side == OrderSide.Buy ? "buy" : "sell");
-        };
-        _client.OnReject += er =>
-        {
-            _capture.WriteEr("reject", er.ClOrdId, er.SecurityId, er.OrderId,
-                origClOrdId: er.OrigClOrdId, ordRejReason: er.RejectReason);
-        };
-        _client.OnDisconnect += reason => _capture.WriteEvent("disconnect", reason);
+            _clOrdToOrderId[name] = new Dictionary<ulong, long>();
+            // Capture loop variable for the closures.
+            var sessionName = name;
+            client.OnNew += er =>
+            {
+                lock (_mapGate) _clOrdToOrderId[sessionName][er.ClOrdId] = er.OrderId;
+                _capture.WriteEr("new", er.ClOrdId, er.SecurityId, er.OrderId,
+                    side: er.Side == OrderSide.Buy ? "buy" : "sell",
+                    session: sessionName);
+            };
+            client.OnTrade += er =>
+            {
+                lock (_mapGate) _clOrdToOrderId[sessionName][er.ClOrdId] = er.OrderId;
+                _capture.WriteEr("trade", er.ClOrdId, er.SecurityId, er.OrderId,
+                    lastQty: er.LastQty, lastPxMantissa: er.LastPxMantissa,
+                    leavesQty: er.LeavesQty, cumQty: er.CumQty,
+                    side: er.Side == OrderSide.Buy ? "buy" : "sell",
+                    session: sessionName);
+            };
+            client.OnCancel += er =>
+            {
+                _capture.WriteEr("cancel", er.ClOrdId, er.SecurityId, er.OrderId,
+                    side: er.Side == OrderSide.Buy ? "buy" : "sell",
+                    session: sessionName);
+            };
+            client.OnReject += er =>
+            {
+                _capture.WriteEr("reject", er.ClOrdId, er.SecurityId, er.OrderId,
+                    origClOrdId: er.OrigClOrdId, ordRejReason: er.RejectReason,
+                    session: sessionName);
+            };
+            client.OnDisconnect += reason => _capture.WriteEvent("disconnect", reason, session: sessionName);
+        }
     }
 
     public async Task RunAsync(IReadOnlyList<ScriptEvent> events, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(events);
-        _capture.WriteEvent("script_start", $"events={events.Count}");
+        _capture.WriteEvent("script_start", $"events={events.Count} sessions={_sessions.Count}");
         foreach (var ev in events)
         {
             ct.ThrowIfCancellationRequested();
             await _clock.DelayUntilAsync(ev.AtMs, ct).ConfigureAwait(false);
-            if (!_client.IsOpen)
+            var sessionName = ev.Session ?? _defaultSession;
+            if (!_sessions.TryGetValue(sessionName, out var client))
             {
-                _logWarn?.Invoke($"client closed before line {ev.LineNumber}; aborting script");
-                _capture.WriteEvent("aborted", $"client_closed_before_line_{ev.LineNumber}");
-                throw new InvalidOperationException("EntryPointClient closed mid-replay");
+                _logWarn?.Invoke($"line {ev.LineNumber}: unknown session '{sessionName}' (registered: {string.Join(",", _sessions.Keys)})");
+                _capture.WriteEvent("aborted", $"unknown_session_{sessionName}_line_{ev.LineNumber}");
+                throw new InvalidOperationException($"line {ev.LineNumber}: unknown session '{sessionName}'");
             }
-            Submit(ev);
+            if (!client.IsOpen)
+            {
+                _logWarn?.Invoke($"client '{sessionName}' closed before line {ev.LineNumber}; aborting script");
+                _capture.WriteEvent("aborted", $"client_closed_before_line_{ev.LineNumber}", session: sessionName);
+                throw new InvalidOperationException($"EntryPointClient '{sessionName}' closed mid-replay");
+            }
+            Submit(client, sessionName, ev);
         }
         _capture.WriteEvent("script_end", $"submitted={EventsSubmitted}");
         _logInfo?.Invoke($"script complete; events submitted={EventsSubmitted}");
     }
 
-    private void Submit(ScriptEvent ev)
+    private void Submit(EntryPointClient client, string sessionName, ScriptEvent ev)
     {
         var side = ev.Side == Side.Buy ? OrderSide.Buy : OrderSide.Sell;
         switch (ev.Kind)
@@ -100,20 +151,28 @@ public sealed class ReplayRunner
                         Tif.FOK => OrderTifIntent.FOK,
                         _ => OrderTifIntent.Day,
                     };
-                    if (!_client.SendNewOrder(ev.ClOrdId, ev.SecurityId, side, type, tif, ev.Quantity, ev.PriceMantissa))
-                        throw new InvalidOperationException($"line {ev.LineNumber}: failed to enqueue NewOrder (client closed?)");
+                    if (!client.SendNewOrder(ev.ClOrdId, ev.SecurityId, side, type, tif, ev.Quantity, ev.PriceMantissa))
+                        throw new InvalidOperationException($"line {ev.LineNumber}: failed to enqueue NewOrder on session '{sessionName}' (client closed?)");
                     EventsSubmitted++;
-                    _capture.WriteEvent("submit_new", $"clOrdId={ev.ClOrdId} sec={ev.SecurityId} side={ev.Side} qty={ev.Quantity} px={ev.PriceMantissa} tif={ev.Tif}");
+                    _capture.WriteEvent("submit_new",
+                        $"clOrdId={ev.ClOrdId} sec={ev.SecurityId} side={ev.Side} qty={ev.Quantity} px={ev.PriceMantissa} tif={ev.Tif}",
+                        session: sessionName);
                     break;
                 }
             case ScriptEventKind.Cancel:
                 {
                     long orderId;
-                    lock (_mapGate) _clOrdToOrderId.TryGetValue(ev.OrigClOrdId, out orderId);
-                    if (!_client.SendCancel(ev.ClOrdId, ev.SecurityId, (ulong)orderId, ev.OrigClOrdId, side))
-                        throw new InvalidOperationException($"line {ev.LineNumber}: failed to enqueue Cancel (client closed?)");
+                    lock (_mapGate)
+                    {
+                        var map = _clOrdToOrderId[sessionName];
+                        map.TryGetValue(ev.OrigClOrdId, out orderId);
+                    }
+                    if (!client.SendCancel(ev.ClOrdId, ev.SecurityId, (ulong)orderId, ev.OrigClOrdId, side))
+                        throw new InvalidOperationException($"line {ev.LineNumber}: failed to enqueue Cancel on session '{sessionName}' (client closed?)");
                     EventsSubmitted++;
-                    _capture.WriteEvent("submit_cancel", $"clOrdId={ev.ClOrdId} origClOrdId={ev.OrigClOrdId} sec={ev.SecurityId} resolvedOrderId={orderId}");
+                    _capture.WriteEvent("submit_cancel",
+                        $"clOrdId={ev.ClOrdId} origClOrdId={ev.OrigClOrdId} sec={ev.SecurityId} resolvedOrderId={orderId}",
+                        session: sessionName);
                     break;
                 }
         }

--- a/tools/ScenarioReplay/ScriptEvent.cs
+++ b/tools/ScenarioReplay/ScriptEvent.cs
@@ -17,7 +17,8 @@ public sealed record ScriptEvent(
     long Quantity,
     long PriceMantissa,
     ulong OrigClOrdId,
-    int LineNumber);
+    int LineNumber,
+    string? Session = null);
 
 public enum ScriptEventKind { New, Cancel }
 public enum Side : byte { Buy, Sell }

--- a/tools/ScenarioReplay/ScriptParser.cs
+++ b/tools/ScenarioReplay/ScriptParser.cs
@@ -87,7 +87,8 @@ public static class ScriptParser
         {
             ulong origClOrdId = (ulong)ReadLong(root, "origClOrdId", lineNo, required: true);
             return new ScriptEvent(atMs, kind, clOrdId, securityId, side,
-                OrderType.Limit, Tif.Day, 0, 0, origClOrdId, lineNo);
+                OrderType.Limit, Tif.Day, 0, 0, origClOrdId, lineNo,
+                Session: ReadString(root, "session", lineNo, required: false));
         }
 
         var typeStr = ReadString(root, "type", lineNo, required: false) ?? "limit";
@@ -108,7 +109,8 @@ public static class ScriptParser
         long qty = ReadLong(root, "qty", lineNo, required: true);
         long px = type == OrderType.Market ? 0 : ReadLong(root, "px", lineNo, required: true);
         if (qty <= 0) throw new FormatException($"line {lineNo}: qty must be > 0");
-        return new ScriptEvent(atMs, kind, clOrdId, securityId, side, type, tif, qty, px, 0, lineNo);
+        return new ScriptEvent(atMs, kind, clOrdId, securityId, side, type, tif, qty, px, 0, lineNo,
+            Session: ReadString(root, "session", lineNo, required: false));
     }
 
     private static long ReadLong(JsonElement root, string name, int lineNo, bool required)


### PR DESCRIPTION
Closes #115.

Builds on PR #134 (FIXP-capable EntryPoint client) so a single replay tape can now drive several concurrent FIXP sessions.

## What

### Schema
- Optional `session` field on each event identifying which session sends it. When absent, the event routes to the default (first-declared) session, which keeps every pre-#115 script working unchanged.

### CLI
- `--session <name>=<sessionId>:<firm>[@host:port]` (repeatable). Each named session opens its own `EntryPointClient` with a full FIXP handshake.
- `--access-key <name>=<key>` (repeatable; defaults to empty — fine on `auth.devMode=true` hosts).
- Single-session legacy `--host`/`--port` mode preserved when no `--session` is given.

### Runtime
- `ReplayRunner` gains a multi-session constructor with a `defaultSession`; per-session `clOrdId → orderId` maps so the gateway's `(firm, clOrdId)` namespacing translates 1:1 to the runner. Single-session constructor kept for back-compat.
- `CaptureWriter` tags ER + event records with the originating `session` name.

## Validation

- 619/619 tests green (617 baseline + 2 new).
- New `MultiSessionReplayTests`:
  1. Two sessions on different firms; opposite sides cross at the same px; both sides observe ER_Trade tagged with their session.
  2. Back-compat: a script with no `session` field routes to the only declared session.
- `dotnet format` clean.
- README updated with `--session` usage, crossing example, and tape-format change.

## Notes

clOrdId reuse across sessions is fine (gateway namespaces by `(firm, clOrdId)`); the runner mirrors that with per-session maps. This unblocks #116 (tape-diff harness).