### PR TITLE
issue/167: centralize OrderState in per-channel OrderRegistry

### DIFF
--- a/src/B3.Exchange.Contracts/Ports.cs
+++ b/src/B3.Exchange.Contracts/Ports.cs
@@ -40,29 +40,30 @@ public interface ICoreOutbound
 
     /// <summary>
     /// Routes an <c>ExecutionReport_Trade</c> for the resting (passive) side
-    /// of <paramref name="e"/>. The Core does not know which session owns
-    /// the resting order: implementations resolve <paramref name="restingOrderId"/>
-    /// → <c>(SessionId, ClOrdId)</c> via the Gateway-side
-    /// <c>OrderOwnershipMap</c> and forward the wire-encoded ER. When the
-    /// resting order's owner has gone away the report is dropped silently
-    /// (same behaviour as the active path).
+    /// of <paramref name="e"/>. The Core resolves the resting order's owning
+    /// session locally on the dispatch thread (via its per-channel
+    /// <c>OrderRegistry</c>) and passes the resolved
+    /// <paramref name="ownerSession"/> + <paramref name="ownerClOrdId"/>
+    /// here; the Gateway forwards the wire-encoded ER. When the resting
+    /// order's owner has gone away the report is dropped silently (same
+    /// behaviour as the active path).
     /// </summary>
-    bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e,
-        long leavesQty, long cumQty);
+    bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId,
+        in TradeEvent e, long leavesQty, long cumQty);
 
     /// <summary>
     /// Routes an <c>ExecutionReport_Cancel</c> for the owner of
     /// <paramref name="orderId"/> (whether the cancel was self-initiated, a
-    /// mass-cancel, or any other engine-driven cancel). The Gateway resolves
-    /// the owning session from the ownership map, sends the ER, and evicts
-    /// the entry — passing <paramref name="requesterClOrdIdOrZero"/> as the
-    /// new <c>ClOrdId</c> on the wire (with the owner's original ClOrdId
-    /// becoming <c>OrigClOrdID</c>); pass zero when the cancel was not
-    /// initiated by a request from a live session (e.g. engine-internal
-    /// cancel).
+    /// mass-cancel, or any other engine-driven cancel). The Core has already
+    /// resolved <paramref name="ownerSession"/> + <paramref name="ownerClOrdId"/>
+    /// on the dispatch thread; the Gateway sends the ER passing
+    /// <paramref name="requesterClOrdIdOrZero"/> as the new <c>ClOrdId</c>
+    /// on the wire (with the owner's original ClOrdId becoming
+    /// <c>OrigClOrdID</c>); pass zero when the cancel was not initiated by
+    /// a request from a live session (e.g. engine-internal cancel).
     /// </summary>
-    bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e,
-        ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue);
+    bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId,
+        in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportModify(SessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
@@ -70,14 +71,6 @@ public interface ICoreOutbound
         ulong receivedTimeNanos = ulong.MaxValue);
 
     bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue);
-
-    /// <summary>
-    /// Signals that <paramref name="orderId"/> has reached a terminal state
-    /// other than cancel (currently: full fill). The Gateway evicts the
-    /// owner entry; no <c>ExecutionReport</c> is emitted (the per-fill
-    /// <c>ER_Trade</c>s have already done the wire work).
-    /// </summary>
-    void NotifyOrderTerminal(long orderId);
 }
 
 /// <summary>

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -24,6 +24,7 @@ public sealed partial class ChannelDispatcher
         // from the dispatch loop.
         AssertOnLoopThread();
         _engine.ResetForChannelReset();
+        _orders.Clear();
         Volatile.Write(ref _sequenceVersion, (ushort)(_sequenceVersion + 1));
         Volatile.Write(ref _sequenceNumber, 0u);
         _snapshotRotator?.BumpSequenceVersion();

