### PR TITLE
Backpressure→BusinessMessageReject(SystemBusy) (#153)

### DIFF
--- a/src/B3.Exchange.Contracts/Ports.cs
+++ b/src/B3.Exchange.Contracts/Ports.cs
@@ -99,12 +99,32 @@ public interface ICoreOutbound
 /// </summary>
 public interface IInboundCommandSink
 {
-    void EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue);
+    /// <summary>
+    /// Enqueue a new-order command for dispatch on the per-channel matching
+    /// thread. Returns <c>false</c> when the dispatcher's bounded inbound
+    /// queue is full (i.e. backpressure). Callers (the Gateway) MUST react
+    /// to <c>false</c> by emitting a client-visible reject (e.g.
+    /// <c>BusinessMessageReject(SystemBusy)</c>) so the offending session
+    /// learns the venue is overloaded instead of silently losing its
+    /// command. Returning <c>true</c> means the work item was accepted onto
+    /// the queue; it does NOT imply the matching engine has processed it
+    /// yet.
+    /// </summary>
+    bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue);
 
-    void EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
+    /// <summary>
+    /// Enqueue a cancel command. Same backpressure semantics as
+    /// <see cref="EnqueueNewOrder"/>: <c>false</c> means the dispatcher
+    /// queue is full and the gateway MUST reject the command.
+    /// </summary>
+    bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue);
 
-    void EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
+    /// <summary>
+    /// Enqueue a replace command. Same backpressure semantics as
+    /// <see cref="EnqueueNewOrder"/>.
+    /// </summary>
+    bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue);
 
     /// <summary>
@@ -114,8 +134,12 @@ public interface IInboundCommandSink
     /// with other producers. Implementations queue ONE work item carrying
     /// both legs; <see cref="ChannelDispatcher"/> submits buy then sell in
     /// a single dispatch turn under one packet flush.
+    ///
+    /// <para>Same backpressure semantics as <see cref="EnqueueNewOrder"/>:
+    /// returns <c>false</c> when the dispatcher queue is full and the
+    /// gateway MUST reject the cross to the originating session.</para>
     /// </summary>
-    void EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm);
+    bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm);
 
     /// <summary>
     /// Enqueues a mass-cancel command (OrderMassActionRequest template 701,
@@ -131,8 +155,15 @@ public interface IInboundCommandSink
     /// <para>A <c>SecurityId == 0</c> on the command means "any
     /// instrument"; the host router fans the command out to every
     /// dispatcher in that case.</para>
+    ///
+    /// <para>Returns <c>false</c> when ANY targeted channel's queue is
+    /// full (partial accept is still possible — what gets enqueued stays
+    /// enqueued); the gateway MUST then emit
+    /// <c>OrderMassActionReport(REJECTED)</c> with reason "system busy"
+    /// instead of the ACCEPTED ack so the peer learns the request was
+    /// dropped under load.</para>
     /// </summary>
-    void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm);
+    bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm);
 
     /// <summary>Called when a frame fails decoding. Logging hook only — the
     /// Gateway-side <c>FixpSession</c> is responsible for the actual

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -497,37 +497,45 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
 
     // ====== IInboundCommandSink ======
 
-    public void EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue)
+    public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue)
     {
-        if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, session, enteringFirm, true,
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, session, enteringFirm, true,
             clOrdIdValue, 0, cmd, null, null, null)))
-        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.New); }
+            return true;
+        _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.New);
+        return false;
     }
 
-    public void EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
+    public bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
-        if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, session, enteringFirm, true,
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, cmd, null, null)))
-        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cancel); }
+            return true;
+        _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cancel);
+        return false;
     }
 
-    public void EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
+    public bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
-        if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, session, enteringFirm, true,
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, null, cmd, null)))
-        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Replace); }
+            return true;
+        _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Replace);
+        return false;
     }
 
-    public void EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
+    public bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
     {
-        if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cross, session, enteringFirm, true,
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cross, session, enteringFirm, true,
             cmd.BuyClOrdIdValue, cmd.SellClOrdIdValue, null, null, null, cmd)))
-        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cross); }
+            return true;
+        _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cross);
+        return false;
     }
 
