### PR TITLE
Move metrics types to Contracts (#154)

### DIFF
--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -1,0 +1,56 @@
+using System.Threading;
+
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Process-wide counters tracking FIXP session lifecycle transitions
+/// (Established / Suspended / Rebound / Reaped / CancelOnDisconnect).
+/// Owned by the Core <c>MetricsRegistry</c> and exposed via
+/// <c>MetricsRegistry.Sessions</c>. All increments are atomic and
+/// safe to call from any thread (state-machine transitions, listener
+/// reaper, etc).
+///
+/// <para>Lives in <c>B3.Exchange.Contracts</c> so the Gateway can consume
+/// the type without taking a project reference on Core (issue #154).</para>
+/// </summary>
+public sealed class SessionLifecycleMetrics
+{
+    private long _established;
+    private long _suspended;
+    private long _rebound;
+    private long _reaped;
+    private long _cancelOnDisconnectFired;
+
+    public long Established => Interlocked.Read(ref _established);
+    public long Suspended => Interlocked.Read(ref _suspended);
+    public long Rebound => Interlocked.Read(ref _rebound);
+    public long Reaped => Interlocked.Read(ref _reaped);
+    public long CancelOnDisconnectFired => Interlocked.Read(ref _cancelOnDisconnectFired);
+
+    public void IncEstablished() => Interlocked.Increment(ref _established);
+    public void IncSuspended() => Interlocked.Increment(ref _suspended);
+    public void IncRebound() => Interlocked.Increment(ref _rebound);
+    public void IncReaped() => Interlocked.Increment(ref _reaped);
+    public void IncCancelOnDisconnectFired() => Interlocked.Increment(ref _cancelOnDisconnectFired);
+}
+
+/// <summary>
+/// Process-wide counters for the per-session inbound sliding-window
+/// throttle (issue #56 / GAP-20, guidelines §4.9). Increments are atomic
+/// so the FIXP recv thread can advance them while a metrics scrape runs
+/// concurrently on the HTTP thread.
+///
+/// <para>Lives in <c>B3.Exchange.Contracts</c> so the Gateway can consume
+/// the type without taking a project reference on Core (issue #154).</para>
+/// </summary>
+public sealed class ThrottleMetrics
+{
+    private long _accepted;
+    private long _rejected;
+
+    public long Accepted => Interlocked.Read(ref _accepted);
+    public long Rejected => Interlocked.Read(ref _rejected);
+
+    public void IncAccepted() => Interlocked.Increment(ref _accepted);
+    public void IncRejected() => Interlocked.Increment(ref _rejected);
+}

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using B3.Exchange.Contracts;
 
 namespace B3.Exchange.Core;
 
@@ -94,51 +95,6 @@ public readonly record struct SessionDiagnostics(
 /// list firms without a Core→Gateway dependency.
 /// </summary>
 public readonly record struct FirmInfo(string Id, string Name, uint EnteringFirmCode);
-
-/// <summary>
-/// Process-wide counters for FIXP session lifecycle events. Exposed via
-/// <see cref="MetricsRegistry.Sessions"/>. All increments are atomic and
-/// safe to call from any thread (state-machine transitions, listener
-/// reaper, etc).
-/// </summary>
-public sealed class SessionLifecycleMetrics
-{
-    private long _established;
-    private long _suspended;
-    private long _rebound;
-    private long _reaped;
-    private long _cancelOnDisconnectFired;
-
-    public long Established => Interlocked.Read(ref _established);
-    public long Suspended => Interlocked.Read(ref _suspended);
-    public long Rebound => Interlocked.Read(ref _rebound);
-    public long Reaped => Interlocked.Read(ref _reaped);
-    public long CancelOnDisconnectFired => Interlocked.Read(ref _cancelOnDisconnectFired);
-
-    public void IncEstablished() => Interlocked.Increment(ref _established);
-    public void IncSuspended() => Interlocked.Increment(ref _suspended);
-    public void IncRebound() => Interlocked.Increment(ref _rebound);
-    public void IncReaped() => Interlocked.Increment(ref _reaped);
-    public void IncCancelOnDisconnectFired() => Interlocked.Increment(ref _cancelOnDisconnectFired);
-}
-
-/// <summary>
-/// Process-wide counters for the per-session inbound sliding-window
-/// throttle (issue #56 / GAP-20, guidelines §4.9). Increments are atomic
-/// so the FIXP recv thread can advance them while a metrics scrape runs
-/// concurrently on the HTTP thread.
-/// </summary>
-public sealed class ThrottleMetrics
-{
-    private long _accepted;
-    private long _rejected;
-
-    public long Accepted => Interlocked.Read(ref _accepted);
-    public long Rejected => Interlocked.Read(ref _rejected);
-
-    public void IncAccepted() => Interlocked.Increment(ref _accepted);
-    public void IncRejected() => Interlocked.Increment(ref _rejected);
-}
 
 /// <summary>
 /// Central registry of channel metrics + a Prometheus text-format

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -61,7 +61,7 @@ public sealed record FixpSessionOptions
     /// successful reap. Optional so unit tests can construct sessions
     /// without wiring <c>MetricsRegistry</c>.
     /// </summary>
-    public B3.Exchange.Core.SessionLifecycleMetrics? LifecycleMetrics { get; init; }
+    public B3.Exchange.Contracts.SessionLifecycleMetrics? LifecycleMetrics { get; init; }
 
     /// <summary>
     /// Per-session inbound rate cap (issue #56 / GAP-20, guidelines §4.9):
@@ -81,12 +81,12 @@ public sealed record FixpSessionOptions
 
     /// <summary>
     /// Optional process-wide throttle counters. When non-null the session
-    /// increments <see cref="B3.Exchange.Core.ThrottleMetrics.Accepted"/>
+    /// increments <see cref="B3.Exchange.Contracts.ThrottleMetrics.Accepted"/>
     /// every time an application message is admitted by the throttle and
-    /// <see cref="B3.Exchange.Core.ThrottleMetrics.Rejected"/> on every
+    /// <see cref="B3.Exchange.Contracts.ThrottleMetrics.Rejected"/> on every
     /// throttle-driven BusinessMessageReject.
     /// </summary>
-    public B3.Exchange.Core.ThrottleMetrics? ThrottleMetrics { get; init; }
+    public B3.Exchange.Contracts.ThrottleMetrics? ThrottleMetrics { get; init; }
 
     public static FixpSessionOptions Default { get; } = new();
 

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -198,7 +198,7 @@ public class FixpSessionThrottleTests
         try
         {
             long now = 1_000_000;
-            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var metrics = new B3.Exchange.Contracts.ThrottleMetrics();
             var session = NewSession(server,
                 new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 3, ThrottleMetrics = metrics },
                 () => now);
@@ -227,7 +227,7 @@ public class FixpSessionThrottleTests
         try
         {
             long now = 1_000_000;
-            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var metrics = new B3.Exchange.Contracts.ThrottleMetrics();
             var session = NewSession(server,
                 new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 2, ThrottleMetrics = metrics },
                 () => now);
@@ -260,7 +260,7 @@ public class FixpSessionThrottleTests
         try
         {
             long now = 1_000_000;
-            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var metrics = new B3.Exchange.Contracts.ThrottleMetrics();
             var session = NewSession(server,
                 new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 2, ThrottleMetrics = metrics },
                 () => now);
@@ -294,7 +294,7 @@ public class FixpSessionThrottleTests
         try
         {
             long now = 1_000_000;
-            var metrics = new B3.Exchange.Core.ThrottleMetrics();
+            var metrics = new B3.Exchange.Contracts.ThrottleMetrics();
             var session = NewSession(server,
                 new FixpSessionOptions { ThrottleTimeWindowMs = 1_000, ThrottleMaxMessages = 1, ThrottleMetrics = metrics },
                 () => now);


### PR DESCRIPTION
Closes #154

Moves `SessionLifecycleMetrics` and `ThrottleMetrics` from `B3.Exchange.Core` to `B3.Exchange.Contracts`. `FixpSessionOptions` no longer needs Core types in its public surface.

Note: Gateway still references Core for the legacy `IInboundCommandSink` / `IGatewayResponseChannel` ports. Fully removing that ProjectReference is part of the larger Wave C cleanup (canonical Contracts ports).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>