### PR TITLE
Add throughput counters per channel/feed/exec-type to /metrics (#174)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -429,6 +429,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                         _outbound.WriteExecutionReportReject(_currentSession,
                             new RejectEvent(_currentClOrdId.ToString(), 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
                             _currentClOrdId);
+                        _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
                     }
                     break;
             }
@@ -477,6 +478,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             _outbound.WriteExecutionReportReject(_currentSession,
                 new RejectEvent(clOrdId, securityId, 0, RejectReason.UnknownOrderId, nowNanos),
                 _currentClOrdId);
+            _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
         }
     }
 
@@ -513,6 +515,11 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _packetSink.Publish(ChannelNumber, _packetBuf.AsSpan(0, _packetWritten));
         LogPacketFlushed(ChannelNumber, _sequenceNumber, _packetWritten);
         _metrics?.IncPacketsOut();
+        // Issue #174: per-feed packet/byte throughput. The incremental feed
+        // is published from the dispatcher's command-loop FlushPacket; the
+        // snapshot/instrumentdef feeds account for themselves via the
+        // CountingUdpPacketSinkDecorator wired in the host.
+        _metrics?.IncUmdfPacket(UmdfFeedKind.Incremental, _packetWritten);
         _packetWritten = 0;
     }
 
@@ -552,7 +559,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, session, enteringFirm, true,
             clOrdIdValue, 0, cmd, null, null, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-            return true;
+        { _metrics?.IncInboundMessage(InboundMessageKind.New); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.New);
         return false;
     }
@@ -562,7 +569,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, cmd, null, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-            return true;
+        { _metrics?.IncInboundMessage(InboundMessageKind.Cancel); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cancel);
         return false;
     }
@@ -572,7 +579,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, null, cmd, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-            return true;
+        { _metrics?.IncInboundMessage(InboundMessageKind.Replace); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Replace);
         return false;
     }
@@ -581,7 +588,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cross, session, enteringFirm, true,
             cmd.BuyClOrdIdValue, cmd.SellClOrdIdValue, null, null, null, cmd, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-            return true;
+        { _metrics?.IncInboundMessage(InboundMessageKind.Cross); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cross);
         return false;
     }
@@ -615,7 +622,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
             0, 0, null, null, null, null, mc, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-            return true;
+        { _metrics?.IncInboundMessage(InboundMessageKind.MassCancel); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.MassCancel);
         return false;
     }
@@ -624,8 +631,9 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         _logger.LogWarning("channel {ChannelNumber} inbound decode error: {Error}", ChannelNumber, error);
         _metrics?.IncDecodeErrors();
+        _metrics?.IncInboundMessage(InboundMessageKind.DecodeError);
         if (!_inbound.Writer.TryWrite(new WorkItem(WorkKind.DecodeError, session, 0, true,
-            0, 0, null, null, null, null)))
+            0, 0, null, null, null, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
         { _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.DecodeError); }
     }
 
@@ -722,7 +730,10 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         Commit(n);
 
         if (_hasCurrentSession)
+        {
             _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, e, _currentReceivedTimeNanos);
+            _metrics?.IncExecutionReport(ExecutionReportKind.New);
+        }
     }
 
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e)
@@ -763,6 +774,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         // so the wire ER carries the requester's id while OrigClOrdID
         // points to the owner's original ClOrdID.
         _outbound.WriteExecutionReportPassiveCancel(e.OrderId, e, _currentClOrdId, _currentReceivedTimeNanos);
+        _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
     }
 
     public void OnOrderFilled(in OrderFilledEvent e)
@@ -807,17 +819,22 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             _outbound.WriteExecutionReportTrade(_currentSession, e, isAggressor: true,
                 ownerOrderId: e.AggressorOrderId, clOrdIdValue: _currentClOrdId,
                 leavesQty: 0, cumQty: e.Quantity);
