### PR TITLE
Emit UMDF MassDeleteOrders_MBO_52 for mass cancel (#199)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -59,6 +59,20 @@ public sealed partial class ChannelDispatcher
         Commit(n);
     }
 
+    public void OnOrderMassCanceled(in OrderMassCanceledEvent e)
+    {
+        AssertOnLoopThread();
+        var entryType = e.Side == Side.Buy
+            ? B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeBid
+            : B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeOffer;
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.MassDeleteOrdersBlockLength);
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteMassDeleteOrdersFrame(
+            dst, e.SecurityId, entryType, e.RptSeq, e.TransactTimeNanos);
+        Commit(n);
+    }
+
     public void OnOrderCanceled(in OrderCanceledEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -92,6 +92,23 @@ public readonly record struct RejectEvent(
     ulong TransactTimeNanos);
 
 /// <summary>
+/// Fired ONCE per (SecurityID, Side) pair touched by a single
+/// <see cref="MatchingEngine.MassCancel"/> invocation, BEFORE the per-order
+/// <see cref="OrderCanceledEvent"/>s for the same group. The integration
+/// layer translates this to a <c>MassDeleteOrders_MBO_52</c> UMDF frame so
+/// consumers that recognise mass-delete semantics can apply them as an
+/// atomic boundary; consumers that only follow per-order
+/// <c>DeleteOrder_MBO_51</c>s remain correct because the per-order events
+/// are still emitted.
+/// </summary>
+public readonly record struct OrderMassCanceledEvent(
+    long SecurityId,
+    Side Side,
+    int CancelledCount,
+    ulong TransactTimeNanos,
+    uint RptSeq);
+
+/// <summary>
 /// Sink of matching events. Implementations MUST NOT call back into the engine
 /// from any of these methods — the engine is single-threaded per channel and
 /// reentrant commands corrupt internal linked lists.
@@ -104,4 +121,12 @@ public interface IMatchingEventSink
     void OnOrderFilled(in OrderFilledEvent e);
     void OnTrade(in TradeEvent e);
     void OnReject(in RejectEvent e);
+
+    /// <summary>
+    /// Optional summary event emitted once per (SecurityId, Side) at the
+    /// start of a mass-cancel. Default implementation is a no-op so legacy
+    /// sinks keep compiling; the production <c>ChannelDispatcher</c>
+    /// overrides it to emit the UMDF <c>MassDeleteOrders_MBO_52</c> frame.
+    /// </summary>
+    void OnOrderMassCanceled(in OrderMassCanceledEvent e) { }
 }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -233,6 +233,39 @@ public sealed class MatchingEngine
         EnterDispatch();
         try
         {
+            // First pass — group target orderIds by (SecurityId, Side) so we
+            // can emit one OrderMassCanceledEvent summary per group BEFORE
+            // the per-order cancels (UMDF MassDeleteOrders_MBO_52, gap #8).
+            // Orders that no longer resolve are silently dropped, matching
+            // the second-pass behaviour below. We use a small dictionary
+            // since the typical mass-cancel touches O(10) groups.
+            Dictionary<(long securityId, Side side), int>? groups = null;
+            foreach (var orderId in orderIds)
+            {
+                foreach (var book in _booksById.Values)
+                {
+                    if (book.TryGet(orderId, out var resting))
+                    {
+                        groups ??= new Dictionary<(long, Side), int>();
+                        var key = (book.SecurityId, resting.Side);
+                        groups[key] = groups.TryGetValue(key, out var c) ? c + 1 : 1;
+                        break;
+                    }
+                }
+            }
+            if (groups is not null)
+            {
+                foreach (var kv in groups)
+                {
+                    _sink.OnOrderMassCanceled(new OrderMassCanceledEvent(
+                        SecurityId: kv.Key.securityId,
+                        Side: kv.Key.side,
+                        CancelledCount: kv.Value,
+                        TransactTimeNanos: enteredAtNanos,
+                        RptSeq: NextRptSeq()));
+                }
+            }
+
             int cancelled = 0;
             foreach (var orderId in orderIds)
             {

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -399,6 +399,46 @@ public static class UmdfWireEncoder
         return total;
     }
 
+    /// <summary>
+    /// Writes <c>MassDeleteOrders_MBO_52</c> (V16). Returns total bytes.
+    /// Emitted once per (SecurityID, Side) at the start of a mass-cancel
+    /// operation as an atomic boundary marker (gap-functional #8 / #199).
+    /// Per-order <c>DeleteOrder_MBO_51</c> frames for the same orders
+    /// follow in the same UMDF packet, so consumers that ignore
+    /// <c>MassDeleteOrders</c> remain correct.
+    /// </summary>
+    public static int WriteMassDeleteOrdersFrame(
+        Span<byte> dst,
+        long securityId,
+        byte mdEntryType,
+        uint rptSeq,
+        ulong transactTimeNanos)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.MassDeleteOrdersBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.MassDeleteOrders_MBO_52Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.MassDeleteOrdersBlockLength);
+        body.Clear();
+
+        MemoryMarshal.Write(body.Slice(WireOffsets.MassDeleteOrdersBodySecurityIdOffset, 8), in securityId);
+        // MatchEventIndicator overlays SecurityExchange at offset 8 in the
+        // V16 schema (1 byte). Leave at 0 (no event flags set).
+        body[WireOffsets.MassDeleteOrdersBodyMdUpdateActionOffset] = (byte)MDUpdateAction.DELETE_THRU;
+        body[WireOffsets.MassDeleteOrdersBodyMdEntryTypeOffset] = mdEntryType;
+        MemoryMarshal.Write(body.Slice(WireOffsets.MassDeleteOrdersBodyTransactTimeOffset, 8), in transactTimeNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.MassDeleteOrdersBodyRptSeqOffset, 4), in rptSeq);
+
+        return total;
+    }
+
     private static void WriteFramingHeader(Span<byte> dst, int totalFrameLength)
     {
         ushort messageLength = checked((ushort)totalFrameLength);

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -98,6 +98,19 @@ public static class WireOffsets
     public const int TradeBustBodyTransactTimeOffset = 36;
     public const int TradeBustBodyRptSeqOffset = 44;
 
+    // ---- MassDeleteOrders_MBO_52 (V16) ----
+    // Body layout (BLOCK_LENGTH=28): securityID@0 (long); securityExchange@8
+    // shares offset with matchEventIndicator@8 (byte); mDUpdateAction@9
+    // (always DELETE_THRU); mDEntryType@10 (BID or OFFER); transactTime@16
+    // (ulong nanos); rptSeq@24 (uint, 0 = NULL).
+    public const int MassDeleteOrdersBlockLength = 28;
+    public const int MassDeleteOrdersBodySecurityIdOffset = 0;
+    public const int MassDeleteOrdersBodyMatchEventIndicatorOffset = 8;
+    public const int MassDeleteOrdersBodyMdUpdateActionOffset = 9;
+    public const int MassDeleteOrdersBodyMdEntryTypeOffset = 10;
+    public const int MassDeleteOrdersBodyTransactTimeOffset = 16;
+    public const int MassDeleteOrdersBodyRptSeqOffset = 24;
+
     // ---- ChannelReset_11 (V16) ----
     // Body: MatchEventIndicator @0 (4 bytes — UMDF wire treats the bitset as
     // a 4-byte block, see schema offset="4" on MDEntryTimestamp), then

--- a/tests/B3.Exchange.Matching.Tests/MassCancelMassDeleteEventTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/MassCancelMassDeleteEventTests.cs
@@ -1,0 +1,70 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #199 (gap-functional §8): a single MassCancel must publish one
+/// summary <see cref="OrderMassCanceledEvent"/> per (SecurityId, Side)
+/// pair before the per-order <see cref="OrderCanceledEvent"/>s. The
+/// integration layer translates the summary into a UMDF
+/// <c>MassDeleteOrders_MBO_52</c> frame.
+/// </summary>
+public class MassCancelMassDeleteEventTests
+{
+    [Fact]
+    public void MassCancel_GroupsByBidAndOffer_EmitsTwoSummariesAhead()
+    {
+        var eng = NewEngine(out var sink);
+        // Two bids + two offers resting on the same book.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        eng.Submit(new NewOrderCommand("b2", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 11, 1001));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.01m), 100, 11, 1002));
+        eng.Submit(new NewOrderCommand("s2", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.02m), 100, 11, 1003));
+        var orderIds = sink.Accepted.Select(a => a.OrderId).ToList();
+        Assert.Equal(4, orderIds.Count);
+        sink.Clear();
+
+        int n = eng.MassCancel(orderIds, enteredAtNanos: 9_000);
+
+        Assert.Equal(4, n);
+        // 2 mass-cancel summaries (Buy, Sell) + 4 per-order cancels.
+        Assert.Equal(2, sink.MassCanceled.Count);
+        Assert.Equal(4, sink.Canceled.Count);
+        // Summaries must come before per-order cancels in the event stream.
+        int firstCancelIdx = sink.Events.FindIndex(e => e is OrderCanceledEvent);
+        int lastSummaryIdx = sink.Events.FindLastIndex(e => e is OrderMassCanceledEvent);
+        Assert.True(lastSummaryIdx < firstCancelIdx,
+            $"summaries must precede per-order cancels (lastSummary={lastSummaryIdx}, firstCancel={firstCancelIdx})");
+
+        var bidSummary = Assert.Single(sink.MassCanceled, m => m.Side == Side.Buy);
+        var askSummary = Assert.Single(sink.MassCanceled, m => m.Side == Side.Sell);
+        Assert.Equal(2, bidSummary.CancelledCount);
+        Assert.Equal(2, askSummary.CancelledCount);
+        Assert.Equal(PetrSecId, bidSummary.SecurityId);
+        Assert.Equal(9_000ul, bidSummary.TransactTimeNanos);
+        // Each summary consumes a unique RptSeq strictly before any
+        // per-order cancel's RptSeq.
+        Assert.True(sink.MassCanceled.All(m =>
+                sink.Canceled.All(c => m.RptSeq < c.RptSeq)),
+            "summary RptSeq must precede per-order cancel RptSeq");
+    }
+
+    [Fact]
+    public void MassCancel_EmptyInput_EmitsNoEvents()
+    {
+        var eng = NewEngine(out var sink);
+        int n = eng.MassCancel(Array.Empty<long>(), enteredAtNanos: 0);
+        Assert.Equal(0, n);
+        Assert.Empty(sink.Events);
+    }
+
+    [Fact]
+    public void MassCancel_UnknownIds_EmitsNoSummary()
+    {
+        var eng = NewEngine(out var sink);
+        int n = eng.MassCancel(new long[] { 99, 100, 101 }, enteredAtNanos: 0);
+        Assert.Equal(0, n);
+        Assert.Empty(sink.MassCanceled);
+        Assert.Empty(sink.Canceled);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -38,6 +38,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<OrderCanceledEvent> Canceled => Events.OfType<OrderCanceledEvent>().ToList();
     public List<OrderFilledEvent> Filled => Events.OfType<OrderFilledEvent>().ToList();
     public List<OrderQuantityReducedEvent> QtyReduced => Events.OfType<OrderQuantityReducedEvent>().ToList();
+    public List<OrderMassCanceledEvent> MassCanceled => Events.OfType<OrderMassCanceledEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -45,4 +46,5 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnOrderFilled(in OrderFilledEvent e) => Events.Add(e);
     public void OnTrade(in TradeEvent e) => Events.Add(e);
     public void OnReject(in RejectEvent e) => Events.Add(e);
+    public void OnOrderMassCanceled(in OrderMassCanceledEvent e) => Events.Add(e);
 }

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -255,6 +255,24 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void MassDeleteOrders_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WriteMassDeleteOrdersFrame(buf,
+            securityId: 4242L, mdEntryType: UmdfWireEncoder.MdEntryTypeBid,
+            rptSeq: 7, transactTimeNanos: 1_700_000_000_000_000_000UL);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.MassDeleteOrdersBlockLength, n);
+
+        Assert.True(MassDeleteOrders_MBO_52Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.MassDeleteOrdersBlockLength), out var rdr));
+        Assert.Equal(4242L, (long)rdr.Data.SecurityID.Value);
+        Assert.Equal(MDEntryType.BID, rdr.Data.MDEntryType);
+        Assert.Equal(MDUpdateAction.DELETE_THRU, rdr.Data.MDUpdateAction);
+        Assert.Equal(1_700_000_000_000_000_000UL, rdr.Data.TransactTime.Time);
+        Assert.Equal(7u, rdr.Data.RptSeq);
+    }
+
+    [Fact]
     public void Encoder_ThrowsOnSmallBuffer()
     {
         var small = new byte[8];


### PR DESCRIPTION
Closes #199.

## Problem

B3 UMDF clients expect `MassDeleteOrders_MBO_52` (TID 52,
`BLOCK_LENGTH=28`, `MDUpdateAction=DELETE_THRU`) as an atomic
boundary marker when the venue mass-deletes orders. The simulator's
mass-cancel path was firing only N `DeleteOrder_MBO_51` frames per
order, so consumers that recognise mass-delete semantics did not see
the summary.

## Change

- New matching event `OrderMassCanceledEvent` (`SecurityId`, `Side`,
  `CancelledCount`, `TransactTime`, `RptSeq`) and
  `IMatchingEventSink.OnOrderMassCanceled` with a default no-op so
  every legacy sink compiles unchanged.
- `MatchingEngine.MassCancel` now does a first pass that groups the
  target orderIds by `(SecurityId, Side)` and emits one summary per
  group (each consuming its own `RptSeq`), **before** the existing
  per-order cancellation loop. Empty / unresolved inputs emit no
  summary; per-order `OrderCanceledEvent`s + `ER_CancelPassive`
  semantics are preserved.
- `UmdfWireEncoder.WriteMassDeleteOrdersFrame` + `WireOffsets`
  entries for the V16 `MassDeleteOrders_MBO_52` body (28 bytes:
  securityID@0, MEI@8, MDUpdateAction@9, MDEntryType@10,
  TransactTime@16, RptSeq@24).
- `ChannelDispatcher.Sinks.OnOrderMassCanceled` writes the new
  frame into the per-command UMDF packet; the per-order
  `DeleteOrder_51` frames for the same orders still follow in the
  same packet so consumers that ignore the mass-delete summary
  remain correct.

## Tests

- `MassCancelMassDeleteEventTests`:
  - Groups bid/offer separately; summaries precede per-order
    cancels in the event stream and consume distinct `RptSeq`s.
  - Empty input → no events.
  - Unknown orderIds → no summary.
- `UmdfWireEncoderTests.MassDeleteOrders_Roundtrip`: SBE-generated
  reader confirms securityId / side / `MDUpdateAction.DELETE_THRU` /
  transactTime / rptSeq round-trip.

## Validation

- `dotnet build -c Release` — 0/0
- `dotnet test -c Release` — full suite green
- `dotnet format --verify-no-changes` — clean