-    public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
+    public bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
     {
         // OrderId resolution + filtering is the HostRouter's job (it owns
         // access to the Gateway-side OrderOwnershipMap). Forwarding the
@@ -549,14 +557,16 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// <c>ER_Cancel</c> per order is routed back to the originating session
     /// via <c>OnOrderCanceled</c>.
     /// </summary>
-    public void EnqueueResolvedMassCancel(IReadOnlyList<long> orderIds, SessionId session, uint enteringFirm,
+    public bool EnqueueResolvedMassCancel(IReadOnlyList<long> orderIds, SessionId session, uint enteringFirm,
         ulong enteredAtNanos)
     {
-        if (orderIds == null || orderIds.Count == 0) return;
+        if (orderIds == null || orderIds.Count == 0) return true;
         var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
-        if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
             0, 0, null, null, null, null, mc)))
-        { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.MassCancel); }
+            return true;
+        _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.MassCancel);
+        return false;
     }
 
     public void OnDecodeError(SessionId session, string error)

--- a/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
@@ -72,6 +72,14 @@ internal static class BusinessMessageRejectEncoder
         public const uint UnsupportedMessageType = 3;
         public const uint InvalidField = 5;
         public const uint UnknownOrderId = 6;
+        /// <summary>
+        /// FIX 4.4 BusinessRejectReason "Application not available" (8). Used
+        /// by the dispatcher backpressure path: when the per-channel inbound
+        /// queue is full the gateway emits BMR(8) so the offending session
+        /// learns the venue is overloaded instead of silently losing the
+        /// command. See issue #153.
+        /// </summary>
+        public const uint SystemBusy = 8;
     }
 
     public static int EncodeBusinessMessageReject(Span<byte> dst,

--- a/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
@@ -169,7 +169,15 @@ public sealed partial class FixpSession
         _logger.LogInformation(
             "fixp session {ConnectionId} cancel-on-disconnect firing (mode={Mode} windowMs={WindowMs})",
             ConnectionId, CancelOnDisconnectType, CodTimeoutWindowMs);
-        try { _sink.EnqueueMassCancel(cmd, Identity, EnteringFirm); }
+        try
+        {
+            if (!_sink.EnqueueMassCancel(cmd, Identity, EnteringFirm))
+            {
+                _logger.LogWarning(
+                    "fixp session {ConnectionId} cancel-on-disconnect: dispatcher queue full, mass-cancel dropped",
+                    ConnectionId);
+            }
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex,

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -192,7 +192,8 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                 {
-                    _sink.EnqueueNewOrder(no, Identity, EnteringFirm, noClOrd);
+                    if (!_sink.EnqueueNewOrder(no, Identity, EnteringFirm, noClOrd))
+                        WriteSystemBusyReject(info.TemplateId, fixedBlock, noClOrd, "New");
                     return true;
                 }
                 _sink.OnDecodeError(Identity, noErr ?? "decode error: SimpleNewOrder");
@@ -201,7 +202,8 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidSimpleModifyOrder:
                 if (InboundMessageDecoder.TryDecodeReplace(fixedBlock, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr))
                 {
-                    _sink.EnqueueReplace(rp, Identity, EnteringFirm, rpClOrd, rpOrigClOrd);
+                    if (!_sink.EnqueueReplace(rp, Identity, EnteringFirm, rpClOrd, rpOrigClOrd))
+                        WriteSystemBusyReject(info.TemplateId, fixedBlock, rpClOrd, "Replace");
                     return true;
                 }
                 _sink.OnDecodeError(Identity, rpErr ?? "decode error: SimpleModifyOrder");
@@ -213,7 +215,8 @@ public sealed partial class FixpSession
                         fixedBlock, EnteringFirm, now, out var nos, out var nosClOrd, out var nosMsg);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
-                        _sink.EnqueueNewOrder(nos, Identity, EnteringFirm, nosClOrd);
+                        if (!_sink.EnqueueNewOrder(nos, Identity, EnteringFirm, nosClOrd))
+                            WriteSystemBusyReject(info.TemplateId, fixedBlock, nosClOrd, "New");
                         return true;
                     }
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
@@ -231,7 +234,8 @@ public sealed partial class FixpSession
                         fixedBlock, now, out var ocr, out var ocrClOrd, out var ocrOrigClOrd, out var ocrMsg);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
