### PR TITLE
Contain UDP publish errors with resilient decorator (#172)

### DIFF
--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -25,6 +25,9 @@ public sealed class ChannelMetrics
     private long _dispatchQueueFull;
     private long _decodeErrors;
     private long _dispatcherCrashes;
+    private long _publishErrors;
+    private long _publishErrorsHostUnreachable;
+    private long _publishErrorsMessageTooLarge;
 
     public ChannelMetrics(byte channelNumber)
     {
@@ -42,6 +45,9 @@ public sealed class ChannelMetrics
     public long DispatchQueueFull => Interlocked.Read(ref _dispatchQueueFull);
     public long DecodeErrors => Interlocked.Read(ref _decodeErrors);
     public long DispatcherCrashes => Interlocked.Read(ref _dispatcherCrashes);
+    public long PublishErrors => Interlocked.Read(ref _publishErrors);
+    public long PublishErrorsHostUnreachable => Interlocked.Read(ref _publishErrorsHostUnreachable);
+    public long PublishErrorsMessageTooLarge => Interlocked.Read(ref _publishErrorsMessageTooLarge);
 
     public void IncOrdersIn() => Interlocked.Increment(ref _ordersIn);
     public void IncPacketsOut() => Interlocked.Increment(ref _packetsOut);
@@ -53,6 +59,9 @@ public sealed class ChannelMetrics
     public void IncDispatchQueueFull() => Interlocked.Increment(ref _dispatchQueueFull);
     public void IncDecodeErrors() => Interlocked.Increment(ref _decodeErrors);
     public void IncDispatcherCrashes() => Interlocked.Increment(ref _dispatcherCrashes);
+    public void IncPublishErrorSocketError() => Interlocked.Increment(ref _publishErrors);
+    public void IncPublishErrorHostUnreachable() => Interlocked.Increment(ref _publishErrorsHostUnreachable);
+    public void IncPublishErrorMessageTooLarge() => Interlocked.Increment(ref _publishErrorsMessageTooLarge);
 
     /// <summary>
     /// Heartbeat. Called from the dispatch thread on every loop wakeup so
@@ -193,6 +202,21 @@ public sealed class MetricsRegistry
             "Total work-items whose ProcessOne raised an unhandled exception (issue #170). The dispatcher loop catches and logs these, then continues draining; a non-zero value is a hard bug-report signal — every increment is a wedge that would have killed the channel before the containment fix.",
             channels, c => c.DispatcherCrashes);
 
+        // Issue #172: per-channel UDP publish errors broken down by kind.
+        // Multiple series (one per kind) under a single metric name with a
+        // 'kind' label so operators can alert on socket_error specifically
+        // (likely transient route loss) vs message_too_large (a hard bug —
+        // engine is producing an oversized UMDF packet).
+        sb.Append("# HELP exch_umdf_publish_errors_total ")
+          .Append("Total UMDF packet publish failures per channel and error kind (issue #172). The decorator catches the SocketException, increments this counter, and continues — the dispatcher loop is never poisoned by a publish failure. kind=host_unreachable usually means a transient route/multicast issue; kind=message_too_large is a packetizer bug; kind=socket_error covers everything else.\n");
+        sb.Append("# TYPE exch_umdf_publish_errors_total counter\n");
+        EmitLabeledCounter(sb, "exch_umdf_publish_errors_total", "kind", "socket_error",
+            channels, c => c.PublishErrors);
+        EmitLabeledCounter(sb, "exch_umdf_publish_errors_total", "kind", "host_unreachable",
+            channels, c => c.PublishErrorsHostUnreachable);
+        EmitLabeledCounter(sb, "exch_umdf_publish_errors_total", "kind", "message_too_large",
+            channels, c => c.PublishErrorsMessageTooLarge);
+
         sb.Append("# HELP exch_send_queue_depth Per-session ExecutionReport send-queue depth (channel=\"all\" because the session queue is shared).\n");
         sb.Append("# TYPE exch_send_queue_depth gauge\n");
         SessionDiagnostics[] sessionSnap = sessions != null
@@ -275,6 +299,22 @@ public sealed class MetricsRegistry
             sb.Append(name).Append("{channel=\"")
               .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
               .Append("\"} ")
+              .Append(selector(c).ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+    }
+
+    private static void EmitLabeledCounter(StringBuilder sb, string name, string label, string labelValue,
+        ChannelMetrics[] channels, Func<ChannelMetrics, long> selector)
+    {
+        // Emits {channel,label} pairs reusing an already-emitted HELP/TYPE
+        // header. Caller is responsible for emitting the header exactly once
+        // before the first call for a given metric name.
+        foreach (var c in channels)
+        {
+            sb.Append(name).Append("{channel=\"")
+              .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
+              .Append("\",").Append(label).Append("=\"").Append(labelValue).Append("\"} ")
               .Append(selector(c).ToString(CultureInfo.InvariantCulture))
               .Append('\n');
         }

--- a/src/B3.Exchange.Core/ResilientUdpPacketSinkDecorator.cs
+++ b/src/B3.Exchange.Core/ResilientUdpPacketSinkDecorator.cs
@@ -1,0 +1,97 @@
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #172 — <see cref="IUmdfPacketSink"/> decorator that contains
+/// publish-time exceptions raised by the underlying socket sink. Without
+/// this wrapper, a transient network failure on the multicast publish
+/// path (NIC down, route lost, ARP timeout) would propagate out of the
+/// dispatcher's <c>FlushPacket</c> and abort the entire channel — the
+/// market-data side counterpart of the dispatcher containment fix in
+/// #170.
+///
+/// The decorator catches every <see cref="SocketException"/>, classifies
+/// it into one of three buckets, increments the matching
+/// <see cref="ChannelMetrics"/> counter
+/// (<c>exch_umdf_publish_errors_total{kind=...}</c>), and logs at
+/// <see cref="LogLevel.Warning"/> with a per-kind throttle so a sustained
+/// outage does not flood the log. <see cref="ObjectDisposedException"/>
+/// (race against <see cref="Dispose"/>) is also swallowed silently. Other
+/// exceptions are re-thrown — they indicate logic errors that ops should
+/// see immediately.
+/// </summary>
+public sealed class ResilientUdpPacketSinkDecorator : IUmdfPacketSink, IDisposable
+{
+    private readonly IUmdfPacketSink _inner;
+    private readonly ChannelMetrics? _metrics;
+    private readonly ILogger<ResilientUdpPacketSinkDecorator> _logger;
+
+    // Per-kind log throttle: log only when the count crosses a power-of-two
+    // boundary so the first error, then 2nd, 4th, 8th, ... are logged but a
+    // sustained 100k/s flood is bounded to log2(N) lines.
+    private long _logSocketError;
+    private long _logHostUnreachable;
+    private long _logMessageTooLarge;
+
+    public ResilientUdpPacketSinkDecorator(
+        IUmdfPacketSink inner,
+        ILogger<ResilientUdpPacketSinkDecorator> logger,
+        ChannelMetrics? metrics = null)
+    {
+        ArgumentNullException.ThrowIfNull(inner);
+        ArgumentNullException.ThrowIfNull(logger);
+        _inner = inner;
+        _logger = logger;
+        _metrics = metrics;
+    }
+
+    public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+    {
+        try
+        {
+            _inner.Publish(channelNumber, packet);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Race with Dispose() during shutdown — swallow.
+        }
+        catch (SocketException ex)
+        {
+            switch (ex.SocketErrorCode)
+            {
+                case SocketError.HostUnreachable:
+                case SocketError.NetworkUnreachable:
+                case SocketError.NetworkDown:
+                case SocketError.HostDown:
+                    _metrics?.IncPublishErrorHostUnreachable();
+                    if (ShouldLog(ref _logHostUnreachable))
+                        _logger.LogWarning(ex, "umdf publish: host unreachable on channel {Channel} (socketErr={SocketErr}); packet dropped",
+                            channelNumber, ex.SocketErrorCode);
+                    break;
+                case SocketError.MessageSize:
+                    _metrics?.IncPublishErrorMessageTooLarge();
+                    if (ShouldLog(ref _logMessageTooLarge))
+                        _logger.LogError(ex, "umdf publish: packet too large for transport on channel {Channel} (size={Size}); packet dropped — engine bug",
+                            channelNumber, packet.Length);
+                    break;
+                default:
+                    _metrics?.IncPublishErrorSocketError();
+                    if (ShouldLog(ref _logSocketError))
+                        _logger.LogWarning(ex, "umdf publish: socket error on channel {Channel} (socketErr={SocketErr}); packet dropped",
+                            channelNumber, ex.SocketErrorCode);
+                    break;
+            }
+        }
+    }
+
+    private static bool ShouldLog(ref long counter)
+    {
+        long n = Interlocked.Increment(ref counter);
+        // True at n = 1, 2, 4, 8, 16, ... (n & (n-1)) == 0 picks powers of two.
+        return (n & (n - 1)) == 0;
+    }
+
+    public void Dispose() => (_inner as IDisposable)?.Dispose();
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -109,6 +109,7 @@ public sealed class ExchangeHost : IAsyncDisposable
         foreach (var ch in _config.Channels)
         {
             var instruments = InstrumentLoader.LoadFromFile(ch.InstrumentsFile);
+            var channelMetrics = _metrics.RegisterChannel(ch.ChannelNumber);
             IUmdfPacketSink sink;
             if (_packetSinkFactory != null)
             {
@@ -116,12 +117,13 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
             else
             {
-                sink = BuildUdpSink(ch.Transport, ch.IncrementalGroup, ch.IncrementalPort,
-                    ch.LocalInterface, ch.Ttl);
+                sink = WrapResilient(
+                    BuildUdpSink(ch.Transport, ch.IncrementalGroup, ch.IncrementalPort,
+                        ch.LocalInterface, ch.Ttl),
+                    channelMetrics);
             }
             if (sink is IDisposable d) _ownedSinks.Add(d);
             var engineLogger = _loggerFactory.CreateLogger<MatchingEngine>();
-            var channelMetrics = _metrics.RegisterChannel(ch.ChannelNumber);
 
             // Wrap with chaos decorator if configured (issue #119). Off by
             // default; only activates when the operator opts in via config.
@@ -175,8 +177,10 @@ public sealed class ExchangeHost : IAsyncDisposable
                 }
                 else
                 {
-                    snapSink = BuildUdpSink(ch.Transport, snap.Group, snap.Port,
-                        ch.LocalInterface, snap.Ttl ?? ch.Ttl);
+                    snapSink = WrapResilient(
+                        BuildUdpSink(ch.Transport, snap.Group, snap.Port,
+                            ch.LocalInterface, snap.Ttl ?? ch.Ttl),
+                        channelMetrics);
                 }
                 if (snapSink is IDisposable sd) _ownedSinks.Add(sd);
 
@@ -208,7 +212,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                 else
                 {
                     var localIface = idCfg.LocalInterface ?? ch.LocalInterface;
-                    idSink = BuildUdpSink(ch.Transport, idCfg.Group, idCfg.Port, localIface, idCfg.Ttl);
+                    idSink = WrapResilient(
+                        BuildUdpSink(ch.Transport, idCfg.Group, idCfg.Port, localIface, idCfg.Ttl),
+                        channelMetrics);
                 }
                 if (idSink is IDisposable idd) _ownedSinks.Add(idd);
                 byte idChan = idCfg.ChannelNumber == 0 ? ch.ChannelNumber : idCfg.ChannelNumber;
@@ -350,6 +356,21 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
         }
     }
+
+    /// <summary>
+    /// Issue #172 — wrap any UDP-backed sink with the resilient decorator
+    /// so transient publish failures (NIC down, route lost, MTU mismatch)
+    /// are caught + counted via <c>exch_umdf_publish_errors_total</c>
+    /// instead of propagating into the dispatcher loop and aborting the
+    /// channel. Test paths injecting their own sink via
+    /// <c>packetSinkFactory</c> are deliberately not wrapped — tests may
+    /// want raw access to assert wire-level behaviour.
+    /// </summary>
+    private IUmdfPacketSink WrapResilient(IUmdfPacketSink inner, ChannelMetrics metrics)
+        => new ResilientUdpPacketSinkDecorator(
+            inner,
+            _loggerFactory.CreateLogger<ResilientUdpPacketSinkDecorator>(),
+            metrics);
 
     private IUmdfPacketSink BuildUdpSink(UmdfTransport transport, string host, int port,
         string? localInterface, byte ttl)

--- a/tests/B3.Exchange.Core.Tests/ResilientUdpPacketSinkDecoratorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ResilientUdpPacketSinkDecoratorTests.cs
@@ -1,0 +1,123 @@
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Core.Tests;
+
+/// <summary>
+/// Issue #172 — UDP publish errors must be contained inside the sink:
+/// a SocketException from the underlying transport must NOT propagate
+/// out of <see cref="IUmdfPacketSink.Publish"/>; it must bump the right
+/// per-kind counter on <see cref="ChannelMetrics"/> and continue. The
+/// dispatcher loop is the consumer of this guarantee — without it, any
+/// transient route loss would kill the channel just like the engine
+/// crash class fixed in #170.
+/// </summary>
+public class ResilientUdpPacketSinkDecoratorTests
+{
+    private sealed class ThrowingSink : IUmdfPacketSink
+    {
+        public Exception? NextThrow;
+        public int PublishCalls;
+        public int SuccessfulPublishCalls;
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            PublishCalls++;
+            if (NextThrow is { } ex) { NextThrow = null; throw ex; }
+            SuccessfulPublishCalls++;
+        }
+    }
+
+    private static (ResilientUdpPacketSinkDecorator dec, ThrowingSink inner, ChannelMetrics m) Build()
+    {
+        var inner = new ThrowingSink();
+        var m = new ChannelMetrics(channelNumber: 7);
+        var dec = new ResilientUdpPacketSinkDecorator(
+            inner, NullLogger<ResilientUdpPacketSinkDecorator>.Instance, m);
+        return (dec, inner, m);
+    }
+
+    [Fact]
+    public void Publish_HappyPath_ForwardsToInner_NoMetric()
+    {
+        var (dec, inner, m) = Build();
+        dec.Publish(7, new byte[] { 1, 2, 3 });
+        Assert.Equal(1, inner.SuccessfulPublishCalls);
+        Assert.Equal(0, m.PublishErrors);
+        Assert.Equal(0, m.PublishErrorsHostUnreachable);
+        Assert.Equal(0, m.PublishErrorsMessageTooLarge);
+    }
+
+    [Fact]
+    public void Publish_HostUnreachableSocketException_Caught_AndKindCounterIncrements()
+    {
+        var (dec, inner, m) = Build();
+        inner.NextThrow = new SocketException((int)SocketError.HostUnreachable);
+        dec.Publish(7, new byte[] { 1, 2, 3 });
+        Assert.Equal(1, m.PublishErrorsHostUnreachable);
+        Assert.Equal(0, m.PublishErrors);
+        Assert.Equal(0, m.PublishErrorsMessageTooLarge);
+
+        // Loop survives — next publish goes through.
+        dec.Publish(7, new byte[] { 9, 9 });
+        Assert.Equal(1, inner.SuccessfulPublishCalls);
+    }
+
+    [Fact]
+    public void Publish_MessageSizeSocketException_Caught_AsMessageTooLarge()
+    {
+        var (dec, inner, m) = Build();
+        inner.NextThrow = new SocketException((int)SocketError.MessageSize);
+        dec.Publish(7, new byte[] { 1 });
+        Assert.Equal(1, m.PublishErrorsMessageTooLarge);
+        Assert.Equal(0, m.PublishErrorsHostUnreachable);
+        Assert.Equal(0, m.PublishErrors);
+    }
+
+    [Fact]
+    public void Publish_OtherSocketException_Caught_AsGenericSocketError()
+    {
+        var (dec, inner, m) = Build();
+        inner.NextThrow = new SocketException((int)SocketError.ConnectionReset);
+        dec.Publish(7, new byte[] { 1 });
+        Assert.Equal(1, m.PublishErrors);
+        Assert.Equal(0, m.PublishErrorsHostUnreachable);
+        Assert.Equal(0, m.PublishErrorsMessageTooLarge);
+    }
+
+    [Fact]
+    public void Publish_ObjectDisposedException_SilentlySwallowed_NoMetric()
+    {
+        // Race with Dispose during shutdown is benign — no counter, no log.
+        var (dec, inner, m) = Build();
+        inner.NextThrow = new ObjectDisposedException("Socket");
+        dec.Publish(7, new byte[] { 1 });
+        Assert.Equal(0, m.PublishErrors);
+        Assert.Equal(0, m.PublishErrorsHostUnreachable);
+        Assert.Equal(0, m.PublishErrorsMessageTooLarge);
+    }
+
+    [Fact]
+    public void Publish_NonSocketException_PropagatesUp()
+    {
+        // Logic errors must be visible immediately — never silently dropped.
+        var (dec, inner, _) = Build();
+        inner.NextThrow = new InvalidOperationException("logic bug");
+        Assert.Throws<InvalidOperationException>(() => dec.Publish(7, new byte[] { 1 }));
+    }
+
+    [Fact]
+    public void Publish_SustainedFailure_CounterMonotonic_NoExceptionEscapes()
+    {
+        // 100 publishes all fail with HostUnreachable; counter is exact,
+        // no exception escapes. Log throttling is a side benefit (we don't
+        // observe the log here — just the contract that the loop survives).
+        var (dec, inner, m) = Build();
+        for (int i = 0; i < 100; i++)
+        {
+            inner.NextThrow = new SocketException((int)SocketError.HostUnreachable);
+            dec.Publish(7, new byte[] { (byte)i });
+        }
+        Assert.Equal(100, m.PublishErrorsHostUnreachable);
+    }
+}


### PR DESCRIPTION
Closes #172.

`MulticastUdpPacketSink`/`UnicastUdpPacketSink` had no exception handling — a transient route loss or NIC down would propagate a `SocketException` from `FlushPacket` and abort the entire channel. This is the market-data twin of #170.

## Changes
- New `ResilientUdpPacketSinkDecorator` in `B3.Exchange.Core`: catches `SocketException`, classifies it (`host_unreachable` / `message_too_large` / `socket_error`), bumps `ChannelMetrics` counter, logs at WARN with power-of-two throttle. Swallows `ObjectDisposedException` (Dispose race). Re-throws other exceptions so logic bugs stay visible.
- `ChannelMetrics` gains `PublishErrors{,HostUnreachable,MessageTooLarge}`, exposed as `exch_umdf_publish_errors_total{channel,kind}` via new `EmitLabeledCounter` helper.
- `ExchangeHost` wraps every UDP sink it builds (incremental, snapshot, instrument-def). Test injection via `packetSinkFactory` is not wrapped (tests may want raw access).
- 7 new unit tests covering happy path, each kind classification, dispose swallow, non-socket re-throw, and sustained-failure monotonic counter.

All 656 tests pass; `dotnet format` clean.
