### PR TITLE
Implement graceful shutdown phases on SIGTERM (#171)

### DIFF
--- a/src/B3.EntryPoint.Wire/SessionRejectEncoder.cs
+++ b/src/B3.EntryPoint.Wire/SessionRejectEncoder.cs
@@ -29,6 +29,10 @@ public static class SessionRejectEncoder
     public static class TerminationCode
     {
         public const byte Unspecified = 0;
+        /// <summary>Sender announces a clean session termination (graceful
+        /// shutdown). Used by the host on SIGTERM (issue #171) so clients
+        /// can distinguish an orderly drain from an abrupt RST/timeout.</summary>
+        public const byte Finished = 1;
         /// <summary>Peer sent an application message before completing
         /// FIXP <c>Negotiate</c>. Spec §4.5 strict-gating rule.</summary>
         public const byte Unnegotiated = 2;

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -81,6 +81,15 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// <see cref="SequenceVersion"/>. Safe to read from any thread.</summary>
     public uint SequenceNumber => Volatile.Read(ref _sequenceNumber);
 
+    /// <summary>
+    /// Pending work-items in the bounded inbound channel. Snapshot value;
+    /// safe to read from any thread (the underlying <see cref="System.Threading.Channels.Channel{T}"/>
+    /// reader supports counting). Used by the host's graceful-shutdown
+    /// drain loop (issue #171) to wait until in-flight commands have been
+    /// observed by the engine before broadcasting Terminate.
+    /// </summary>
+    public int InboundQueueDepth => _inbound.Reader.Count;
+
     private readonly System.Threading.Channels.Channel<WorkItem> _inbound;
     private readonly MatchingEngine _engine;
     private readonly IUmdfPacketSink _packetSink;

--- a/src/B3.Exchange.Core/IReadinessProbe.cs
+++ b/src/B3.Exchange.Core/IReadinessProbe.cs
@@ -39,3 +39,26 @@ public sealed class StartupReadinessProbe : IReadinessProbe
 
     public void MarkReady() => Interlocked.Exchange(ref _ready, 1);
 }
+
+/// <summary>
+/// Inverse-polarity readiness probe used during graceful shutdown
+/// (issue #171 / A7). Starts ready; <see cref="MarkNotReady"/> flips it
+/// to NOT_READY so /health/ready returns 503 and load balancers stop
+/// routing new connections to the host while in-flight work drains.
+/// Idempotent and lock-free.
+/// </summary>
+public sealed class ShutdownReadinessProbe : IReadinessProbe
+{
+    private int _notReady;
+
+    public ShutdownReadinessProbe(string name = "shutdown")
+    {
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public bool IsReady => Volatile.Read(ref _notReady) == 0;
+
+    public void MarkNotReady() => Interlocked.Exchange(ref _notReady, 1);
+}

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -234,6 +234,63 @@ public sealed class EntryPointListener : IAsyncDisposable
         return closed;
     }
 
+    /// <summary>
+    /// Graceful-shutdown phase 1 (issue #171 / A7): stop accepting new TCP
+    /// connections without closing the existing sessions or unbinding the
+    /// listening socket. The accept loop and the suspended-session reaper
+    /// are cancelled and awaited; existing sessions keep flowing inbound +
+    /// outbound traffic so the host can continue to drain in-flight work
+    /// before the subsequent <see cref="TerminateAllSessionsAsync"/> step.
+    ///
+    /// <para>Idempotent: safe to call multiple times. Subsequent calls
+    /// short-circuit because <see cref="_acceptTask"/> is already torn
+    /// down. After this returns, <see cref="DisposeAsync"/> is still
+    /// required to release sockets and dispose remaining sessions.</para>
+    /// </summary>
+    public async Task StopAcceptingAsync()
+    {
+        try { _cts.Cancel(); } catch { }
+        try { _listener?.Stop(); } catch { }
+        if (_acceptTask != null) { try { await _acceptTask.ConfigureAwait(false); } catch { } _acceptTask = null; }
+        if (_reaperTask != null) { try { await _reaperTask.ConfigureAwait(false); } catch { } _reaperTask = null; }
+        _logger.LogInformation("entrypoint listener stopped accepting new connections");
+    }
+
+    /// <summary>
+    /// Graceful-shutdown phase 2 (issue #171 / A7): broadcast
+    /// <c>Terminate(<paramref name="terminationCode"/>)</c> to every live
+    /// FIXP session, then close them. Awaits each direct-send to give the
+    /// peer a chance to read the frame before TCP RST/FIN; failures are
+    /// logged and swallowed so one stuck session can't block the rest.
+    /// Returns the number of sessions that were live at snapshot time.
+    /// </summary>
+    public async Task<int> TerminateAllSessionsAsync(byte terminationCode, string reason)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(reason);
+        FixpSession[] snapshot;
+        lock (_lock) snapshot = _sessions.ToArray();
+        int closed = 0;
+        foreach (var s in snapshot)
+        {
+            if (!s.IsOpen) continue;
+            try
+            {
+                await s.SendTerminateAndCloseAsync(terminationCode, reason).ConfigureAwait(false);
+                closed++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "graceful terminate failed for session {ConnectionId}",
+                    s.ConnectionId);
+            }
+        }
+        _logger.LogInformation(
+            "broadcast Terminate({Code}) to {Count} session(s) (reason={Reason})",
+            terminationCode, closed, reason);
+        return closed;
+    }
+
     private async Task RunAcceptLoopAsync(CancellationToken ct)
     {
         try
@@ -427,10 +484,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         _logger.LogInformation("entrypoint listener stopping");
-        try { _cts.Cancel(); } catch { }
-        try { _listener?.Stop(); } catch { }
-        if (_acceptTask != null) { try { await _acceptTask.ConfigureAwait(false); } catch { } }
-        if (_reaperTask != null) { try { await _reaperTask.ConfigureAwait(false); } catch { } }
+        await StopAcceptingAsync().ConfigureAwait(false);
         FixpSession[] toClose;
         lock (_lock) { toClose = _sessions.ToArray(); _sessions.Clear(); }
         foreach (var s in toClose) await s.DisposeAsync().ConfigureAwait(false);

--- a/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
@@ -101,6 +101,16 @@ public sealed partial class FixpSession
     /// closes the session.
     /// </summary>
     private async Task TerminateAndCloseAsync(byte terminationCode, string reason)
+        => await SendTerminateAndCloseAsync(terminationCode, reason).ConfigureAwait(false);
+
+    /// <summary>
+    /// Public wrapper around <see cref="TerminateAndCloseAsync"/> so the
+    /// graceful-shutdown coordinator (issue #171) can broadcast
+    /// <c>Terminate(Finished)</c> to every live session before the host
+    /// tears the listener down. Idempotent: a session already closed
+    /// returns immediately without attempting any IO.
+    /// </summary>
+    public async Task SendTerminateAndCloseAsync(byte terminationCode, string reason)
     {
         if (!IsOpen) { Close(reason); return; }
         var frame = new byte[SessionRejectEncoder.TerminateTotal];

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using B3.EntryPoint.Wire;
 using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
@@ -33,6 +34,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly List<Timer> _snapshotTimers = new();
     private readonly MetricsRegistry _metrics = new();
     private readonly StartupReadinessProbe _startupProbe = new("startup");
+    private readonly ShutdownReadinessProbe _shutdownProbe = new("shutdown");
     private readonly List<IReadinessProbe> _probes = new();
     private readonly object _probesLock = new();
     private EntryPointListener? _listener;
@@ -52,6 +54,7 @@ public sealed class ExchangeHost : IAsyncDisposable
         _snapshotSinkFactory = snapshotSinkFactory;
         _instrumentDefSinkFactory = instrumentDefSinkFactory;
         _probes.Add(_startupProbe);
+        _probes.Add(_shutdownProbe);
     }
 
     public IPEndPoint? TcpEndpoint => _listener?.LocalEndpoint;
@@ -479,7 +482,7 @@ public sealed class ExchangeHost : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        _logger.LogInformation("exchange host shutting down");
+        await StopAsync().ConfigureAwait(false);
         if (_dailyReset != null) await _dailyReset.DisposeAsync().ConfigureAwait(false);
         if (_http != null) await _http.DisposeAsync().ConfigureAwait(false);
         foreach (var t in _snapshotTimers) await t.DisposeAsync().ConfigureAwait(false);
@@ -487,5 +490,130 @@ public sealed class ExchangeHost : IAsyncDisposable
         foreach (var p in _instrumentDefPublishers) await p.DisposeAsync().ConfigureAwait(false);
         foreach (var d in _dispatchers) await d.DisposeAsync().ConfigureAwait(false);
         foreach (var s in _ownedSinks) s.Dispose();
+    }
+
+    private int _stopCalled;
+
+    /// <summary>
+    /// Graceful shutdown (issue #171 / A7). Drives the host through the
+    /// phases the operability spec requires:
+    ///
+    /// <list type="number">
+    ///   <item>Flip the shutdown readiness probe → NOT_READY so /health/ready
+    ///         returns 503 and load balancers stop routing traffic to us.</item>
+    ///   <item>Stop the EntryPoint accept loop (no new TCP connections).</item>
+    ///   <item>Wait up to <c>HostConfig.Shutdown.DrainGraceMs</c> for every
+    ///         per-channel inbound queue to drain so in-flight work is
+    ///         observed by the engine before we close anything.</item>
+    ///   <item>Broadcast <c>Terminate(Finished=1)</c> to every live FIXP
+    ///         session so clients see an orderly drain instead of an RST/timeout.</item>
+    ///   <item>Dispose dispatchers (each flushes its last UMDF packet on
+    ///         the way down) and the listener.</item>
+    /// </list>
+    ///
+    /// <para>Each phase logs <c>shutdown phase=X duration=Yms</c>. Idempotent —
+    /// only the first caller does work; subsequent callers return immediately.
+    /// <see cref="DisposeAsync"/> calls this; callers driving shutdown
+    /// from a SIGTERM handler should call it explicitly so they can pass
+    /// a <see cref="CancellationToken"/> bounding the total duration.</para>
+    /// </summary>
+    public async Task StopAsync(CancellationToken ct = default)
+    {
+        if (Interlocked.Exchange(ref _stopCalled, 1) == 1) return;
+        var totalSw = System.Diagnostics.Stopwatch.StartNew();
+        _logger.LogInformation("graceful shutdown starting");
+
+        // Phase 1: flip readiness so external probes (LB, k8s) stop sending traffic.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        _shutdownProbe.MarkNotReady();
+        sw.Stop();
+        _logger.LogInformation("shutdown phase=mark-not-ready duration={DurationMs}ms", sw.ElapsedMilliseconds);
+
+        // Phase 2: stop accepting new connections; existing sessions stay alive.
+        sw.Restart();
+        if (_listener != null)
+        {
+            try { await _listener.StopAcceptingAsync().ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "stop-accepting threw"); }
+        }
+        sw.Stop();
+        _logger.LogInformation("shutdown phase=stop-accepting duration={DurationMs}ms", sw.ElapsedMilliseconds);
+
+        // Phase 3: poll-wait for per-channel inbound queues to drain so the
+        // engine has observed every command currently held by the gateway.
+        sw.Restart();
+        int graceMs = Math.Max(0, _config.Shutdown.DrainGraceMs);
+        int pollMs = Math.Max(1, _config.Shutdown.DrainPollMs);
+        var drainDeadline = System.Diagnostics.Stopwatch.StartNew();
+        int residual;
+        while (true)
+        {
+            residual = 0;
+            foreach (var d in _dispatchers) residual += d.InboundQueueDepth;
+            if (residual == 0) break;
+            if (drainDeadline.ElapsedMilliseconds >= graceMs) break;
+            if (ct.IsCancellationRequested) break;
+            try { await Task.Delay(pollMs, ct).ConfigureAwait(false); }
+            catch (OperationCanceledException) { break; }
+        }
+        sw.Stop();
+        if (residual == 0)
+        {
+            _logger.LogInformation("shutdown phase=drain-inbound duration={DurationMs}ms residual=0",
+                sw.ElapsedMilliseconds);
+        }
+        else
+        {
+            _logger.LogWarning("shutdown phase=drain-inbound duration={DurationMs}ms residual={Residual} (grace expired)",
+                sw.ElapsedMilliseconds, residual);
+        }
+
+        // Phase 4: broadcast Terminate(Finished) and close each session.
+        sw.Restart();
+        int terminated = 0;
+        if (_listener != null)
+        {
+            try
+            {
+                terminated = await _listener.TerminateAllSessionsAsync(
+                    SessionRejectEncoder.TerminationCode.Finished, "graceful-shutdown")
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex) { _logger.LogWarning(ex, "terminate-all threw"); }
+        }
+        sw.Stop();
+        _logger.LogInformation("shutdown phase=terminate-sessions duration={DurationMs}ms count={Count}",
+            sw.ElapsedMilliseconds, terminated);
+
+        // Phase 5: stop snapshot/instrument-def cadence so we don't emit
+        // packets after dispatchers tear their sinks down.
+        sw.Restart();
+        foreach (var t in _snapshotTimers)
+        {
+            try { await t.DisposeAsync().ConfigureAwait(false); } catch { }
+        }
+        _snapshotTimers.Clear();
+        foreach (var p in _instrumentDefPublishers)
+        {
+            try { await p.DisposeAsync().ConfigureAwait(false); } catch { }
+        }
+        _instrumentDefPublishers.Clear();
+        sw.Stop();
+        _logger.LogInformation("shutdown phase=stop-publishers duration={DurationMs}ms", sw.ElapsedMilliseconds);
+
+        // Phase 6: dispose dispatchers (each flushes its last UMDF packet).
+        sw.Restart();
+        foreach (var d in _dispatchers)
+        {
+            try { await d.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex)
+            { _logger.LogWarning(ex, "dispatcher dispose threw"); }
+        }
+        _dispatchers.Clear();
+        sw.Stop();
+        _logger.LogInformation("shutdown phase=close-dispatchers duration={DurationMs}ms", sw.ElapsedMilliseconds);
+
+        totalSw.Stop();
+        _logger.LogInformation("graceful shutdown complete totalDuration={TotalMs}ms", totalSw.ElapsedMilliseconds);
     }
 }

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -16,7 +16,27 @@ public sealed class HostConfig
     [JsonPropertyName("sessions")] public List<SessionConfig> Sessions { get; set; } = new();
     [JsonPropertyName("http")] public HttpConfig? Http { get; set; }
     [JsonPropertyName("dailyReset")] public DailyResetConfig? DailyReset { get; set; }
