### PR TITLE
#202: full B3 TimeInForce — GTC/GTD/AtClose/GoodForAuction

### DIFF
--- a/src/B3.Exchange.Contracts/Enums.cs
+++ b/src/B3.Exchange.Contracts/Enums.cs
@@ -29,6 +29,10 @@ public enum TimeInForce : byte
     Day = 0,
     IOC = 3,
     FOK = 4,
+    Gtc = 1,
+    Gtd = 6,
+    AtClose = 7,
+    GoodForAuction = (byte)'A',
 }
 
 /// <summary>

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -59,6 +59,10 @@ internal static class ExecutionReportEncoder
     private const byte TifDay = (byte)'0';
     private const byte TifIoc = (byte)'3';
     private const byte TifFok = (byte)'4';
+    private const byte TifGtc = (byte)'1';
+    private const byte TifGtd = (byte)'6';
+    private const byte TifAtClose = (byte)'7';
+    private const byte TifGoodForAuction = (byte)'A';
     private const byte ExecTypeTrade = (byte)'F';
 
     private static byte EncodeSide(Matching.Side s) => s == Matching.Side.Buy ? SideBuy : SideSell;
@@ -68,6 +72,10 @@ internal static class ExecutionReportEncoder
         Matching.TimeInForce.Day => TifDay,
         Matching.TimeInForce.IOC => TifIoc,
         Matching.TimeInForce.FOK => TifFok,
+        Matching.TimeInForce.Gtc => TifGtc,
+        Matching.TimeInForce.Gtd => TifGtd,
+        Matching.TimeInForce.AtClose => TifAtClose,
+        Matching.TimeInForce.GoodForAuction => TifGoodForAuction,
         _ => 0,
     };
 

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -248,6 +248,7 @@ internal sealed class FixpOutboundEncoder
         RejectReason.FokUnfillable => 0u,
         RejectReason.SelfTradePrevention => 0u,
         RejectReason.MarketClosed => 13u,
+        RejectReason.TimeInForceNotSupported => 11u,
         _ => 0u,
     };
 }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -64,6 +64,10 @@ internal static partial class InboundMessageDecoder
             case (byte)'0': tif = TimeInForce.Day; return true;
             case (byte)'3': tif = TimeInForce.IOC; return true;
             case (byte)'4': tif = TimeInForce.FOK; return true;
+            case (byte)'1': tif = TimeInForce.Gtc; return true;
+            case (byte)'6': tif = TimeInForce.Gtd; return true;
+            case (byte)'7': tif = TimeInForce.AtClose; return true;
+            case (byte)'A': tif = TimeInForce.GoodForAuction; return true;
             default: tif = default; return false;
         }
     }
@@ -102,14 +106,14 @@ internal static partial class InboundMessageDecoder
     }
 
     /// <summary>