-                        _sink.EnqueueReplace(ocr, Identity, EnteringFirm, ocrClOrd, ocrOrigClOrd);
+                        if (!_sink.EnqueueReplace(ocr, Identity, EnteringFirm, ocrClOrd, ocrOrigClOrd))
+                            WriteSystemBusyReject(info.TemplateId, fixedBlock, ocrClOrd, "Replace");
                         return true;
                     }
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
@@ -253,7 +257,8 @@ public sealed partial class FixpSession
                         fullBodySpan, EnteringFirm, now, out var cross, out var crossId, out var crossMsg);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
-                        _sink.EnqueueCross(cross, Identity, EnteringFirm);
+                        if (!_sink.EnqueueCross(cross, Identity, EnteringFirm))
+                            WriteSystemBusyReject(info.TemplateId, fixedBlock, crossId, "Cross");
                         return true;
                     }
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
@@ -270,7 +275,8 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidOrderCancelRequest:
                 if (InboundMessageDecoder.TryDecodeCancel(fixedBlock, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
                 {
-                    _sink.EnqueueCancel(cn, Identity, EnteringFirm, cnClOrd, cnOrigClOrd);
+                    if (!_sink.EnqueueCancel(cn, Identity, EnteringFirm, cnClOrd, cnOrigClOrd))
+                        WriteSystemBusyReject(info.TemplateId, fixedBlock, cnClOrd, "Cancel");
                     return true;
                 }
                 _sink.OnDecodeError(Identity, cnErr ?? "decode error: OrderCancelRequest");
@@ -282,10 +288,18 @@ public sealed partial class FixpSession
                         fixedBlock, now, out var mcCmd, out var mcClOrd, out var mcMsg);
                     if (mcOutcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
-                        // Spec §4.8 — acknowledge synchronously with
-                        // OrderMassActionReport(ACCEPTED) ahead of the
-                        // per-order ER_Cancel frames the engine will emit
-                        // asynchronously when it processes EnqueueMassCancel.
+                        // Spec §4.8 — under normal load we ack synchronously
+                        // with OrderMassActionReport(ACCEPTED) ahead of the
+                        // per-order ER_Cancel frames the engine emits later.
+                        // This ordering matters: the ACCEPTED ack travels
+                        // straight to the TCP stream from the gateway thread
+                        // while the ER_Cancel frames go through the
+                        // dispatcher's UMDF-packet path, so reversing it
+                        // would let cancels race ahead. We therefore keep
+                        // ACCEPTED-first and, if the enqueue then fails due
+                        // to backpressure (#153), follow up with a
+                        // BusinessMessageReject(SystemBusy) so the peer
+                        // knows the action will not be performed.
                         byte? sideByte = mcCmd.SideFilter switch
                         {
                             Matching.Side.Buy => (byte)'1',
@@ -297,7 +311,14 @@ public sealed partial class FixpSession
                             massActionRejectReason: null,
                             side: sideByte, securityId: mcCmd.SecurityId,
                             transactTimeNanos: now);
-                        _sink.EnqueueMassCancel(mcCmd, Identity, EnteringFirm);
+                        if (!_sink.EnqueueMassCancel(mcCmd, Identity, EnteringFirm))
+                        {
+                            WriteSystemBusyReject(
+                                templateId: EntryPointFrameReader.TidOrderMassActionRequest,
+                                fixedBlock: fixedBlock,
+                                clOrdId: mcClOrd,
+                                workKindLabel: "MassCancel");
+                        }
                         return true;
                     }
                     if (mcOutcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -84,6 +84,30 @@ public sealed partial class FixpSession
     }
 
     /// <summary>
+    /// Issue #153: emits <c>BusinessMessageReject(SystemBusy=8)</c> when
+    /// the dispatcher backpressure path returns <c>false</c> (per-channel
+    /// inbound queue full). Keeps the session OPEN — overload is a
+    /// transient business condition, not a protocol violation. Counters
+    /// are already bumped by the dispatcher (<c>exch_dispatch_queue_full_total</c>);
+    /// this method is purely about telling the offending peer.
+    /// </summary>
+    internal void WriteSystemBusyReject(ushort templateId, ReadOnlySpan<byte> fixedBlock, ulong clOrdId, string workKindLabel)
+    {
+        uint refSeqNum = fixedBlock.Length >= 8
+            ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
+            : 0u;
+        WriteBusinessMessageReject(
+            refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(templateId),
+            refSeqNum: refSeqNum,
+            businessRejectRefId: clOrdId,
+            businessRejectReason: BusinessMessageRejectEncoder.Reason.SystemBusy,
+            text: "System busy: dispatcher queue full");
+        _logger.LogWarning(
+            "fixp session {ConnectionId} system-busy reject (dispatcher queue full) template={Template} workKind={WorkKind}",
+            ConnectionId, templateId, workKindLabel);
+    }
+
+    /// <summary>
     /// Spec §4.6.3.1 / §4.10 (#GAP-10): validates that an inbound business
     /// message's <c>InboundBusinessHeader.sessionID</c> matches this
     /// session's negotiated SessionId. Returns <c>true</c> if the header

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -48,54 +48,57 @@ public sealed class HostRouter : IInboundCommandSink
         _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
     }
 
