### PR TITLE
feat(metrics): SRE counters for dispatch/decode/transport overflow (#155)

### DIFF
--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -54,3 +54,22 @@ public sealed class ThrottleMetrics
     public void IncAccepted() => Interlocked.Increment(ref _accepted);
     public void IncRejected() => Interlocked.Increment(ref _rejected);
 }
+
+/// <summary>
+/// Process-wide SRE counter for transport-layer backpressure events
+/// (issue #155). Today the gateway's <c>TcpTransport</c> closes a
+/// connection on send-queue overflow to avoid unbounded memory growth;
+/// this counter records every such event so operators can alert on
+/// repeated overflows (typically a stuck or slow peer).
+///
+/// <para>Lives in <c>B3.Exchange.Contracts</c> so the Gateway can consume
+/// the type without taking a project reference on Core.</para>
+/// </summary>
+public sealed class TransportMetrics
+{
+    private long _sendQueueFull;
+
+    public long SendQueueFull => Interlocked.Read(ref _sendQueueFull);
+
+    public void IncSendQueueFull() => Interlocked.Increment(ref _sendQueueFull);
+}

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -149,7 +149,11 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             {
                 SingleReader = true,
                 SingleWriter = false,
-                FullMode = System.Threading.Channels.BoundedChannelFullMode.DropWrite,
+                // Use Wait so that TryWrite returns false when the channel
+                // is full (instead of silently dropping the item as DropWrite
+                // does). Callers handle the false return by incrementing the
+                // exch_dispatch_queue_full_total counter and logging.
+                FullMode = System.Threading.Channels.BoundedChannelFullMode.Wait,
             });
         _engine = engineFactory(this);
     }
@@ -497,7 +501,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, session, enteringFirm, true,
             clOrdIdValue, 0, cmd, null, null, null)))
-            LogQueueFull(ChannelNumber, WorkKind.New);
+        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.New); }
     }
 
     public void EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
@@ -505,7 +509,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, cmd, null, null)))
-            LogQueueFull(ChannelNumber, WorkKind.Cancel);
+        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cancel); }
     }
 
     public void EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
@@ -513,14 +517,14 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, null, cmd, null)))
-            LogQueueFull(ChannelNumber, WorkKind.Replace);
+        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Replace); }
     }
 
     public void EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
     {
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cross, session, enteringFirm, true,
             cmd.BuyClOrdIdValue, cmd.SellClOrdIdValue, null, null, null, cmd)))
-            LogQueueFull(ChannelNumber, WorkKind.Cross);
+        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cross); }
     }
 
     public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
@@ -552,15 +556,16 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
             0, 0, null, null, null, null, mc)))
-            LogQueueFull(ChannelNumber, WorkKind.MassCancel);
+        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.MassCancel); }
     }
 
     public void OnDecodeError(SessionId session, string error)
     {
         _logger.LogWarning("channel {ChannelNumber} inbound decode error: {Error}", ChannelNumber, error);
+        _metrics?.IncDecodeErrors();
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.DecodeError, session, 0, true,
             0, 0, null, null, null, null)))
-            LogQueueFull(ChannelNumber, WorkKind.DecodeError);
+        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.DecodeError); }
     }
 
     /// <summary>

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -22,6 +22,8 @@ public sealed class ChannelMetrics
     private long _chaosDropped;
     private long _chaosDuplicated;
     private long _chaosReordered;
