### PR TITLE
Tighten Contracts/Gateway boundary: drop Gateway -> Core ref (#166)

### DIFF
--- a/src/B3.Exchange.Contracts/ExchangeTelemetry.cs
+++ b/src/B3.Exchange.Contracts/ExchangeTelemetry.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace B3.Exchange.Core;
+namespace B3.Exchange.Contracts;
 
 /// <summary>
 /// Shared <see cref="ActivitySource"/> for B3 exchange spans (issue #175).

--- a/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
+++ b/src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\B3.EntryPoint.Wire\B3.EntryPoint.Wire.csproj" />
     <ProjectReference Include="..\B3.Exchange.Contracts\B3.Exchange.Contracts.csproj" />
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
-    <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -2,7 +2,6 @@ using B3.EntryPoint.Wire;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Exchange.Gateway;

--- a/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.Establish.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Establish.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -1,7 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -1,5 +1,4 @@
 using B3.Exchange.Contracts;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;

--- a/src/B3.Exchange.Host/TracingBootstrap.cs
+++ b/src/B3.Exchange.Host/TracingBootstrap.cs
@@ -1,4 +1,4 @@
-using B3.Exchange.Core;
+using B3.Exchange.Contracts;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Resources;

--- a/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSessionIdValidationTests.cs
@@ -4,7 +4,6 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -1,6 +1,5 @@
 using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
-using B3.Exchange.Core;
 using System.Net;
 using System.Net.Sockets;
 using B3.Exchange.Gateway;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerDailyResetTests.cs
@@ -1,7 +1,6 @@
 using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointListenerReaperTests.cs
@@ -1,7 +1,6 @@
 using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointStrictGatingTests.cs
@@ -1,6 +1,5 @@
 using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using System.Buffers.Binary;
 using System.Net;

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointTerminateOnErrorTests.cs
@@ -1,6 +1,5 @@
 using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
-using B3.Exchange.Core;
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionBackpressureRejectTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionBackpressureRejectTests.cs
@@ -4,7 +4,6 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
@@ -2,7 +2,6 @@ using B3.Exchange.Contracts;
 using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachReplayE2ETests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachReplayE2ETests.cs
@@ -4,7 +4,6 @@ using RejectEvent = B3.Exchange.Matching.RejectEvent;
 using B3.EntryPoint.Wire;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
@@ -1,7 +1,6 @@
 using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
@@ -4,7 +4,6 @@ using RejectEvent = B3.Exchange.Matching.RejectEvent;
 using B3.EntryPoint.Wire;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionSuspendTests.cs
@@ -1,7 +1,6 @@
 using B3.Exchange.Contracts;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -4,7 +4,6 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMsgSeqNumGapTests.cs
@@ -4,7 +4,6 @@ using System.Buffers.Binary;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
@@ -1,5 +1,4 @@
 using B3.EntryPoint.Wire;
-using B3.Exchange.Core;
 using B3.Exchange.Gateway;
 using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
 

--- a/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionLifecycleMetricsWiringTests.cs
@@ -1,6 +1,5 @@
 using B3.Exchange.Contracts;
 using System.IO;
-using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 


### PR DESCRIPTION
Closes #166.

Tightens the architectural boundary so **`B3.Exchange.Gateway` no longer references `B3.Exchange.Core`**. The gateway has been pure port-interface-driven for a while (post-#137 / Onda H), but the `ProjectReference` survived along with stale `using B3.Exchange.Core;` directives that masked the cleanliness of the actual call graph.

## Changes

- **Gateway → Core ProjectReference removed.** Gateway compiles against `Contracts` + `Matching` + `EntryPoint.{Sbe,Wire}` only. Same for `B3.Exchange.Gateway.Tests`.
- **`ExchangeTelemetry` moved from `Core` to `Contracts`** so both Gateway (gateway.decode span) and Core (dispatch.enqueue / engine.process / outbound.emit spans) reach the same `ActivitySource("B3.Exchange")` without forming a Gateway → Core dependency. This is the natural home — it's a pure constants/`ActivitySource` definition with zero behavior.
- **Stale `using B3.Exchange.Core;` directives pruned** in 11 Gateway files and 16 Gateway-test files — they referenced no Core symbols (just XML-doc cross-references).
- `TracingBootstrap` (Host) now imports the new namespace.

## Boundary state after this PR

```
Contracts   (port types: Side, Events, Commands, ICoreOutbound, IInboundCommandSink, ExchangeTelemetry, ...)
   ↑
Matching    (engine + book; supplies Side/Events used by port signatures)
   ↑
Gateway ────► Contracts + Matching + EntryPoint.{Sbe,Wire}      // no longer depends on Core
   ↓ (port interfaces)
Core    ────► Contracts + Matching + Instruments + Umdf.WireEncoder
   ↑
Host    ────► Core + Gateway + Matching + Instruments
```

Promoting `Events.cs` / `Side` from Matching into Contracts (so Contracts becomes truly port-side-pure with no domain dependency) is a deeper change with a much larger blast radius — left as a follow-up so this PR stays surgical and reviewable.

## SBE refs in Contracts

The issue mentioned `B3.EntryPoint.Sbe` / `B3.Umdf.Sbe` references in Contracts. Those are not present in `B3.Exchange.Contracts.csproj` today (only `B3.Exchange.Matching` is there); flagging in case the issue text predates an earlier cleanup pass.

## Tests

Full suite green (561 tests across 6 projects); `dotnet format --verify-no-changes` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