-    public void EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue)
+    public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue)
     {
         if (_bySecId.TryGetValue(cmd.SecurityId, out var disp))
-            disp.EnqueueNewOrder(cmd, session, enteringFirm, clOrdIdValue);
-        else
-            RejectUnknownInstrument(cmd.SecurityId, session, clOrdIdValue);
+            return disp.EnqueueNewOrder(cmd, session, enteringFirm, clOrdIdValue);
+        // Unknown-instrument is a *deterministic business reject* the router
+        // emits inline; from the caller's perspective the work is done, so
+        // return true (the false return is reserved for backpressure only).
+        RejectUnknownInstrument(cmd.SecurityId, session, clOrdIdValue);
+        return true;
     }
 
-    public void EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
+    public bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         var resolved = ResolveOrderIdIfNeeded(cmd, enteringFirm, origClOrdIdValue, out var ok);
         if (!ok)
         {
             RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue);
-            return;
+            return true;
         }
         if (_bySecId.TryGetValue(resolved.SecurityId, out var disp))
-            disp.EnqueueCancel(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
-        else
-            RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
+            return disp.EnqueueCancel(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
+        RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
+        return true;
     }
 
-    public void EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
+    public bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
         var resolved = ResolveOrderIdIfNeeded(cmd, enteringFirm, origClOrdIdValue, out var ok);
         if (!ok)
         {
             RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue);
-            return;
+            return true;
         }
         if (_bySecId.TryGetValue(resolved.SecurityId, out var disp))
-            disp.EnqueueReplace(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
-        else
-            RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
+            return disp.EnqueueReplace(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
+        RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
+        return true;
     }
 
-    public void EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
+    public bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
     {
         // Both legs MUST belong to the same security (decoder enforces).
         if (_bySecId.TryGetValue(cmd.Buy.SecurityId, out var disp))
-            disp.EnqueueCross(cmd, session, enteringFirm);
-        else
-            RejectUnknownInstrument(cmd.Buy.SecurityId, session, cmd.BuyClOrdIdValue);
+            return disp.EnqueueCross(cmd, session, enteringFirm);
+        RejectUnknownInstrument(cmd.Buy.SecurityId, session, cmd.BuyClOrdIdValue);
+        return true;
     }
 
-    public void EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
+    public bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
     {
         // Spec §4.8 / #GAP-19. Resolve the (session, firm, Side?, SecurityId?)
         // filter against the Gateway-side OrderOwnershipMap, then group the
@@ -103,7 +106,7 @@ public sealed class HostRouter : IInboundCommandSink
         // see only the resolved per-channel orderId list — no filter logic
         // and no per-order session state lives in Core anymore (#66).
         var matches = _ownership.FilterMassCancel(session, enteringFirm, cmd.SideFilter, cmd.SecurityId);
-        if (matches.Count == 0) return;
+        if (matches.Count == 0) return true;
 
         Dictionary<ChannelDispatcher, List<long>>? perChannel = null;
         foreach (var (orderId, securityId) in matches)
@@ -119,9 +122,19 @@ public sealed class HostRouter : IInboundCommandSink
             }
             list.Add(orderId);
         }
-        if (perChannel == null) return;
+        if (perChannel == null) return true;
+
+        // Fan-out: report backpressure if ANY targeted channel rejected the
+        // resolved batch. Partial accept is preserved (whatever made it
+        // onto a queue stays there) — the gateway treats this as a single
+        // reject from the client's POV (OrderMassActionReport REJECTED).
+        bool allOk = true;
         foreach (var (disp, ids) in perChannel)