--- a/src/B3.Exchange.Core/ChannelDispatcher.OrderState.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.OrderState.cs
@@ -1,0 +1,57 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// OrderState facet of <see cref="ChannelDispatcher"/> (issue #167):
+/// the cross-thread query surface that <c>HostRouter</c> uses to ask each
+/// dispatcher about its own resting orders. All methods are safe to call
+/// from inbound (Gateway recv-loop) threads; they delegate to the
+/// per-channel <see cref="OrderRegistry"/>, which is single-writer
+/// (dispatch thread) + multi-reader (cross-thread).
+/// </summary>
+public sealed partial class ChannelDispatcher
+{
+    /// <summary>
+    /// Resolves <paramref name="origClOrdId"/> for <paramref name="firm"/>
+    /// against this channel's registry. Returns <c>true</c> with the
+    /// engine-assigned <paramref name="orderId"/> + the SecurityId of the
+    /// resting order when an entry exists; <c>false</c> + zeroes otherwise.
+    /// </summary>
+    public bool TryResolveByClOrdId(uint firm, ulong origClOrdId, out long orderId, out long securityId)
+    {
+        if (_orders.TryResolveByClOrdId(firm, origClOrdId, out orderId)
+            && _orders.TryResolve(orderId, out var owner))
+        {
+            securityId = owner.SecurityId;
+            return true;
+        }
+        orderId = 0;
+        securityId = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns every <c>(OrderId, SecurityId)</c> tuple in this channel
+    /// owned by <paramref name="session"/> + <paramref name="firm"/> that
+    /// matches the optional Side / SecurityId filters. See
+    /// <see cref="OrderRegistry.FilterMassCancel"/>.
+    /// </summary>
+    public IReadOnlyList<(long OrderId, long SecurityId)> FilterMassCancelLocal(
+        SessionId session, uint firm, Side? sideFilter, long securityIdFilter)
+        => _orders.FilterMassCancel(session, firm, sideFilter, securityIdFilter);
+
+    /// <summary>
+    /// Drops every entry in this channel owned by <paramref name="session"/>.
+    /// Returns the number of entries removed. Called from
+    /// <c>HostRouter.OnSessionClosed</c> on the gateway recv-loop thread —
+    /// the orders themselves stay on the book, but passive fills against
+    /// them stop trying to route to a (now-defunct) session.
+    /// </summary>
+    public int EvictSessionLocal(SessionId session) => _orders.EvictSession(session);
+
+    /// <summary>Total resting-order entries currently registered in this
+    /// channel. Diagnostic only.</summary>
+    public int OrderRegistryCount => _orders.Count;
+}

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -29,6 +29,11 @@ public sealed partial class ChannelDispatcher
 
         if (_hasCurrentSession)
         {
+            // Issue #167: register canonical order-state on the dispatch
+            // thread (single writer) BEFORE emitting the ER so any passive
+            // trade fired in the same dispatch turn can resolve owner ↦
+            // session locally.
+            _orders.Register(e.OrderId, _currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId);
             _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, e, _currentReceivedTimeNanos);
             _metrics?.IncExecutionReport(ExecutionReportKind.New);
         }
@@ -67,12 +72,17 @@ public sealed partial class ChannelDispatcher
             e.SecurityId, e.OrderId, entryType, e.RemainingQuantityAtCancel, e.RptSeq, e.TransactTimeNanos, e.PriceMantissa);
         Commit(n);
 
-        // Gateway resolves OrderId → owning session via OrderOwnershipMap
-        // and evicts the entry. Pass the active session's ClOrdId (if any)
-        // so the wire ER carries the requester's id while OrigClOrdID
-        // points to the owner's original ClOrdID.
-        _outbound.WriteExecutionReportPassiveCancel(e.OrderId, e, _currentClOrdId, _currentReceivedTimeNanos);
-        _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
+        // Issue #167: resolve owner locally on the dispatch thread, then
+        // evict the canonical entry. Pass the active session's ClOrdId (if
+        // any) so the wire ER carries the requester's id while
+        // OrigClOrdID points to the owner's original ClOrdID.
+        if (_orders.TryResolve(e.OrderId, out var owner))
+        {
+            _orders.Evict(e.OrderId);
+            _outbound.WriteExecutionReportPassiveCancel(owner.Session, owner.ClOrdId, e.OrderId, e,
+                _currentClOrdId, _currentReceivedTimeNanos);
+            _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
+        }
     }
 
     public void OnOrderFilled(in OrderFilledEvent e)
@@ -90,9 +100,10 @@ public sealed partial class ChannelDispatcher
             e.SecurityId, e.OrderId, entryType, e.FinalFilledQuantity, e.RptSeq, e.TransactTimeNanos, e.PriceMantissa);
         Commit(n);
 
-        // Tell the Gateway to release the ownership entry — no wire ER here
-        // (the per-trade ER_Trade frames have already covered the fills).
-        _outbound.NotifyOrderTerminal(e.OrderId);
+        // Tell the canonical registry the order has reached terminal state
+        // — no wire ER here (the per-trade ER_Trade frames have already
+        // covered the fills).
+        _orders.Evict(e.OrderId);
     }
 
     public void OnTrade(in TradeEvent e)
@@ -119,10 +130,16 @@ public sealed partial class ChannelDispatcher
                 leavesQty: 0, cumQty: e.Quantity);
             _metrics?.IncExecutionReport(ExecutionReportKind.Trade);
         }
-        // ER_Trade for the resting side: Gateway resolves owner via the
-        // OrderOwnershipMap.
-        _outbound.WriteExecutionReportPassiveTrade(e.RestingOrderId, e, leavesQty: 0, cumQty: e.Quantity);
-        _metrics?.IncExecutionReport(ExecutionReportKind.TradePassive);
+        // ER_Trade for the resting side: resolve owner locally on the
+        // dispatch thread (#167) and pass pre-resolved (session, clOrdId)
+        // to the Gateway. If the owner has no live session entry the
+        // Gateway drops at SessionRegistry.TryGet.
+        if (_orders.TryResolve(e.RestingOrderId, out var owner))
+        {
+            _outbound.WriteExecutionReportPassiveTrade(owner.Session, owner.ClOrdId, e.RestingOrderId,
+                e, leavesQty: 0, cumQty: e.Quantity);
+            _metrics?.IncExecutionReport(ExecutionReportKind.TradePassive);
+        }
     }
 
     public void OnReject(in B3.Exchange.Matching.RejectEvent e)

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -57,7 +57,8 @@ namespace B3.Exchange.Core;
 /// or buffer state is mutated from the producer thread.</description></item>
 /// <item><description><b>The dispatch loop thread</b> (the single
 /// <see cref="Thread"/> spun up by <see cref="Start"/>) is the sole mutator of