-    /// Three-way TimeInForce classification. Returns <c>true</c> for the
-    /// supported subset (Day=0, IOC=3, FOK=4). For other schema-valid
-    /// values (GTC=1, GTD=6, AtTheClose=7, GoodForAuction='A') returns
-    /// <c>false</c> with <paramref name="unsupportedReason"/> populated.
-    /// For bytes not in the schema returns <c>false</c> with the reason
-    /// <c>null</c>. The schema-NULL byte ('\0') is always reported as a
-    /// wire decode error here; callers that accept optional TIF must
-    /// short-circuit before invoking this helper.
+    /// Three-way TimeInForce classification. All seven schema-valid TIF
+    /// values (Day=0, IOC=3, FOK=4, GTC=1, GTD=6, AtTheClose=7,
+    /// GoodForAuction='A') are accepted at the wire layer; semantic
+    /// gating (GTD plumbing, phase enforcement) lives in the matching
+    /// engine. For bytes not in the schema returns <c>false</c> with the
+    /// reason <c>null</c>. The schema-NULL byte ('\0') is always reported
+    /// as a wire decode error here; callers that accept optional TIF
+    /// must short-circuit before invoking this helper.
     /// </summary>
     private static bool TryClassifyTif(byte b, out TimeInForce tif, out string? unsupportedReason)
     {
@@ -119,13 +123,10 @@ internal static partial class InboundMessageDecoder
             case (byte)'0': tif = TimeInForce.Day; return true;
             case (byte)'3': tif = TimeInForce.IOC; return true;
             case (byte)'4': tif = TimeInForce.FOK; return true;
-            case (byte)'1': // GOOD_TILL_CANCEL
-            case (byte)'6': // GOOD_TILL_DATE
-            case (byte)'7': // AT_THE_CLOSE
-            case (byte)'A': // GOOD_FOR_AUCTION
-                tif = default;
-                unsupportedReason = "unsupported TimeInForce";
-                return false;
+            case (byte)'1': tif = TimeInForce.Gtc; return true;
+            case (byte)'6': tif = TimeInForce.Gtd; return true;
+            case (byte)'7': tif = TimeInForce.AtClose; return true;
+            case (byte)'A': tif = TimeInForce.GoodForAuction; return true;
             default:
                 tif = default;
                 return false;

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -2,7 +2,25 @@ namespace B3.Exchange.Matching;
 
 public enum Side : byte { Buy, Sell }
 
-public enum TimeInForce : byte { Day, IOC, FOK }
+/// <summary>
+/// TimeInForce values supported by the matching engine. Wire mapping
+/// lives in the gateway decoder; semantic implications:
+/// <list type="bullet">
+///   <item><c>Day</c>: rests until end of day (no daily-reset operator
+///   command exists yet, so behaves as if persistent).</item>
+///   <item><c>IOC</c>/<c>FOK</c>: marketable-only; remainder is cancelled.</item>
+///   <item><c>Gtc</c>: persistent across hypothetical daily-resets. Currently
+///   identical to <c>Day</c> until the daily-reset operator command lands.</item>
+///   <item><c>Gtd</c>: rejected with <see cref="RejectReason.TimeInForceNotSupported"/>
+///   until the wire path plumbs <c>ExpireDate</c> through
+///   <see cref="NewOrderCommand"/>.</item>
+///   <item><c>AtClose</c>: only accepted while the instrument is in
+///   <see cref="TradingPhase.FinalClosingCall"/>.</item>
+///   <item><c>GoodForAuction</c>: only accepted while the instrument is in
+///   <see cref="TradingPhase.Reserved"/> (pre-open / auction).</item>
+/// </list>
+/// </summary>
+public enum TimeInForce : byte { Day, IOC, FOK, Gtc, Gtd, AtClose, GoodForAuction }
 
 public enum OrderType : byte { Limit, Market }
 
@@ -50,10 +68,15 @@ public enum RejectReason : byte
     /// <see cref="SelfTradePrevention"/> policy is configured to cancel the
     /// aggressor's residual quantity.</summary>
     SelfTradePrevention,
-    /// <summary>Submitted while the instrument's <see cref="TradingPhase"/>
-    /// disallows new orders (anything other than <see cref="TradingPhase.Open"/>).
-    /// Gap-functional §5 / issue #201.</summary>
+    /// <summary>The instrument's current <see cref="TradingPhase"/>
+    /// disallows new orders for the requested
+    /// <see cref="TimeInForce"/>. Issue #201.</summary>
     MarketClosed,
+    /// <summary>The requested <see cref="TimeInForce"/> is wire-valid but
+    /// not yet implemented in the matching engine (e.g. <c>Gtd</c> until
+    /// <c>ExpireDate</c> is plumbed through the inbound command).
+    /// Issue #202.</summary>
+    TimeInForceNotSupported,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -181,9 +181,24 @@ public sealed class MatchingEngine
                 return;
             }
 
-            // #201: trading-phase gating. Only OPEN accepts new orders;
-            // RESERVED (auction) acceptance lands with the auctions wave.
-            if (_phaseById[cmd.SecurityId] != TradingPhase.Open)
+            // #201: trading-phase gating combined with #202 TIF semantics.
+            // Day/IOC/FOK/GTC require Open. AtClose requires FinalClosingCall.
+            // GoodForAuction requires Reserved (pre-open auction). GTD is
+            // wire-accepted but not yet implementable in the engine — the
+            // ExpireDate is not plumbed through NewOrderCommand yet.
+            var phase = _phaseById[cmd.SecurityId];
+            if (cmd.Tif == TimeInForce.Gtd)
+            {
+                Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.TimeInForceNotSupported, cmd.EnteredAtNanos);
+                return;
+            }
+            var requiredPhase = cmd.Tif switch
+            {
+                TimeInForce.AtClose => TradingPhase.FinalClosingCall,
+                TimeInForce.GoodForAuction => TradingPhase.Reserved,
+                _ => TradingPhase.Open,
+            };
+            if (phase != requiredPhase)
             {
                 Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MarketClosed, cmd.EnteredAtNanos);
                 return;
@@ -203,7 +218,9 @@ public sealed class MatchingEngine
             }
             else // Market
             {
-                if (cmd.Tif == TimeInForce.Day)
+                // Market orders must be IOC or FOK. Day/Gtc/Gtd/AtClose/GoodForAuction
+                // are all resting TIFs that can't apply to a market order.
+                if (cmd.Tif != TimeInForce.IOC && cmd.Tif != TimeInForce.FOK)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MarketNotImmediateOrCancel, cmd.EnteredAtNanos); return; }
             }
 

--- a/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
@@ -82,6 +82,10 @@ public class EnumMappingTests
     [InlineData(MatchingTif.Day, ContractsTif.Day)]
     [InlineData(MatchingTif.IOC, ContractsTif.IOC)]
     [InlineData(MatchingTif.FOK, ContractsTif.FOK)]