+            _metrics?.IncExecutionReport(ExecutionReportKind.Trade);
         }
         // ER_Trade for the resting side: Gateway resolves owner via the
         // OrderOwnershipMap.
         _outbound.WriteExecutionReportPassiveTrade(e.RestingOrderId, e, leavesQty: 0, cumQty: e.Quantity);
+        _metrics?.IncExecutionReport(ExecutionReportKind.TradePassive);
     }
 
     public void OnReject(in RejectEvent e)
     {
         AssertOnLoopThread();
         if (_hasCurrentSession)
+        {
             _outbound.WriteExecutionReportReject(_currentSession, e, _currentClOrdId);
+            _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
+        }
     }
 
     // ====== shutdown ======

--- a/src/B3.Exchange.Core/CountingUdpPacketSinkDecorator.cs
+++ b/src/B3.Exchange.Core/CountingUdpPacketSinkDecorator.cs
@@ -1,0 +1,40 @@
+using B3.Exchange.Contracts;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Counts every packet/byte published through an <see cref="IUmdfPacketSink"/>
+/// and forwards to the inner sink unchanged. Used to populate
+/// <c>exch_umdf_packets_total{channel,feed}</c> and
+/// <c>exch_umdf_bytes_total{channel,feed}</c> for the snapshot and
+/// instrument-definition feeds (issue #174). The incremental feed is
+/// counted directly inside <see cref="ChannelDispatcher.FlushPacket"/>
+/// because it has access to the same packet length without an extra
+/// decorator wrap.
+/// </summary>
+public sealed class CountingUdpPacketSinkDecorator : IUmdfPacketSink, IDisposable
+{
+    private readonly IUmdfPacketSink _inner;
+    private readonly ChannelMetrics _metrics;
+    private readonly UmdfFeedKind _feed;
+
+    public CountingUdpPacketSinkDecorator(IUmdfPacketSink inner, ChannelMetrics metrics, UmdfFeedKind feed)
+    {
+        _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+        _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
+        _feed = feed;
+    }
+
+    public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+    {
+        // Count BEFORE delegating so a throwing inner sink does not mask
+        // the measurement (we still observed the produce-side intent).
+        _metrics.IncUmdfPacket(_feed, packet.Length);
+        _inner.Publish(channelNumber, packet);
+    }
+
+    public void Dispose()
+    {
+        if (_inner is IDisposable d) d.Dispose();
+    }
+}

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -6,6 +6,37 @@ using B3.Exchange.Contracts;
 namespace B3.Exchange.Core;
 
 /// <summary>
+/// Inbound command kinds counted by <c>exch_inbound_messages_total</c>
+/// (issue #174). Bounded set; the label cardinality on the metric is
+/// fixed.
+/// </summary>
+public enum InboundMessageKind
+{
+    New = 0, Cancel = 1, Replace = 2, Cross = 3, MassCancel = 4, DecodeError = 5,
+}
+
+/// <summary>
+/// ExecutionReport kinds counted by <c>exch_execution_reports_total</c>
+/// (issue #174). Distinguishes active vs passive sides of trades and
+/// cancels because that's the breakdown SREs need to spot a runaway
+/// passive replay.
+/// </summary>
+public enum ExecutionReportKind
+{
+    New = 0, Trade = 1, TradePassive = 2, Cancel = 3, CancelPassive = 4, Replace = 5, Reject = 6,
+}
+
+/// <summary>
+/// UMDF feed kinds counted by <c>exch_umdf_packets_total</c> /
+/// <c>exch_umdf_bytes_total</c> (issue #174). Three values, one per
+/// physical multicast group the host publishes on.
+/// </summary>
+public enum UmdfFeedKind
+{
+    Incremental = 0, Snapshot = 1, InstrumentDef = 2,
+}
+
+/// <summary>
 /// Per-channel atomic counters and gauges. All mutating methods are
 /// designed to be called from the channel's single dispatch thread (no
 /// internal locking; lock-free <see cref="Interlocked"/> primitives are