-/// engine state, the packet buffer, the <c>_clOrdId</c> index, and the
+/// engine state, the packet buffer, the per-channel <c>OrderRegistry</c>,
+/// and the
 /// <see cref="SequenceNumber"/> / <see cref="SequenceVersion"/> counters.
 /// Every mutation path asserts <c>Thread.CurrentThread == _loopThread</c>
 /// in DEBUG builds via <c>AssertOnLoopThread</c>.</description></item>
@@ -121,6 +122,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly ushort _tradeDate;
     private readonly ChannelMetrics? _metrics;
     private readonly BoundedSessionFirmCounters? _sessionFirmCounters;
+    private readonly OrderRegistry _orders = new();
 
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -2,52 +2,48 @@ using System.Collections.Concurrent;
 using B3.Exchange.Contracts;
 using Side = B3.Exchange.Matching.Side;
 
-namespace B3.Exchange.Gateway;
+namespace B3.Exchange.Core;
 
 /// <summary>
-/// Per-process map keyed by engine-assigned <c>OrderId</c> that tracks
-/// which <see cref="SessionId"/> + (EnteringFirm, ClOrdId) tuple owns each
-/// resting order and which side / instrument it sits on.
+/// Per-channel canonical order-state index keyed by engine-assigned
+/// <c>OrderId</c>. Tracks which <see cref="SessionId"/> + (EnteringFirm,
+/// ClOrdId) tuple owns each resting order and which side / instrument it
+/// sits on. One instance per <see cref="ChannelDispatcher"/> (issue #167).
 ///
-/// <para>Lives in the Gateway because the Core (matching engine + channel
-/// dispatchers) intentionally does not hold any session/transport state.
-/// Populated by <see cref="GatewayRouter"/> on every
-/// <see cref="ICoreOutbound.WriteExecutionReportNew"/> callback and evicted
-/// on terminal events (<c>OnOrderCanceled</c>, full fill, session close).
-/// Also serves as the resolver for <c>OrigClOrdID → OrderId</c> on
-/// inbound Cancel/Replace and for the mass-cancel filter in
-/// <see cref="HostRouter"/>.</para>
-///
-/// <para>Thread-safety: invoked from any <c>ChannelDispatcher</c> dispatch
-/// thread (writes via <see cref="GatewayRouter"/>) and from any
-/// <c>FixpSession</c> recv loop thread (reads + filter via
-/// <c>HostRouter</c>). Backed by <see cref="ConcurrentDictionary{TKey,
-/// TValue}"/> for both indices.</para>
+/// <para>Single writer: every mutation runs on the owning dispatcher's
+/// dispatch thread (<see cref="ChannelDispatcher"/> calls
+/// <see cref="Register"/> from <c>OnOrderAccepted</c> and
+/// <see cref="Evict"/> from <c>OnOrderCanceled</c> / <c>OnOrderFilled</c>).
+/// Multi-reader: <see cref="TryResolve"/>, <see cref="TryResolveByClOrdId"/>,
+/// <see cref="FilterMassCancel"/>, and <see cref="EvictSession"/> are called
+/// from inbound (Gateway recv-loop) threads via
+/// <c>HostRouter</c>; backed by <see cref="ConcurrentDictionary{TKey, TValue}"/>
+/// for cross-thread reads.</para>
 ///
 /// <para>Ordering invariant: every passive trade emitted by the engine
 /// against a resting order is preceded — on the same dispatch thread — by
-/// the resting order's <c>OrderAccepted</c> event, so
-/// <see cref="GatewayRouter"/>'s <c>Register</c> always runs before the
-/// first <see cref="TryResolve"/> for that <c>OrderId</c>.</para>
+/// the resting order's <c>OrderAccepted</c> event, so <see cref="Register"/>
+/// always runs before the first <see cref="TryResolve"/> for that
+/// <c>OrderId</c>.</para>
 /// </summary>
