### PR TITLE
#201: trading-phase + UMDF SecurityStatus_3 / SecurityGroupPhase_10

### DIFF
--- a/src/B3.Exchange.Contracts/Enums.cs
+++ b/src/B3.Exchange.Contracts/Enums.cs
@@ -60,5 +60,6 @@ public enum OrdRejReason : byte
     UnknownOrder = 5,
     DuplicateOrder = 6,
     UnsupportedOrderCharacteristic = 11,
+    ExchangeClosed = 13,
     Other = 99,
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -44,6 +44,12 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.OperatorSetTradingPhase)
+        {
+            ProcessSetTradingPhase(item.TradingPhase!);
+            return;
+        }
+
         _currentSession = item.Session;
         _currentFirm = item.Firm;
         _hasCurrentSession = item.HasSession;

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -131,4 +131,32 @@ public sealed partial class ChannelDispatcher
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorTradeBust, default, 0, false,
             0, 0, null, null, null, null,
             TradeBust: new OperatorTradeBust(securityId, priceMantissa, size, tradeId, tradeDate)));
+
+    /// <summary>
+    /// Operator command (gap-functional §5 / issue #201): transitions the
+    /// supplied instrument to the requested <see cref="TradingPhase"/>. The
+    /// transition is applied on the dispatch thread; if it changes the
+    /// current phase the engine emits a <c>TradingPhaseChangedEvent</c>
+    /// which is published as a <c>SecurityStatus_3</c> frame on the
+    /// incremental channel under the current <c>SequenceVersion</c>.
+    /// Idempotent: a no-op transition emits no frame. Returns <c>false</c>
+    /// if the inbound queue is full. Safe to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorSetTradingPhase(long securityId, B3.Exchange.Matching.TradingPhase phase)
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorSetTradingPhase, default, 0, false,
+            0, 0, null, null, null, null,
+            TradingPhase: new OperatorTradingPhase(securityId, phase)));
+
+    private void ProcessSetTradingPhase(OperatorTradingPhase op)
+    {
+        AssertOnLoopThread();
+        // The engine emits the TradingPhaseChangedEvent inline (if the
+        // transition is non-trivial); the sink writes a SecurityStatus_3
+        // frame into the per-command packet buffer. Flush it as a
+        // single-message packet so consumers see the status update
+        // immediately, mirroring the trade-bust pattern.
+        _packetWritten = 0;
+        _engine.SetTradingPhase(op.SecurityId, op.Phase, _nowNanos());
+        if (_packetWritten > 0) FlushPacket();
+    }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -84,6 +84,27 @@ public sealed partial class ChannelDispatcher
         Commit(n);
     }
 
+    public void OnTradingPhaseChanged(in TradingPhaseChangedEvent e)
+    {
+        AssertOnLoopThread();
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SecurityStatusBlockLength);
+        // tradingSessionID/securityTradingEvent unused for now (255 = NULL
+        // for the optional event); tradeDate/tradSesOpenTime defaulted to 0.
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteSecurityStatusFrame(
+            dst,
+            securityId: e.SecurityId,
+            tradingSessionId: 0,
+            securityTradingStatus: (byte)e.Phase,
+            securityTradingEvent: 255,
+            tradeDate: 0,
+            tradSesOpenTimeNanos: 0,
+            transactTimeNanos: e.TransactTimeNanos,
+            rptSeq: e.RptSeq);
+        Commit(n);
+    }
+
     public void OnOrderCanceled(in OrderCanceledEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase }
 
     internal sealed record WorkItem(
         WorkKind Kind,
@@ -25,6 +25,7 @@ public sealed partial class ChannelDispatcher
         CrossOrderCommand? Cross,
         ResolvedMassCancel? MassCancel = null,
         OperatorTradeBust? TradeBust = null,
+        OperatorTradingPhase? TradingPhase = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -46,6 +47,14 @@ public sealed partial class ChannelDispatcher
         long Size,
         uint TradeId,
         ushort TradeDate);
