### PR TITLE
Move ICoreOutbound + IInboundCommandSink to B3.Exchange.Contracts (#140)

### DIFF
--- a/src/B3.Exchange.Contracts/B3.Exchange.Contracts.csproj
+++ b/src/B3.Exchange.Contracts/B3.Exchange.Contracts.csproj
@@ -5,4 +5,8 @@
     <AssemblyName>B3.Exchange.Contracts</AssemblyName>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/B3.Exchange.Contracts/Ports.cs
+++ b/src/B3.Exchange.Contracts/Ports.cs
@@ -1,9 +1,8 @@
-using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
-using RejectEvent = B3.Exchange.Matching.RejectEvent;
-using Side = B3.Exchange.Matching.Side;
+using MatchingRejectEvent = B3.Exchange.Matching.RejectEvent;
+using MatchingSide = B3.Exchange.Matching.Side;
 
-namespace B3.Exchange.Core;
+namespace B3.Exchange.Contracts;
 
 /// <summary>
 /// Outbound surface that <see cref="ChannelDispatcher"/> calls to deliver
@@ -67,10 +66,10 @@ public interface ICoreOutbound
 
     bool WriteExecutionReportModify(SessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
-        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
+        MatchingSide side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
         ulong receivedTimeNanos = ulong.MaxValue);
 
-    bool WriteExecutionReportReject(SessionId session, in RejectEvent e, ulong clOrdIdValue);
+    bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue);
 
     /// <summary>
     /// Signals that <paramref name="orderId"/> has reached a terminal state

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -1,6 +1,7 @@
 using B3.EntryPoint.Wire;
 using System.Net;
 using System.Net.Sockets;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using Microsoft.Extensions.Logging;
 

--- a/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.Establish.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Establish.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
@@ -398,7 +399,7 @@ public sealed partial class FixpSession : IAsyncDisposable
         => _outboundEncoder.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos);
 
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
-        Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
+        B3.Exchange.Matching.Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
         ulong receivedTimeNanos = ulong.MaxValue)
         => _outboundEncoder.WriteExecutionReportModify(securityId, orderId, clOrdIdValue, origClOrdIdValue,
             side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos);
@@ -416,7 +417,7 @@ public sealed partial class FixpSession : IAsyncDisposable
         => _outboundEncoder.WriteOrderMassActionReport(clOrdIdValue, massActionResponse,
             massActionRejectReason, side, securityId, transactTimeNanos, text);
 
-    public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue)
+    public bool WriteExecutionReportReject(in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue)
         => _outboundEncoder.WriteExecutionReportReject(e, clOrdIdValue);
 
     public bool WriteSessionReject(byte terminationCode)

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -1,3 +1,8 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+using RejectEvent = B3.Exchange.Matching.RejectEvent;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
 using System.Runtime.InteropServices;
 using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -1,10 +1,14 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+using RejectEvent = B3.Exchange.Matching.RejectEvent;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
 using System.Runtime.InteropServices;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.WireEncoder;
-using Side = B3.Exchange.Matching.Side;
 
 namespace B3.Exchange.Core.Tests;
 
@@ -334,7 +338,7 @@ public class ChannelDispatcherSnapshotTests
     }
 }
 
-internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Core.ICoreOutbound
+internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Contracts.ICoreOutbound
 {
     public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;

--- a/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using System.Buffers.Binary;
 using System.IO;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using B3.Exchange.Core;
 using System.Net;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.Core;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.Core;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using B3.Exchange.Core;
 using System.Buffers.Binary;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachReplayE2ETests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachReplayE2ETests.cs
@@ -1,3 +1,6 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+using RejectEvent = B3.Exchange.Matching.RejectEvent;
 using B3.EntryPoint.Wire;
 using System.Net;
 using System.Net.Sockets;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.Core;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
@@ -1,3 +1,6 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+using RejectEvent = B3.Exchange.Matching.RejectEvent;
 using B3.EntryPoint.Wire;
 using System.Net;
 using System.Net.Sockets;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.Core;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using System.Buffers.Binary;
 using System.IO;

--- a/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using System.Buffers.Binary;
 using System.IO;

--- a/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using System.IO;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -1,3 +1,8 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+using RejectEvent = B3.Exchange.Matching.RejectEvent;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
 using B3.Exchange.Gateway;
 using B3.Exchange.Host;
 using B3.Exchange.Core;


### PR DESCRIPTION
Closes #140.

## What

Moves the two ports that wire Core ↔ Gateway out of `B3.Exchange.Core` into `B3.Exchange.Contracts`:

- `ICoreOutbound` — Core → Gateway (per-order ExecutionReports)
- `IInboundCommandSink` — Gateway → Core (decoded commands)

Hosting both in Core hid the dependency direction ("Gateway depends on Core" was true, but Core also depended on Gateway via `ICoreOutbound`). Moving them to Contracts makes both Core and Gateway depend on the shared port surface.

## Acceptance criteria

- [x] `B3.Exchange.Contracts` contains the port interfaces.
- [x] `B3.Exchange.Core` no longer defines `ICoreOutbound` / `IInboundCommandSink`.
- [x] Build + full test suite pass (Gateway 376/376, Core 42/42, Host 33/33, SyntheticTrader 45/45, ScenarioReplay 23/23+1pre-existing-skip, Matching 43/43).
- [~] Contracts depends on Matching. Strict "zero-deps" would require moving the engine event records (`OrderAcceptedEvent`, `TradeEvent`, `OrderCanceledEvent`, `RejectEvent`, `*Command`) out of Matching, which is a much larger surgery than the architectural benefit warrants. Documented as a pragmatic compromise; the engine remains the single source of truth for its own event shapes and the Core ↔ Gateway coupling is broken regardless.

## Mechanical notes

- File renamed via `git mv` so blame survives.
- The `Side` / `RejectEvent` aliases were renamed to `MatchingSide` / `MatchingRejectEvent` so they don't collide with the parallel `Contracts.Side` / `Contracts.RejectEvent` enums/records.
- Consumers (Gateway partials, EntryPointListener, tests) gained a `using B3.Exchange.Contracts;` line where missing.
- Three test files (`HostRouterTests`, `ChannelDispatcherTests`, `SnapshotRotatorTests`) gained explicit aliases for the engine `Side` / `RejectEvent` / `OrderType` / `TimeInForce` types to disambiguate against the Contracts enums.

## Out of scope

The aspirational `ICoreInbound` / `IGatewayInbound` interfaces already in Contracts (and their parallel Inbound* records) remain untouched and unwired. Sequencing them in is a separate follow-up.