-public sealed class OrderOwnershipMap
+public sealed class OrderRegistry
 {
-    public readonly record struct OrderOwnership(
+    public readonly record struct OrderState(
         SessionId Session, ulong ClOrdId, uint Firm, Side Side, long SecurityId);
 
-    private readonly ConcurrentDictionary<long, OrderOwnership> _byOrderId = new();
+    private readonly ConcurrentDictionary<long, OrderState> _byOrderId = new();
     private readonly ConcurrentDictionary<(uint Firm, ulong ClOrdId), long> _byClOrdId = new();
 
     public int Count => _byOrderId.Count;
 
     public void Register(long orderId, SessionId session, ulong clOrdId, uint firm, Side side, long securityId)
     {
-        _byOrderId[orderId] = new OrderOwnership(session, clOrdId, firm, side, securityId);
+        _byOrderId[orderId] = new OrderState(session, clOrdId, firm, side, securityId);
         if (clOrdId != 0)
             _byClOrdId[(firm, clOrdId)] = orderId;
     }
 
-    public bool TryResolve(long orderId, out OrderOwnership owner)
+    public bool TryResolve(long orderId, out OrderState owner)
         => _byOrderId.TryGetValue(orderId, out owner);
 
     public bool TryResolveByClOrdId(uint firm, ulong origClOrdId, out long orderId)
@@ -73,11 +69,12 @@ public sealed class OrderOwnershipMap
 
     /// <summary>
     /// Returns every <c>(OrderId, SecurityId)</c> tuple owned by
-    /// <paramref name="session"/> + <paramref name="firm"/> that matches
-    /// the optional <paramref name="sideFilter"/> and the optional
-    /// <paramref name="securityIdFilter"/> (zero ⇒ "any instrument").
-    /// Empty list ⇒ no matching orders. The caller is responsible for
-    /// grouping the result by channel before forwarding to the relevant
+    /// <paramref name="session"/> + <paramref name="firm"/> in this channel
+    /// that matches the optional <paramref name="sideFilter"/> and the
+    /// optional <paramref name="securityIdFilter"/> (zero ⇒ "any
+    /// instrument"). Empty list ⇒ no matching orders. The caller (typically
+    /// <c>HostRouter.EnqueueMassCancel</c>) is responsible for grouping the
+    /// result by channel before forwarding to the relevant
     /// <c>ChannelDispatcher</c>(s).
     /// </summary>
     public IReadOnlyList<(long OrderId, long SecurityId)> FilterMassCancel(
@@ -108,7 +105,7 @@ public sealed class OrderOwnershipMap
         foreach (var kv in _byOrderId)
         {
             if (kv.Value.Session != session) continue;
-            if (_byOrderId.TryRemove(new KeyValuePair<long, OrderOwnership>(kv.Key, kv.Value)))
+            if (_byOrderId.TryRemove(new KeyValuePair<long, OrderState>(kv.Key, kv.Value)))
             {
                 removed++;
                 if (kv.Value.ClOrdId != 0)
@@ -116,5 +113,18 @@ public sealed class OrderOwnershipMap
             }
         }
         return removed;
+    }
+
+    /// <summary>
+    /// Drops every entry. Called when the channel is reset (operator
+    /// channel-reset / engine <c>ResetForChannelReset</c>) so stale
+    /// ownership entries don't outlive the engine state.
+    /// </summary>
+    public int Clear()
+    {
+        int n = _byOrderId.Count;
+        _byOrderId.Clear();
+        _byClOrdId.Clear();
+        return n;
     }
 }

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -14,6 +14,12 @@ namespace B3.Exchange.Gateway;
 /// <see cref="FixpSession"/> via the <see cref="SessionRegistry"/>, and
 /// invokes the session's encoders.
 ///
+/// <para>Issue #167: the canonical per-order owner state lives in Core's
+/// per-channel <c>OrderRegistry</c>; <see cref="ChannelDispatcher"/>
+/// resolves the owning session on the dispatch thread and passes the
+/// pre-resolved <c>(SessionId, ClOrdId)</c> on every passive ER call. The
+/// Gateway no longer holds an ownership map.</para>
+///
 /// <para>If the session is no longer registered (peer disconnected
 /// between the inbound command and the engine emitting the event) the
 /// report is dropped silently. Phase 3 (Suspended sessions) will route
@@ -27,26 +33,19 @@ namespace B3.Exchange.Gateway;
 public sealed class GatewayRouter : ICoreOutbound
 {
     private readonly SessionRegistry _registry;
-    private readonly OrderOwnershipMap _ownership;
     private readonly ILogger<GatewayRouter> _logger;
 
-    public GatewayRouter(SessionRegistry registry, OrderOwnershipMap ownership, ILogger<GatewayRouter> logger)
+    public GatewayRouter(SessionRegistry registry, ILogger<GatewayRouter> logger)
     {
         ArgumentNullException.ThrowIfNull(registry);
-        ArgumentNullException.ThrowIfNull(ownership);
         ArgumentNullException.ThrowIfNull(logger);
         _registry = registry;
-        _ownership = ownership;
         _logger = logger;
     }
 
     public bool WriteExecutionReportNew(ContractsSessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e,
         ulong receivedTimeNanos = ulong.MaxValue)
     {
-        // Register ownership before sending so a passive trade emitted in
-        // the same dispatch turn (single-threaded by construction) finds the
-        // entry. Eviction lives on the cancel/full-fill paths below.
-        _ownership.Register(e.OrderId, session, clOrdIdValue, enteringFirm, e.Side, e.SecurityId);
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportNew"); return false; }
         return s.WriteExecutionReportNew(e, receivedTimeNanos);
     }
@@ -58,32 +57,19 @@ public sealed class GatewayRouter : ICoreOutbound
         return s.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty);
     }
 
-    public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e,
-        long leavesQty, long cumQty)
+    public bool WriteExecutionReportPassiveTrade(ContractsSessionId ownerSession, ulong ownerClOrdId, long restingOrderId,
+        in TradeEvent e, long leavesQty, long cumQty)
     {
-        if (!_ownership.TryResolve(restingOrderId, out var owner))
-        {
-            _logger.LogTrace("dropping passive ExecReportTrade for unknown orderId {OrderId}", restingOrderId);
-            return false;
-        }
-        if (!_registry.TryGet(owner.Session, out var s)) { LogMiss(owner.Session, "ExecReportPassiveTrade"); return false; }
-        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, owner.ClOrdId, leavesQty, cumQty);
+        if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportPassiveTrade"); return false; }
+        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, ownerClOrdId, leavesQty, cumQty);
     }
 