+
+    /// <summary>
+    /// Operator-triggered trading-phase change payload (gap-functional §5
+    /// / issue #201): identifies the affected instrument and the target
+    /// phase. The transition is applied on the dispatch thread so the
+    /// engine remains single-threaded.
+    /// </summary>
+    internal sealed record OperatorTradingPhase(long SecurityId, B3.Exchange.Matching.TradingPhase Phase);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -247,6 +247,7 @@ internal sealed class FixpOutboundEncoder
         RejectReason.MarketNoLiquidity => 0u,
         RejectReason.FokUnfillable => 0u,
         RejectReason.SelfTradePrevention => 0u,
+        RejectReason.MarketClosed => 13u,
         _ => 0u,
     };
 }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -7,6 +7,28 @@ public enum TimeInForce : byte { Day, IOC, FOK }
 public enum OrderType : byte { Limit, Market }
 
 /// <summary>
+/// Per-instrument trading phase (gap-functional §5 / #201). The values
+/// map directly to the SBE <c>SecurityTradingStatus</c> enum used in
+/// UMDF <c>SecurityStatus_3</c> so the integration layer can encode
+/// without translation.
+/// </summary>
+public enum TradingPhase : byte
+{
+    /// <summary>Trading halt (PAUSE = 2 in UMDF).</summary>
+    Pause = 2,
+    /// <summary>Closed; no orders accepted (CLOSE = 4 in UMDF).</summary>
+    Close = 4,
+    /// <summary>Continuous trading (OPEN = 17 in UMDF).</summary>
+    Open = 17,
+    /// <summary>Forbidden / unavailable for trading (FORBIDDEN = 18 in UMDF).</summary>
+    Forbidden = 18,
+    /// <summary>Pre-open / Reserved auction phase (RESERVED = 21 in UMDF).</summary>
+    Reserved = 21,
+    /// <summary>Final closing call (FINAL_CLOSING_CALL = 101 in UMDF).</summary>
+    FinalClosingCall = 101,
+}
+
+/// <summary>
 /// Reasons a matching command can be rejected. Some rejects occur before any state change;
 /// others (e.g., <see cref="SelfTradePrevention"/>) may occur after fills against other firms.
 /// </summary>
@@ -28,6 +50,10 @@ public enum RejectReason : byte
     /// <see cref="SelfTradePrevention"/> policy is configured to cancel the
     /// aggressor's residual quantity.</summary>
     SelfTradePrevention,
+    /// <summary>Submitted while the instrument's <see cref="TradingPhase"/>
+    /// disallows new orders (anything other than <see cref="TradingPhase.Open"/>).
+    /// Gap-functional §5 / issue #201.</summary>
+    MarketClosed,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -92,6 +92,18 @@ public readonly record struct RejectEvent(
     ulong TransactTimeNanos);
 
 /// <summary>
+/// Fired when the trading phase for an instrument transitions. Carries
+/// the new phase plus a per-event RptSeq so the integration layer can
+/// emit a sequenced UMDF <c>SecurityStatus_3</c> frame
+/// (gap-functional §5 / #201).
+/// </summary>
+public readonly record struct TradingPhaseChangedEvent(
+    long SecurityId,
+    TradingPhase Phase,
+    ulong TransactTimeNanos,
+    uint RptSeq);
+
+/// <summary>
 /// Fired when a book side that had at least one resting order becomes
 /// empty as a result of an order cancel/fill in the same dispatch turn.
 /// The integration layer translates this to the UMDF
@@ -149,4 +161,12 @@ public interface IMatchingEventSink
     /// <c>ChannelDispatcher</c> overrides it to emit <c>EmptyBook_9</c>.
     /// </summary>
     void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e) { }