@@ -36,6 +67,48 @@ public sealed class ChannelMetrics
     public LatencyHistogram EngineProcess { get; } = new();
     public LatencyHistogram OutboundEmit { get; } = new();
     public LatencyHistogram InboundDecode { get; } = new();
+
+    // Issue #174: throughput counters — per-channel, labelled by a small
+    // bounded set (msg_type / exec_type / feed). Indexed by the enum's
+    // numeric value so increments are a single Interlocked op.
+    private readonly long[] _inboundByKind = new long[InboundMessageKindNames.Length];
+    private readonly long[] _execReportsByKind = new long[ExecutionReportKindNames.Length];
+    private readonly long[] _packetsByFeed = new long[UmdfFeedKindNames.Length];
+    private readonly long[] _bytesByFeed = new long[UmdfFeedKindNames.Length];
+
+    internal static readonly string[] InboundMessageKindNames = new[]
+    {
+        "new", "cancel", "replace", "cross", "mass_cancel", "decode_error",
+    };
+
+    internal static readonly string[] ExecutionReportKindNames = new[]
+    {
+        "new", "trade", "trade_passive", "cancel", "cancel_passive", "replace", "reject",
+    };
+
+    internal static readonly string[] UmdfFeedKindNames = new[]
+    {
+        "incremental", "snapshot", "instrumentdef",
+    };
+
+    public void IncInboundMessage(InboundMessageKind kind)
+        => Interlocked.Increment(ref _inboundByKind[(int)kind]);
+    public void IncExecutionReport(ExecutionReportKind kind)
+        => Interlocked.Increment(ref _execReportsByKind[(int)kind]);
+    public void IncUmdfPacket(UmdfFeedKind feed, int bytes)
+    {
+        Interlocked.Increment(ref _packetsByFeed[(int)feed]);
+        Interlocked.Add(ref _bytesByFeed[(int)feed], bytes);
+    }
+
+    internal long ReadInboundMessages(InboundMessageKind kind)
+        => Interlocked.Read(ref _inboundByKind[(int)kind]);
+    internal long ReadExecutionReports(ExecutionReportKind kind)
+        => Interlocked.Read(ref _execReportsByKind[(int)kind]);
+    internal long ReadUmdfPackets(UmdfFeedKind feed)
+        => Interlocked.Read(ref _packetsByFeed[(int)feed]);
+    internal long ReadUmdfBytes(UmdfFeedKind feed)
+        => Interlocked.Read(ref _bytesByFeed[(int)feed]);
 
     public ChannelMetrics(byte channelNumber)
     {
@@ -304,6 +377,29 @@ public sealed class MetricsRegistry
             "Latency to flush the per-command UMDF packet to the outbound sink (engine exit → packet sink return), in seconds.",
             channels, c => c.OutboundEmit);
 
+        // Issue #174: throughput counters. Bounded labels (msg_type ≤ 6,
+        // exec_type ≤ 7, feed = 3) — safe to ship per-channel.
+        EmitLabeledChannelCounter(sb, "exch_inbound_messages_total",
+            "Total inbound application commands received by the dispatcher, broken down by message kind.",
+            "msg_type", channels,
+            ChannelMetrics.InboundMessageKindNames,
+            (c, i) => c.ReadInboundMessages((InboundMessageKind)i));
+        EmitLabeledChannelCounter(sb, "exch_execution_reports_total",
+            "Total ExecutionReports emitted to client sessions, broken down by ER kind. Passive variants are reports for resting orders touched by another session's aggressor.",
+            "exec_type", channels,
+            ChannelMetrics.ExecutionReportKindNames,
+            (c, i) => c.ReadExecutionReports((ExecutionReportKind)i));
+        EmitLabeledChannelCounter(sb, "exch_umdf_packets_total",
+            "Total UMDF packets published per multicast feed.",
+            "feed", channels,
+            ChannelMetrics.UmdfFeedKindNames,
+            (c, i) => c.ReadUmdfPackets((UmdfFeedKind)i));
+        EmitLabeledChannelCounter(sb, "exch_umdf_bytes_total",
+            "Total bytes (UDP payload, including UMDF packet header) published per multicast feed.",
+            "feed", channels,
+            ChannelMetrics.UmdfFeedKindNames,
+            (c, i) => c.ReadUmdfBytes((UmdfFeedKind)i));
+
         EmitRuntimeMetrics(sb);
 
         return sb.ToString();
