### PR TITLE
FIXP client recovery test harness (#179)

### DIFF
--- a/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FakeFixpServer.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FakeFixpServer.cs
@@ -1,0 +1,150 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using B3.EntryPoint.Wire;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.SyntheticTrader.Tests.Fixp;
+
+/// <summary>
+/// In-process fake FIXP server for <see cref="FixpClient"/> recovery
+/// tests. It listens on a loopback port, accepts a single client,
+/// completes the FIXP handshake (Negotiate→NegotiateResponse,
+/// Establish→EstablishAck) with configurable behavior, and then
+/// exposes the post-handshake server-side stream so individual tests
+/// can either read frames the client emits (heartbeat,
+/// RetransmitRequest, Terminate) or push session-layer frames into
+/// the client (Sequence, Terminate, NotApplied, Retransmission).
+///
+/// Tests that only need to exercise the post-handshake state machine
+/// can also call <see cref="FixpClient.HandleInboundFrame"/> and
+/// <see cref="FixpClient.TrackInboundBusinessSeq"/> directly without
+/// going over the socket.
+/// </summary>
+internal sealed class FakeFixpServer : IAsyncDisposable
+{
+    private readonly TcpListener _listener;
+    private TcpClient? _serverSide;
+    private NetworkStream? _serverStream;
+
+    /// <summary>Port the listener is bound to.</summary>
+    public int Port { get; }
+
+    public FakeFixpServer()
+    {
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+    }
+
+    /// <summary>Server-side stream after the client has connected.</summary>
+    public NetworkStream Stream => _serverStream
+        ?? throw new InvalidOperationException("client has not connected yet");
+
+    /// <summary>
+    /// Accepts one client and runs the handshake. Returns the
+    /// last-incoming-seq-no the server should report in
+    /// <c>EstablishAck</c> (0 for a fresh session, or a higher value
+    /// to simulate a re-bind after the client lost messages).
+    /// </summary>
+    public async Task RunHandshakeAsync(uint serverNextSeqNo = 1, uint lastIncomingSeqNo = 0,
+        CancellationToken ct = default)
+    {
+        _serverSide = await _listener.AcceptTcpClientAsync(ct).ConfigureAwait(false);
+        _serverStream = _serverSide.GetStream();
+
+        // Read Negotiate.
+        var negFrame = await ReadFrameAsync(ct).ConfigureAwait(false);
+        if (negFrame.TemplateId != EntryPointFrameReader.TidNegotiate)
+            throw new InvalidOperationException($"expected Negotiate, got templateId={negFrame.TemplateId}");
+        uint sessionId = BinaryPrimitives.ReadUInt32LittleEndian(negFrame.Body.AsSpan(0, 4));
+        ulong sessionVerId = BinaryPrimitives.ReadUInt64LittleEndian(negFrame.Body.AsSpan(4, 8));
+
+        // Send NegotiateResponse.
+        var negResp = new byte[NegotiateResponseEncoder.Total];
+        NegotiateResponseEncoder.Encode(negResp, sessionId, sessionVerId,
+            requestTimestampNanos: 0, enteringFirm: 7,
+            semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+        await _serverStream.WriteAsync(negResp, ct).ConfigureAwait(false);
+
+        // Read Establish.
+        var estFrame = await ReadFrameAsync(ct).ConfigureAwait(false);
+        if (estFrame.TemplateId != EntryPointFrameReader.TidEstablish)
+            throw new InvalidOperationException($"expected Establish, got templateId={estFrame.TemplateId}");
+
+        // Send EstablishAck.
+        var ack = new byte[EstablishAckEncoder.Total];
+        EstablishAckEncoder.Encode(ack, sessionId, sessionVerId,
+            requestTimestampNanos: 0, keepAliveIntervalMillis: 2000,
+            nextSeqNo: serverNextSeqNo, lastIncomingSeqNo: lastIncomingSeqNo,
+            semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+        await _serverStream.WriteAsync(ack, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reject the Negotiate handshake instead of completing it.
+    /// </summary>
+    public async Task RunRejectingHandshakeAsync(FixpSbe.NegotiationRejectCode rejectCode,
+        CancellationToken ct = default)
+    {
+        _serverSide = await _listener.AcceptTcpClientAsync(ct).ConfigureAwait(false);
+        _serverStream = _serverSide.GetStream();
+        var negFrame = await ReadFrameAsync(ct).ConfigureAwait(false);
+        if (negFrame.TemplateId != EntryPointFrameReader.TidNegotiate)
+            throw new InvalidOperationException($"expected Negotiate, got templateId={negFrame.TemplateId}");
+        uint sessionId = BinaryPrimitives.ReadUInt32LittleEndian(negFrame.Body.AsSpan(0, 4));
+        ulong sessionVerId = BinaryPrimitives.ReadUInt64LittleEndian(negFrame.Body.AsSpan(4, 8));
+
+        var rej = new byte[NegotiateRejectEncoder.Total];
+        NegotiateRejectEncoder.Encode(rej, sessionId, sessionVerId,
+            requestTimestampNanos: 0, enteringFirm: 7,
+            rejectCode: rejectCode, currentSessionVerId: sessionVerId);
+        await _serverStream.WriteAsync(rej, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Reads one fully-framed inbound message from the client.</summary>
+    public async Task<DecodedFrame> ReadFrameAsync(CancellationToken ct = default)
+    {
+        var hdr = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(Stream, hdr, ct).ConfigureAwait(false);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(0, 2));
+        ushort blockLength = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(EntryPointFrameReader.SofhSize, 2));
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        if (bodyLen > 0) await ReadExactAsync(Stream, body, ct).ConfigureAwait(false);
+        return new DecodedFrame(templateId, blockLength, body);
+    }
+
+    /// <summary>Reads the next frame matching <paramref name="templateId"/>.</summary>
+    public async Task<DecodedFrame> ReadUntilAsync(ushort templateId, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        while (true)
+        {
+            var f = await ReadFrameAsync(cts.Token).ConfigureAwait(false);
+            if (f.TemplateId == templateId) return f;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { _serverStream?.Dispose(); } catch { }
+        try { _serverSide?.Dispose(); } catch { }
+        try { _listener.Stop(); } catch { }
+        await Task.CompletedTask;
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buf, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buf.Length)
+        {
+            int n = await stream.ReadAsync(buf.AsMemory(read), ct).ConfigureAwait(false);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+
+    public readonly record struct DecodedFrame(ushort TemplateId, ushort BlockLength, byte[] Body);
+}

--- a/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpClientRecoveryTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpClientRecoveryTests.cs
@@ -1,0 +1,354 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.EntryPoint.Wire;
+using B3.Exchange.SyntheticTrader.Fixp;
+using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
+
+namespace B3.Exchange.SyntheticTrader.Tests.Fixp;
+
+/// <summary>
+/// Recovery / failure-path tests for <see cref="FixpClient"/>
+/// (issue #179, GAP-02). These exercise the post-handshake state
+/// machine using <see cref="FakeFixpServer"/> to drive realistic
+/// wire scenarios:
+///
+/// <list type="bullet">
+///   <item>Inbound gap on the recoverable stream (<c>Sequence</c> with
+///   higher peerNextSeq) → optional <c>RetransmitRequest</c>.</item>
+///   <item>Inbound gap on a business message → <c>RetransmitRequest</c>
+///   when enabled, silent advance otherwise.</item>
+///   <item>Duplicate inbound business <c>msgSeqNum</c> → dropped, no
+///   counter advance.</item>
+///   <item>Server-initiated <c>Terminate</c> → client transitions to
+///   <see cref="FixpClientState.Closed"/>.</item>
+///   <item>Peer-stale detection after no inbound traffic for
+///   &gt; 1.5 × keepAlive.</item>
+///   <item>Re-bind after dispose: a second <c>FixpClient</c> with the
+///   same SessionId picks a fresh <c>SessionVerId</c>.</item>
+///   <item>Negotiate reject → <see cref="FixpClientState.Failed"/>.</item>
+/// </list>
+/// </summary>
+public class FixpClientRecoveryTests
+{
+    private const string SessionId = "100";
+    private const uint SessionIdNum = 100;
+
+    private static FixpClientOptions BuildOptions(int keepAliveMs = 2000, bool retransmit = false) => new()
+    {
+        SessionId = SessionId,
+        EnteringFirm = 7,
+        KeepAliveIntervalMillis = (uint)keepAliveMs,
+        CancelOnDisconnect = false,
+        RetransmitOnGap = retransmit,
+        HandshakeTimeout = TimeSpan.FromSeconds(5),
+    };
+
+    private static async Task<(TcpClient tcp, NetworkStream stream, FixpClient client)>
+        ConnectAndHandshakeAsync(FakeFixpServer server, FixpClientOptions opts,
+            uint serverNextSeqNo = 1, uint lastIncomingSeqNo = 0,
+            CancellationToken ct = default)
+    {
+        var serverHandshake = server.RunHandshakeAsync(serverNextSeqNo, lastIncomingSeqNo, ct);
+        var tcp = new TcpClient { NoDelay = true };
+        await tcp.ConnectAsync("127.0.0.1", server.Port, ct);
+        var stream = tcp.GetStream();
+        var client = new FixpClient(stream, opts);
+
+        // FixpClient.NegotiateAndEstablishAsync awaits its TCS; nothing
+        // pumps inbound for it. We pump manually here by reading the
+        // two server response frames and dispatching them.
+        var negotiateTask = client.NegotiateAndEstablishAsync(ct);
+        await PumpOneInboundAsync(stream, client, ct); // NegotiateResponse
+        await PumpOneInboundAsync(stream, client, ct); // EstablishAck
+        await negotiateTask;
+        await serverHandshake;
+        return (tcp, stream, client);
+    }
+
+    private static async Task PumpOneInboundAsync(NetworkStream stream, FixpClient client, CancellationToken ct)
+    {
+        var hdr = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, hdr, ct);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(0, 2));
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, ct);
+        client.HandleInboundFrame(templateId, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buf, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buf.Length)
+        {
+            int n = await stream.ReadAsync(buf.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+
+    private static byte[] EncodeSequence(uint nextSeqNo)
+    {
+        var buf = new byte[EntryPointFixpFrameCodec.SequenceBlock + EntryPointFrameReader.WireHeaderSize];
+        EntryPointFixpFrameCodec.EncodeSequence(buf, nextSeqNo);
+        return buf;
+    }
+
+    private static byte[] EncodeTerminate(uint sessionId, ulong sessionVerId, byte code)
+    {
+        var buf = new byte[EntryPointFixpFrameCodec.TerminateBlock + EntryPointFrameReader.WireHeaderSize];
+        EntryPointFixpFrameCodec.EncodeTerminate(buf, sessionId, sessionVerId, code);
+        return buf;
+    }
+
+    /// <summary>Splits a fully-framed FIXP message into (templateId, body).</summary>
+    private static (ushort tid, byte[] body) Split(byte[] frame)
+    {
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(frame.AsSpan(0, 2));
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(frame.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        Array.Copy(frame, EntryPointFrameReader.WireHeaderSize, body, 0, bodyLen);
+        return (templateId, body);
+    }
+
+    [Fact]
+    public async Task Handshake_PutsClientInEstablished()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server, BuildOptions(), ct: cts.Token);
+        try
+        {
+            Assert.Equal(FixpClientState.Established, client.State);
+            Assert.Equal(SessionIdNum, client.SessionIdNumeric);
+            Assert.Equal(1u, client.NextOutboundSeqNo);
+            Assert.Equal(1u, client.ExpectedInboundSeqNo);
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task NegotiateRejected_ClientTransitionsToFailed()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var serverTask = server.RunRejectingHandshakeAsync(
+            FixpSbe.NegotiationRejectCode.CREDENTIALS, cts.Token);
+        var tcp = new TcpClient { NoDelay = true };
+        await tcp.ConnectAsync("127.0.0.1", server.Port, cts.Token);
+        var stream = tcp.GetStream();
+        var client = new FixpClient(stream, BuildOptions());
+        try
+        {
+            var negotiateTask = client.NegotiateAndEstablishAsync(cts.Token);
+            // Pump the NegotiateReject the server sends back.
+            await PumpOneInboundAsync(stream, client, cts.Token);
+            await Assert.ThrowsAsync<FixpHandshakeRejectedException>(() => negotiateTask);
+            Assert.Equal(FixpClientState.Failed, client.State);
+            await serverTask;
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task ServerSendsTerminate_ClientTransitionsToClosed()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server, BuildOptions(), ct: cts.Token);
+        try
+        {
+            // Simulate the server pushing a Terminate. The embedding
+            // read loop would call HandleInboundFrame(TidTerminate, ...).
+            var term = EncodeTerminate(SessionIdNum, client.SessionVerId,
+                (byte)FixpSbe.TerminationCode.UNSPECIFIED);
+            var (tid, body) = Split(term);
+            var disp = client.HandleInboundFrame(tid, body);
+
+            Assert.Equal(InboundDisposition.PeerTerminated, disp);
+            Assert.Equal(FixpClientState.Closed, client.State);
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task DuplicateInboundBusinessSeq_IsDroppedWithoutAdvancingExpected()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server, BuildOptions(), ct: cts.Token);
+        try
+        {
+            // First message in-order.
+            Assert.True(client.TrackInboundBusinessSeq(1));
+            Assert.Equal(2u, client.ExpectedInboundSeqNo);
+
+            // Replay of seq=1 → duplicate, drop, do not advance.
+            Assert.False(client.TrackInboundBusinessSeq(1));
+            Assert.Equal(2u, client.ExpectedInboundSeqNo);
+
+            // Next in-order continues to advance.
+            Assert.True(client.TrackInboundBusinessSeq(2));
+            Assert.Equal(3u, client.ExpectedInboundSeqNo);
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task SequenceWithGap_FiresRetransmitRequest_WhenEnabled()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server,
+            BuildOptions(retransmit: true), ct: cts.Token);
+        try
+        {
+            // Server signals it's about to send seq 5 but we only have
+            // expected=1. HandleInboundFrame should NOT advance expected
+            // (gap fill via retransmission) and should fire a
+            // RetransmitRequest async — which the server-side socket will
+            // then receive.
+            var seq = EncodeSequence(nextSeqNo: 5);
+            var (tid, body) = Split(seq);
+            client.HandleInboundFrame(tid, body);
+
+            // Expect RetransmitRequest from client on the wire.
+            var rr = await server.ReadUntilAsync(EntryPointFrameReader.TidRetransmitRequest,
+                TimeSpan.FromSeconds(3));
+            Assert.Equal(EntryPointFrameReader.TidRetransmitRequest, rr.TemplateId);
+            // Body layout: sessionID(4) | requestTimestamp(8) | fromSeqNo(4) | count(4)
+            uint fromSeqNo = BinaryPrimitives.ReadUInt32LittleEndian(rr.Body.AsSpan(12, 4));
+            uint count = BinaryPrimitives.ReadUInt32LittleEndian(rr.Body.AsSpan(16, 4));
+            Assert.Equal(1u, fromSeqNo);
+            Assert.Equal(4u, count);
+
+            // Expected stays at 1 (gap not yet filled).
+            Assert.Equal(1u, client.ExpectedInboundSeqNo);
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task SequenceWithGap_DoesNotFireRetransmit_WhenDisabled()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server,
+            BuildOptions(retransmit: false), ct: cts.Token);
+        try
+        {
+            var seq = EncodeSequence(nextSeqNo: 5);
+            var (tid, body) = Split(seq);
+            client.HandleInboundFrame(tid, body);
+
+            // Wait briefly to ensure no RetransmitRequest gets written.
+            using var readCts = new CancellationTokenSource(TimeSpan.FromMilliseconds(300));
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => server.ReadFrameAsync(readCts.Token));
+
+            // Expected stays at 1; the client logged-and-ignored the gap.
+            Assert.Equal(1u, client.ExpectedInboundSeqNo);
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task BusinessSeqGap_FiresRetransmitRequest_WhenEnabled()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server,
+            BuildOptions(retransmit: true), ct: cts.Token);
+        try
+        {
+            // First in-order business message.
+            Assert.True(client.TrackInboundBusinessSeq(1));
+            // Now jump from expected=2 to seq=10 (gap of 8).
+            Assert.True(client.TrackInboundBusinessSeq(10));
+
+            var rr = await server.ReadUntilAsync(EntryPointFrameReader.TidRetransmitRequest,
+                TimeSpan.FromSeconds(3));
+            uint fromSeqNo = BinaryPrimitives.ReadUInt32LittleEndian(rr.Body.AsSpan(12, 4));
+            uint count = BinaryPrimitives.ReadUInt32LittleEndian(rr.Body.AsSpan(16, 4));
+            Assert.Equal(2u, fromSeqNo);
+            Assert.Equal(8u, count);
+
+            // Expected was advanced past the seen seq (gap message itself
+            // was accepted as in-order-ish so retransmissions fill 2..9).
+            Assert.Equal(11u, client.ExpectedInboundSeqNo);
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task PeerStale_DetectedAfterInactivity()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        // Tiny keep-alive so the test is fast; threshold is 1.5×.
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server,
+            BuildOptions(keepAliveMs: 100), ct: cts.Token);
+        try
+        {
+            Assert.False(client.IsPeerStale());
+            // Wait > 1.5 × keepAlive without any inbound from server.
+            await Task.Delay(250, cts.Token);
+            Assert.True(client.IsPeerStale(),
+                $"expected peer stale (LastInbound={client.LastInboundUtc:HH:mm:ss.fff}, now={DateTime.UtcNow:HH:mm:ss.fff})");
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task PeerStale_ResetByInboundFrame()
+    {
+        await using var server = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var (tcp, _, client) = await ConnectAndHandshakeAsync(server,
+            BuildOptions(keepAliveMs: 100), ct: cts.Token);
+        try
+        {
+            await Task.Delay(250, cts.Token);
+            Assert.True(client.IsPeerStale());
+
+            // Any inbound frame should refresh the watchdog.
+            var seq = EncodeSequence(nextSeqNo: 1);
+            var (tid, body) = Split(seq);
+            client.HandleInboundFrame(tid, body);
+            Assert.False(client.IsPeerStale());
+        }
+        finally { tcp.Dispose(); }
+    }
+
+    [Fact]
+    public async Task Rebind_PicksFreshSessionVerIdPerConnection()
+    {
+        await using var server1 = new FakeFixpServer();
+        await using var server2 = new FakeFixpServer();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var (tcp1, _, client1) = await ConnectAndHandshakeAsync(server1, BuildOptions(), ct: cts.Token);
+        ulong ver1;
+        try
+        {
+            ver1 = client1.SessionVerId;
+            Assert.True(ver1 > 0);
+        }
+        finally { tcp1.Dispose(); }
+
+        // Allow at least 1ms so the millisecond-resolution sessionVerId
+        // is guaranteed to be distinct on the second connection.
+        await Task.Delay(5, cts.Token);
+
+        var (tcp2, _, client2) = await ConnectAndHandshakeAsync(server2, BuildOptions(), ct: cts.Token);
+        try
+        {
+            Assert.NotEqual(ver1, client2.SessionVerId);
+            Assert.Equal(SessionIdNum, client2.SessionIdNumeric);
+            Assert.Equal(FixpClientState.Established, client2.State);
+        }
+        finally { tcp2.Dispose(); }
+    }
+}


### PR DESCRIPTION
Closes #179.

Adds a recovery / failure-path test harness for `FixpClient` (the
SyntheticTrader's client-side FIXP session layer). Previously the only
coverage was a happy-path handshake test against a real `ExchangeHost`;
the recovery code (gap detection, RetransmitRequest, peer-stale,
unexpected Terminate, Negotiate reject) was untested.

## What was added

- **`FakeFixpServer`** — minimal in-process FIXP server. Listens on a
  loopback port, completes the handshake (or rejects it on demand),
  exposes the post-handshake server-side stream so tests can both
  read frames the client emits (RetransmitRequest, heartbeat,
  Terminate) and push session-layer frames into the client.

- **`FixpClientRecoveryTests`** — 10 scenario tests:
  1. Handshake puts client in `Established` with seq counters at 1.
  2. `Negotiate` reject → client transitions to `Failed` and throws
     `FixpHandshakeRejectedException`.
  3. Server-initiated `Terminate` → client transitions to `Closed`
     with disposition `PeerTerminated`.
  4. Duplicate inbound business `msgSeqNum` → dropped, expected
     counter does not advance.
  5. `Sequence` with peerNextSeq ahead of expected → fires
     `RetransmitRequest` when `RetransmitOnGap=true`; expected stays
     pinned at the gap start.
  6. Same `Sequence` gap → does **not** emit any frame when
     `RetransmitOnGap=false`.
  7. Business `msgSeqNum` jumping ahead → fires `RetransmitRequest`
     with the correct (fromSeqNo, count) and advances expected past
     the gap.
  8. Peer-stale watchdog fires after &gt; 1.5 × keepAlive of inbound
     silence.
  9. Peer-stale watchdog resets when any inbound frame arrives.
  10. Re-bind: a second `FixpClient` on the same `SessionId` picks a
      fresh `SessionVerId` distinct from the first.

## Notes

- The harness uses real loopback sockets so wire-level outbound from
  the client (e.g. `RetransmitRequest`) is observable end-to-end via
  the server-side stream.
- For state-only assertions that don't need a server response, tests
  call `HandleInboundFrame`/`TrackInboundBusinessSeq` directly with
  encoder-built frames — fast and deterministic.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