+
+    /// <summary>
+    /// Optional event emitted when an instrument's trading phase changes.
+    /// Default no-op so legacy sinks compile; the production
+    /// <c>ChannelDispatcher</c> overrides it to emit
+    /// <c>SecurityStatus_3</c>.
+    /// </summary>
+    void OnTradingPhaseChanged(in TradingPhaseChangedEvent e) { }
 }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -50,6 +50,12 @@ public sealed class MatchingEngine
     private uint _nextTradeId = 1;
     private uint _rptSeq;
 
+    // Per-instrument trading phase (gap-functional §5 / issue #201).
+    // Defaults to Open for every loaded instrument so existing tests and
+    // operators that never call SetTradingPhase keep observing the
+    // continuous-trading behaviour.
+    private readonly Dictionary<long, TradingPhase> _phaseById;
+
     private bool _dispatching;
 
     // Single-thread invariant (issue #169). Latched on first call to any
@@ -72,11 +78,13 @@ public sealed class MatchingEngine
         _stp = selfTradePrevention;
         _rulesById = new Dictionary<long, InstrumentTradingRules>();
         _booksById = new Dictionary<long, LimitOrderBook>();
+        _phaseById = new Dictionary<long, TradingPhase>();
         foreach (var i in instruments)
         {
             var rules = new InstrumentTradingRules(i);
             _rulesById.Add(i.SecurityId, rules);
             _booksById.Add(i.SecurityId, new LimitOrderBook(i.SecurityId));
+            _phaseById.Add(i.SecurityId, TradingPhase.Open);
         }
         _logger.LogInformation("matching engine initialized with {InstrumentCount} instruments", _rulesById.Count);
     }
@@ -131,6 +139,37 @@ public sealed class MatchingEngine
 
     public int OrderCount(long securityId) => _booksById[securityId].OrderCount;
 
+    /// <summary>
+    /// Current trading phase for the supplied security. Throws
+    /// <see cref="KeyNotFoundException"/> if the security is unknown.
+    /// </summary>
+    public TradingPhase GetTradingPhase(long securityId) => _phaseById[securityId];
+
+    /// <summary>
+    /// Operator-issued trading-phase transition for a single instrument
+    /// (gap-functional §5 / #201). Idempotent: a no-op transition emits no
+    /// event. Otherwise the engine emits a <see cref="TradingPhaseChangedEvent"/>
+    /// (consuming one <c>RptSeq</c>) which the integration layer translates
+    /// into a UMDF <c>SecurityStatus_3</c> frame. Must be invoked from the
+    /// dispatch thread; cannot run mid-dispatch.
+    /// </summary>
+    public bool SetTradingPhase(long securityId, TradingPhase phase, ulong txnNanos)
+    {
+        AssertOnOwnerThread();
+        if (_dispatching)
+            throw new InvalidOperationException("SetTradingPhase called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
+        if (!_phaseById.TryGetValue(securityId, out var current))
+            throw new KeyNotFoundException($"unknown securityId {securityId}");
+        if (current == phase) return false;
+        _phaseById[securityId] = phase;
+        _sink.OnTradingPhaseChanged(new TradingPhaseChangedEvent(
+            SecurityId: securityId,
+            Phase: phase,
+            TransactTimeNanos: txnNanos,
+            RptSeq: ++_rptSeq));
+        return true;
+    }
+
     public void Submit(NewOrderCommand cmd)
     {
         EnterDispatch();
@@ -139,6 +178,14 @@ public sealed class MatchingEngine
             if (!_rulesById.TryGetValue(cmd.SecurityId, out var rules))
             {
                 Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.UnknownInstrument, cmd.EnteredAtNanos);
+                return;
+            }
+
+            // #201: trading-phase gating. Only OPEN accepts new orders;
+            // RESERVED (auction) acceptance lands with the auctions wave.
+            if (_phaseById[cmd.SecurityId] != TradingPhase.Open)
+            {
+                Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MarketClosed, cmd.EnteredAtNanos);
                 return;
             }
 

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -511,6 +511,98 @@ public static class UmdfWireEncoder
         return total;
     }
 
