### PR TITLE
Replace dispatcher reflection with TestProbe (#157)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -768,6 +768,51 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         try { _cts.Cancel(); } catch { }
     }
 
+    /// <summary>
+    /// Returns a test-only probe that exposes drain/kill helpers without
+    /// requiring reflection or InternalsVisibleTo. The probe is the
+    /// supported test seam — internal fields and methods are not part of
+    /// the supported surface and can change without notice.
+    /// </summary>
+    public TestProbe CreateTestProbe() => new TestProbe(this);
+
+    /// <summary>
+    /// Test-only probe encapsulating drain/kill operations on a
+    /// <see cref="ChannelDispatcher"/>. Production code must not call
+    /// <see cref="CreateTestProbe"/>; the probe exists solely so tests
+    /// can drive the dispatcher synchronously without piercing
+    /// encapsulation via reflection.
+    /// </summary>
+    public sealed class TestProbe
+    {
+        private readonly ChannelDispatcher _disp;
+
+        internal TestProbe(ChannelDispatcher disp) => _disp = disp;
+
+        /// <summary>
+        /// Synchronously processes every pending <c>WorkItem</c> on the
+        /// dispatcher's inbound queue using the dispatcher's own
+        /// <c>ProcessOne</c> path. The dispatcher loop is bypassed; the
+        /// caller's thread does the work. Useful in unit tests that
+        /// enqueue commands and need a deterministic point at which the
+        /// engine has observed them.
+        /// </summary>
+        public void DrainInbound()
+        {
+            var reader = _disp._inbound.Reader;
+            while (reader.TryRead(out var item))
+            {
+                _disp.ProcessOne(item);
+            }
+        }
+
+        /// <summary>
+        /// Cancels the dispatcher loop without disposing. See
+        /// <see cref="ChannelDispatcher.KillForTesting"/>.
+        /// </summary>
+        public void Kill() => _disp.KillForTesting();
+    }
+
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("channel {ChannelNumber} dispatcher stopping (sequenceNumber={SequenceNumber})",

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -481,20 +481,5 @@ public class ChannelDispatcherTests
         return (MatchingEngine)f.GetValue(disp)!;
     }
 
-    private static void DrainInbound(ChannelDispatcher disp)
-    {
-        // Reflect into the bounded channel and process until empty without
-        // starting the dispatcher's own loop.
-        var field = typeof(ChannelDispatcher).GetField("_inbound", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        var inbound = field.GetValue(disp)!;
-        var readerProp = inbound.GetType().GetProperty("Reader")!;
-        var reader = readerProp.GetValue(inbound)!;
-        var tryRead = reader.GetType().GetMethod("TryRead")!;
-        var args = new object?[] { null };
-        var processOne = typeof(ChannelDispatcher).GetMethod("ProcessOne", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        while ((bool)tryRead.Invoke(reader, args)!)
-        {
-            processOne.Invoke(disp, new[] { args[0] });
-        }
-    }
+    private static void DrainInbound(ChannelDispatcher disp) => disp.CreateTestProbe().DrainInbound();
 }

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -322,20 +322,7 @@ public class ChannelDispatcherSnapshotTests
         Assert.Equal(3u, hdr.Data.LastRptSeq);
     }
 
-    private static void Drain(ChannelDispatcher disp)
-    {
-        var field = typeof(ChannelDispatcher).GetField("_inbound", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        var inbound = field.GetValue(disp)!;
-        var readerProp = inbound.GetType().GetProperty("Reader")!;
-        var reader = readerProp.GetValue(inbound)!;
-        var tryRead = reader.GetType().GetMethod("TryRead")!;
-        var args = new object?[] { null };
-        var processOne = typeof(ChannelDispatcher).GetMethod("ProcessOne", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        while ((bool)tryRead.Invoke(reader, args)!)
-        {
-            processOne.Invoke(disp, new[] { args[0] });
-        }
-    }
+    private static void Drain(ChannelDispatcher disp) => disp.CreateTestProbe().DrainInbound();
 }
 
 internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Contracts.ICoreOutbound

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -77,15 +77,9 @@ public class HostRouterTests
             new B3.Exchange.Contracts.SessionId("s1"), enteringFirm: 1, clOrdIdValue: 1);
 
         Assert.Empty(outbound.Rejects);
-        // Drain the dispatcher queue + assert it actually processed an order
-        var field = typeof(ChannelDispatcher).GetField("_inbound", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        var inbound = field.GetValue(disp)!;
-        var reader = inbound.GetType().GetProperty("Reader")!.GetValue(inbound)!;
-        var tryRead = reader.GetType().GetMethod("TryRead")!;
-        var args = new object?[] { null };
-        var processOne = typeof(ChannelDispatcher).GetMethod("ProcessOne", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        Assert.True((bool)tryRead.Invoke(reader, args)!);
-        processOne.Invoke(disp, new[] { args[0] });
+        // Drain the dispatcher queue and assert it processed the order
+        // (replaces the prior reflection-based drain — issue #157).
+        disp.CreateTestProbe().DrainInbound();
         Assert.Single(pkt.Calls);
     }
 

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -119,13 +119,10 @@ public class HttpServerTests
         using var live = await client.GetAsync("/health/live");
         Assert.Equal(System.Net.HttpStatusCode.OK, live.StatusCode);
 
-        // Wedge the dispatcher loop without disposing. KillForTesting is an
-        // internal test seam; reach it via reflection so this test does not
-        // require Core/Gateway IVT to Host.Tests (issue #141).
-        var killForTesting = typeof(B3.Exchange.Core.ChannelDispatcher).GetMethod(
-            "KillForTesting",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
-        foreach (var d in host.Dispatchers) killForTesting.Invoke(d, null);
+        // Wedge the dispatcher loop without disposing via the public test
+        // probe (issue #157 — replaces the prior reflection on the
+        // internal KillForTesting method).
+        foreach (var d in host.Dispatchers) d.CreateTestProbe().Kill();
 
         // Poll until /health/live flips to 503. Bound wait at 8 s (issue
         // acceptance: <10 s).


### PR DESCRIPTION
Closes #157

Adds a public nested `ChannelDispatcher.TestProbe` exposing two test-only operations (`DrainInbound`, `KillLoop`) backed by existing internal members. Tests in Core.Tests and Host.Tests no longer use reflection on private fields/methods.

Surface widening is intentionally minimal: only `CreateTestProbe()` becomes public. Method names signal test-only intent.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>