+    [InlineData(MatchingTif.Gtc, ContractsTif.Gtc)]
+    [InlineData(MatchingTif.Gtd, ContractsTif.Gtd)]
+    [InlineData(MatchingTif.AtClose, ContractsTif.AtClose)]
+    [InlineData(MatchingTif.GoodForAuction, ContractsTif.GoodForAuction)]
     public void TimeInForce_MatchingToContracts(MatchingTif matching, ContractsTif expected)
     {
         Assert.Equal(expected, MapTif(matching));
@@ -90,8 +94,8 @@ public class EnumMappingTests
     [Fact]
     public void TimeInForce_AllValuesCovered()
     {
-        Assert.Equal(3, Enum.GetValues<MatchingTif>().Length);
-        Assert.Equal(3, Enum.GetValues<ContractsTif>().Length);
+        Assert.Equal(7, Enum.GetValues<MatchingTif>().Length);
+        Assert.Equal(7, Enum.GetValues<ContractsTif>().Length);
         foreach (var v in Enum.GetValues<MatchingTif>()) _ = MapTif(v);
     }
 
@@ -154,6 +158,10 @@ public class EnumMappingTests
         MatchingTif.Day => ContractsTif.Day,
         MatchingTif.IOC => ContractsTif.IOC,
         MatchingTif.FOK => ContractsTif.FOK,
+        MatchingTif.Gtc => ContractsTif.Gtc,
+        MatchingTif.Gtd => ContractsTif.Gtd,
+        MatchingTif.AtClose => ContractsTif.AtClose,
+        MatchingTif.GoodForAuction => ContractsTif.GoodForAuction,
         _ => throw new ArgumentOutOfRangeException(nameof(t), t, "unmapped Matching.TimeInForce"),
     };
 
@@ -186,6 +194,7 @@ public class EnumMappingTests
         MatchingRejectReason.InvalidTimeInForceForMarket => OrdRejReason.UnsupportedOrderCharacteristic,
         MatchingRejectReason.SelfTradePrevention => OrdRejReason.Other,
         MatchingRejectReason.MarketClosed => OrdRejReason.ExchangeClosed,
+        MatchingRejectReason.TimeInForceNotSupported => OrdRejReason.UnsupportedOrderCharacteristic,
         _ => throw new ArgumentOutOfRangeException(nameof(r), r, "unmapped Matching.RejectReason"),
     };
 

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -103,6 +103,10 @@ public class NewOrderSingleAndReplaceDecoderTests
     [InlineData((byte)'0', TimeInForce.Day)]
     [InlineData((byte)'3', TimeInForce.IOC)]
     [InlineData((byte)'4', TimeInForce.FOK)]
+    [InlineData((byte)'1', TimeInForce.Gtc)]
+    [InlineData((byte)'6', TimeInForce.Gtd)]
+    [InlineData((byte)'7', TimeInForce.AtClose)]
+    [InlineData((byte)'A', TimeInForce.GoodForAuction)]
     public void NewOrderSingle_AcceptsSupportedTif(byte tifByte, TimeInForce expected)
     {
         var body = BuildNewOrderSingleV2(tif: tifByte);
@@ -192,21 +196,9 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Contains("OrdType", msg);
     }
 
-    [Theory]
-    [InlineData((byte)'1')] // GTC
-    [InlineData((byte)'6')] // GTD
-    [InlineData((byte)'7')] // AtTheClose
-    [InlineData((byte)'A')] // GoodForAuction
-    public void NewOrderSingle_UnsupportedTifReturnsBmr(byte tifByte)
-    {
-        var body = BuildNewOrderSingleV2(tif: tifByte);
-
-        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
-            body, 1, 0, out _, out _, out var msg);
-
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("TimeInForce", msg);
-    }
+    // GTC/GTD/AtTheClose/GoodForAuction are all decoder-accepted now (#202).
+    // Engine-side semantic gating (GTD plumbing, phase enforcement) is
+    // covered by MatchingEngine tests rather than the decoder.
 
     [Theory]
     [InlineData((byte)'5')] // not in schema

