### PR TITLE
Add UMDF Sequence_2/SequenceReset_1/EmptyBook_9 encoders; emit EmptyBook on side drain (#200)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -59,6 +59,17 @@ public sealed partial class ChannelDispatcher
         Commit(n);
     }
 
+    public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e)
+    {
+        AssertOnLoopThread();
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.EmptyBookBlockLength);
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteEmptyBookFrame(
+            dst, e.SecurityId, e.TransactTimeNanos);
+        Commit(n);
+    }
+
     public void OnOrderMassCanceled(in OrderMassCanceledEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -92,6 +92,19 @@ public readonly record struct RejectEvent(
     ulong TransactTimeNanos);
 
 /// <summary>
+/// Fired when a book side that had at least one resting order becomes
+/// empty as a result of an order cancel/fill in the same dispatch turn.
+/// The integration layer translates this to the UMDF
+/// <c>EmptyBook_9</c> frame (gap-functional §22 / #200). Carries no
+/// <c>RptSeq</c> because the spec uses <c>EmptyBook_9</c> as a
+/// boundary marker, not a per-instrument sequenced event.
+/// </summary>
+public readonly record struct OrderBookSideEmptyEvent(
+    long SecurityId,
+    Side Side,
+    ulong TransactTimeNanos);
+
+/// <summary>
 /// Fired ONCE per (SecurityID, Side) pair touched by a single
 /// <see cref="MatchingEngine.MassCancel"/> invocation, BEFORE the per-order
 /// <see cref="OrderCanceledEvent"/>s for the same group. The integration
@@ -129,4 +142,11 @@ public interface IMatchingEventSink
     /// overrides it to emit the UMDF <c>MassDeleteOrders_MBO_52</c> frame.
     /// </summary>
     void OnOrderMassCanceled(in OrderMassCanceledEvent e) { }
+
+    /// <summary>
+    /// Optional event emitted when a book side empties out after a cancel
+    /// or fill. Default is a no-op so legacy sinks compile; the production
+    /// <c>ChannelDispatcher</c> overrides it to emit <c>EmptyBook_9</c>.
+    /// </summary>
+    void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e) { }
 }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -429,15 +429,24 @@ public sealed class MatchingEngine
                     long finalFilled = tradeQty; // For simplicity OrderFilledEvent reports
                                                  // the LAST trade's qty; downstream cares
                                                  // only about the delete, not the fill total.
+                    var makerSide = maker.Side;
                     book.Remove(maker);
                     _sink.OnOrderFilled(new OrderFilledEvent(
                         SecurityId: book.SecurityId,
                         OrderId: maker.OrderId,
-                        Side: maker.Side,
+                        Side: makerSide,
                         PriceMantissa: maker.PriceMantissa,
                         FinalFilledQuantity: finalFilled,
                         TransactTimeNanos: cmd.EnteredAtNanos,
                         RptSeq: NextRptSeq()));
+                    // #200: emit EmptyBook_9 if this fill drained the side.
+                    if (book.BestLevel(makerSide) is null)
+                    {
+                        _sink.OnOrderBookSideEmpty(new OrderBookSideEmptyEvent(
+                            SecurityId: book.SecurityId,
+                            Side: makerSide,
+                            TransactTimeNanos: cmd.EnteredAtNanos));
+                    }
                 }
                 else
                 {
@@ -527,6 +536,16 @@ public sealed class MatchingEngine
             TransactTimeNanos: txn,
             Reason: reason,
             RptSeq: NextRptSeq()));
+        // #200: when this cancel emptied the side, publish EmptyBook_9 so
+        // recovery consumers can drop their per-side state without waiting
+        // for the next snapshot rotation.
+        if (book.BestLevel(side) is null)
+        {
+            _sink.OnOrderBookSideEmpty(new OrderBookSideEmptyEvent(
+                SecurityId: book.SecurityId,
+                Side: side,
+                TransactTimeNanos: txn));
+        }
     }
 
     private void Reject(string clOrdId, long securityId, long orderId, RejectReason r, ulong txn)

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -400,6 +400,78 @@ public static class UmdfWireEncoder
     }
 
     /// <summary>
