### PR TITLE
Add bounded per-firm / per-session counters (#176)

### DIFF
--- a/src/B3.Exchange.Core/BoundedSessionFirmCounters.cs
+++ b/src/B3.Exchange.Core/BoundedSessionFirmCounters.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Bounded-cardinality per-firm and per-session message counters
+/// (issue #176 / B4). Operators need to spot "which client is causing
+/// the storm", but Prometheus label cardinality cannot grow without
+/// bound — a single misbehaving fleet of test clients could otherwise
+/// blow up the TSDB. We cap each dimension; once the cap is reached,
+/// every additional first-seen firm/session funnels into the
+/// <c>"_other"</c> overflow series.
+///
+/// <para>Thread-safety: <see cref="Inc"/> is lock-free and safe to call
+/// from any thread (including the gateway's accept loop and per-channel
+/// dispatcher threads concurrently). The per-key counter is held in a
+/// <c>long[1]</c> so <see cref="Interlocked.Increment(ref long)"/> can
+/// mutate it atomically without re-keying the dictionary on every hit.
+/// Caps are advisory: under contention the dictionary can briefly grow a
+/// handful of entries past the limit before the size check rejects new
+/// keys; the slack is bounded by the number of concurrent first-time
+/// inserters and is acceptable because the goal is bounded long-term
+/// growth, not strict real-time enforcement.</para>
+///
+/// <para>Snapshot is taken via <see cref="ConcurrentDictionary{TKey,TValue}.ToArray"/>
+/// for stable iteration during a Prometheus scrape. The overflow
+/// counter is read with <see cref="Volatile.Read(ref long)"/>.</para>
+/// </summary>
+public sealed class BoundedSessionFirmCounters
+{
+    public const int DefaultMaxFirms = 100;
+    public const int DefaultMaxSessions = 500;
+    public const string OverflowLabel = "_other";
+
+    private readonly ConcurrentDictionary<uint, long[]> _firms = new();
+    private readonly ConcurrentDictionary<string, long[]> _sessions = new();
+    private long _firmOverflow;
+    private long _sessionOverflow;
+
+    public int MaxFirms { get; }
+    public int MaxSessions { get; }
+
+    public BoundedSessionFirmCounters(int maxFirms = DefaultMaxFirms, int maxSessions = DefaultMaxSessions)
+    {
+        if (maxFirms <= 0) throw new ArgumentOutOfRangeException(nameof(maxFirms));
+        if (maxSessions <= 0) throw new ArgumentOutOfRangeException(nameof(maxSessions));
+        MaxFirms = maxFirms;
+        MaxSessions = maxSessions;
+    }
+
+    /// <summary>
+    /// Increment the firm and session counters for one inbound application
+    /// message. <paramref name="sessionId"/> may be empty/null when the
+    /// message arrives before a FIXP session is bound to a logical id;
+    /// in that case only the firm dimension is incremented.
+    /// </summary>
+    public void Inc(uint firmCode, string? sessionId)
+    {
+        IncInDimension(_firms, firmCode, MaxFirms, ref _firmOverflow);
+        if (!string.IsNullOrEmpty(sessionId))
+        {
+            IncInDimension(_sessions, sessionId, MaxSessions, ref _sessionOverflow);
+        }
+    }
+
+    private static void IncInDimension<TKey>(ConcurrentDictionary<TKey, long[]> map,
+        TKey key, int cap, ref long overflow) where TKey : notnull
+    {
+        if (map.TryGetValue(key, out var existing))
+        {
+            Interlocked.Increment(ref existing[0]);
+            return;
+        }
+        if (map.Count >= cap)
+        {
+            Interlocked.Increment(ref overflow);
+            return;
+        }
+        var box = new long[1] { 1 };
+        if (!map.TryAdd(key, box))
+        {
+            // Lost the add race; another thread won. Re-fetch and bump it
+            // (correctness preserved — the +1 we counted goes onto the
+            // winner's box). On the rare overflow race the size check above
+            // already passed for both threads; that's the documented slack.
+            if (map.TryGetValue(key, out var winner))
+                Interlocked.Increment(ref winner[0]);
+            else
+                Interlocked.Increment(ref overflow);
+        }
+    }
+
+    /// <summary>Snapshot of the per-firm counters at the moment of the call.</summary>
+    public KeyValuePair<uint, long>[] FirmsSnapshot()
+        => _firms.ToArray().Select(kv => new KeyValuePair<uint, long>(kv.Key, Volatile.Read(ref kv.Value[0]))).ToArray();
+
+    /// <summary>Snapshot of the per-session counters at the moment of the call.</summary>
+    public KeyValuePair<string, long>[] SessionsSnapshot()
+        => _sessions.ToArray().Select(kv => new KeyValuePair<string, long>(kv.Key, Volatile.Read(ref kv.Value[0]))).ToArray();
+
+    public long FirmOverflowCount => Volatile.Read(ref _firmOverflow);
+    public long SessionOverflowCount => Volatile.Read(ref _sessionOverflow);
+}

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -98,6 +98,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly Func<ulong> _nowNanos;
     private readonly ushort _tradeDate;
     private readonly ChannelMetrics? _metrics;
+    private readonly BoundedSessionFirmCounters? _sessionFirmCounters;
 
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
@@ -137,7 +138,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         ICoreOutbound outbound,
         ILogger<ChannelDispatcher> logger,
         Func<ulong>? nowNanos = null, ushort tradeDate = 0, int inboundCapacity = DefaultInboundCapacity,
-        ChannelMetrics? metrics = null)
+        ChannelMetrics? metrics = null,
+        BoundedSessionFirmCounters? sessionFirmCounters = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -148,6 +150,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _nowNanos = nowNanos ?? DefaultNowNanos;
         _tradeDate = tradeDate;
         _metrics = metrics;