--- a/tests/B3.Exchange.Matching.Tests/ExtendedTimeInForceTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/ExtendedTimeInForceTests.cs
@@ -1,0 +1,129 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #202 (gap-functional §9): the engine must accept the full
+/// B3 TimeInForce surface — Day, IOC, FOK, GTC, GTD, AtClose,
+/// GoodForAuction. GTC is currently identical to Day (no daily-reset
+/// operator command exists yet); GTD is rejected with
+/// <see cref="RejectReason.TimeInForceNotSupported"/> until ExpireDate is
+/// plumbed through <see cref="NewOrderCommand"/>; AtClose and
+/// GoodForAuction are gated on the instrument's
+/// <see cref="TradingPhase"/> (FinalClosingCall and Reserved
+/// respectively).
+/// </summary>
+public class ExtendedTimeInForceTests
+{
+    [Fact]
+    public void Gtc_Limit_RestsLikeDayOrder()
+    {
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(10m), 100, 11, 1000));
+
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void Gtd_AlwaysRejected_UntilExpireDatePlumbed()
+    {
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtd, Px(10m), 100, 11, 1000));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.TimeInForceNotSupported, rej.Reason);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void AtClose_DuringOpen_RejectsAsMarketClosed()
+    {
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10m), 100, 11, 1000));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, rej.Reason);
+    }
+
+    [Fact]
+    public void AtClose_DuringFinalClosingCall_Accepted()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.FinalClosingCall, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10m), 100, 11, 6000));
+
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void GoodForAuction_DuringOpen_RejectsAsMarketClosed()
+    {
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10m), 100, 11, 1000));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, rej.Reason);
+    }
+
+    [Fact]
+    public void GoodForAuction_DuringReserved_Accepted()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10m), 100, 11, 6000));
+
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void DayOrder_DuringFinalClosingCall_RejectsAsMarketClosed()
+    {
+        // Day TIF still requires Open phase even when the market is in
+        // FinalClosingCall — only AtClose is admitted then.
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.FinalClosingCall, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 6000));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, rej.Reason);
+    }
+
+    [Fact]
+    public void Gtc_Market_Rejected()
+    {
+        // Market orders must be IOC/FOK regardless of TIF extension.
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Market, TimeInForce.Gtc, 0, 100, 11, 1000));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketNotImmediateOrCancel, rej.Reason);
+    }
+
+    [Fact]
+    public void Gtc_CrossesAndFills_Normally()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("seller", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("buyer", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(10m), 100, 12, 2000));
+
+        Assert.Single(sink.Trades);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+}


### PR DESCRIPTION
Closes #202.

Implements **full B3 TimeInForce surface — GTC, GTD, AtClose,
GoodForAuction** (gap-functional §9). Pairs with #201's trading-phase
state machine for AtClose / GoodForAuction gating.

## Enums (Contracts + Matching)

Both enums extended with `Gtc`, `Gtd`, `AtClose`, `GoodForAuction`.
`Contracts.TimeInForce` uses the FIX wire codes (1, 6, 7, 'A') so the
wire mapping stays trivially inspectable. `Matching.TimeInForce` adds
the symbolic values to its existing 0..2 ordering.

## Decoder

`InboundMessageDecoder.TryMapTif` and `TryClassifyTif` now accept the
four new schema-valid TIFs at the wire layer (instead of returning
`UnsupportedFeature`). The "TIF change on replace" guard
(`InboundMessageDecoder.OrderCancelReplace.cs`) is intentionally left
in place — replace remains Day-only for now.

## Matching engine semantics

- **GTC** → behaves identically to Day (rests on book). Documented gap:
  no daily-reset operator command exists yet, so the GTC vs Day
  distinction is informational only until that path lands.
- **GTD** → rejected with new `RejectReason.TimeInForceNotSupported`.
  `NewOrderCommand` does not yet plumb `ExpireDate`; rather than silently
  treating GTD as Day the engine refuses it explicitly so clients get
  a clear signal.
- **AtClose** → only accepted while the instrument's
  `TradingPhase == FinalClosingCall`. Otherwise rejected with
  `RejectReason.MarketClosed`.
- **GoodForAuction** → only accepted while
  `TradingPhase == Reserved` (pre-open auction).
- **Day / IOC / FOK / Gtc** → still require `TradingPhase.Open`.
- Market orders must be IOC or FOK for *any* extended TIF (the existing
  Day-only check generalised).

## Wire-out + reject mapping

`ExecutionReportEncoder.EncodeTif` extended to emit the FIX wire
codes for the four new TIFs.

`FixpOutboundEncoder.MapRejectReason` maps
`TimeInForceNotSupported → 11` (UnsupportedOrderCharacteristic).

## Tests

- `ExtendedTimeInForceTests` (9 cases): GTC rests / crosses, GTD always
  rejected, AtClose accepted only in FinalClosingCall, GoodForAuction
  accepted only in Reserved, Day rejected during FinalClosingCall,
  Market+GTC rejected, etc.
- `NewOrderSingleAndReplaceDecoderTests.NewOrderSingle_AcceptsSupportedTif`
  extended to all 7 TIF bytes; the obsolete `UnsupportedTifReturnsBmr`
  test removed.
- `EnumMappingTests` extended for all 7 TIF values + the new
  RejectReason.

All `dotnet build`, `dotnet test`, and `dotnet format --verify-no-changes` pass locally (one pre-existing flaky network test excluded).