-    public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e,
-        ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+    public bool WriteExecutionReportPassiveCancel(ContractsSessionId ownerSession, ulong ownerClOrdId, long orderId,
+        in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
     {
-        if (!_ownership.TryResolve(orderId, out var owner))
-        {
-            _logger.LogTrace("dropping passive ExecReportCancel for unknown orderId {OrderId}", orderId);
-            return false;
-        }
-        // Always evict — the order is gone from the book regardless of
-        // whether the routing succeeds.
-        _ownership.Evict(orderId);
-        if (!_registry.TryGet(owner.Session, out var s)) { LogMiss(owner.Session, "ExecReportPassiveCancel"); return false; }
-        ulong clOrdIdOnWire = requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : owner.ClOrdId;
-        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, owner.ClOrdId, receivedTimeNanos);
+        if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportPassiveCancel"); return false; }
+        ulong clOrdIdOnWire = requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : ownerClOrdId;
+        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, ownerClOrdId, receivedTimeNanos);
     }
 
     public bool WriteExecutionReportModify(ContractsSessionId session, long securityId, long orderId,
@@ -101,8 +87,6 @@ public sealed class GatewayRouter : ICoreOutbound
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportReject"); return false; }
         return s.WriteExecutionReportReject(e, clOrdIdValue);
     }
