### PR TITLE
Tape-diff harness for tools/ScenarioReplay

### DIFF
--- a/tests/ScenarioReplay.Tests/TapeDiffTests.cs
+++ b/tests/ScenarioReplay.Tests/TapeDiffTests.cs
@@ -1,0 +1,156 @@
+namespace B3.Exchange.ScenarioReplay.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="TapeDiff"/>: the regression-diffing harness
+/// added in #116. Exercises identical / reordered / ignored-field /
+/// truncated / malformed cases.
+/// </summary>
+public class TapeDiffTests
+{
+    private static readonly HashSet<string> Defaults =
+        new(StringComparer.Ordinal) { "t", "sendingTime" };
+
+    private static string WriteTape(string contents)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"tapediff-{Guid.NewGuid():N}.jsonl");
+        File.WriteAllText(path, contents);
+        return path;
+    }
+
+    [Fact]
+    public void IdenticalTapes_AreEquivalent()
+    {
+        var a = WriteTape(
+            "{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1,\"orderId\":42}\n" +
+            "{\"t\":2,\"src\":\"er\",\"execType\":\"trade\",\"clOrdId\":1,\"orderId\":42,\"lastQty\":100}\n");
+        var b = WriteTape(
+            "{\"t\":99,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1,\"orderId\":42}\n" +
+            "{\"t\":100,\"src\":\"er\",\"execType\":\"trade\",\"clOrdId\":1,\"orderId\":42,\"lastQty\":100}\n");
+        try
+        {
+            var result = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            Assert.True(result.IsEquivalent);
+            Assert.Null(result.FirstDivergence);
+            Assert.Equal(2, result.BaselineCount);
+            Assert.Equal(2, result.CandidateCount);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+
+    [Fact]
+    public void ReorderedRecords_Diverge()
+    {
+        var a = WriteTape(
+            "{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1}\n" +
+            "{\"t\":2,\"src\":\"er\",\"execType\":\"trade\",\"clOrdId\":1}\n");
+        var b = WriteTape(
+            "{\"t\":1,\"src\":\"er\",\"execType\":\"trade\",\"clOrdId\":1}\n" +
+            "{\"t\":2,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1}\n");
+        try
+        {
+            var result = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            Assert.False(result.IsEquivalent);
+            Assert.Equal(2, result.Modified);
+            Assert.NotNull(result.FirstDivergence);
+            Assert.Equal(0, result.FirstDivergence!.Index);
+            Assert.Equal(TapeDiff.DivergenceKind.Modified, result.FirstDivergence.Kind);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+
+    [Fact]
+    public void IgnoredField_OrderId_TolerateDifference()
+    {
+        var a = WriteTape("{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1,\"orderId\":42}\n");
+        var b = WriteTape("{\"t\":2,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1,\"orderId\":99}\n");
+        try
+        {
+            var ignoreWithOrderId = new HashSet<string>(Defaults, StringComparer.Ordinal) { "orderId" };
+            var resultDefault = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            Assert.False(resultDefault.IsEquivalent);  // orderId differs by default
+
+            var resultIgnored = TapeDiff.Compare(TapeDiff.Load(a, ignoreWithOrderId), TapeDiff.Load(b, ignoreWithOrderId));
+            Assert.True(resultIgnored.IsEquivalent);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+
+    [Fact]
+    public void TruncatedCandidate_ReportsOnlyInBaseline()
+    {
+        var a = WriteTape(
+            "{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1}\n" +
+            "{\"t\":2,\"src\":\"er\",\"execType\":\"trade\",\"clOrdId\":1}\n");
+        var b = WriteTape("{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1}\n");
+        try
+        {
+            var result = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            Assert.False(result.IsEquivalent);
+            Assert.Equal(0, result.Modified);
+            Assert.Equal(1, result.OnlyInBaseline);
+            Assert.Equal(0, result.OnlyInCandidate);
+            Assert.NotNull(result.FirstDivergence);
+            Assert.Equal(TapeDiff.DivergenceKind.OnlyInBaseline, result.FirstDivergence!.Kind);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+
+    [Fact]
+    public void ExtraCandidateLines_ReportsOnlyInCandidate()
+    {
+        var a = WriteTape("{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1}\n");
+        var b = WriteTape(
+            "{\"t\":1,\"src\":\"er\",\"execType\":\"new\",\"clOrdId\":1}\n" +
+            "{\"t\":2,\"src\":\"er\",\"execType\":\"trade\",\"clOrdId\":1}\n");
+        try
+        {
+            var result = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            Assert.False(result.IsEquivalent);
+            Assert.Equal(1, result.OnlyInCandidate);
+            Assert.Equal(TapeDiff.DivergenceKind.OnlyInCandidate, result.FirstDivergence!.Kind);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+
+    [Fact]
+    public void MalformedTape_Throws()
+    {
+        var a = WriteTape("not json at all\n");
+        try
+        {
+            Assert.Throws<FormatException>(() => TapeDiff.Load(a, Defaults));
+        }
+        finally { File.Delete(a); }
+    }
+
+    [Fact]
+    public void BlankLines_AreSkipped()
+    {
+        var a = WriteTape("{\"t\":1,\"src\":\"er\",\"execType\":\"new\"}\n\n\n");
+        var b = WriteTape("{\"t\":99,\"src\":\"er\",\"execType\":\"new\"}\n");
+        try
+        {
+            var result = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            Assert.True(result.IsEquivalent);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+
+    [Fact]
+    public void Report_FirstDivergence_IncludesBothLines()
+    {
+        var a = WriteTape("{\"t\":1,\"src\":\"er\",\"clOrdId\":1,\"qty\":100}\n");
+        var b = WriteTape("{\"t\":1,\"src\":\"er\",\"clOrdId\":1,\"qty\":200}\n");
+        try
+        {
+            var result = TapeDiff.Compare(TapeDiff.Load(a, Defaults), TapeDiff.Load(b, Defaults));
+            using var sw = new StringWriter();
+            TapeDiff.WriteReport(sw, result, a, b, Defaults);
+            var report = sw.ToString();
+            Assert.Contains("DIVERGED", report);
+            Assert.Contains("\"qty\":100", report);
+            Assert.Contains("\"qty\":200", report);
+        }
+        finally { File.Delete(a); File.Delete(b); }
+    }
+}

--- a/tools/ScenarioReplay/Program.cs
+++ b/tools/ScenarioReplay/Program.cs
@@ -9,6 +9,11 @@ if (args.Length == 1 && (args[0] == "-h" || args[0] == "--help"))
     return 0;
 }
 
+if (args.Length >= 1 && args[0] == "diff")
+{
+    return RunDiff(args.AsSpan(1).ToArray());
+}
+
 var opts = CliOptions.Parse(args, out var error);
 if (opts == null)
 {
@@ -155,7 +160,79 @@ static void PrintUsage()
                                       the last script event (default 1000)
 
         Exit codes: 0 ok, 1 aborted, 2 usage, 3 script-parse, 4 connect.
+
+        diff subcommand:
+          ScenarioReplay diff --baseline <path> --candidate <path>
+                              [--ignore <field,field,...>] [--out <path>]
+
+          Compares two replay tapes (JSONL) for regression testing.
+          Default ignored fields: t, sendingTime. --ignore is additive
+          (e.g. --ignore orderId tolerates engine-allocated IDs).
+          Diff exit codes: 0 equivalent, 1 diverged, 2 malformed.
         """);
+}
+
+static int RunDiff(string[] args)
+{
+    string? baseline = null, candidate = null, outPath = null;
+    var ignore = new HashSet<string>(StringComparer.Ordinal) { "t", "sendingTime" };
+    for (int i = 0; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--baseline": baseline = NeedArg(args, ref i); break;
+            case "--candidate": candidate = NeedArg(args, ref i); break;
+            case "--out": outPath = NeedArg(args, ref i); break;
+            case "--ignore":
+                {
+                    var v = NeedArg(args, ref i);
+                    foreach (var f in v.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                        ignore.Add(f);
+                    break;
+                }
+            case "-h":
+            case "--help":
+                Console.Error.WriteLine("usage: ScenarioReplay diff --baseline <path> --candidate <path> [--ignore f1,f2] [--out path]");
+                return 2;
+            default:
+                Console.Error.WriteLine($"diff: unknown argument '{args[i]}'");
+                return 2;
+        }
+    }
+    if (string.IsNullOrEmpty(baseline) || string.IsNullOrEmpty(candidate))
+    {
+        Console.Error.WriteLine("diff: --baseline and --candidate are required");
+        return 2;
+    }
+    if (!File.Exists(baseline)) { Console.Error.WriteLine($"diff: baseline not found: {baseline}"); return 2; }
+    if (!File.Exists(candidate)) { Console.Error.WriteLine($"diff: candidate not found: {candidate}"); return 2; }
+
+    List<TapeDiff.NormalisedRecord> b, c;
+    try
+    {
+        b = TapeDiff.Load(baseline, ignore);
+        c = TapeDiff.Load(candidate, ignore);
+    }
+    catch (FormatException fx)
+    {
+        Console.Error.WriteLine($"diff: malformed tape ({fx.Message})");
+        return 2;
+    }
+
+    var result = TapeDiff.Compare(b, c);
+    using TextWriter sink = outPath == null
+        ? Console.Out
+        : new StreamWriter(outPath) { NewLine = "\n" };
+    TapeDiff.WriteReport(sink, result, baseline, candidate, ignore);
+    sink.Flush();
+    return result.IsEquivalent ? 0 : 1;
+
+    static string NeedArg(string[] args, ref int i)
+    {
+        if (i + 1 >= args.Length) throw new ArgumentException($"missing value after '{args[i]}'");
+        i++;
+        return args[i];
+    }
 }
 
 internal sealed class SessionSpec

--- a/tools/ScenarioReplay/README.md
+++ b/tools/ScenarioReplay/README.md
@@ -129,10 +129,43 @@ The `t` field is a unix-millisecond timestamp; mask it (or pipe through
 
 This MVP is intentionally narrow:
 
-- no "diff harness" subcommand (use plain `diff` / `jq` for now —
-  follow-up tracked in #116)
 - single TCP connection per session (no automatic reconnect on drop)
+- the `diff` subcommand compares JSON top-level fields only; UMDF
+  multicast records are matched on full hex-equality of the packet
+  bytes (semantic decoding of inner SBE messages is a follow-up).
 
 Follow-ups will live as separate issues.
+
+## Regression diffing
+
+```bash
+# 1. Capture a baseline tape from a known-good build:
+dotnet run --project tools/ScenarioReplay -- \
+    --script my_scenario.jsonl --out golden.jsonl
+
+# 2. On each PR, replay the same script and diff:
+dotnet run --project tools/ScenarioReplay -- \
+    --script my_scenario.jsonl --out run.jsonl
+
+dotnet run --project tools/ScenarioReplay -- diff \
+    --baseline golden.jsonl --candidate run.jsonl
+echo $?  # 0=equivalent, 1=diverged, 2=malformed/usage
+```
+
+Default ignored fields are `t` (wall-clock timestamp) and `sendingTime`
+(currently inside packet bytes; reserved for future structured-mcast
+diffs). Add more with `--ignore`:
+
+```bash
+# Tolerate engine-allocated orderId (not deterministic across runs):
+dotnet run --project tools/ScenarioReplay -- diff \
+    --baseline golden.jsonl --candidate run.jsonl \
+    --ignore orderId,leavesQty
+```
+
+The diff stops scanning at the first record-level divergence (printed
+side-by-side) but counts total `modified` / `onlyInBaseline` /
+`onlyInCandidate` across the whole pair so a CI summary line carries
+the impact at a glance.
 
 [issue-17]: https://github.com/pedrosakuma/B3MatchingPlatform/issues/17

--- a/tools/ScenarioReplay/TapeDiff.cs
+++ b/tools/ScenarioReplay/TapeDiff.cs
@@ -1,0 +1,135 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace B3.Exchange.ScenarioReplay;
+
+/// <summary>
+/// Compares two replay tapes (JSONL produced by <see cref="CaptureWriter"/>)
+/// for regression testing. Records are aligned by file order (the runner
+/// already emits them in monotonic, deterministic order). A configurable
+/// set of top-level keys is stripped from each record before comparison so
+/// non-deterministic noise (wall-clock <c>t</c>, engine-allocated
+/// <c>orderId</c>, ...) does not produce false positives.
+///
+/// The diff stops scanning at the first record-level divergence to keep the
+/// report compact, but counts add / remove / modify totals across the whole
+/// pair so a CI summary line can include the impact at a glance.
+/// </summary>
+public static class TapeDiff
+{
+    public sealed record DiffResult(
+        int BaselineCount,
+        int CandidateCount,
+        int Modified,
+        int OnlyInBaseline,
+        int OnlyInCandidate,
+        DiffDivergence? FirstDivergence)
+    {
+        public bool IsEquivalent => Modified == 0 && OnlyInBaseline == 0 && OnlyInCandidate == 0;
+    }
+
+    public sealed record DiffDivergence(
+        int Index,
+        DivergenceKind Kind,
+        string? BaselineLine,
+        string? CandidateLine);
+
+    public enum DivergenceKind { Modified, OnlyInBaseline, OnlyInCandidate }
+
+    /// <summary>Loads + normalises every record in a tape file.</summary>
+    public static List<NormalisedRecord> Load(string path, IReadOnlySet<string> ignoreFields)
+    {
+        var list = new List<NormalisedRecord>();
+        int lineNo = 0;
+        foreach (var raw in File.ReadLines(path))
+        {
+            lineNo++;
+            if (string.IsNullOrWhiteSpace(raw)) continue;
+            JsonNode? node;
+            try
+            {
+                node = JsonNode.Parse(raw);
+            }
+            catch (JsonException jx)
+            {
+                throw new FormatException($"{path} line {lineNo}: invalid JSON ({jx.Message})", jx);
+            }
+            if (node is not JsonObject obj)
+                throw new FormatException($"{path} line {lineNo}: expected JSON object");
+            var normalized = NormaliseRecord(obj, ignoreFields);
+            list.Add(new NormalisedRecord(lineNo, raw, normalized));
+        }
+        return list;
+    }
+
+    private static string NormaliseRecord(JsonObject obj, IReadOnlySet<string> ignoreFields)
+    {
+        var clone = new JsonObject();
+        foreach (var kv in obj)
+        {
+            if (ignoreFields.Contains(kv.Key)) continue;
+            clone[kv.Key] = kv.Value?.DeepClone();
+        }
+        return clone.ToJsonString();
+    }
+
+    public static DiffResult Compare(
+        IReadOnlyList<NormalisedRecord> baseline,
+        IReadOnlyList<NormalisedRecord> candidate)
+    {
+        int min = Math.Min(baseline.Count, candidate.Count);
+        int modified = 0;
+        DiffDivergence? first = null;
+        for (int i = 0; i < min; i++)
+        {
+            if (!string.Equals(baseline[i].Normalised, candidate[i].Normalised, StringComparison.Ordinal))
+            {
+                modified++;
+                first ??= new DiffDivergence(i, DivergenceKind.Modified, baseline[i].Raw, candidate[i].Raw);
+            }
+        }
+        int onlyB = baseline.Count > min ? baseline.Count - min : 0;
+        int onlyC = candidate.Count > min ? candidate.Count - min : 0;
+        if (first == null && onlyB > 0)
+            first = new DiffDivergence(min, DivergenceKind.OnlyInBaseline, baseline[min].Raw, null);
+        else if (first == null && onlyC > 0)
+            first = new DiffDivergence(min, DivergenceKind.OnlyInCandidate, null, candidate[min].Raw);
+        return new DiffResult(baseline.Count, candidate.Count, modified, onlyB, onlyC, first);
+    }
+
+    public static void WriteReport(TextWriter @out, DiffResult result, string baselinePath, string candidatePath, IReadOnlySet<string> ignoreFields)
+    {
+        @out.WriteLine($"baseline:  {baselinePath} ({result.BaselineCount} records)");
+        @out.WriteLine($"candidate: {candidatePath} ({result.CandidateCount} records)");
+        @out.WriteLine($"ignored fields: {(ignoreFields.Count == 0 ? "(none)" : string.Join(",", ignoreFields))}");
+        @out.WriteLine();
+        if (result.IsEquivalent)
+        {
+            @out.WriteLine("OK — tapes are equivalent under the ignored-field policy.");
+            return;
+        }
+        @out.WriteLine($"DIVERGED — modified={result.Modified} onlyInBaseline={result.OnlyInBaseline} onlyInCandidate={result.OnlyInCandidate}");
+        @out.WriteLine();
+        if (result.FirstDivergence is { } d)
+        {
+            @out.WriteLine($"first divergence at index {d.Index} ({d.Kind}):");
+            switch (d.Kind)
+            {
+                case DivergenceKind.Modified:
+                    @out.WriteLine($"  - baseline:  {d.BaselineLine}");
+                    @out.WriteLine($"  + candidate: {d.CandidateLine}");
+                    break;
+                case DivergenceKind.OnlyInBaseline:
+                    @out.WriteLine($"  - baseline:  {d.BaselineLine}");
+                    @out.WriteLine("  + candidate: <missing>");
+                    break;
+                case DivergenceKind.OnlyInCandidate:
+                    @out.WriteLine("  - baseline:  <missing>");
+                    @out.WriteLine($"  + candidate: {d.CandidateLine}");
+                    break;
+            }
+        }
+    }
+
+    public sealed record NormalisedRecord(int LineNumber, string Raw, string Normalised);
+}


### PR DESCRIPTION
Closes #116.

Builds on PRs #134 (FIXP client) and #135 (multi-session replay) — completes Tier C of the roadmap.

## What

New `diff` subcommand on `tools/ScenarioReplay`:

```
ScenarioReplay diff --baseline <path> --candidate <path>
                    [--ignore <field,field,...>] [--out <path>]
```

### Behaviour

- Aligns records by file order (runner already emits them in monotonic order).
- Default ignored top-level fields: `t` (wall-clock) and `sendingTime` (reserved for future structured-mcast diffs). `--ignore` is additive — `--ignore orderId` tolerates engine-allocated IDs that don't repeat across runs.
- Reports first divergence with baseline + candidate lines side-by-side; counts `modified` / `onlyInBaseline` / `onlyInCandidate` across the whole pair so a CI summary line carries the impact at a glance.
- Exit codes: `0` equivalent, `1` diverged, `2` malformed/usage.

## Tests

8 new `TapeDiffTests` covering: identical tapes, reordered records, ignored-field tolerance (default vs opt-in `orderId`), truncated candidate, extra candidate lines, malformed JSON, blank-line skipping, report formatting. **627/627 tests green** (619 baseline + 8 new).

## Docs

`tools/ScenarioReplay/README.md` adds a "Regression diffing" section with the canonical capture-baseline → replay → diff workflow and notes on the limitation (UMDF mcast records are matched on full hex equality; structured SBE diff is a follow-up).