+    /// <summary>
+    /// Writes <c>SecurityStatus_3</c> (V16). Returns total bytes. Emitted
+    /// when an instrument's trading phase transitions
+    /// (gap-functional §5 / #201). <paramref name="securityTradingEvent"/>
+    /// is optional (255 = NULL); <paramref name="rptSeq"/> 0 indicates
+    /// NULL on the wire but production callers should always pass the
+    /// engine-allocated sequence so consumers can detect gaps.
+    /// </summary>
+    public static int WriteSecurityStatusFrame(
+        Span<byte> dst,
+        long securityId,
+        byte tradingSessionId,
+        byte securityTradingStatus,
+        byte securityTradingEvent,
+        ushort tradeDate,
+        ulong tradSesOpenTimeNanos,
+        ulong transactTimeNanos,
+        uint rptSeq)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.SecurityStatusBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.SecurityStatus_3Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.SecurityStatusBlockLength);
+        body.Clear();
+
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityStatusBodySecurityIdOffset, 8), in securityId);
+        // MatchEventIndicator overlays SecurityExchange at offset 8 (1 byte).
+        // Leave at 0 (no flags set).
+        body[WireOffsets.SecurityStatusBodyTradingSessionIdOffset] = tradingSessionId;
+        body[WireOffsets.SecurityStatusBodySecurityTradingStatusOffset] = securityTradingStatus;
+        body[WireOffsets.SecurityStatusBodySecurityTradingEventOffset] = securityTradingEvent;
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityStatusBodyTradeDateOffset, 2), in tradeDate);
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityStatusBodyTradSesOpenTimeOffset, 8), in tradSesOpenTimeNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityStatusBodyTransactTimeOffset, 8), in transactTimeNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityStatusBodyRptSeqOffset, 4), in rptSeq);
+
+        return total;
+    }
+
+    /// <summary>
+    /// Writes <c>SecurityGroupPhase_10</c> (V16). Returns total bytes.
+    /// Emitted when a security group's phase transitions
+    /// (gap-functional §5 / #201). <paramref name="securityGroup"/> is an
+    /// 8-byte ASCII identifier left-padded with NUL.
+    /// </summary>
+    public static int WriteSecurityGroupPhaseFrame(
+        Span<byte> dst,
+        ReadOnlySpan<byte> securityGroup,
+        byte tradingSessionId,
+        byte tradingSessionSubId,
+        byte securityTradingEvent,
+        ushort tradeDate,
+        ulong tradSesOpenTimeNanos,
+        ulong transactTimeNanos)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.SecurityGroupPhaseBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.SecurityGroupPhase_10Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.SecurityGroupPhaseBlockLength);
+        body.Clear();
+
+        var groupSlice = body.Slice(
+            WireOffsets.SecurityGroupPhaseBodySecurityGroupOffset,
+            WireOffsets.SecurityGroupPhaseBodySecurityGroupLength);
+        var copyLen = Math.Min(securityGroup.Length, groupSlice.Length);
+        if (copyLen > 0) securityGroup[..copyLen].CopyTo(groupSlice);
+        body[WireOffsets.SecurityGroupPhaseBodyTradingSessionIdOffset] = tradingSessionId;
+        body[WireOffsets.SecurityGroupPhaseBodyTradingSessionSubIdOffset] = tradingSessionSubId;
+        body[WireOffsets.SecurityGroupPhaseBodySecurityTradingEventOffset] = securityTradingEvent;
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityGroupPhaseBodyTradeDateOffset, 2), in tradeDate);
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityGroupPhaseBodyTradSesOpenTimeOffset, 8), in tradSesOpenTimeNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecurityGroupPhaseBodyTransactTimeOffset, 8), in transactTimeNanos);
+
+        return total;
+    }
+
     private static void WriteFramingHeader(Span<byte> dst, int totalFrameLength)
     {
         ushort messageLength = checked((ushort)totalFrameLength);

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -130,6 +130,41 @@ public static class WireOffsets
     public const int MassDeleteOrdersBodyTransactTimeOffset = 16;
     public const int MassDeleteOrdersBodyRptSeqOffset = 24;
 
+    // ---- SecurityStatus_3 (V16) ----
+    // Body layout (BLOCK_LENGTH=36): securityID@0 (long); securityExchange@8
+    // shares offset with matchEventIndicator@8 (byte); tradingSessionID@9
+    // (byte); securityTradingStatus@10 (byte); securityTradingEvent@11
+    // (byte, 255 = NULL); tradeDate@12 (ushort, LocalMktDate); pad@14;
+    // tradSesOpenTime@16 (ulong nanos); transactTime@24 (ulong nanos);
+    // rptSeq@32 (uint, 0 = NULL).
+    public const int SecurityStatusBlockLength = 36;
+    public const int SecurityStatusBodySecurityIdOffset = 0;
+    public const int SecurityStatusBodyMatchEventIndicatorOffset = 8;
+    public const int SecurityStatusBodyTradingSessionIdOffset = 9;
+    public const int SecurityStatusBodySecurityTradingStatusOffset = 10;
+    public const int SecurityStatusBodySecurityTradingEventOffset = 11;
+    public const int SecurityStatusBodyTradeDateOffset = 12;
+    public const int SecurityStatusBodyTradSesOpenTimeOffset = 16;
+    public const int SecurityStatusBodyTransactTimeOffset = 24;
+    public const int SecurityStatusBodyRptSeqOffset = 32;
+
+    // ---- SecurityGroupPhase_10 (V16) ----
+    // Body layout (BLOCK_LENGTH=32): securityGroup@0 (8-byte char array);
+    // matchEventIndicator@8 (byte); tradingSessionID@9 (byte);
+    // tradingSessionSubID@10 (byte); securityTradingEvent@11 (byte,
+    // 255 = NULL); tradeDate@12 (ushort, LocalMktDate); pad@14;
+    // tradSesOpenTime@16 (ulong nanos); transactTime@24 (ulong nanos).
+    public const int SecurityGroupPhaseBlockLength = 32;
+    public const int SecurityGroupPhaseBodySecurityGroupOffset = 0;
+    public const int SecurityGroupPhaseBodySecurityGroupLength = 8;
+    public const int SecurityGroupPhaseBodyMatchEventIndicatorOffset = 8;
+    public const int SecurityGroupPhaseBodyTradingSessionIdOffset = 9;
+    public const int SecurityGroupPhaseBodyTradingSessionSubIdOffset = 10;
+    public const int SecurityGroupPhaseBodySecurityTradingEventOffset = 11;
+    public const int SecurityGroupPhaseBodyTradeDateOffset = 12;
+    public const int SecurityGroupPhaseBodyTradSesOpenTimeOffset = 16;
+    public const int SecurityGroupPhaseBodyTransactTimeOffset = 24;
+
     // ---- ChannelReset_11 (V16) ----
     // Body: MatchEventIndicator @0 (4 bytes — UMDF wire treats the bitset as
     // a 4-byte block, see schema offset="4" on MDEntryTimestamp), then

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -615,4 +615,61 @@ public class ChannelDispatcherTests
     }
 
     private static void DrainInbound(ChannelDispatcher disp) => disp.CreateTestProbe().DrainInbound();
