### PR TITLE
Accept inbound FIXP Terminate (#198)

### DIFF
--- a/src/B3.EntryPoint.Wire/EntryPointFrameReader.cs
+++ b/src/B3.EntryPoint.Wire/EntryPointFrameReader.cs
@@ -112,6 +112,7 @@ public static class EntryPointFrameReader
         (TidNegotiate, 0) => 28,                 // NegotiateData.BLOCK_LENGTH (V6 schema, root version 0)
         (TidEstablish, 0) => 42,                 // EstablishData.BLOCK_LENGTH
         (TidRetransmitRequest, 0) => 20,         // RetransmitRequestData.BLOCK_LENGTH
+        (TidTerminate, 0) => 13,                 // TerminateData.BLOCK_LENGTH (graceful logout from peer)
         _ => -1
     };
 

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -203,6 +203,23 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidRetransmitRequest:
                 ProcessAndEnqueueRetransmitRequest(fixedBlock);
                 return true;
+            case EntryPointFrameReader.TidTerminate:
+                {
+                    // Spec §4.5.4: peer-initiated graceful logout. Echo
+                    // Terminate(FINISHED) back per the symmetric handshake
+                    // requirement and close the transport. The state
+                    // machine accepts Terminate from any state
+                    // (Idle/Negotiated/Established/Suspended).
+                    string reason = "peer-terminate";
+                    if (EntryPointFixpFrameCodec.TryDecodeTerminate(fixedBlock, out var tm))
+                    {
+                        reason = $"peer-terminate:code={tm.TerminationCode}";
+                    }
+                    ApplyTransition(FixpEvent.Terminate);
+                    await TerminateAndCloseAsync(
+                        SessionRejectEncoder.TerminationCode.Finished, reason).ConfigureAwait(false);
+                    return false;
+                }
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                 {

--- a/tests/B3.Exchange.Gateway.Tests/FixpInboundTerminateTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpInboundTerminateTests.cs
@@ -1,0 +1,85 @@
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Contracts;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// #198 (gap-functional §4): the gateway must accept inbound FIXP
+/// <c>Terminate</c> (templateId=7) per spec §4.5.4 and respond with a
+/// graceful <c>Terminate(FINISHED)</c> echo before closing the
+/// transport. Previously the header parser rejected the template
+/// outright (UnsupportedTemplate → DECODING_ERROR Terminate).
+/// </summary>
+public class FixpInboundTerminateTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue) => true;
+        public bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm) => true;
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm) => true;
+        public void OnDecodeError(SessionId session, string error) { }
+        public void OnSessionClosed(SessionId session) { }
+    }
+
+    private static byte[] EncodeInboundTerminate(uint sessionId, ulong sessionVerId, byte code)
+    {
+        var buf = new byte[EntryPointFixpFrameCodec.TerminateBlock + EntryPointFrameReader.WireHeaderSize];
+        EntryPointFixpFrameCodec.EncodeTerminate(buf, sessionId, sessionVerId, code);
+        return buf;
+    }
+
+    [Fact]
+    public void HeaderParser_AcceptsInboundTerminateBlockLength()
+    {
+        // Sanity: the new TidTerminate=7 entry must round-trip the
+        // header parser instead of being rejected as UnsupportedTemplate.
+        Assert.Equal(13, EntryPointFrameReader.ExpectedInboundBlockLength(
+            EntryPointFrameReader.TidTerminate, version: 0));
+    }
+
+    [Fact]
+    public async Task PeerSendsTerminate_GatewayEchoesFinishedAndClosesTransport()
+    {
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            NullLoggerFactory.Instance);
+        listener.Start();
+        await using (listener)
+        using (var client = new TcpClient())
+        {
+            await client.ConnectAsync(listener.LocalEndpoint!.Address, listener.LocalEndpoint!.Port);
+
+            // Send peer-initiated Terminate (graceful logout per spec §4.5.4).
+            var frame = EncodeInboundTerminate(sessionId: 100, sessionVerId: 42,
+                code: SessionRejectEncoder.TerminationCode.Finished);
+            await client.GetStream().WriteAsync(frame);
+
+            // Expect a Terminate echo back from the gateway.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+            var buf = new byte[SessionRejectEncoder.TerminateTotal];
+            var ns = client.GetStream();
+            int read = 0;
+            while (read < buf.Length)
+            {
+                int n = await ns.ReadAsync(buf.AsMemory(read), cts.Token);
+                if (n <= 0) throw new EndOfStreamException("connection closed before Terminate echo received");
+                read += n;
+            }
+
+            ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(
+                buf.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+            Assert.Equal(EntryPointFrameReader.TidTerminate, tid);
+            byte echoedCode = buf[EntryPointFrameReader.WireHeaderSize + 12];
+            Assert.Equal(SessionRejectEncoder.TerminationCode.Finished, echoedCode);
+
+        }
+    }
+}


### PR DESCRIPTION
Closes #198.

## Problem

Per FIXP spec §4.5.4, a peer can initiate a graceful logout by sending
`Terminate` (templateId=7) at any time. The gateway must echo
`Terminate(FINISHED)` and then close the transport.

Previously the inbound header parser had no entry for `TidTerminate=7`
in `ExpectedInboundBlockLength`, so the frame was rejected as
`UnsupportedTemplate` and well-behaved clients were torn down with a
`DECODING_ERROR` Terminate instead of the spec-mandated `FINISHED`.

## Change

- `EntryPointFrameReader.ExpectedInboundBlockLength`: register
  `(TidTerminate, 0) => 13` so the parser passes the body to the
  dispatcher instead of erroring out.
- `FixpSession.Dispatch`: new case that decodes the Terminate body via
  `EntryPointFixpFrameCodec.TryDecodeTerminate`, drives the FIXP state
  machine through `FixpEvent.Terminate` (already wired in
  `FixpStateMachine` for Idle/Negotiated/Established/Suspended), then
  echoes `Terminate(FINISHED)` and closes the transport.
- New `FixpInboundTerminateTests`:
  - Header-parser sanity test (block length round-trips).
  - Loopback test connects to the listener, sends a peer Terminate
    frame, asserts the gateway responds with a Terminate echo whose
    `terminationCode == FINISHED`.

## Validation

- `dotnet build -c Release` — 0/0
- `dotnet test -c Release` — full suite green
- `dotnet format --verify-no-changes` — clean