+    [JsonPropertyName("shutdown")] public ShutdownConfig Shutdown { get; set; } = new();
     [JsonPropertyName("channels")] public List<ChannelConfig> Channels { get; set; } = new();
+}
+
+/// <summary>
+/// Graceful-shutdown tunables (issue #171 / A7). On SIGTERM the host
+/// flips its readiness probe NOT_READY, stops accepting connections,
+/// then waits up to <see cref="DrainGraceMs"/> for the per-channel
+/// dispatcher inbound queues to drain (polled every
+/// <see cref="DrainPollMs"/>) before broadcasting <c>Terminate(Finished)</c>
+/// to every live FIXP session and tearing the listener down.
+/// </summary>
+public sealed class ShutdownConfig
+{
+    /// <summary>Maximum wall-clock time to wait for inbound queues to
+    /// drain before forcing the Terminate broadcast. Default 5 s.</summary>
+    [JsonPropertyName("drainGraceMs")] public int DrainGraceMs { get; set; } = 5_000;
+
+    /// <summary>How often the drain loop polls per-channel queue depth.
+    /// Default 50 ms. Smaller = more responsive shutdown, more CPU.</summary>
+    [JsonPropertyName("drainPollMs")] public int DrainPollMs { get; set; } = 50;
 }
 
 public sealed class TcpConfig