+
+    [Fact]
+    public void OperatorSetTradingPhase_EmitsSecurityStatusFrameAndGatesNewOrders()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        // Transition PETR to CLOSE — engine emits a SecurityStatus frame.
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Close));
+        DrainInbound(disp);
+
+        Assert.Single(pkt.Packets);
+        var packet = pkt.Packets[0];
+        int expectedLen = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecurityStatusBlockLength;
+        Assert.Equal(expectedLen, packet.Length);
+
+        // SBE TemplateId == 3 (SecurityStatus).
+        int sbeHdrStart = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize;
+        ushort templateId = MemoryMarshal.Read<ushort>(packet.AsSpan(sbeHdrStart + 2, 2));
+        Assert.Equal((ushort)3, templateId);
+
+        int bodyStart = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        Assert.Equal(Petr, MemoryMarshal.Read<long>(packet.AsSpan(bodyStart + WireOffsets.SecurityStatusBodySecurityIdOffset, 8)));
+        Assert.Equal((byte)4 /* CLOSE */, packet[bodyStart + WireOffsets.SecurityStatusBodySecurityTradingStatusOffset]);
+        pkt.Packets.Clear();
+
+        // A new order while CLOSE must be rejected with MarketClosed.
+        disp.EnqueueNewOrder(new NewOrderCommand("c1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 9_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        var rej = Assert.Single(reply.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, rej.Reason);
+
+        // Reopen and confirm a subsequent order is accepted.
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Open));
+        DrainInbound(disp);
+        reply.Rejects.Clear();
+        disp.EnqueueNewOrder(new NewOrderCommand("c2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 9_001UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+        Assert.Empty(reply.Rejects);
+        Assert.Equal(1, GetEngine(disp).OrderCount(Petr));
+    }
+
+    [Fact]
+    public void OperatorSetTradingPhase_Idempotent_NoPacketEmitted()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        _ = new FakeSession(outbound);
+
+        // Default is Open; transitioning to Open should be a no-op.
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Open));
+        DrainInbound(disp);
+
+        Assert.Empty(pkt.Packets);
+    }
 }