+    /// Writes <c>Sequence_2</c> (V16). Returns total bytes. Used as an
+    /// idle/heartbeat marker that carries the next expected incremental
+    /// sequence number (gap-functional #22 / #200).
+    /// </summary>
+    public static int WriteSequenceFrame(Span<byte> dst, uint nextSeqNo)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.SequenceBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.Sequence_2Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.SequenceBlockLength);
+        body.Clear();
+        MemoryMarshal.Write(body.Slice(WireOffsets.SequenceBodyNextSeqNoOffset, 4), in nextSeqNo);
+        return total;
+    }
+
+    /// <summary>
+    /// Writes <c>SequenceReset_1</c> (V16). Returns total bytes. Marks the
+    /// start of an instrument-replay or snapshot-recovery loop (the
+    /// schema fixes <c>NewSeqNo=1</c> as a constant; the message has no
+    /// body fields).
+    /// </summary>
+    public static int WriteSequenceResetFrame(Span<byte> dst)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.SequenceResetBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.SequenceReset_1Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+        return total;
+    }
+
+    /// <summary>
+    /// Writes <c>EmptyBook_9</c> (V16). Returns total bytes. Emitted when
+    /// a previously-populated book side becomes empty after a cancel /
+    /// fill (gap-functional #22). The MDUpdateAction (NEW) and
+    /// MDEntryType (EMPTY_BOOK) are template-level constants per schema.
+    /// </summary>
+    public static int WriteEmptyBookFrame(
+        Span<byte> dst,
+        long securityId,
+        ulong mdEntryTimestampNanos)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.EmptyBookBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.EmptyBook_9Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.EmptyBookBlockLength);
+        body.Clear();
+        MemoryMarshal.Write(body.Slice(WireOffsets.EmptyBookBodySecurityIdOffset, 8), in securityId);
+        MemoryMarshal.Write(body.Slice(WireOffsets.EmptyBookBodyMdEntryTimestampOffset, 8), in mdEntryTimestampNanos);
+        return total;
+    }
+
+    /// <summary>
     /// Writes <c>MassDeleteOrders_MBO_52</c> (V16). Returns total bytes.
     /// Emitted once per (SecurityID, Side) at the start of a mass-cancel
     /// operation as an atomic boundary marker (gap-functional #8 / #199).

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -98,6 +98,25 @@ public static class WireOffsets
     public const int TradeBustBodyTransactTimeOffset = 36;
     public const int TradeBustBodyRptSeqOffset = 44;
 
+    // ---- Sequence_2 (V16) ----
+    // Body layout (BLOCK_LENGTH=4): nextSeqNo@0 (uint).
+    public const int SequenceBlockLength = 4;
+    public const int SequenceBodyNextSeqNoOffset = 0;
+
+    // ---- SequenceReset_1 (V16) ----
+    // Body has no fields (BLOCK_LENGTH=0).
+    public const int SequenceResetBlockLength = 0;
+
+    // ---- EmptyBook_9 (V16) ----
+    // Body layout (BLOCK_LENGTH=20): securityID@0 (long); securityExchange@8
+    // shares offset with matchEventIndicator@8 (byte); mDEntryTimestamp@12
+    // (ulong nanos). The MDUpdateAction (NEW) and MDEntryType (EMPTY_BOOK)
+    // are template-level constants — not encoded into the body.
+    public const int EmptyBookBlockLength = 20;
+    public const int EmptyBookBodySecurityIdOffset = 0;
+    public const int EmptyBookBodyMatchEventIndicatorOffset = 8;
+    public const int EmptyBookBodyMdEntryTimestampOffset = 12;
+
     // ---- MassDeleteOrders_MBO_52 (V16) ----
     // Body layout (BLOCK_LENGTH=28): securityID@0 (long); securityExchange@8
     // shares offset with matchEventIndicator@8 (byte); mDUpdateAction@9