@@ -431,6 +527,26 @@ public sealed class MetricsRegistry
               .Append("\",").Append(label).Append("=\"").Append(labelValue).Append("\"} ")
               .Append(selector(c).ToString(CultureInfo.InvariantCulture))
               .Append('\n');
+        }
+    }
+
+    private static void EmitLabeledChannelCounter(StringBuilder sb, string name, string help,
+        string label, ChannelMetrics[] channels, string[] labelValues, Func<ChannelMetrics, int, long> selector)
+    {
+        // Emits {channel,<label>} pairs with a single HELP/TYPE header
+        // covering all label values. Cardinality = channels × labelValues.
+        sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
+        sb.Append("# TYPE ").Append(name).Append(" counter\n");
+        foreach (var c in channels)
+        {
+            for (int i = 0; i < labelValues.Length; i++)
+            {
+                sb.Append(name).Append("{channel=\"")
+                  .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
+                  .Append("\",").Append(label).Append("=\"").Append(labelValues[i]).Append("\"} ")
+                  .Append(selector(c, i).ToString(CultureInfo.InvariantCulture))
+                  .Append('\n');
+            }
         }
     }
 

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -177,10 +177,10 @@ public sealed class ExchangeHost : IAsyncDisposable
                 }
                 else
                 {
-                    snapSink = WrapResilient(
+                    snapSink = WrapResilientCounting(
                         BuildUdpSink(ch.Transport, snap.Group, snap.Port,
                             ch.LocalInterface, snap.Ttl ?? ch.Ttl),
-                        channelMetrics);
+                        channelMetrics, UmdfFeedKind.Snapshot);
                 }
                 if (snapSink is IDisposable sd) _ownedSinks.Add(sd);
 
@@ -212,9 +212,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                 else
                 {
                     var localIface = idCfg.LocalInterface ?? ch.LocalInterface;
-                    idSink = WrapResilient(
+                    idSink = WrapResilientCounting(
                         BuildUdpSink(ch.Transport, idCfg.Group, idCfg.Port, localIface, idCfg.Ttl),
-                        channelMetrics);
+                        channelMetrics, UmdfFeedKind.InstrumentDef);
                 }
                 if (idSink is IDisposable idd) _ownedSinks.Add(idd);
                 byte idChan = idCfg.ChannelNumber == 0 ? ch.ChannelNumber : idCfg.ChannelNumber;
@@ -371,6 +371,15 @@ public sealed class ExchangeHost : IAsyncDisposable
             inner,
             _loggerFactory.CreateLogger<ResilientUdpPacketSinkDecorator>(),
             metrics);
+
+    /// <summary>
+    /// Issue #174: wraps an outbound packet sink with the resilient error
+    /// decorator and a counting decorator for the named feed. The
+    /// incremental feed is counted directly by <c>ChannelDispatcher</c>,
+    /// so this helper is only used for snapshot/instrument-def feeds.
+    /// </summary>
+    private IUmdfPacketSink WrapResilientCounting(IUmdfPacketSink inner, ChannelMetrics metrics, UmdfFeedKind feed)
+        => new CountingUdpPacketSinkDecorator(WrapResilient(inner, metrics), metrics, feed);
 
     private IUmdfPacketSink BuildUdpSink(UmdfTransport transport, string host, int port,
         string? localInterface, byte ttl)

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.Exchange.Core;
 
 namespace B3.Exchange.Core.Tests;