--- a/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
@@ -185,6 +185,7 @@ public class EnumMappingTests
         MatchingRejectReason.MarketNotImmediateOrCancel => OrdRejReason.UnsupportedOrderCharacteristic,
         MatchingRejectReason.InvalidTimeInForceForMarket => OrdRejReason.UnsupportedOrderCharacteristic,
         MatchingRejectReason.SelfTradePrevention => OrdRejReason.Other,
+        MatchingRejectReason.MarketClosed => OrdRejReason.ExchangeClosed,
         _ => throw new ArgumentOutOfRangeException(nameof(r), r, "unmapped Matching.RejectReason"),
     };
 

--- a/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
@@ -42,7 +42,7 @@ public class MapRejectReasonTests
         {
             // Should not throw and must return one of the documented wire codes.
             uint code = FixpSession.MapRejectReason(r);
-            Assert.Contains(code, new uint[] { 0u, 1u, 3u, 5u, 11u });
+            Assert.Contains(code, new uint[] { 0u, 1u, 3u, 5u, 11u, 13u });
         }
     }
 }

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -40,6 +40,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<OrderQuantityReducedEvent> QtyReduced => Events.OfType<OrderQuantityReducedEvent>().ToList();
     public List<OrderMassCanceledEvent> MassCanceled => Events.OfType<OrderMassCanceledEvent>().ToList();
     public List<OrderBookSideEmptyEvent> BookSideEmpty => Events.OfType<OrderBookSideEmptyEvent>().ToList();
+    public List<TradingPhaseChangedEvent> PhaseChanges => Events.OfType<TradingPhaseChangedEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -49,4 +50,5 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnReject(in RejectEvent e) => Events.Add(e);
     public void OnOrderMassCanceled(in OrderMassCanceledEvent e) => Events.Add(e);
     public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e) => Events.Add(e);
+    public void OnTradingPhaseChanged(in TradingPhaseChangedEvent e) => Events.Add(e);
 }