--- a/tests/B3.Exchange.Matching.Tests/EmptyBookSideTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/EmptyBookSideTests.cs
@@ -18,7 +18,7 @@ public class EmptyBookSideTests
         var oid = sink.Accepted.Single().OrderId;
         sink.Clear();
 
-        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, oid, 11, 2000));
+        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, oid, 2000));
 
         Assert.Single(sink.Canceled);
         var ev = Assert.Single(sink.BookSideEmpty);
@@ -36,7 +36,7 @@ public class EmptyBookSideTests
         var firstOid = sink.Accepted[0].OrderId;
         sink.Clear();
 
-        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, firstOid, 11, 2000));
+        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, firstOid, 2000));
 
         Assert.Single(sink.Canceled);
         Assert.Empty(sink.BookSideEmpty);

--- a/tests/B3.Exchange.Matching.Tests/EmptyBookSideTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/EmptyBookSideTests.cs
@@ -1,0 +1,77 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #200 (gap-functional §22): the engine must publish an
+/// <see cref="OrderBookSideEmptyEvent"/> when a cancel or fill drains
+/// the last order from a side; the integration layer translates this to
+/// a UMDF <c>EmptyBook_9</c> frame.
+/// </summary>
+public class EmptyBookSideTests
+{
+    [Fact]
+    public void Cancel_LastOrderOnSide_EmitsBookSideEmpty()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        var oid = sink.Accepted.Single().OrderId;
+        sink.Clear();
+
+        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, oid, 11, 2000));
+
+        Assert.Single(sink.Canceled);
+        var ev = Assert.Single(sink.BookSideEmpty);
+        Assert.Equal(PetrSecId, ev.SecurityId);
+        Assert.Equal(Side.Buy, ev.Side);
+        Assert.Equal(2000ul, ev.TransactTimeNanos);
+    }
+
+    [Fact]
+    public void Cancel_LeavesOtherOrdersOnSide_DoesNotEmitBookSideEmpty()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        eng.Submit(new NewOrderCommand("b2", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, 11, 1001));
+        var firstOid = sink.Accepted[0].OrderId;
+        sink.Clear();
+
+        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, firstOid, 11, 2000));
+
+        Assert.Single(sink.Canceled);
+        Assert.Empty(sink.BookSideEmpty);
+    }
+
+    [Fact]
+    public void Trade_FullyConsumesRestingSide_EmitsBookSideEmpty()
+    {
+        var eng = NewEngine(out var sink);
+        // One resting sell — aggressor buy will fully consume.
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 22, 1000));
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 2000));
+
+        Assert.Single(sink.Trades);
+        Assert.Single(sink.Filled);
+        var ev = Assert.Single(sink.BookSideEmpty);
+        Assert.Equal(Side.Sell, ev.Side);
+        Assert.Equal(PetrSecId, ev.SecurityId);
+    }
+
+    [Fact]
+    public void MassCancel_DrainsBothSides_EmitsTwoBookSideEmpty()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.01m), 100, 11, 1001));
+        var ids = sink.Accepted.Select(a => a.OrderId).ToList();
+        sink.Clear();
+
+        eng.MassCancel(ids, enteredAtNanos: 5_000);
+
+        Assert.Equal(2, sink.BookSideEmpty.Count);
+        Assert.Contains(sink.BookSideEmpty, e => e.Side == Side.Buy);
+        Assert.Contains(sink.BookSideEmpty, e => e.Side == Side.Sell);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -39,6 +39,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<OrderFilledEvent> Filled => Events.OfType<OrderFilledEvent>().ToList();
     public List<OrderQuantityReducedEvent> QtyReduced => Events.OfType<OrderQuantityReducedEvent>().ToList();
     public List<OrderMassCanceledEvent> MassCanceled => Events.OfType<OrderMassCanceledEvent>().ToList();
+    public List<OrderBookSideEmptyEvent> BookSideEmpty => Events.OfType<OrderBookSideEmptyEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -47,4 +48,5 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnTrade(in TradeEvent e) => Events.Add(e);
     public void OnReject(in RejectEvent e) => Events.Add(e);
     public void OnOrderMassCanceled(in OrderMassCanceledEvent e) => Events.Add(e);
