### PR TITLE
Fix flake #146: MultiSessionReplay wait condition (closes #146)

### DIFF
--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -34,7 +34,7 @@ public class MultiSessionReplayTests
         throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
     }
 
-    [Fact(Skip = "Flaky pre-existing on main; tracked by #146. Aggressor session sometimes never receives its ER_Trade callback. Re-enable once #146 lands.")]
+    [Fact]
     public async Task TwoSessions_CrossingScript_LandsErTradesOnBothSides()
     {
         var sink = new CountingSink();
@@ -102,13 +102,17 @@ public class MultiSessionReplayTests
 
         await runner.RunAsync(script, cts.Token);
 
-        // Wait for ER_Trade on both sessions.
-        var deadline = DateTime.UtcNow.AddSeconds(5);
+        // Wait for ER_Trade on BOTH sessions. Poll until both sides have
+        // observed their own trade ER, not just any trade ER (the previous
+        // condition broke as soon as the first side's trade landed, which
+        // races the aggressor's recv loop — see #146).
+        var deadline = DateTime.UtcNow.AddSeconds(10);
         while (DateTime.UtcNow < deadline)
         {
-            var snap = sw.ToString();
-            if (snap.Contains("\"session\":\"firmA\"") && snap.Contains("\"session\":\"firmB\"")
-                && snap.Contains("\"execType\":\"trade\""))
+            var snapLines = sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            bool aTrade = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"trade\""));
+            bool bTrade = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmB\"") && l.Contains("\"execType\":\"trade\""));
+            if (aTrade && bTrade)
                 break;
             await Task.Delay(50, cts.Token);
         }


### PR DESCRIPTION
## Root cause

The wait loop in `TwoSessions_CrossingScript_LandsErTradesOnBothSides` broke as soon as ANY `"execType":"trade"` line appeared. The break condition was:

```csharp
snap.Contains("\"session\":\"firmA\"") && snap.Contains("\"session\":\"firmB\"") && snap.Contains("\"execType\":\"trade\"")
```

But `session:firmA` is present from firmA's `submit_new` event (written before any ER lands), and same for firmB. So the loop satisfied as soon as the **first** side's trade ER arrived — then the test asserted both sides had their own trade ER, while the aggressor's ER_Trade was still in flight on the recv loop → flake.

## Fix

Strict break: parse the tape and require each side to have its **own** `src:er + session:firmX + execType:trade` line. Bump deadline 5s → 10s for first-run JIT headroom. Drop `[Fact(Skip=...)]`.

## Verification

- 20/20 sequential runs of just this test pass locally on Release.
- Full suite: 24/24 ScenarioReplay tests pass (was 23/1-skip), 376 Gateway, 33 Host, etc., all green.
- `dotnet format --verify-no-changes` clean.

Closes #146.