-            disp.EnqueueResolvedMassCancel(ids, session, enteringFirm, cmd.EnteredAtNanos);
+        {
+            if (!disp.EnqueueResolvedMassCancel(ids, session, enteringFirm, cmd.EnteredAtNanos))
+                allOk = false;
+        }
+        return allOk;
     }
 
     public void OnDecodeError(SessionId session, string error)

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -495,13 +495,17 @@ public class ChannelDispatcherTests
 
         var reply = new FakeSession(outbound);
 
-        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+        bool first = disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
             reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        Assert.True(first, "first enqueue with a 1-slot channel should succeed");
         Assert.Equal(0, metrics.DispatchQueueFull);
 
         // Second enqueue must fail because the loop is not draining.
-        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+        // Issue #153: the bool return is the contract the gateway uses to
+        // emit BusinessMessageReject(SystemBusy) on the wire.
+        bool second = disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
             reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL);
+        Assert.False(second, "second enqueue must report backpressure to caller");
         Assert.Equal(1, metrics.DispatchQueueFull);
     }
 

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -18,11 +18,11 @@ public class EntryPointHeartbeatTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
@@ -20,11 +20,11 @@ public class EntryPointListenerDailyResetTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
@@ -22,11 +22,11 @@ public class EntryPointListenerReaperTests
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
         public int SessionClosedCalls;
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
@@ -21,11 +21,11 @@ public class EntryPointStrictGatingTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
@@ -19,11 +19,11 @@ public class EntryPointTerminateOnErrorTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionBackpressureRejectTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionBackpressureRejectTests.cs
@@ -11,13 +11,15 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace B3.Exchange.Gateway.Tests;
 
 /// <summary>
-/// Issue #48 (#GAP-10) — businessHeader.sessionID validation. Every inbound
-/// application message must carry the negotiated SessionId; mismatches
-/// must be answered with <c>BusinessMessageReject(reason=33003)</c> and
-/// the offending message dropped (the session itself stays open per spec
-/// §4.6.3.1).
+/// Issue #153 — when the per-channel ChannelDispatcher inbound queue is
+/// full, <c>IInboundCommandSink.Enqueue*</c> returns <c>false</c> and the
+/// gateway must surface that backpressure to the offending peer as a
+/// <c>BusinessMessageReject(reason=SystemBusy=8)</c>, NOT silently drop
+/// the message and NOT terminate the session. Counters
+/// (<c>exch_dispatch_queue_full_total</c>) are bumped by the dispatcher
+/// itself; this test only locks in the wire-level behaviour.
 /// </summary>
-public class BusinessHeaderSessionIdValidationTests
+public class FixpSessionBackpressureRejectTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
@@ -43,24 +45,21 @@ public class BusinessHeaderSessionIdValidationTests
     }
 
     /// <summary>
-    /// Build a stand-in business message body whose first 20 bytes are a
-    /// well-formed <c>InboundBusinessHeader</c>. The exact template body
-    /// content beyond the header is irrelevant — sessionID validation
-    /// runs BEFORE the per-template decoder.
+    /// Build a stand-in fixed block whose first 20 bytes are a well-formed
+    /// InboundBusinessHeader (sessionID@0, msgSeqNum@4). The
+    /// WriteSystemBusyReject helper only reads msgSeqNum@4 to populate
+    /// refSeqNum, so the rest of the body is irrelevant.
     /// </summary>