-
-    public void NotifyOrderTerminal(long orderId) => _ownership.Evict(orderId);
 
     private void LogMiss(ContractsSessionId session, string kind)
     {

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -103,8 +103,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     {
         _logger.LogInformation("exchange host starting with {ChannelCount} channels", _config.Channels.Count);
         var sessionRegistry = new SessionRegistry();
-        var ownershipMap = new OrderOwnershipMap();
-        var gatewayRouter = new GatewayRouter(sessionRegistry, ownershipMap, _loggerFactory.CreateLogger<GatewayRouter>());
+        var gatewayRouter = new GatewayRouter(sessionRegistry, _loggerFactory.CreateLogger<GatewayRouter>());
 
         var firmRegistry = FirmRegistry;
         var defaultSession = ResolveDefaultSession(firmRegistry);
@@ -234,7 +233,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
         }
 
-        _router = new HostRouter(routing, gatewayRouter, ownershipMap, _loggerFactory.CreateLogger<HostRouter>());
+        _router = new HostRouter(routing, gatewayRouter, _loggerFactory.CreateLogger<HostRouter>());
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
         var sessionOptions = new FixpSessionOptions
         {

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -1,5 +1,4 @@
 using B3.Exchange.Contracts;
-using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
@@ -14,36 +13,36 @@ namespace B3.Exchange.Host;
 /// instrument across any channel; the host owns the SecurityId → Channel
 /// routing table built at startup from per-channel instrument files.
 ///
-/// <para>This is also the integration point for the Gateway-side
-/// <see cref="OrderOwnershipMap"/>: Cancel/Replace by <c>OrigClOrdID</c>
-/// and the mass-cancel filter (spec §4.8 / #GAP-19) are resolved here
-/// against the map BEFORE the resolved command is enqueued onto a
-/// dispatcher's inbound queue. The dispatchers themselves no longer hold
-/// any per-session/per-order state (#66).</para>
+/// <para>Issue #167: per-channel <c>OrderRegistry</c> is the canonical
+/// owner of per-order routing state. Cancel/Replace by <c>OrigClOrdID</c>
+/// and the mass-cancel filter (spec §4.8 / #GAP-19) iterate the
+/// dispatchers and resolve against each channel's local registry. Session
+/// close fans an evict-session call out to every channel. The dispatchers
+/// remain the single writer for their own registry on the dispatch
+/// thread; this router only reads.</para>
 ///
 /// On unknown SecurityId or unresolvable OrigClOrdID the router synthesizes
 /// a reject ER directly back to the session via the
-/// <see cref="GatewayRouter"/> — no engine is involved.
+/// <see cref="ICoreOutbound"/> — no engine is involved.
 /// </summary>
 public sealed class HostRouter : IInboundCommandSink
 {
     private readonly IReadOnlyDictionary<long, ChannelDispatcher> _bySecId;
+    private readonly IReadOnlyList<ChannelDispatcher> _allDispatchers;
     private readonly ICoreOutbound _outbound;
-    private readonly OrderOwnershipMap _ownership;
     private readonly ILogger<HostRouter> _logger;
     private readonly Func<ulong> _nowNanos;
 
     public HostRouter(IReadOnlyDictionary<long, ChannelDispatcher> routing, ICoreOutbound outbound,
-        OrderOwnershipMap ownership,
         ILogger<HostRouter> logger,
         Func<ulong>? nowNanos = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
-        ArgumentNullException.ThrowIfNull(ownership);
         _bySecId = routing;
+        // Distinct dispatcher set (multiple SecurityIds may share one channel).
+        _allDispatchers = routing.Values.Distinct().ToArray();
         _outbound = outbound;
-        _ownership = ownership;
         _logger = logger;
         _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
     }
@@ -101,26 +100,20 @@ public sealed class HostRouter : IInboundCommandSink
     public bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm)
     {
         // Spec §4.8 / #GAP-19. Resolve the (session, firm, Side?, SecurityId?)
-        // filter against the Gateway-side OrderOwnershipMap, then group the
-        // matching orderIds by channel before fanning out. The dispatchers
-        // see only the resolved per-channel orderId list — no filter logic
-        // and no per-order session state lives in Core anymore (#66).
-        var matches = _ownership.FilterMassCancel(session, enteringFirm, cmd.SideFilter, cmd.SecurityId);
-        if (matches.Count == 0) return true;
-
+        // filter against each channel's local OrderRegistry (#167); group
+        // resolved orderIds by channel and fan out. Dispatchers see only
+        // the resolved per-channel orderId list — no per-order session
+        // state lives outside the owning channel.
         Dictionary<ChannelDispatcher, List<long>>? perChannel = null;
-        foreach (var (orderId, securityId) in matches)
+        foreach (var disp in _allDispatchers)
         {
-            if (!_bySecId.TryGetValue(securityId, out var disp))
-                continue; // ownership map references an instrument no longer routed; skip silently
-            (perChannel ??= new Dictionary<ChannelDispatcher, List<long>>())
-                .TryGetValue(disp, out var list);
-            if (list == null)
-            {
-                list = new List<long>();
-                perChannel[disp] = list;
-            }
-            list.Add(orderId);
+            if (cmd.SecurityId != 0 && _bySecId.TryGetValue(cmd.SecurityId, out var byId) && byId != disp)
+                continue;
+            var matches = disp.FilterMassCancelLocal(session, enteringFirm, cmd.SideFilter, cmd.SecurityId);
+            if (matches.Count == 0) continue;
+            var list = new List<long>(matches.Count);
+            foreach (var (orderId, _) in matches) list.Add(orderId);
+            (perChannel ??= new Dictionary<ChannelDispatcher, List<long>>())[disp] = list;
         }
         if (perChannel == null) return true;
 
@@ -148,24 +141,29 @@ public sealed class HostRouter : IInboundCommandSink
 
     public void OnSessionClosed(SessionId session)
     {
-        // Drop every ownership entry held for this session so passive
-        // fills against its resting orders stop trying to route to a
-        // disconnected peer. The orders themselves stay on the book —
-        // they ARE the book — but ER_Trade / ER_Cancel for them will be
-        // dropped in GatewayRouter (Phase 3 / #69 will replace this with
-        // routing into a Suspended-session retx ring).
-        int n = _ownership.EvictSession(session);
-        if (n > 0)
-            _logger.LogDebug("session {Session} closed; evicted {Count} ownership entries", session, n);
+        // Drop every ownership entry held for this session across every
+        // channel so passive fills against its resting orders stop trying
+        // to route to a disconnected peer. The orders themselves stay on
+        // the book — they ARE the book — but ER_Trade / ER_Cancel for them
+        // will be dropped in the dispatcher's OnTrade/OnOrderCanceled when
+        // the local registry no longer resolves them (Phase 3 / #69 will
+        // replace this with routing into a Suspended-session retx ring).
+        int total = 0;
+        foreach (var disp in _allDispatchers)
+            total += disp.EvictSessionLocal(session);
+        if (total > 0)
+            _logger.LogDebug("session {Session} closed; evicted {Count} ownership entries", session, total);
     }
 
     private CancelOrderCommand ResolveOrderIdIfNeeded(in CancelOrderCommand cmd, uint firm, ulong origClOrdId, out bool ok)
     {
         if (cmd.OrderId != 0) { ok = true; return cmd; }
-        if (_ownership.TryResolveByClOrdId(firm, origClOrdId, out var orderId))
+        if (TryResolveAcrossChannels(firm, origClOrdId, out var orderId, out var securityId))
         {
             ok = true;
-            return cmd with { OrderId = orderId };
+            // Stamp the resolved SecurityId so downstream dispatch finds the
+            // owning channel even when the client didn't send one.
+            return cmd with { OrderId = orderId, SecurityId = securityId };
         }
         ok = false;
         return cmd;
@@ -174,13 +172,29 @@ public sealed class HostRouter : IInboundCommandSink
     private ReplaceOrderCommand ResolveOrderIdIfNeeded(in ReplaceOrderCommand cmd, uint firm, ulong origClOrdId, out bool ok)
     {
         if (cmd.OrderId != 0) { ok = true; return cmd; }
-        if (_ownership.TryResolveByClOrdId(firm, origClOrdId, out var orderId))
+        if (TryResolveAcrossChannels(firm, origClOrdId, out var orderId, out var securityId))
         {
             ok = true;
-            return cmd with { OrderId = orderId };
+            return cmd with { OrderId = orderId, SecurityId = securityId };
         }
         ok = false;
         return cmd;
+    }
+
+    private bool TryResolveAcrossChannels(uint firm, ulong origClOrdId, out long orderId, out long securityId)
+    {
+        // ClOrdId is unique per (firm) but its owning channel is unknown
+        // here; iterate the (typically small) dispatcher set. The first
+        // hit wins — registries are partitioned by SecurityId so collisions
+        // are not expected in practice.
+        foreach (var disp in _allDispatchers)
+        {
+            if (disp.TryResolveByClOrdId(firm, origClOrdId, out orderId, out securityId))
+                return true;
+        }
+        orderId = 0;
+        securityId = 0;
+        return false;
     }
 
     private void RejectUnknownInstrument(long secId, SessionId session, ulong clOrdIdValue)

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -67,23 +67,21 @@ public class ChannelDispatcherTests
         { _owners[e.OrderId] = (session, clOrdIdValue); if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
         { if (Find(session) is { } s) { s.Trades.Add(e); s.Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); } return true; }
-        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty)
-        { if (_owners.TryGetValue(restingOrderId, out var o) && Find(o.Session) is { } s) { s.Trades.Add(e); s.Calls.Add("TradePass"); } return true; }
-        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty)
+        { if (Find(ownerSession) is { } s) { s.Trades.Add(e); s.Calls.Add("TradePass"); } return true; }
+        public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
         {
-            if (_owners.TryGetValue(orderId, out var o) && Find(o.Session) is { } s)
+            if (Find(ownerSession) is { } s)
             {
                 s.Cancels.Add(e); s.Calls.Add("Cancel"); s.LastReceivedTime = receivedTimeNanos;
-                if (s.CaptureCancelIds) s.CancelIds.Add((requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : o.ClOrdId, o.ClOrdId));
+                if (s.CaptureCancelIds) s.CancelIds.Add((requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : ownerClOrdId, ownerClOrdId));
             }
-            _owners.Remove(orderId);
             return true;
         }
         public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue)
         { if (Find(session) is { } s) { s.Calls.Add("Modify"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue)
         { if (Find(session) is { } s) { s.Rejects.Add(e); s.Calls.Add("Reject"); } return true; }
-        public void NotifyOrderTerminal(long orderId) => _owners.Remove(orderId);
     }
 
     private static (ChannelDispatcher disp, RecordingPacketSink pkt, RecordingOutbound outbound) NewDispatcher()
@@ -550,11 +548,10 @@ public class ChannelDispatcherTests
             return true;
         }
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
-        public void NotifyOrderTerminal(long orderId) { }
     }
 
     private sealed class TestSession

