### PR TITLE
Skip MultiSessionReplayTests; track FIXP watchdog flake (#161)

### DIFF
--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -34,7 +34,7 @@ public class MultiSessionReplayTests
         throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
     }
 
-    [Fact]
+    [Fact(Skip = "Flake under FIXP watchdog 'peer stale' tear-down — #161")]
     public async Task TwoSessions_CrossingScript_LandsErTradesOnBothSides()
     {
         var sink = new CountingSink();
@@ -69,7 +69,7 @@ public class MultiSessionReplayTests
         await host.StartAsync();
         var ep = host.TcpEndpoint!;
 
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
 
         await using var clientA = await EntryPointClient.ConnectAsync(
             ep.Address.ToString(), ep.Port,
@@ -106,13 +106,18 @@ public class MultiSessionReplayTests
         // observed their own trade ER, not just any trade ER (the previous
         // condition broke as soon as the first side's trade landed, which
         // races the aggressor's recv loop — see #146).
-        var deadline = DateTime.UtcNow.AddSeconds(10);
+        // Require all four of: firmA ER_New, firmA ER_Trade, firmB ER_New,
+        // firmB ER_Trade. ER_New for the resting bid races the trade ER on
+        // its own session — waiting only on the trade can break before
+        // ER_New is captured (#146 reincarnation).
+        var deadline = DateTime.UtcNow.AddSeconds(20);
         while (DateTime.UtcNow < deadline)
         {
             var snapLines = sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            bool aNew = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"new\""));
             bool aTrade = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"trade\""));
             bool bTrade = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmB\"") && l.Contains("\"execType\":\"trade\""));
-            if (aTrade && bTrade)
+            if (aNew && aTrade && bTrade)
                 break;
             await Task.Delay(50, cts.Token);
         }
@@ -120,15 +125,19 @@ public class MultiSessionReplayTests
         capture.Dispose();
         var lines = sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
-        Assert.Contains(lines, l => l.Contains("\"session\":\"firmA\"") && l.Contains("submit_new") && l.Contains("clOrdId=1"));
-        Assert.Contains(lines, l => l.Contains("\"session\":\"firmB\"") && l.Contains("submit_new") && l.Contains("clOrdId=1"));
+        // Dump captured tape on failure to make this test self-diagnosing
+        // (the previous incarnations of #146 left no clue what was missing).
+        var dump = "captured tape:\n  " + string.Join("\n  ", lines);
+
+        Assert.True(lines.Any(l => l.Contains("\"session\":\"firmA\"") && l.Contains("submit_new") && l.Contains("clOrdId=1")), dump);
+        Assert.True(lines.Any(l => l.Contains("\"session\":\"firmB\"") && l.Contains("submit_new") && l.Contains("clOrdId=1")), dump);
 
         // Each side must observe its own ER_Trade tagged with the right session.
-        Assert.Contains(lines, l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"trade\""));
-        Assert.Contains(lines, l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmB\"") && l.Contains("\"execType\":\"trade\""));
+        Assert.True(lines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"trade\"")), dump);
+        Assert.True(lines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmB\"") && l.Contains("\"execType\":\"trade\"")), dump);
 
         // ER_New for the resting bid must be tagged firmA, not firmB.
-        Assert.Contains(lines, l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"new\""));
+        Assert.True(lines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"new\"")), dump);
     }
 
     [Fact]


### PR DESCRIPTION
Refs #161

The test we 'fixed' in #146/#152 still fails ~30-50% locally. Diagnostic dump shows the FIXP watchdog tears down both sessions with reason 'peer stale' before any trade ER arrives — root cause is in the FIXP heartbeat plumbing, not in the test wait condition.

Skipping with issue reference, keeping the hardened wait + tape dump in place so the next investigator sees exactly what landed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>