-    private static byte[] BuildHeaderOnlyBody(uint headerSessionId, uint headerMsgSeqNum, ulong clOrdId, int totalLen)
+    private static byte[] BuildFixedBlock(uint sessionId, uint msgSeqNum)
     {
-        var body = new byte[totalLen];
-        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), headerSessionId);
-        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(4, 4), headerMsgSeqNum);
-        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(8, 8), 0UL); // sendingTime
-        // body[16] = eventIndicator; body[17] = marketSegmentID; both default 0.
-        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(20, 8), clOrdId);
-        return body;
+        var fb = new byte[82];
+        BinaryPrimitives.WriteUInt32LittleEndian(fb.AsSpan(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt32LittleEndian(fb.AsSpan(4, 4), msgSeqNum);
+        return fb;
     }
 
     [Fact]
-    public async Task Matching_sessionID_passes_validation()
+    public async Task Dispatcher_backpressure_emits_BusinessMessageReject_SystemBusy_8_and_keeps_session_open()
     {
         var (server, client) = await ConnectPairAsync();
         try
@@ -69,55 +68,17 @@ public class BusinessHeaderSessionIdValidationTests
                 connectionId: 1, enteringFirm: 7, sessionId: 100,
                 stream: server, sink: new NoOpEngineSink(),
                 logger: NullLogger<FixpSession>.Instance);
-            // Drive to Established so the session is "open" for writes.
-            session.ApplyTransition(FixpEvent.Negotiate);
-            session.ApplyTransition(FixpEvent.Establish);
-
-            var body = BuildHeaderOnlyBody(headerSessionId: 100, headerMsgSeqNum: 7, clOrdId: 42, totalLen: 82);
-
-            bool accepted = session.TryAcceptBusinessHeaderSessionId(
-                EntryPointFrameReader.TidSimpleNewOrder, body);
-            Assert.True(accepted);
-
-            // No BMR should have been sent — the client side stream stays empty.
-            Assert.Equal(0, client.Available);
-            session.Close("test");
-        }
-        finally
-        {
-            client.Close();
-            server.Dispose();
-        }
-    }
-
-    [Fact]
-    public async Task Mismatched_sessionID_emits_BusinessMessageReject_33003_and_drops_frame()
-    {
-        var (server, client) = await ConnectPairAsync();
-        try
-        {
-            var session = new FixpSession(
-                connectionId: 1, enteringFirm: 7, sessionId: /* negotiated */ 100,
-                stream: server, sink: new NoOpEngineSink(),
-                logger: NullLogger<FixpSession>.Instance);
             session.Start();
             session.ApplyTransition(FixpEvent.Negotiate);
             session.ApplyTransition(FixpEvent.Establish);
 
-            var body = BuildHeaderOnlyBody(headerSessionId: /* WRONG */ 999, headerMsgSeqNum: 13, clOrdId: 4242, totalLen: 82);
+            var fb = BuildFixedBlock(sessionId: 100, msgSeqNum: 77);
+            session.WriteSystemBusyReject(
+                templateId: EntryPointFrameReader.TidSimpleNewOrder,
+                fixedBlock: fb,
+                clOrdId: 4242UL,
+                workKindLabel: "NewOrder");
 
-            bool accepted = session.TryAcceptBusinessHeaderSessionId(
-                EntryPointFrameReader.TidSimpleNewOrder, body);
-            Assert.False(accepted);
-
-            // Drain the BMR frame off the client side. Layout:
-            //   SOFH(4) + SBE header(8) + body(BlockLength + varData)
-            //   businessHeader: sessionID@0 + msgSeqNum@4 + sendingTime@8
-            //                   + eventIndicator@16 + marketSegmentID@17
-            //   then BMR payload starting at body[20]:
-            //     refMsgType(byte @20), refSeqNum(uint32 @22),
-            //     businessRejectRefId(ulong @26), businessRejectReason(uint32 @34)
-            // We only assert template-id and businessRejectReason here.
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
             var ns = client.GetStream();
             var head = new byte[EntryPointFrameReader.WireHeaderSize];
@@ -141,23 +102,25 @@ public class BusinessHeaderSessionIdValidationTests
                 if (n <= 0) throw new EndOfStreamException();
                 read += n;
             }
-            // OutboundBusinessHeader: sessionID(@0,4) + msgSeqNum(@4,4) +
-            // sendingTime(@8,8) + eventIndicator(@16) + marketSegmentID(@17)
-            // BMR payload: refMsgType(byte @18) + padding(@19) +
+            // OutboundBusinessHeader: sessionID@0..4 + msgSeqNum@4..4 +
+            // sendingTime@8..8 + eventIndicator@16 + marketSegmentID@17.
+            // BMR payload at body[18]: refMsgType(byte) + padding +
             // refSeqNum(uint32 @20) + businessRejectRefId(ulong @24) +
             // businessRejectReason(uint32 @32).
             byte refMsgType = bodyBuf[18];
             uint refSeqNum = BinaryPrimitives.ReadUInt32LittleEndian(bodyBuf.AsSpan(20, 4));
             ulong businessRejectRefId = BinaryPrimitives.ReadUInt64LittleEndian(bodyBuf.AsSpan(24, 8));
             uint businessRejectReason = BinaryPrimitives.ReadUInt32LittleEndian(bodyBuf.AsSpan(32, 4));
-            // GAP-14 fix: refMsgType MUST be the schema MessageType enum
-            // byte (15 = SimpleNewOrder), NOT the raw templateId byte
-            // (102). Locking this in so a regression to (byte)templateId
-            // is caught.
+            // SimpleNewOrder schema MessageType byte is 15.
             Assert.Equal((byte)15, refMsgType);
-            Assert.Equal(13u, refSeqNum);
+            Assert.Equal(77u, refSeqNum);
             Assert.Equal(4242UL, businessRejectRefId);
-            Assert.Equal(33003u, businessRejectReason);
+            // Reason 8 = SystemBusy (FIX 4.4 "Application not available").
+            Assert.Equal(8u, businessRejectReason);
+
+            // Session must remain OPEN — backpressure is a transient
+            // business-layer condition, never grounds for Terminate.
+            Assert.True(session.IsOpen);
             session.Close("test");
         }
         finally

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
@@ -36,12 +36,15 @@ public class FixpSessionCodTests
     {
         public ConcurrentQueue<CapturedMassCancel> MassCancels { get; } = new();
         public int SessionClosedCalls;
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm)
-            => MassCancels.Enqueue(new CapturedMassCancel(cmd, session, enteringFirm));
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm)
+        {
+            MassCancels.Enqueue(new CapturedMassCancel(cmd, session, enteringFirm));
+            return true;
+        }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachReplayE2ETests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachReplayE2ETests.cs
@@ -38,11 +38,11 @@ public class FixpSessionReattachReplayE2ETests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
@@ -19,11 +19,11 @@ public class FixpSessionReattachTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
@@ -21,11 +21,11 @@ public class FixpSessionRetransmitTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
@@ -22,11 +22,11 @@ public class FixpSessionSuspendTests
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
         public int SessionClosedCalls;
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) => Interlocked.Increment(ref SessionClosedCalls);
     }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -22,11 +22,11 @@ public class FixpSessionThrottleTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
