### PR TITLE
Contain dispatcher work-item crashes (#170)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -202,7 +202,26 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                 if (!more) return; // channel completed
                 while (reader.TryRead(out var item))
                 {
-                    ProcessOne(item);
+                    // Issue #170: contain unhandled exceptions per work-item
+                    // so a single bad command (engine bug, sink throw, etc.)
+                    // cannot kill the dispatch loop and silence the entire
+                    // channel. We log with full context and bump
+                    // exch_dispatcher_crash_total; the loop continues so
+                    // healthy commands still get serviced. Cancellation
+                    // bypasses containment because it is the cooperative
+                    // shutdown path — let it bubble to the outer handler.
+                    try
+                    {
+                        ProcessOne(item);
+                    }
+                    catch (OperationCanceledException) { throw; }
+                    catch (Exception ex)
+                    {
+                        _metrics?.IncDispatcherCrashes();
+                        LogDispatcherCrash(ex, ChannelNumber, item.Kind,
+                            item.HasSession ? item.Session.ToString() : "(no-session)",
+                            item.Firm, item.ClOrdId);
+                    }
                     RecordHeartbeat();
                 }
             }
@@ -328,6 +347,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             _ => ulong.MaxValue,
         };
         _packetWritten = 0;
+        bool succeeded = false;
         try
         {
             switch (item.Kind)
@@ -404,10 +424,22 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                     break;
             }
             LogCommandProcessed(ChannelNumber, item.Kind, _currentClOrdId);
+            succeeded = true;
         }
         finally
         {
-            FlushPacket();
+            // Issue #170: do not publish a half-built UMDF packet if the
+            // command crashed mid-flight — the dispatcher loop will catch
+            // the exception, count the crash, and move on; flushing
+            // partial state would corrupt downstream consumers.
+            if (succeeded)
+            {
+                FlushPacket();
+            }
+            else
+            {
+                _packetWritten = 0;
+            }
             _currentSession = default;
             _currentFirm = 0;
             _hasCurrentSession = false;
@@ -886,4 +918,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     [LoggerMessage(EventId = 1003, Level = LogLevel.Warning,
         Message = "channel {ChannelNumber} inbound queue full; dropped {WorkKind} (slow consumer)")]
     private partial void LogQueueFull(byte channelNumber, WorkKind workKind);
+
+    [LoggerMessage(EventId = 1004, Level = LogLevel.Error,
+        Message = "channel {ChannelNumber} dispatcher work-item crash workKind={WorkKind} session={Session} firm={Firm} clOrdId={ClOrdId}")]
+    private partial void LogDispatcherCrash(Exception ex, byte channelNumber, WorkKind workKind, string session, uint firm, ulong clOrdId);
 }

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -24,6 +24,7 @@ public sealed class ChannelMetrics
     private long _chaosReordered;
     private long _dispatchQueueFull;
     private long _decodeErrors;
+    private long _dispatcherCrashes;
 
     public ChannelMetrics(byte channelNumber)
     {
@@ -40,6 +41,7 @@ public sealed class ChannelMetrics
     public long ChaosReordered => Interlocked.Read(ref _chaosReordered);
     public long DispatchQueueFull => Interlocked.Read(ref _dispatchQueueFull);
     public long DecodeErrors => Interlocked.Read(ref _decodeErrors);
+    public long DispatcherCrashes => Interlocked.Read(ref _dispatcherCrashes);
 
     public void IncOrdersIn() => Interlocked.Increment(ref _ordersIn);
     public void IncPacketsOut() => Interlocked.Increment(ref _packetsOut);
@@ -50,6 +52,7 @@ public sealed class ChannelMetrics
     public void IncChaosReordered() => Interlocked.Increment(ref _chaosReordered);
     public void IncDispatchQueueFull() => Interlocked.Increment(ref _dispatchQueueFull);
     public void IncDecodeErrors() => Interlocked.Increment(ref _decodeErrors);
+    public void IncDispatcherCrashes() => Interlocked.Increment(ref _dispatcherCrashes);
 
     /// <summary>
     /// Heartbeat. Called from the dispatch thread on every loop wakeup so
@@ -186,6 +189,9 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_decode_errors_total",
             "Total inbound frames that failed gateway decoding for this channel (issue #155). A non-zero value indicates a malformed/incompatible producer; the gateway emits a SessionReject and may close the session.",
             channels, c => c.DecodeErrors);