@@ -240,6 +241,79 @@ public class MetricsRegistryTests
         Assert.Equal(0, snap.OverflowCount);
         Assert.All(snap.BucketCounts, c => Assert.Equal(0, c));
         Assert.Equal(0.0, snap.SumSeconds);
+    }
+
+    [Fact]
+    public void Render_EmitsThroughputCounters_Issue174()
+    {
+        var reg = new MetricsRegistry();
+        var ch = reg.RegisterChannel(11);
+
+        ch.IncInboundMessage(InboundMessageKind.New);
+        ch.IncInboundMessage(InboundMessageKind.New);
+        ch.IncInboundMessage(InboundMessageKind.Cancel);
+        ch.IncInboundMessage(InboundMessageKind.DecodeError);
+
+        ch.IncExecutionReport(ExecutionReportKind.New);
+        ch.IncExecutionReport(ExecutionReportKind.Trade);
+        ch.IncExecutionReport(ExecutionReportKind.TradePassive);
+        ch.IncExecutionReport(ExecutionReportKind.CancelPassive);
+        ch.IncExecutionReport(ExecutionReportKind.Reject);
+
+        ch.IncUmdfPacket(UmdfFeedKind.Incremental, 1200);
+        ch.IncUmdfPacket(UmdfFeedKind.Incremental, 800);
+        ch.IncUmdfPacket(UmdfFeedKind.Snapshot, 1400);
+        ch.IncUmdfPacket(UmdfFeedKind.InstrumentDef, 600);
+
+        var text = reg.RenderProm();
+
+        // Single HELP/TYPE per metric covering every label permutation.
+        Assert.Contains("# TYPE exch_inbound_messages_total counter\n", text);
+        Assert.Contains("exch_inbound_messages_total{channel=\"11\",msg_type=\"new\"} 2\n", text);
+        Assert.Contains("exch_inbound_messages_total{channel=\"11\",msg_type=\"cancel\"} 1\n", text);
+        Assert.Contains("exch_inbound_messages_total{channel=\"11\",msg_type=\"decode_error\"} 1\n", text);
+        // Unobserved kinds are still emitted with value 0 so the series
+        // exists from t=0 (Prometheus treats absent series as gaps).
+        Assert.Contains("exch_inbound_messages_total{channel=\"11\",msg_type=\"replace\"} 0\n", text);
+
+        Assert.Contains("# TYPE exch_execution_reports_total counter\n", text);
+        Assert.Contains("exch_execution_reports_total{channel=\"11\",exec_type=\"new\"} 1\n", text);
+        Assert.Contains("exch_execution_reports_total{channel=\"11\",exec_type=\"trade\"} 1\n", text);
+        Assert.Contains("exch_execution_reports_total{channel=\"11\",exec_type=\"trade_passive\"} 1\n", text);
+        Assert.Contains("exch_execution_reports_total{channel=\"11\",exec_type=\"cancel_passive\"} 1\n", text);
+        Assert.Contains("exch_execution_reports_total{channel=\"11\",exec_type=\"reject\"} 1\n", text);
+
+        Assert.Contains("# TYPE exch_umdf_packets_total counter\n", text);
+        Assert.Contains("exch_umdf_packets_total{channel=\"11\",feed=\"incremental\"} 2\n", text);
+        Assert.Contains("exch_umdf_packets_total{channel=\"11\",feed=\"snapshot\"} 1\n", text);
+        Assert.Contains("exch_umdf_packets_total{channel=\"11\",feed=\"instrumentdef\"} 1\n", text);
+
+        Assert.Contains("# TYPE exch_umdf_bytes_total counter\n", text);
+        Assert.Contains("exch_umdf_bytes_total{channel=\"11\",feed=\"incremental\"} 2000\n", text);
+        Assert.Contains("exch_umdf_bytes_total{channel=\"11\",feed=\"snapshot\"} 1400\n", text);
+        Assert.Contains("exch_umdf_bytes_total{channel=\"11\",feed=\"instrumentdef\"} 600\n", text);
+    }
+
+    [Fact]
+    public void CountingUdpPacketSinkDecorator_Increments_ThenForwards()
+    {
+        var reg = new MetricsRegistry();
+        var ch = reg.RegisterChannel(3);
+        var inner = new CapturingSink();
+        var dec = new CountingUdpPacketSinkDecorator(inner, ch, UmdfFeedKind.Snapshot);
+
+        dec.Publish(3, new byte[] { 1, 2, 3, 4, 5 });
+        dec.Publish(3, new byte[] { 9, 9 });
+
+        Assert.Equal(2, ch.ReadUmdfPackets(UmdfFeedKind.Snapshot));
+        Assert.Equal(7, ch.ReadUmdfBytes(UmdfFeedKind.Snapshot));
+        Assert.Equal(2, inner.PublishCount);
+    }
+
+    private sealed class CapturingSink : IUmdfPacketSink
+    {
+        public int PublishCount;
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => PublishCount++;
     }
 
     private sealed class StubSessionProvider : ISessionMetricsProvider