--- a/src/B3.Exchange.Host/Program.cs
+++ b/src/B3.Exchange.Host/Program.cs
@@ -63,4 +63,9 @@ try { await Task.Delay(Timeout.Infinite, shutdown.Token).ConfigureAwait(false); 
 catch (OperationCanceledException) { }
 
 bootLogger.LogInformation("shutting down");
+// Bound the graceful shutdown so a stuck phase can't pin the process
+// indefinitely. The host's per-phase logging makes any breach visible.
+using var stopCts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+try { await host.StopAsync(stopCts.Token).ConfigureAwait(false); }
+catch (Exception ex) { bootLogger.LogError(ex, "graceful shutdown failed"); }
 return 0;

--- a/tests/B3.Exchange.Host.Tests/GracefulShutdownTests.cs
+++ b/tests/B3.Exchange.Host.Tests/GracefulShutdownTests.cs
@@ -1,0 +1,172 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #171 (A7): graceful shutdown E2E. Verifies the
+/// <see cref="ExchangeHost.StopAsync"/> contract:
+///   • readiness probe flips NOT_READY immediately,
+///   • live FIXP sessions receive a <c>Terminate(Finished)</c> frame
+///     before the TCP socket closes (so peers see an orderly drain
+///     instead of an RST/timeout),
+///   • the call is idempotent.
+/// </summary>
+public class GracefulShutdownTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static HostConfig BuildConfig()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        return new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Shutdown = new ShutdownConfig { DrainGraceMs = 200, DrainPollMs = 10 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 91,
+                    IncrementalGroup = "239.255.91.1",
+                    IncrementalPort = 30191,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                },
+            },
+        };
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task StopAsync_BroadcastsTerminateFinished_BeforeTcpClose()
+    {
+        var cfg = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        // Wait briefly so the listener has registered the FixpSession in
+        // its _sessions list before we start shutdown (accept-loop runs
+        // the registration asynchronously).
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline && CountReadyForShutdown(host) == 0)
+            await Task.Delay(20);
+        Assert.True(CountReadyForShutdown(host) > 0, "expected listener to have registered the connected client");
+
+        // Trigger the graceful shutdown on a background task; we then
+        // read from the client to prove the Terminate frame arrives.
+        var stopTask = host.StopAsync();
+
+        var frame = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+        Assert.Equal(EntryPointFrameReader.TidTerminate, frame.TemplateId);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.Finished, frame.Body[12]);
+
+        await stopTask;
+    }
+
+    private static int CountReadyForShutdown(ExchangeHost host)
+    {
+        // Probe the listener through a short reflection-free contract:
+        // count active sessions via the ChannelDispatcher list is not
+        // useful here, so we just attempt to read via a private getter.
+        // Simpler: rely on time-based wait — but we want a deterministic
+        // signal, so peek the listener's ActiveSessions count. The
+        // EntryPointListener is exposed through a friend assembly via
+        // InternalsVisibleTo("B3.Exchange.Host.Tests"). Use it.
+        var listener = typeof(ExchangeHost)
+            .GetField("_listener", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!
+            .GetValue(host) as B3.Exchange.Gateway.EntryPointListener;
+        return listener?.ActiveSessions.Count ?? 0;
+    }
+
+    [Fact]
+    public async Task StopAsync_FlipsReadinessProbeImmediately()
+    {
+        var cfg = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+        await host.StartAsync();
+
+        var probe = GetShutdownProbe(host);
+        Assert.True(probe.IsReady, "shutdown probe must start ready");
+
+        await host.StopAsync();
+
+        Assert.False(probe.IsReady, "shutdown probe must flip NOT_READY after StopAsync");
+    }
+
+    [Fact]
+    public async Task StopAsync_IsIdempotent()
+    {
+        var cfg = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+        await host.StartAsync();
+
+        await host.StopAsync();
+        // Second call must not throw and must return promptly.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        await host.StopAsync();
+        sw.Stop();
+        Assert.True(sw.ElapsedMilliseconds < 500, $"second StopAsync should short-circuit, took {sw.ElapsedMilliseconds}ms");
+    }
+
+    private static ShutdownReadinessProbe GetShutdownProbe(ExchangeHost host)
+    {
+        var f = typeof(ExchangeHost)
+            .GetField("_shutdownProbe", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+        return (ShutdownReadinessProbe)f.GetValue(host)!;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}


### PR DESCRIPTION
Closes #171.

Implements **A7 — Graceful shutdown** so SIGTERM no longer leaves clients staring at an RST/timeout, in-flight inbound work no longer gets dropped on the floor, and the last UMDF packet is flushed before the multicast socket closes.

## Phases

`ExchangeHost.StopAsync(CancellationToken)` is idempotent (CAS-guarded) and runs:

| # | Phase                | What                                                                                   |
| - | -------------------- | -------------------------------------------------------------------------------------- |
| 1 | `mark-not-ready`     | Flips a new `ShutdownReadinessProbe` → NOT_READY so `/health/ready` returns 503        |
| 2 | `stop-accepting`     | New `EntryPointListener.StopAcceptingAsync()` cancels the accept loop only             |
| 3 | `drain-inbound`      | Polls `ChannelDispatcher.InboundQueueDepth` until zero or `shutdown.drainGraceMs` fires |
| 4 | `terminate-sessions` | Broadcasts `Terminate(Finished=1)` to every live FIXP session via direct-send + close   |
| 5 | `stop-publishers`    | Disposes snapshot timers + instrument-def publishers                                    |
| 6 | `close-dispatchers`  | Disposes each `ChannelDispatcher` (each flushes its last UMDF packet on the way out)    |

Each phase logs `shutdown phase=X duration=Yms` per the acceptance criteria.

## Wire-protocol piece

Adds `SessionRejectEncoder.TerminationCode.Finished = 1` (B3 schema standard FIXP value for a clean operator-initiated termination). `FixpSession.SendTerminateAndCloseAsync(byte, string)` exposes the existing private `TerminateAndCloseAsync` to the listener, and `EntryPointListener.TerminateAllSessionsAsync(byte, string)` iterates and awaits each direct-send.

## Config

```jsonc
"shutdown": {
  "drainGraceMs": 5000,    // total inbound-drain budget
  "drainPollMs": 50        // poll cadence
}
```

Defaults preserve the previous (no-config) behavior modulo the additional drain phase: 5 s grace is generous for a healthy queue, and the drain loop short-circuits on `residual == 0`.

`Program.Main` now calls `await host.StopAsync(stopCts.Token)` on Ctrl+C / SIGTERM with a 30 s upper bound so a stuck phase can't pin the process forever; `DisposeAsync` calls `StopAsync` first (idempotent) so existing test `await using` patterns also exercise the new path.

## Tests

- `GracefulShutdownTests.StopAsync_BroadcastsTerminateFinished_BeforeTcpClose` — connects a TCP client, calls `StopAsync()`, asserts the client reads `templateId=7` (Terminate) with `terminationCode=1` (Finished) before EOF.
- `StopAsync_FlipsReadinessProbeImmediately` — probe goes NOT_READY after `StopAsync`.
- `StopAsync_IsIdempotent` — second call short-circuits in <500 ms.

All 663+3 tests green. `dotnet format --verify-no-changes` clean.

## Out of scope (follow-ups)

- Hooking `IHostApplicationLifetime` (this codebase uses a hand-rolled `Program.Main`, not `Microsoft.Extensions.Hosting`); current `CancelKeyPress` + `ProcessExit` handlers already cover SIGTERM/Ctrl-C.
- `/health/ready` route already exists and consumes the probe additively — no HTTP change required.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