+        EmitCounter(sb, "exch_dispatcher_crash_total",
+            "Total work-items whose ProcessOne raised an unhandled exception (issue #170). The dispatcher loop catches and logs these, then continues draining; a non-zero value is a hard bug-report signal — every increment is a wedge that would have killed the channel before the containment fix.",
+            channels, c => c.DispatcherCrashes);
 
         sb.Append("# HELP exch_send_queue_depth Per-session ExecutionReport send-queue depth (channel=\"all\" because the session queue is shared).\n");
         sb.Append("# TYPE exch_send_queue_depth gauge\n");

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -531,6 +531,85 @@ public class ChannelDispatcherTests
         Assert.Equal(2, metrics.DecodeErrors);
     }
 
+    /// <summary>
+    /// Issue #170 — a single bad work-item (engine bug, sink throw, etc.)
+    /// must NOT terminate the channel's dispatch loop. The loop catches
+    /// the exception, increments <c>exch_dispatcher_crash_total</c>, logs
+    /// with full context, and continues draining so subsequent commands
+    /// still get serviced.
+    /// </summary>
+    private sealed class ThrowingOutbound : ICoreOutbound
+    {
+        public int Throws;
+        public int Successes;
+        public bool ThrowOnNext = true;
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        {
+            if (ThrowOnNext) { ThrowOnNext = false; Throws++; throw new InvalidOperationException("synthetic crash"); }
+            Successes++;
+            return true;
+        }
+        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
+        public void NotifyOrderTerminal(long orderId) { }
+    }
+
+    private sealed class TestSession
+    {
+        public B3.Exchange.Contracts.SessionId Id { get; } = new("crashtest");
+        public uint EnteringFirm => 7;
+    }
+
+    [Fact]
+    public async Task DispatcherLoop_ContainsWorkItemException_LoopSurvivesAndCrashCounterIncrements()
+    {
+        var pkt = new RecordingPacketSink();
+        var outbound = new ThrowingOutbound();
+        var metrics = new ChannelMetrics(channelNumber: 1);
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL, tradeDate: 19_000,
+            metrics: metrics);
+        try
+        {
+            disp.Start();
+            var reply = new TestSession();
+
+            // First enqueue triggers the throw inside ProcessOne →
+            // dispatch loop catches it and bumps the crash counter.
+            Assert.True(disp.EnqueueNewOrder(
+                new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+                reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL));
+
+            // Second enqueue must succeed and be serviced — the loop must
+            // still be alive after containing the prior crash.
+            Assert.True(disp.EnqueueNewOrder(
+                new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(11m), 100, 7, 1_000UL),
+                reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL));
+
+            // Wait up to 2s for both work items to be processed.
+            var deadline = DateTime.UtcNow.AddSeconds(2);
+            while (DateTime.UtcNow < deadline && (metrics.DispatcherCrashes < 1 || outbound.Successes < 1))
+            {
+                await Task.Delay(20);
+            }
+
+            Assert.Equal(1, metrics.DispatcherCrashes);
+            Assert.Equal(1, outbound.Throws);
+            Assert.True(outbound.Successes >= 1, "second order must be processed after the loop survived the crash");
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+
     private static MatchingEngine GetEngine(ChannelDispatcher disp)
     {
         var f = typeof(ChannelDispatcher).GetField("_engine",


### PR DESCRIPTION
Closes #170.

A single bad work-item (engine bug, sink throw, race in routing) used to take down the entire `ChannelDispatcher` loop — every instrument on that channel went silent until host restart.

## Changes
- `ChannelDispatcher.RunLoopAsync` wraps each `ProcessOne` in try/catch; `OperationCanceledException` re-throws so cooperative shutdown works
- `ChannelDispatcher.ProcessOne` tracks `succeeded` so the finally only `FlushPacket()` when the command completed normally — a half-built UMDF packet is never published after a crash
- New `ChannelMetrics.DispatcherCrashes` + `exch_dispatcher_crash_total` Prometheus series
- New `LoggerMessage` 1004 with structured fields (channel, workKind, session, firm, clOrdId)
- Test `DispatcherLoop_ContainsWorkItemException_LoopSurvivesAndCrashCounterIncrements` injects a throwing `ICoreOutbound` and asserts the loop survives a crash and processes the next order

All 649 tests pass; `dotnet format` clean.