### PR DESCRIPTION
Closes #174.

Adds throughput counters to `/metrics` so SREs can build saturation dashboards (msgs/sec, bytes/sec) per channel and per feed.

### New series
- `exch_inbound_messages_total{channel,msg_type}` — incremented by `ChannelDispatcher.EnqueueX` / `OnDecodeError`. `msg_type ∈ {new, cancel, replace, cross, mass_cancel, decode_error}`.
- `exch_execution_reports_total{channel,exec_type}` — incremented at every `WriteExecutionReport*` call site in the dispatcher. `exec_type ∈ {new, trade, trade_passive, cancel, cancel_passive, replace, reject}` (passive = report sent to the resting-order owner).
- `exch_umdf_packets_total{channel,feed}` and `exch_umdf_bytes_total{channel,feed}` — `feed ∈ {incremental, snapshot, instrumentdef}`. Incremental is counted directly inside `ChannelDispatcher.FlushPacket`; snapshot and instrumentdef are counted via a new `CountingUdpPacketSinkDecorator` chained on top of the resilient decorator (#172) inside `ExchangeHost`.

### Cardinality
Bounded by design: 6 + 7 + 3 + 3 = 19 label values × `channels`. Safe for any plausible deployment.

### Implementation notes
- Three new public enums in `B3.Exchange.Core` (`InboundMessageKind`, `ExecutionReportKind`, `UmdfFeedKind`) provide the typed surface so callers can't fat-finger label strings.
- Counters are stored as fixed-size `long[]` arrays inside `ChannelMetrics`, indexed by the enum value — single `Interlocked.Increment` per observation.
- `CountingUdpPacketSinkDecorator` counts before delegating so a throwing inner sink still records the produce-side intent (matches the rest of `MetricsRegistry`'s philosophy: instrument-first, error-paths-second).
- `ExecutionReportKind.Cancel` and `Replace` enum values are reserved for future direct-route paths (currently the dispatcher only emits passive cancels and no modify ERs); the series renders with count=0 until those paths land.
- `inbound_bytes_total` from the issue's wishlist is **not** in this PR — it requires gateway-side plumbing (the dispatcher does not see byte counts for inbound frames). Tracked as a follow-up; the existing series cover the most actionable saturation signals.

### Tests
- `Render_EmitsThroughputCounters_Issue174` — exercises every counter family + asserts cumulative bytes per feed.
- `CountingUdpPacketSinkDecorator_Increments_ThenForwards` — covers the new decorator in isolation.

All 663 tests green; `dotnet format --verify-no-changes` clean.