+    private long _dispatchQueueFull;
+    private long _decodeErrors;
 
     public ChannelMetrics(byte channelNumber)
     {
@@ -36,6 +38,8 @@ public sealed class ChannelMetrics
     public long ChaosDropped => Interlocked.Read(ref _chaosDropped);
     public long ChaosDuplicated => Interlocked.Read(ref _chaosDuplicated);
     public long ChaosReordered => Interlocked.Read(ref _chaosReordered);
+    public long DispatchQueueFull => Interlocked.Read(ref _dispatchQueueFull);
+    public long DecodeErrors => Interlocked.Read(ref _decodeErrors);
 
     public void IncOrdersIn() => Interlocked.Increment(ref _ordersIn);
     public void IncPacketsOut() => Interlocked.Increment(ref _packetsOut);
@@ -44,6 +48,8 @@ public sealed class ChannelMetrics
     public void IncChaosDropped() => Interlocked.Increment(ref _chaosDropped);
     public void IncChaosDuplicated() => Interlocked.Increment(ref _chaosDuplicated);
     public void IncChaosReordered() => Interlocked.Increment(ref _chaosReordered);
+    public void IncDispatchQueueFull() => Interlocked.Increment(ref _dispatchQueueFull);
+    public void IncDecodeErrors() => Interlocked.Increment(ref _decodeErrors);
 
     /// <summary>
     /// Heartbeat. Called from the dispatch thread on every loop wakeup so
@@ -108,9 +114,11 @@ public sealed class MetricsRegistry
     private ISessionMetricsProvider? _sessions;
     private readonly SessionLifecycleMetrics _sessionLifecycle = new();
     private readonly ThrottleMetrics _throttle = new();
+    private readonly TransportMetrics _transport = new();
 
     public SessionLifecycleMetrics Sessions => _sessionLifecycle;
     public ThrottleMetrics Throttle => _throttle;
+    public TransportMetrics Transport => _transport;
 
     public ChannelMetrics RegisterChannel(byte channelNumber)
     {
@@ -172,6 +180,12 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "umdf_chaos_reordered_total",
             "Total UMDF packets held back for reorder by the chaos decorator (issue #119).",
             channels, c => c.ChaosReordered);
+        EmitCounter(sb, "exch_dispatch_queue_full_total",
+            "Total inbound work items dropped because the per-channel dispatcher's bounded queue was full (issue #155). A non-zero value usually means a producer is outpacing the engine — alert / investigate.",
+            channels, c => c.DispatchQueueFull);
+        EmitCounter(sb, "exch_decode_errors_total",
+            "Total inbound frames that failed gateway decoding for this channel (issue #155). A non-zero value indicates a malformed/incompatible producer; the gateway emits a SessionReject and may close the session.",
+            channels, c => c.DecodeErrors);
 
         sb.Append("# HELP exch_send_queue_depth Per-session ExecutionReport send-queue depth (channel=\"all\" because the session queue is shared).\n");
         sb.Append("# TYPE exch_send_queue_depth gauge\n");
@@ -231,6 +245,9 @@ public sealed class MetricsRegistry
         EmitProcessCounter(sb, "exch_throttle_rejected_total",
             "Total inbound application messages rejected with BusinessMessageReject(\"Throttle limit exceeded\") by the per-session sliding-window throttle (issue #56 / GAP-20).",
             _throttle.Rejected);
+        EmitProcessCounter(sb, "exch_transport_send_queue_full_total",
+            "Total times the gateway's TcpTransport closed a session because its bounded outbound send queue overflowed (issue #155). A non-zero value means a stuck/slow consumer is causing teardowns — alert.",
+            _transport.SendQueueFull);
 
         return sb.ToString();
     }

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -336,7 +336,8 @@ public sealed partial class FixpSession : IAsyncDisposable
     {
         TcpTransport? bound = null;
         bound = new TcpTransport(ConnectionId, stream, _transportLogger, _sendQueueCapacity,
-            onClose: reason => OnTransportClosed(reason, bound));
+            onClose: reason => OnTransportClosed(reason, bound),
+            onSendQueueFull: _options.OnTransportSendQueueFull);
         return bound;
     }
 

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -86,6 +86,13 @@ public sealed record FixpSessionOptions
     /// <see cref="B3.Exchange.Contracts.ThrottleMetrics.Rejected"/> on every
     /// throttle-driven BusinessMessageReject.
     /// </summary>
