### PR TITLE
Prune InternalsVisibleTo: drop Host.Tests from Core+Gateway (#141)

### DIFF
--- a/src/B3.Exchange.Core/B3.Exchange.Core.csproj
+++ b/src/B3.Exchange.Core/B3.Exchange.Core.csproj
@@ -14,7 +14,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="B3.Exchange.Core.Tests" />
-    <InternalsVisibleTo Include="B3.Exchange.Host.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
+++ b/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
@@ -16,7 +16,6 @@
   <ItemGroup>
     <InternalsVisibleTo Include="B3.Exchange.Gateway.Tests" />
     <InternalsVisibleTo Include="B3.Exchange.SyntheticTrader.Tests" />
-    <InternalsVisibleTo Include="B3.Exchange.Host.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -119,8 +119,13 @@ public class HttpServerTests
         using var live = await client.GetAsync("/health/live");
         Assert.Equal(System.Net.HttpStatusCode.OK, live.StatusCode);
 
-        // Wedge the dispatcher loop without disposing.
-        foreach (var d in host.Dispatchers) d.KillForTesting();
+        // Wedge the dispatcher loop without disposing. KillForTesting is an
+        // internal test seam; reach it via reflection so this test does not
+        // require Core/Gateway IVT to Host.Tests (issue #141).
+        var killForTesting = typeof(B3.Exchange.Core.ChannelDispatcher).GetMethod(
+            "KillForTesting",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        foreach (var d in host.Dispatchers) killForTesting.Invoke(d, null);
 
         // Poll until /health/live flips to 503. Bound wait at 8 s (issue
         // acceptance: <10 s).

--- a/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
@@ -1,6 +1,7 @@
 using B3.EntryPoint.Wire;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
+using B3.Exchange.SyntheticTrader;
 
 namespace B3.Exchange.SyntheticTrader.Tests;
 


### PR DESCRIPTION
Audit per #141: `B3.Exchange.Host.Tests` had no genuine cross-internal usage of Core or Gateway internals. The one direct call (`ChannelDispatcher.KillForTesting` in HttpServerTests) is now invoked via reflection — matching the existing reflection pattern used by HostRouterTests for `ProcessOne`.

### Changes
- `src/B3.Exchange.Core/B3.Exchange.Core.csproj` — IVT now: `Core.Tests` only (dropped `Host.Tests`).
- `src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj` — IVT now: `Gateway.Tests` + `SyntheticTrader.Tests` (dropped `Host.Tests`).
- `tests/B3.Exchange.Host.Tests/HttpServerTests.cs` — reflection on `KillForTesting`.

### Why SyntheticTrader.Tests IVT to Gateway is retained
`WireFormatCompatTests` exercises Gateway's internal wire codec (`InboundMessageDecoder`, `ExecutionReportEncoder`) against `EntryPointClient`'s internal `Encode/Decode` helpers. Those test-only helpers live in SyntheticTrader, so the test is naturally hosted there. Moving it would require either promoting the codecs to public (broadens API surface) or making SyntheticTrader a test dependency of Gateway.Tests (adds a transitive coupling for marginal gain).

### Verification
- `dotnet build -c Release` clean (warnings-as-errors)
- Full suite green (376 Gateway + 33 Host + others)
- `dotnet format --verify-no-changes` clean

Closes #141.