### PR TITLE
Fix invalid expression in bench-nightly.yml (push-time validation failures)

### DIFF
--- a/.github/workflows/bench-nightly.yml
+++ b/.github/workflows/bench-nightly.yml
@@ -58,7 +58,7 @@ jobs:
           dotnet run --no-build -c Release
           --project bench/B3.Exchange.Bench
           --
-          --filter '${{ github.event.inputs.filter || ''*'' }}'
+          --filter '${{ github.event.inputs.filter || '*' }}'
           --exporters github
 
       - name: Upload BenchmarkDotNet artifacts


### PR DESCRIPTION
Fix invalid expression in `bench-nightly.yml` that caused a workflow-validation failure on every push (and a noisy "no jobs were run" email).

## Root cause

Line 61 used `${{ github.event.inputs.filter || ''*'' }}`.

The `run:` block is a folded scalar (`>`), where single quotes are literal — there is no YAML escaping in effect. GitHub Actions expression parser therefore receives the literal source `github.event.inputs.filter || ''*''`, which it tries to parse as `'' * ''` (empty string * empty string) and fails with:

> (Line: 57, Col: 14): Unexpected symbol: '*'. Located at position 33 within expression: github.event.inputs.filter || ''*''

Because the workflow file is invalid, GitHub creates a phantom failed run for every `push` event (validation pass), even though the workflow only subscribes to `schedule` + `workflow_dispatch`. That is the source of the "no jobs were run" failure emails the maintainer has been receiving on PRs and merges.

## Fix

Replace the doubled-single-quote escape with a single quote (which is the correct GHA expression-string syntax inside a folded scalar):

```yaml
--filter '${{ github.event.inputs.filter || '*' }}'
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
