### PR TITLE
issue/169: protect single-thread invariant on MatchingEngine

### DIFF
--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -24,7 +24,12 @@ TCP client ──► EntryPointSession ──► HostRouter ──► ChannelDis
 * `HostRouter` dispatches each inbound command (NewOrder/Cancel/Replace) to
   the `ChannelDispatcher` whose channel owns the order's instrument.
 * Each `ChannelDispatcher` runs a single dispatch thread (the matching engine
-  is not thread-safe by design — single-threaded per channel).
+  is not thread-safe by design — single-threaded per channel). The engine is
+  bound to that thread on dispatcher startup via
+  `MatchingEngine.BindToDispatchThread`; every public engine entry point and
+  every `IMatchingEventSink` callback asserts the owner thread in DEBUG
+  builds (issue #169). Cross-thread access must go through the dispatcher's
+  `Enqueue*` methods, which post a `WorkItem` onto the inbox channel.
 * Per-command emitted events are batched into one UMDF packet (PacketHeader +
   N inc messages) before being multicast.
 * The `orderId → reply` map ensures execution reports for passive (resting)

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -186,6 +186,10 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         // AssertOnLoopThread() in mutation paths can enforce the
         // single-writer invariant in DEBUG builds (issue #138).
         _loopThread = Thread.CurrentThread;
+        // Issue #169: bind the matching engine eagerly so any off-thread
+        // engine call is caught on the very first invocation, not just
+        // after the first in-thread call has latched the owner.
+        _engine.BindToDispatchThread(_loopThread);
 
         // Heartbeat is recorded on every loop wakeup (whether triggered by
         // new work or by the periodic timeout) so a stuck/dead dispatch

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -9,6 +9,18 @@ namespace B3.Exchange.Matching;
 /// allocators and an <see cref="RptSeq"/> that is incremented on every emitted
 /// MBO/Trade event so the integration layer can stamp <c>RptSeq</c> on UMDF
 /// frames without separate bookkeeping.
+///
+/// <para>
+/// Threading invariant (issue #169): every public mutation/read entry point
+/// (<see cref="Submit"/>, <see cref="Cancel"/>, <see cref="Replace"/>,
+/// <see cref="MassCancel"/>, <see cref="AllocateNextRptSeq"/>,
+/// <see cref="ResetForChannelReset"/>) plus the <see cref="IMatchingEventSink"/>
+/// callbacks they trigger MUST run on a single owner thread. The
+/// <c>ChannelDispatcher</c> binds its loop thread via
+/// <see cref="BindToDispatchThread"/> on startup. In DEBUG builds, a
+/// per-call assert fires if any caller violates this. Any cross-thread
+/// invocation must be marshalled via <c>ChannelDispatcher.EnqueueXxx</c>.
+/// </para>
 /// </summary>
 public sealed class MatchingEngine
 {
@@ -39,6 +51,14 @@ public sealed class MatchingEngine
     private uint _rptSeq;
 
     private bool _dispatching;
+
+    // Single-thread invariant (issue #169). Latched on first call to any
+    // mutation/read entry point (or eagerly via BindToDispatchThread) so
+    // future call-site regressions are caught at test time. Production
+    // callers (ChannelDispatcher) bind explicitly so even the very first
+    // engine call is checked. Unit tests that exercise the engine on the
+    // xUnit thread without binding are tolerated via lazy latching.
+    private Thread? _ownerThread;
 
     public MatchingEngine(IEnumerable<Instrument> instruments, IMatchingEventSink sink,
         ILogger<MatchingEngine> logger,
@@ -76,6 +96,7 @@ public sealed class MatchingEngine
     /// </summary>
     public uint AllocateNextRptSeq()
     {
+        AssertOnOwnerThread();
         if (_dispatching)
             throw new InvalidOperationException("AllocateNextRptSeq called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
         return ++_rptSeq;
@@ -94,6 +115,7 @@ public sealed class MatchingEngine
     /// </summary>
     public void ResetForChannelReset()
     {
+        AssertOnOwnerThread();
         if (_dispatching)
             throw new InvalidOperationException("cannot reset while a command is being dispatched");
         foreach (var book in _booksById.Values) book.Clear();
@@ -481,10 +503,48 @@ public sealed class MatchingEngine
 
     private void EnterDispatch()
     {
+        AssertOnOwnerThread();
         if (_dispatching)
             throw new InvalidOperationException("MatchingEngine called reentrantly from a sink callback. Sinks must not invoke engine methods.");
         _dispatching = true;
     }
 
     private void ExitDispatch() => _dispatching = false;
+
+    /// <summary>
+    /// Eagerly binds the engine to the dispatch-loop thread. Called by
+    /// <c>ChannelDispatcher</c> on entry to its run loop so that any
+    /// off-thread engine call is caught on the very first invocation in
+    /// DEBUG builds. Subsequent calls with the same thread are no-ops;
+    /// calls from a different thread fail the assert.
+    /// Issue #169 (single-thread invariant audit).
+    /// </summary>
+    public void BindToDispatchThread(Thread thread)
+    {
+        ArgumentNullException.ThrowIfNull(thread);
+        var prior = Interlocked.CompareExchange(ref _ownerThread, thread, null);
+        System.Diagnostics.Debug.Assert(
+            prior == null || prior == thread,
+            $"MatchingEngine already bound to a different thread "
+            + $"(existing={prior?.ManagedThreadId}, new={thread.ManagedThreadId})");
+    }
+
+    /// <summary>
+    /// Asserts the calling thread owns the engine. Latches the owner
+    /// thread on first call if no explicit binding was made (so unit
+    /// tests that drive the engine directly remain consistent across
+    /// their lifetime). Compiled out in Release.
+    /// Issue #169 (single-thread invariant).
+    /// </summary>
+    [System.Diagnostics.Conditional("DEBUG")]
+    private void AssertOnOwnerThread()
+    {
+        var current = Thread.CurrentThread;
+        var owner = Interlocked.CompareExchange(ref _ownerThread, current, null);
+        System.Diagnostics.Debug.Assert(
+            owner == null || owner == current,
+            $"MatchingEngine entered off the owner thread "
+            + $"(owner={owner?.ManagedThreadId}, "
+            + $"actual={current.ManagedThreadId})");
+    }
 }

--- a/tests/B3.Exchange.Matching.Tests/SingleThreadInvariantTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/SingleThreadInvariantTests.cs
@@ -1,0 +1,120 @@
+using System.Diagnostics;
+
+namespace B3.Exchange.Matching.Tests;
+
+/// <summary>
+/// Issue #169: the matching engine documents a single-thread invariant —
+/// every public mutation/read entry point and every sink callback must
+/// run on the bound owner thread. These tests verify the DEBUG-only
+/// assertion fires on cross-thread access and that the eager
+/// <see cref="MatchingEngine.BindToDispatchThread"/> path is honoured.
+/// </summary>
+public class SingleThreadInvariantTests
+{
+    public SingleThreadInvariantTests()
+    {
+        // Make Debug.Assert throw instead of popping a UI / silently
+        // logging, so we can observe the assertion in tests.
+        if (!Trace.Listeners.OfType<ThrowOnAssertListener>().Any())
+        {
+            Trace.Listeners.Clear();
+            Trace.Listeners.Add(new ThrowOnAssertListener());
+        }
+    }
+
+    [Fact]
+    public void Bind_then_call_on_same_thread_succeeds()
+    {
+        var engine = TestFactory.NewEngine(out _);
+        engine.BindToDispatchThread(Thread.CurrentThread);
+        // Should not throw.
+        _ = engine.AllocateNextRptSeq();
+    }
+
+    [Fact]
+    public void Lazy_latch_allows_unbound_first_call_and_pins_thread()
+    {
+        var engine = TestFactory.NewEngine(out _);
+        // First call (no explicit binding) latches current thread.
+        _ = engine.AllocateNextRptSeq();
+        // Second call from another thread must trigger the assert.
+        Exception? captured = null;
+        var t = new Thread(() =>
+        {
+            try { _ = engine.AllocateNextRptSeq(); }
+            catch (Exception ex) { captured = ex; }
+        });
+        t.Start();
+        t.Join();
+
+#if DEBUG
+        Assert.NotNull(captured);
+        Assert.IsType<DebugAssertException>(captured);
+#else
+        Assert.Null(captured);
+#endif
+    }
+
+    [Fact]
+    public void Bind_then_call_from_other_thread_asserts_in_debug()
+    {
+        var engine = TestFactory.NewEngine(out _);
+        engine.BindToDispatchThread(Thread.CurrentThread);
+
+        Exception? captured = null;
+        var t = new Thread(() =>
+        {
+            try { _ = engine.AllocateNextRptSeq(); }
+            catch (Exception ex) { captured = ex; }
+        });
+        t.Start();
+        t.Join();
+
+#if DEBUG
+        Assert.NotNull(captured);
+        Assert.IsType<DebugAssertException>(captured);
+#else
+        Assert.Null(captured);
+#endif
+    }
+
+    [Fact]
+    public void Rebinding_to_a_different_thread_asserts_in_debug()
+    {
+        var engine = TestFactory.NewEngine(out _);
+        engine.BindToDispatchThread(Thread.CurrentThread);
+
+        Exception? captured = null;
+        var t = new Thread(() =>
+        {
+            try { engine.BindToDispatchThread(Thread.CurrentThread); }
+            catch (Exception ex) { captured = ex; }
+        });
+        t.Start();
+        t.Join();
+
+#if DEBUG
+        Assert.NotNull(captured);
+        Assert.IsType<DebugAssertException>(captured);
+#else
+        Assert.Null(captured);
+#endif
+    }
+
+    private sealed class ThrowOnAssertListener : TraceListener
+    {
+        public override void Fail(string? message)
+            => throw new DebugAssertException(message ?? "assert failed");
+
+        public override void Fail(string? message, string? detailMessage)
+            => throw new DebugAssertException(($"{message} {detailMessage}").Trim());
+
+        public override void Write(string? message) { }
+        public override void WriteLine(string? message) { }
+    }
+
+    public sealed class DebugAssertException : Exception
+    {
+        public DebugAssertException(string message) : base(message) { }
+    }
+}


### PR DESCRIPTION
## #169 — A4: protect single-thread invariant on the matching engine

The engine documents a "single owner thread per channel" invariant but had
no enforcement. ChannelDispatcher already asserts its loop thread on every
mutation path; `MatchingEngine` did not, so a future regression that called
into the engine off-thread would be silent.

### Audit

- All `ChannelDispatcher.Enqueue*` paths post `WorkItem`s onto the
  inbox `Channel<>` and never touch the engine directly. Snapshot ticks
  scheduled by the host's `System.Threading.Timer` go through
  `EnqueueSnapshotTick` → inbox → dispatch loop, so `SnapshotRotator.PublishNext()`
  also runs on the dispatch thread (verified via existing `AssertOnLoopThread()`
  in `ProcessOne`).
- The only direct engine entry points outside the dispatch loop today are
  unit tests that drive the engine from the xUnit thread. Those remain
  valid because the assert is *thread-affinity*, not *specific-thread*.

### Changes

- `MatchingEngine.BindToDispatchThread(Thread)` — eager binding API.
  `ChannelDispatcher.RunLoopAsync` calls it after capturing `_loopThread`
  so production violations are caught on the very first off-thread call.
- `[Conditional("DEBUG")] AssertOnOwnerThread()` — latches owner on first
  call (preserves test ergonomics) and asserts on subsequent calls.
  Wired into `EnterDispatch()` (covers Submit/Cancel/Replace/MassCancel),
  `AllocateNextRptSeq`, and `ResetForChannelReset`.
- XML doc on `MatchingEngine` documents the invariant.
- `docs/EXCHANGE-SIMULATOR.md` updated to mention the binding + DEBUG assert.

### Tests

`tests/B3.Exchange.Matching.Tests/SingleThreadInvariantTests.cs` — 4 tests
covering bind+same-thread (passes), lazy latch + cross-thread (asserts in
DEBUG), explicit bind + cross-thread (asserts in DEBUG), and rebinding
to a different thread (asserts in DEBUG). Tests use a custom
`TraceListener` so `Debug.Assert` throws instead of silently logging.
Compiled-out branches are guarded with `#if DEBUG`/`#else` so the file
also passes under Release.

### Verification

```
dotnet build SbeB3Exchange.slnx -c Release   # 0 warn / 0 err
dotnet test  SbeB3Exchange.slnx --no-build -c Release   # 565 passed (+4)
dotnet test  tests/B3.Exchange.Matching.Tests -c Debug --filter "...SingleThreadInvariantTests"
                                              # 4/4 (DEBUG path)
dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
```

Closes #169