+    public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e) => Events.Add(e);
 }

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -255,6 +255,40 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void Sequence_Roundtrip()
+    {
+        var buf = new byte[64];
+        int n = UmdfWireEncoder.WriteSequenceFrame(buf, nextSeqNo: 12345);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SequenceBlockLength, n);
+        Assert.True(Sequence_2Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.SequenceBlockLength), out var rdr));
+        Assert.Equal(12345u, (uint)rdr.Data.NextSeqNo.Value);
+    }
+
+    [Fact]
+    public void SequenceReset_Roundtrip_BodyEmpty()
+    {
+        var buf = new byte[64];
+        int n = UmdfWireEncoder.WriteSequenceResetFrame(buf);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize, n);
+        Assert.True(SequenceReset_1Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.SequenceResetBlockLength), out _));
+    }
+
+    [Fact]
+    public void EmptyBook_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WriteEmptyBookFrame(buf,
+            securityId: 4242L, mdEntryTimestampNanos: 1_700_000_000_000_000_000UL);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.EmptyBookBlockLength, n);
+        Assert.True(EmptyBook_9Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.EmptyBookBlockLength), out var rdr));
+        Assert.Equal(4242L, (long)rdr.Data.SecurityID.Value);
+        Assert.Equal(1_700_000_000_000_000_000UL, rdr.Data.MDEntryTimestamp.Time);
+    }
+
+    [Fact]
     public void MassDeleteOrders_Roundtrip()
     {
         var buf = new byte[80];


### PR DESCRIPTION
Closes #200.

## Problem

UMDF spec defines `Sequence_2` (idle heartbeat / next-seq marker),
`SequenceReset_1` (loop-boundary reset for snapshot/instrument-replay
recovery loops) and `EmptyBook_9` (book-side drained marker). The
simulator's encoder previously implemented only `ChannelReset_11`
among the session/recovery templates.

## Change

### Encoders (foundation)

- `WireOffsets`: block-length / field-offset constants for the three
  templates.
- `UmdfWireEncoder`:
  - `WriteSequenceFrame(nextSeqNo)` — TID 2, 4-byte body.
  - `WriteSequenceResetFrame()` — TID 1, 0-byte body.
  - `WriteEmptyBookFrame(securityId, mdEntryTimestampNanos)` — TID 9,
    20-byte body (`MDUpdateAction=NEW`, `MDEntryType=EMPTY_BOOK` are
    template constants per schema, not encoded into the body).

### EmptyBook_9 emission

- New `OrderBookSideEmptyEvent` (`SecurityId`, `Side`, `TransactTime`)
  and `IMatchingEventSink.OnOrderBookSideEmpty` with a default no-op
  so legacy sinks compile unchanged.
- `MatchingEngine.EmitCanceled` and the cross/fill maker-removal path
  publish `OrderBookSideEmptyEvent` when `book.BestLevel(side)` becomes
  null after the operation. Mass-cancels that drain both sides
  therefore emit two events in the same dispatch turn.
- `ChannelDispatcher.Sinks.OnOrderBookSideEmpty` writes the
  `EmptyBook_9` frame into the per-command UMDF packet so consumers
  can drop their per-side state without waiting for the next
  snapshot rotation.

### Out of scope (deferred to recovery / snapshot work)

Periodic `Sequence_2` heartbeats and loop-boundary `SequenceReset_1`
emission are not wired in here; those land alongside snapshot
rotation enhancements. The encoders are in place so the integration
can adopt them without a follow-up wire change.

## Tests

- `UmdfWireEncoderTests` — roundtrip Sequence_2, SequenceReset_1 (no
  body), EmptyBook_9 through the SBE-generated readers.
- `EmptyBookSideTests`:
  - cancel of the last order on a side fires the event.
  - cancel that leaves another order does NOT fire it.
  - full-fill of the resting side fires it (Side = maker side).
  - mass-cancel of both sides fires two events.

## Validation

- `dotnet build -c Release` — 0/0
- `dotnet test -c Release` — full suite green
- `dotnet format --verify-no-changes` — clean