--- a/tests/B3.Exchange.Core.Tests/OrderRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/OrderRegistryTests.cs
@@ -1,17 +1,17 @@
 using B3.Exchange.Contracts;
-using B3.Exchange.Gateway;
+using B3.Exchange.Core;
 using Side = B3.Exchange.Matching.Side;
 
-namespace B3.Exchange.Gateway.Tests;
+namespace B3.Exchange.Core.Tests;
 
-public class OrderOwnershipMapTests
+public class OrderRegistryTests
 {
     private static SessionId S(string s) => new SessionId(s);
 
     [Fact]
     public void Register_Then_TryResolve_ReturnsOwner()
     {
-        var map = new OrderOwnershipMap();
+        var map = new OrderRegistry();
         map.Register(orderId: 100, S("a"), clOrdId: 7, firm: 1, Side.Buy, securityId: 42);
 
         Assert.True(map.TryResolve(100, out var owner));
@@ -25,7 +25,7 @@ public class OrderOwnershipMapTests
     [Fact]
     public void TryResolveByClOrdId_FindsOrderId()
     {
-        var map = new OrderOwnershipMap();
+        var map = new OrderRegistry();
         map.Register(100, S("a"), 7, 1, Side.Buy, 42);
 
         Assert.True(map.TryResolveByClOrdId(1, 7, out var oid));
@@ -39,7 +39,7 @@ public class OrderOwnershipMapTests
     [Fact]
     public void Evict_RemovesBothIndices()
     {
-        var map = new OrderOwnershipMap();
+        var map = new OrderRegistry();
         map.Register(100, S("a"), 7, 1, Side.Buy, 42);
 
         Assert.True(map.Evict(100));
@@ -51,7 +51,7 @@ public class OrderOwnershipMapTests
     [Fact]
     public void FilterMassCancel_ScopesBySessionFirmSideInstrument()
     {
-        var map = new OrderOwnershipMap();
+        var map = new OrderRegistry();
         map.Register(1, S("a"), 1, 1, Side.Buy, 42);
         map.Register(2, S("a"), 2, 1, Side.Sell, 42);
         map.Register(3, S("a"), 3, 1, Side.Buy, 99);
@@ -78,7 +78,7 @@ public class OrderOwnershipMapTests
     [Fact]
     public void EvictSession_DropsOnlyMatchingSessionEntries()
     {
-        var map = new OrderOwnershipMap();
+        var map = new OrderRegistry();
         map.Register(1, S("a"), 1, 1, Side.Buy, 42);
         map.Register(2, S("a"), 2, 1, Side.Buy, 42);
         map.Register(3, S("b"), 3, 1, Side.Buy, 42);
@@ -95,7 +95,7 @@ public class OrderOwnershipMapTests
     [Fact]
     public void Register_OverwritesSameOrderId()
     {
-        var map = new OrderOwnershipMap();
+        var map = new OrderRegistry();
         map.Register(100, S("a"), 7, 1, Side.Buy, 42);
         map.Register(100, S("b"), 8, 2, Side.Sell, 99);
 

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -329,9 +329,8 @@ internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Con
 {
     public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
+    public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+    public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
     public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
-    public void NotifyOrderTerminal(long orderId) { }
 }

--- a/tests/B3.Exchange.Core.Tests/TracingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/TracingTests.cs
@@ -46,11 +46,10 @@ public class TracingTests
     {
         public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, MatchingSide side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue) => true;
-        public void NotifyOrderTerminal(long orderId) { }
     }
 
     private static ChannelDispatcher NewDispatcher() => new(

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -3,7 +3,6 @@ using Side = B3.Exchange.Matching.Side;
 using RejectEvent = B3.Exchange.Matching.RejectEvent;
 using OrderType = B3.Exchange.Matching.OrderType;
 using TimeInForce = B3.Exchange.Matching.TimeInForce;
-using B3.Exchange.Gateway;
 using B3.Exchange.Host;
 using B3.Exchange.Core;
 using B3.Exchange.Instruments;
@@ -25,11 +24,10 @@ public class HostRouterTests
         public List<RejectEvent> Rejects { get; } = new();
         public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) { Rejects.Add(e); return true; }
-        public void NotifyOrderTerminal(long orderId) { }
     }
 
     [Fact]
@@ -37,7 +35,7 @@ public class HostRouterTests
     {
         var routing = new Dictionary<long, ChannelDispatcher>(); // empty
         var outbound = new RecordingOutbound();
-        var router = new HostRouter(routing, outbound, new OrderOwnershipMap(), NullLogger<HostRouter>.Instance, () => 1_000UL);
+        var router = new HostRouter(routing, outbound, NullLogger<HostRouter>.Instance, () => 1_000UL);
         router.EnqueueNewOrder(
             new NewOrderCommand("1", SecurityId: 12345, Side.Buy, OrderType.Limit, TimeInForce.Day, 100, 100, 1, 0),
             new B3.Exchange.Contracts.SessionId("s1"), enteringFirm: 1, clOrdIdValue: 1);
@@ -70,7 +68,7 @@ public class HostRouterTests
             logger: NullLogger<ChannelDispatcher>.Instance,
             nowNanos: () => 1_000UL);
         // Dispatcher loop not started; we read inbound queue directly.
-        var router = new HostRouter(new Dictionary<long, ChannelDispatcher> { [42] = disp }, outbound, new OrderOwnershipMap(), NullLogger<HostRouter>.Instance);
+        var router = new HostRouter(new Dictionary<long, ChannelDispatcher> { [42] = disp }, outbound, NullLogger<HostRouter>.Instance);
 
         router.EnqueueNewOrder(
             new NewOrderCommand("1", SecurityId: 42, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 1, 0),


### PR DESCRIPTION
## #167 A2 — Centralize OrderState (per-channel partitioning)

Eliminates the split-brain between `MatchingEngine` book state and the
former `Gateway.OrderOwnershipMap`. The canonical per-order routing
state (`Session`, `Firm`, `ClOrdId`, `Side`, `SecurityId`) now lives in a
**per-channel** `OrderRegistry` owned by each `ChannelDispatcher`.

### Single writer, multi-reader

- **Writes** (`Register`, `Evict`, `Clear`) happen exclusively on the
  dispatcher's loop thread:
  - `OnOrderAccepted` → `Register`
  - `OnOrderCanceled` → resolve owner locally + `Evict`
  - `OnOrderFilled` → `Evict` (replaces former `NotifyOrderTerminal`)
  - `ProcessBumpVersion` → `Clear` (channel reset wipes both engine and
    registry — fixes the prior gap where reset cleared books but not
    ownership entries).
- **Reads** from inbound (Gateway recv-loop) threads use the cross-channel
  facade methods on `ChannelDispatcher`:
  `TryResolveByClOrdId`, `FilterMassCancelLocal`, `EvictSessionLocal`.
  Backed by `ConcurrentDictionary` for safe concurrent access.

### Boundary cleanup

- `ICoreOutbound.WriteExecutionReportPassiveTrade` /
  `WriteExecutionReportPassiveCancel` now take **pre-resolved**
  `(SessionId ownerSession, ulong ownerClOrdId)` — the dispatcher
  resolves owners on the dispatch thread before calling out. The Gateway
  is no longer responsible for `OrderId → Session` resolution.
- `ICoreOutbound.NotifyOrderTerminal` removed (the dispatcher evicts
  itself).
- `GatewayRouter` no longer holds an ownership map and no longer
  registers/evicts. It is now a thin `ICoreOutbound` ↦ `FixpSession`
  adapter.
- `HostRouter` no longer holds an ownership map. Mass-cancel and
  `OrigClOrdID` resolution iterate the (typically small) dispatcher set
  and ask each channel's local registry. `OnSessionClosed` fans
  evict-session out to every dispatcher.

### Files

- `src/B3.Exchange.Core/OrderRegistry.cs` (moved from
  `src/B3.Exchange.Gateway/OrderOwnershipMap.cs`; renamed type +
  documented invariants; added `Clear()` for channel reset).
- `src/B3.Exchange.Core/ChannelDispatcher.OrderState.cs` (new partial-
  class facet exposing the cross-thread query surface).
- `src/B3.Exchange.Core/ChannelDispatcher.{cs,Sinks,Operator}.cs`
  (single-writer wiring).
- `src/B3.Exchange.Contracts/Ports.cs` (`ICoreOutbound` signature
  changes).
- `src/B3.Exchange.Gateway/GatewayRouter.cs` (drop ownership map; passive
  methods take pre-resolved owner).
- `src/B3.Exchange.Host/{HostRouter.cs,ExchangeHost.cs}` (drop
  ownership map; iterate dispatchers).
- `tests/B3.Exchange.Core.Tests/OrderRegistryTests.cs` (moved from
  `tests/B3.Exchange.Gateway.Tests/OrderOwnershipMapTests.cs`).
- `tests/**/*.cs` — `ICoreOutbound` test stubs updated for the new
  passive ER signatures.

### Validation

- `dotnet build  -c Release` → 0 warnings, 0 errors
- `dotnet test   -c Release` → all suites green (Core.Tests +6:
  `OrderRegistryTests`).
- `dotnet format --verify-no-changes` → clean.

Closes #167.