+    /// <summary>Optional callback invoked when the per-session
+    /// <c>TcpTransport</c> closes the connection because its bounded
+    /// outbound send queue overflowed (issue #155). The host wires this
+    /// to <c>MetricsRegistry.Transport.IncSendQueueFull()</c> so SREs can
+    /// alert on repeated overflows (typically a stuck/slow peer).</summary>
+    public Action? OnTransportSendQueueFull { get; init; }
+
     public B3.Exchange.Contracts.ThrottleMetrics? ThrottleMetrics { get; init; }
 
     public static FixpSessionOptions Default { get; } = new();

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -30,6 +30,7 @@ public sealed class TcpTransport : IAsyncDisposable
     private readonly SemaphoreSlim _streamWriteLock = new(1, 1);
     private readonly long _connectionId;
     private readonly Action<string>? _onClose;
+    private readonly Action? _onSendQueueFull;
     private int _isOpen = 1;
     private long _lastOutboundTickMs;
     private Task? _sendTask;
@@ -59,7 +60,8 @@ public sealed class TcpTransport : IAsyncDisposable
     public long LastOutboundTickMs => Volatile.Read(ref _lastOutboundTickMs);
 
     public TcpTransport(long connectionId, Stream stream, ILogger<TcpTransport> logger,
-        int sendQueueCapacity, Action<string>? onClose = null)
+        int sendQueueCapacity, Action<string>? onClose = null,
+        Action? onSendQueueFull = null)
     {
         ArgumentNullException.ThrowIfNull(stream);
         ArgumentNullException.ThrowIfNull(logger);
@@ -67,6 +69,7 @@ public sealed class TcpTransport : IAsyncDisposable
         _stream = stream;
         _logger = logger;
         _onClose = onClose;
+        _onSendQueueFull = onSendQueueFull;
         _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(sendQueueCapacity)
         {
             SingleReader = true,
@@ -96,6 +99,7 @@ public sealed class TcpTransport : IAsyncDisposable
     {
         if (!IsOpen) return false;
         if (_sendQueue.Writer.TryWrite(frame)) return true;
+        try { _onSendQueueFull?.Invoke(); } catch { }
         Close("send-queue-full");
         return false;
     }

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -235,6 +235,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             ThrottleTimeWindowMs = _config.Tcp.Throttle?.TimeWindowMs ?? 0,
             ThrottleMaxMessages = _config.Tcp.Throttle?.MaxMessages ?? 0,
             ThrottleMetrics = _config.Tcp.Throttle is not null ? _metrics.Throttle : null,
+            OnTransportSendQueueFull = _metrics.Transport.IncSendQueueFull,
         };
         // Phase 2 (#42): real Negotiate handshake. The validator is pure
         // (no IO); the claim ledger lives for the host process lifetime

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -474,6 +474,59 @@ public class ChannelDispatcherTests
         }
     }
 