+        _sessionFirmCounters = sessionFirmCounters;
         // Direct field writes are safe here: ctor runs on the constructing
         // thread before Start() and before any other thread can observe the
         // instance. No memory barrier is needed.
@@ -568,7 +571,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, session, enteringFirm, true,
             clOrdIdValue, 0, cmd, null, null, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-        { _metrics?.IncInboundMessage(InboundMessageKind.New); return true; }
+        { _metrics?.IncInboundMessage(InboundMessageKind.New); _sessionFirmCounters?.Inc(enteringFirm, session.Value); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.New);
         return false;
     }
@@ -578,7 +581,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, cmd, null, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-        { _metrics?.IncInboundMessage(InboundMessageKind.Cancel); return true; }
+        { _metrics?.IncInboundMessage(InboundMessageKind.Cancel); _sessionFirmCounters?.Inc(enteringFirm, session.Value); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cancel);
         return false;
     }
@@ -588,7 +591,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, session, enteringFirm, true,
             clOrdIdValue, origClOrdIdValue, null, null, cmd, null, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-        { _metrics?.IncInboundMessage(InboundMessageKind.Replace); return true; }
+        { _metrics?.IncInboundMessage(InboundMessageKind.Replace); _sessionFirmCounters?.Inc(enteringFirm, session.Value); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Replace);
         return false;
     }
@@ -597,7 +600,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     {
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cross, session, enteringFirm, true,
             cmd.BuyClOrdIdValue, cmd.SellClOrdIdValue, null, null, null, cmd, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-        { _metrics?.IncInboundMessage(InboundMessageKind.Cross); return true; }
+        { _metrics?.IncInboundMessage(InboundMessageKind.Cross); _sessionFirmCounters?.Inc(enteringFirm, session.Value); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.Cross);
         return false;
     }
@@ -631,7 +634,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,
             0, 0, null, null, null, null, mc, EnqueueTicks: System.Diagnostics.Stopwatch.GetTimestamp())))