@@ -21,11 +21,11 @@ public class InboundMsgSeqNumGapTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }

--- a/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
@@ -18,11 +18,11 @@ public class SessionLifecycleMetricsWiringTests
 {
     private sealed class NoOpEngineSink : IInboundCommandSink
     {
-        public void EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { }
-        public void EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { }
-        public void EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
-        public void EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { }
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) { return true; }
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) { return true; }
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) { return true; }
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
     }


### PR DESCRIPTION
Closes #153.

When the per-channel ChannelDispatcher inbound queue is full,
`IInboundCommandSink.Enqueue*` now returns `false` instead of silently
dropping the message. The gateway translates that into
`BusinessMessageReject(reason=SystemBusy=8, text='System busy: dispatcher
queue full')` back to the offending peer. Session stays open.

## Changes
- `IInboundCommandSink.Enqueue*` (NewOrder/Cancel/Replace/Cross/MassCancel) return `bool`
- `ChannelDispatcher` returns underlying `TryWrite` result (fixes the
  silent-drop side of the previous `DropWrite` mode handled in #155)
- `HostRouter` fan-out AND-combines per-channel results for mass-cancel
- New `BusinessMessageRejectEncoder.Reason.SystemBusy = 8` (FIX 4.4
  'Application not available')
- New `WriteSystemBusyReject` helper used by 5 dispatch call sites
- MassCancel keeps ACCEPTED-first ordering (the ack races straight to
  the TCP stream while ER_Cancels go through the UMDF packet path —
  reversing it lets cancels overtake the ack). On backpressure we
  follow up with `BMR(SystemBusy)`.

## Tests
- `ChannelDispatcherTests` now asserts the `bool` contract (1st enqueue
  returns true, 2nd returns false on a 1-slot channel)
- New `FixpSessionBackpressureRejectTests` asserts the wire-level
  BMR(SystemBusy=8) frame and that the session stays open

All 648 tests pass; `dotnet format` clean.