+    [Fact]
+    public void DispatchQueueFull_IncrementsMetricAndDropsItem()
+    {
+        // Issue #155: verify the SRE counter ticks when the bounded
+        // dispatch queue is full. inboundCapacity=1 + a non-started
+        // dispatcher leaves the queue static so the second TryWrite
+        // returns false deterministically.
+        var pkt = new RecordingPacketSink();
+        var outbound = new RecordingOutbound();
+        var metrics = new ChannelMetrics(channelNumber: 1);
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL, tradeDate: 19_000,
+            inboundCapacity: 1,
+            metrics: metrics);
+
+        var reply = new FakeSession(outbound);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        Assert.Equal(0, metrics.DispatchQueueFull);
+
+        // Second enqueue must fail because the loop is not draining.
+        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL);
+        Assert.Equal(1, metrics.DispatchQueueFull);
+    }
+
+    [Fact]
+    public void OnDecodeError_IncrementsDecodeErrorsMetric()
+    {
+        // Issue #155: every gateway decode failure must bump the SRE counter.
+        var pkt = new RecordingPacketSink();
+        var outbound = new RecordingOutbound();
+        var metrics = new ChannelMetrics(channelNumber: 1);
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL, tradeDate: 19_000,
+            metrics: metrics);
+
+        var reply = new FakeSession(outbound);
+        disp.OnDecodeError(reply.Id, "bad sbe header");
+        disp.OnDecodeError(reply.Id, "short body");
+
+        Assert.Equal(2, metrics.DecodeErrors);
+    }
+
     private static MatchingEngine GetEngine(ChannelDispatcher disp)
     {
         var f = typeof(ChannelDispatcher).GetField("_engine",

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -106,6 +106,45 @@ public class MetricsRegistryTests
         Assert.Contains("exch_session_reaped_total 0\n", text);
     }
 
+    [Fact]
+    public void SreCounters_AreRenderedEvenAtZero()
+    {
+        // Issue #155: dispatch-queue-full, decode-errors, and
+        // transport-send-queue-full counters must be present in the
+        // scrape output from t=0 so alerting rules can be written
+        // before the first incident happens.
+        var reg = new MetricsRegistry();
+        reg.RegisterChannel(84);
+
+        var text = reg.RenderProm();
+
+        Assert.Contains("# TYPE exch_dispatch_queue_full_total counter\n", text);
+        Assert.Contains("exch_dispatch_queue_full_total{channel=\"84\"} 0\n", text);
+        Assert.Contains("# TYPE exch_decode_errors_total counter\n", text);
+        Assert.Contains("exch_decode_errors_total{channel=\"84\"} 0\n", text);
+        Assert.Contains("# TYPE exch_transport_send_queue_full_total counter\n", text);
+        Assert.Contains("exch_transport_send_queue_full_total 0\n", text);
+    }
+
+    [Fact]
+    public void SreCounters_IncrementsArePropagatedToScrape()
+    {
+        var reg = new MetricsRegistry();
+        var ch = reg.RegisterChannel(84);
+        ch.IncDispatchQueueFull();
+        ch.IncDispatchQueueFull();
+        ch.IncDispatchQueueFull();
+        ch.IncDecodeErrors();
+        reg.Transport.IncSendQueueFull();
+        reg.Transport.IncSendQueueFull();
+
+        var text = reg.RenderProm();
+
+        Assert.Contains("exch_dispatch_queue_full_total{channel=\"84\"} 3\n", text);
+        Assert.Contains("exch_decode_errors_total{channel=\"84\"} 1\n", text);
+        Assert.Contains("exch_transport_send_queue_full_total 2\n", text);
+    }
+
     private sealed class StubSessionProvider : ISessionMetricsProvider
     {
         private readonly SessionDiagnostics[] _samples;


### PR DESCRIPTION
Closes #155.

## What

Three new Prometheus counters that surface backpressure and decode failures:

| Series | Scope | Bumped when |
|---|---|---|
| `exch_dispatch_queue_full_total{channel}` | per channel | `ChannelDispatcher.TryWrite` returns false (inbound queue full) |
| `exch_decode_errors_total{channel}` | per channel | gateway calls `OnDecodeError` |
| `exch_transport_send_queue_full_total` | process-wide | `TcpTransport` drops a frame because the per-session send channel is full |

Also moves `TransportMetrics` into `B3.Exchange.Contracts` to keep Gateway free of Core refs (Onda H direction).

## Bug found while writing the test

`ChannelDispatcher`'s bounded inbound channel was created with `FullMode=DropWrite`. With that mode, `TryWrite` always returns `true` (silently drops the new item), which made the pre-existing `if (!_inbound.Writer.TryWrite(...)) { LogQueueFull(...); }` branches unreachable. Switched to `FullMode=Wait`, which makes `TryWrite` return `false` immediately when full — exactly what those handlers already expected.

This means dispatch-queue overflow was happening silently before this PR. With the change, it logs **and** bumps the counter.

## Tests

- `MetricsRegistryTests`: zero-rendering + increment propagation for all three series.
- `ChannelDispatcherTests`: drives queue-full deterministically (capacity=1, loop not started) and counts `OnDecodeError` calls.

Full suite green locally, `dotnet format --verify-no-changes` clean.