-        { _metrics?.IncInboundMessage(InboundMessageKind.MassCancel); return true; }
+        { _metrics?.IncInboundMessage(InboundMessageKind.MassCancel); _sessionFirmCounters?.Inc(enteringFirm, session.Value); return true; }
         _metrics?.IncDispatchQueueFull(); LogQueueFull(ChannelNumber, WorkKind.MassCancel);
         return false;
     }

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -208,10 +208,19 @@ public sealed class MetricsRegistry
     private readonly SessionLifecycleMetrics _sessionLifecycle = new();
     private readonly ThrottleMetrics _throttle = new();
     private readonly TransportMetrics _transport = new();
+    private readonly BoundedSessionFirmCounters _sessionFirmMessages = new();
 
     public SessionLifecycleMetrics Sessions => _sessionLifecycle;
     public ThrottleMetrics Throttle => _throttle;
     public TransportMetrics Transport => _transport;
+
+    /// <summary>
+    /// Bounded-cardinality per-firm/per-session inbound message counters
+    /// (issue #176). Increment from the dispatcher; rendered as
+    /// <c>exch_session_messages_total{firm,session_id}</c> with an
+    /// <c>"_other"</c> overflow series when the cap is exceeded.
+    /// </summary>
+    public BoundedSessionFirmCounters SessionFirmMessages => _sessionFirmMessages;
 
     public ChannelMetrics RegisterChannel(byte channelNumber)
     {
@@ -400,9 +409,74 @@ public sealed class MetricsRegistry
             ChannelMetrics.UmdfFeedKindNames,
             (c, i) => c.ReadUmdfBytes((UmdfFeedKind)i));
 
+        EmitSessionFirmCounters(sb);
+
         EmitRuntimeMetrics(sb);
 
         return sb.ToString();
+    }
+
+    private void EmitSessionFirmCounters(StringBuilder sb)
+    {
+        // Issue #176 (B4): bounded-cardinality per-firm and per-session
+        // inbound message counters. Two metric names with disjoint label
+        // sets so dashboards can group on either dimension cheaply
+        // without exploding the time-series count.
+        //
+        // Cardinality budget: ≤ MaxFirms+1 firm-series and
+        // ≤ MaxSessions+1 session-series (the +1 is the "_other"
+        // overflow). Beyond the cap, every newly-seen firm/session
+        // contributes to the overflow series only — its identity is
+        // lost on the metric (still visible via /sessions and audit
+        // logs). Document the cap in the operability runbook.
+        sb.Append("# HELP exch_session_messages_by_firm_total ")
+          .Append("Total inbound application messages received from a given firm (issue #176). Bounded to ")
+          .Append(_sessionFirmMessages.MaxFirms.ToString(CultureInfo.InvariantCulture))
+          .Append(" firms; overflow funnels into firm=\"")
+          .Append(BoundedSessionFirmCounters.OverflowLabel)
+          .Append("\".\n");
+        sb.Append("# TYPE exch_session_messages_by_firm_total counter\n");
+        var firms = _sessionFirmMessages.FirmsSnapshot();
+        Array.Sort(firms, (a, b) => a.Key.CompareTo(b.Key));
+        foreach (var kv in firms)
+        {
+            sb.Append("exch_session_messages_by_firm_total{firm=\"")
+              .Append(kv.Key.ToString(CultureInfo.InvariantCulture))
+              .Append("\"} ")
+              .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+        // Always emit the overflow series so dashboards can alert on
+        // rate(...{firm="_other"}[5m]) > 0 without having to special-case
+        // an absent label.
+        sb.Append("exch_session_messages_by_firm_total{firm=\"")
+          .Append(BoundedSessionFirmCounters.OverflowLabel)
+          .Append("\"} ")
+          .Append(_sessionFirmMessages.FirmOverflowCount.ToString(CultureInfo.InvariantCulture))
+          .Append('\n');
+
+        sb.Append("# HELP exch_session_messages_by_session_total ")
+          .Append("Total inbound application messages received on a given FIXP session (issue #176). Bounded to ")
+          .Append(_sessionFirmMessages.MaxSessions.ToString(CultureInfo.InvariantCulture))
+          .Append(" sessions; overflow funnels into session_id=\"")
+          .Append(BoundedSessionFirmCounters.OverflowLabel)
+          .Append("\".\n");
+        sb.Append("# TYPE exch_session_messages_by_session_total counter\n");
+        var sessionsArr = _sessionFirmMessages.SessionsSnapshot();
+        Array.Sort(sessionsArr, (a, b) => StringComparer.Ordinal.Compare(a.Key, b.Key));
+        foreach (var kv in sessionsArr)
+        {
+            sb.Append("exch_session_messages_by_session_total{session_id=\"")
+              .Append(EscapeLabel(kv.Key))
+              .Append("\"} ")
+              .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+        sb.Append("exch_session_messages_by_session_total{session_id=\"")
+          .Append(BoundedSessionFirmCounters.OverflowLabel)
+          .Append("\"} ")
+          .Append(_sessionFirmMessages.SessionOverflowCount.ToString(CultureInfo.InvariantCulture))
+          .Append('\n');
     }
 
     private static void EmitRuntimeMetrics(StringBuilder sb)

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -158,7 +158,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 packetSink: sink,
                 outbound: gatewayRouter,
                 logger: _loggerFactory.CreateLogger<ChannelDispatcher>(),
-                metrics: channelMetrics);
+                metrics: channelMetrics,
+                sessionFirmCounters: _metrics.SessionFirmMessages);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -295,6 +295,72 @@ public class MetricsRegistryTests
     }
 
     [Fact]