--- a/tests/B3.Exchange.Matching.Tests/TradingPhaseTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/TradingPhaseTests.cs
@@ -1,0 +1,120 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #201 (gap-functional §5): per-instrument trading phase. The
+/// engine defaults to <see cref="TradingPhase.Open"/>, allows operator
+/// transitions via <c>SetTradingPhase</c>, emits a
+/// <see cref="TradingPhaseChangedEvent"/> with a fresh <c>RptSeq</c> on
+/// every non-trivial transition, and rejects new orders with
+/// <see cref="RejectReason.MarketClosed"/> while the phase is anything
+/// other than Open.
+/// </summary>
+public class TradingPhaseTests
+{
+    [Fact]
+    public void DefaultPhase_IsOpen_AllowsSubmission()
+    {
+        var eng = NewEngine(out var sink);
+
+        Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void SetTradingPhase_NonOpen_EmitsEventWithRptSeq()
+    {
+        var eng = NewEngine(out var sink);
+
+        var changed = eng.SetTradingPhase(PetrSecId, TradingPhase.Close, txnNanos: 5000);
+
+        Assert.True(changed);
+        var ev = Assert.Single(sink.PhaseChanges);
+        Assert.Equal(PetrSecId, ev.SecurityId);
+        Assert.Equal(TradingPhase.Close, ev.Phase);
+        Assert.Equal(5000ul, ev.TransactTimeNanos);
+        Assert.Equal(1u, ev.RptSeq);
+        Assert.Equal(1u, eng.CurrentRptSeq);
+        Assert.Equal(TradingPhase.Close, eng.GetTradingPhase(PetrSecId));
+    }
+
+    [Fact]
+    public void SetTradingPhase_Idempotent_NoEvent()
+    {
+        var eng = NewEngine(out var sink);
+
+        var changed = eng.SetTradingPhase(PetrSecId, TradingPhase.Open, txnNanos: 5000);
+
+        Assert.False(changed);
+        Assert.Empty(sink.PhaseChanges);
+        Assert.Equal(0u, eng.CurrentRptSeq);
+    }
+
+    [Fact]
+    public void Submit_DuringClose_RejectsWithMarketClosed()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Close, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 6000));
+
+        Assert.Empty(sink.Accepted);
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, rej.Reason);
+        Assert.Equal("o1", rej.ClOrdId);
+    }
+
+    [Fact]
+    public void Submit_DuringPause_RejectsWithMarketClosed()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Pause, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 6000));
+
+        Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, sink.Rejects[0].Reason);
+    }
+
+    [Fact]
+    public void Cancel_DuringClose_StillSucceeds()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        var oid = sink.Accepted.Single().OrderId;
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Close, 5000);
+        sink.Clear();
+
+        eng.Cancel(new CancelOrderCommand("c1", PetrSecId, oid, 6000));
+
+        Assert.Single(sink.Canceled);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void SetTradingPhase_BackToOpen_AllowsSubmission()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Close, 5000);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Open, 6000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 7000));
+
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void SetTradingPhase_UnknownSecurity_Throws()
+    {
+        var eng = NewEngine(out _);
+        Assert.Throws<KeyNotFoundException>(() => eng.SetTradingPhase(123L, TradingPhase.Close, 1000));
+    }
+}

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -307,6 +307,55 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void SecurityStatus_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WriteSecurityStatusFrame(buf,
+            securityId: 4242L,
+            tradingSessionId: 1,
+            securityTradingStatus: (byte)SecurityTradingStatus.OPEN,
+            securityTradingEvent: 255,
+            tradeDate: 9000,
+            tradSesOpenTimeNanos: 0UL,
+            transactTimeNanos: 1_700_000_000_000_000_000UL,
+            rptSeq: 42);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecurityStatusBlockLength, n);
+        Assert.True(SecurityStatus_3Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.SecurityStatusBlockLength), out var rdr));
+        Assert.Equal(4242L, (long)rdr.Data.SecurityID.Value);
+        Assert.Equal(SecurityTradingStatus.OPEN, rdr.Data.SecurityTradingStatus);
+        Assert.Null(rdr.Data.SecurityTradingEvent);
+        Assert.Equal((ushort)9000, rdr.Data.TradeDate.Value);
+        Assert.Equal(1_700_000_000_000_000_000UL, rdr.Data.TransactTime.Time);
+        Assert.Equal(42u, rdr.Data.RptSeq);
+    }
+
+    [Fact]
+    public void SecurityGroupPhase_Roundtrip()
+    {
+        var buf = new byte[80];
+        var group = System.Text.Encoding.ASCII.GetBytes("PETR");
+        int n = UmdfWireEncoder.WriteSecurityGroupPhaseFrame(buf,
+            securityGroup: group,
+            tradingSessionId: 1,
+            tradingSessionSubId: (byte)TradingSessionSubID.OPEN,
+            securityTradingEvent: 255,
+            tradeDate: 9000,
+            tradSesOpenTimeNanos: 0UL,
+            transactTimeNanos: 1_700_000_000_000_000_000UL);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecurityGroupPhaseBlockLength, n);
+        Assert.True(SecurityGroupPhase_10Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.SecurityGroupPhaseBlockLength), out var rdr));
+        Assert.Equal(TradingSessionSubID.OPEN, rdr.Data.TradingSessionSubID);
+        Assert.Null(rdr.Data.SecurityTradingEvent);
+        Assert.Equal((ushort)9000, rdr.Data.TradeDate.Value);
+        Assert.Equal(1_700_000_000_000_000_000UL, rdr.Data.TransactTime.Time);
+        // Verify the group bytes were written at offset 0.
+        var groupSlice = buf.AsSpan(FrameOffset, 4).ToArray();
+        Assert.Equal(group, groupSlice);
+    }
+
+    [Fact]
     public void Encoder_ThrowsOnSmallBuffer()
     {
         var small = new byte[8];


### PR DESCRIPTION
Closes #201.

Implements **trading-phase state machine + UMDF `SecurityStatus_3` /
`SecurityGroupPhase_10`** (gap-functional §5).

## Engine

- New `TradingPhase` enum (Pause/Close/Open/Forbidden/Reserved/FinalClosingCall) with values that map directly to the SBE `SecurityTradingStatus` byte codes (no translation needed in the encoder).
- `MatchingEngine` now keeps a per-instrument `Dictionary<long, TradingPhase>`, defaulting every loaded instrument to `Open` so existing tests / callers see no behavioural change.
- New `SetTradingPhase(securityId, phase, txnNanos)`:
  - Idempotent — no event/RptSeq consumed when the phase doesn't change.
  - Emits a new `TradingPhaseChangedEvent` (carrying its own `RptSeq`) when it does.
  - Asserts the dispatch-thread invariant.
- `Submit` rejects new orders with the new `RejectReason.MarketClosed` whenever the instrument's phase is anything other than `Open`. `Cancel` is intentionally still allowed during halts.

## Wire

- `WriteSecurityStatusFrame` (template 3, 36-byte body) and `WriteSecurityGroupPhaseFrame` (template 10, 32-byte body) added to `UmdfWireEncoder` with matching `WireOffsets.*` constants.
- New `IMatchingEventSink.OnTradingPhaseChanged` (default no-op) and `ChannelDispatcher.Sinks.OnTradingPhaseChanged` writes the SecurityStatus_3 frame.

## Operator API

- New `WorkKind.OperatorSetTradingPhase` + `EnqueueOperatorSetTradingPhase(securityId, phase)` mirroring the trade-bust pattern. The processor flushes a single-message packet under the current `SequenceVersion` (only when the engine actually emitted an event).

## Reject mapping

- New `OrdRejReason.ExchangeClosed = 13` in Contracts.
- `FixpOutboundEncoder.MapRejectReason` maps `MarketClosed → 13`.
- Existing exhaustiveness tests in `EnumMappingTests` and `MapRejectReasonTests` extended for the new enum value.

## Tests

- `TradingPhaseTests` (8 cases): default Open, set→event with RptSeq, idempotence, Submit rejected during Close & Pause, Cancel still works during Close, reopen path, unknown securityId throws.
- `UmdfWireEncoderTests`: SecurityStatus_3 + SecurityGroupPhase_10 roundtrips.
- `ChannelDispatcherTests`: operator path emits SecurityStatus packet (template 3) + gates new orders + reopen accepts; idempotent transition emits no packet.

All `dotnet build`, `dotnet test`, and `dotnet format --verify-no-changes` pass locally.