+    public void Render_EmitsBoundedSessionFirmCounters_Issue176()
+    {
+        var reg = new MetricsRegistry();
+        var bsfc = reg.SessionFirmMessages;
+
+        bsfc.Inc(7, "conn-1");
+        bsfc.Inc(7, "conn-1");
+        bsfc.Inc(7, "conn-2");
+        bsfc.Inc(42, "conn-3");
+
+        var text = reg.RenderProm();
+
+        Assert.Contains("# TYPE exch_session_messages_by_firm_total counter\n", text);
+        Assert.Contains("exch_session_messages_by_firm_total{firm=\"7\"} 3\n", text);
+        Assert.Contains("exch_session_messages_by_firm_total{firm=\"42\"} 1\n", text);
+        Assert.Contains("exch_session_messages_by_firm_total{firm=\"_other\"} 0\n", text);
+
+        Assert.Contains("# TYPE exch_session_messages_by_session_total counter\n", text);
+        Assert.Contains("exch_session_messages_by_session_total{session_id=\"conn-1\"} 2\n", text);
+        Assert.Contains("exch_session_messages_by_session_total{session_id=\"conn-2\"} 1\n", text);
+        Assert.Contains("exch_session_messages_by_session_total{session_id=\"conn-3\"} 1\n", text);
+        Assert.Contains("exch_session_messages_by_session_total{session_id=\"_other\"} 0\n", text);
+    }
+
+    [Fact]
+    public void BoundedSessionFirmCounters_OverflowsIntoOther_PastCap()
+    {
+        var bsfc = new BoundedSessionFirmCounters(maxFirms: 2, maxSessions: 2);
+
+        // First two firms / sessions take their own slot.
+        bsfc.Inc(1, "s1");
+        bsfc.Inc(2, "s2");
+        // Re-incrementing existing keys after the cap is reached is still
+        // routed to the existing slot (not overflow).
+        bsfc.Inc(1, "s1");
+        // New firm / session past the cap funnels into _other.
+        bsfc.Inc(3, "s3");
+        bsfc.Inc(4, "s4");
+        bsfc.Inc(5, "s5");
+
+        var firms = bsfc.FirmsSnapshot().ToDictionary(kv => kv.Key, kv => kv.Value);
+        Assert.Equal(2, firms[1]); // 1 hit twice
+        Assert.Equal(1, firms[2]);
+        Assert.Equal(2, firms.Count); // capped
+        Assert.Equal(3, bsfc.FirmOverflowCount); // firms 3,4,5
+
+        var sess = bsfc.SessionsSnapshot().ToDictionary(kv => kv.Key, kv => kv.Value);
+        Assert.Equal(2, sess["s1"]);
+        Assert.Equal(1, sess["s2"]);
+        Assert.Equal(2, sess.Count);
+        Assert.Equal(3, bsfc.SessionOverflowCount);
+    }
+
+    [Fact]
+    public void BoundedSessionFirmCounters_NullSessionId_OnlyIncsFirm()
+    {
+        var bsfc = new BoundedSessionFirmCounters();
+        bsfc.Inc(1, null);
+        bsfc.Inc(1, "");
+
+        Assert.Single(bsfc.FirmsSnapshot());
+        Assert.Equal(2, bsfc.FirmsSnapshot()[0].Value);
+        Assert.Empty(bsfc.SessionsSnapshot());
+    }
+
+    [Fact]
     public void CountingUdpPacketSinkDecorator_Increments_ThenForwards()
     {
         var reg = new MetricsRegistry();


### PR DESCRIPTION
Closes #176.

Adds **bounded-cardinality per-firm and per-session inbound message counters** so SREs can identify *which client is causing the storm* without risking a Prometheus TSDB explosion under a misbehaving fleet of test clients.

## Metrics

```
# HELP exch_session_messages_by_firm_total Total inbound application messages received from a given firm. Bounded to 100 firms; overflow funnels into firm="_other".
# TYPE exch_session_messages_by_firm_total counter
exch_session_messages_by_firm_total{firm="7"} 1532
exch_session_messages_by_firm_total{firm="42"} 89
exch_session_messages_by_firm_total{firm="_other"} 0

# HELP exch_session_messages_by_session_total Total inbound application messages received on a given FIXP session. Bounded to 500 sessions; overflow funnels into session_id="_other".
# TYPE exch_session_messages_by_session_total counter
exch_session_messages_by_session_total{session_id="conn-12345"} 1234
exch_session_messages_by_session_total{session_id="_other"} 0
```

The `_other` overflow series is **always emitted** (even at 0) so dashboards can `rate(...{firm="_other"}[5m]) > 0` without special-casing absent labels.

## Cardinality bounds (per #176 acceptance criteria)

| Dimension | Cap | Series after cap |
| --------- | --- | ---------------- |
| Firms     | 100 | `firm="_other"`  |
| Sessions  | 500 | `session_id="_other"` |

Caps are advisory under contention — the dictionary may briefly grow a handful of entries past the limit before the size check rejects new keys. Slack is bounded by the number of concurrent first-time inserters and is acceptable because the goal is bounded **long-term** growth, not strict real-time enforcement.

## Implementation

- New `BoundedSessionFirmCounters` (in `B3.Exchange.Core/`) — lock-free with `ConcurrentDictionary<TKey, long[1]>` + `Interlocked.Increment` on the boxed counter so the hot path takes no locks and never re-keys after the first sighting.
- `MetricsRegistry.SessionFirmMessages` exposes the registry-scoped counters; `RenderProm` emits both metric families with sorted keys for stable diffs.
- `ChannelDispatcher` ctor takes an optional `BoundedSessionFirmCounters`; every successful `Enqueue*` call (NewOrder, Cancel, Replace, Cross, MassCancel) bumps `(firmCode, sessionId.Value)`. Failed enqueues (queue full) are NOT counted — they're already covered by `exch_dispatch_queue_full_total`.
- `ExchangeHost.StartAsync` wires `_metrics.SessionFirmMessages` into every dispatcher.

## Tests

- `Render_EmitsBoundedSessionFirmCounters_Issue176` — both metric families render correctly with the `_other` zero series.
- `BoundedSessionFirmCounters_OverflowsIntoOther_PastCap` — past-cap firms/sessions count toward overflow; existing keys keep their slot.
- `BoundedSessionFirmCounters_NullSessionId_OnlyIncsFirm` — pre-Negotiate frames bump the firm counter only.

All 666+3 tests green; format clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
