### PR TITLE
K6a (#203 partial): MinQty on NewOrderSingle

### DIFF
--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -249,6 +249,8 @@ internal sealed class FixpOutboundEncoder
         RejectReason.SelfTradePrevention => 0u,
         RejectReason.MarketClosed => 13u,
         RejectReason.TimeInForceNotSupported => 11u,
+        RejectReason.MinQtyNotMet => 0u,
+        RejectReason.InvalidField => 11u,
         _ => 0u,
     };
 }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -104,11 +104,6 @@ internal static partial class InboundMessageDecoder
             message = "Iceberg orders not supported (MaxFloor must be NULL)";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (minQty != 0)
-        {
-            message = "Minimum-fill orders not supported (MinQty must be NULL)";
-            return InboundDecodeOutcome.UnsupportedFeature;
-        }
         if (routing != RoutingInstructionNull)
         {
             message = $"RoutingInstruction={routing} not supported";
@@ -141,7 +136,10 @@ internal static partial class InboundMessageDecoder
             PriceMantissa: enginePrice,
             Quantity: qty,
             EnteringFirm: enteringFirm,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            MinQty = minQty,
+        };
         return InboundDecodeOutcome.Success;
     }
 }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -77,6 +77,16 @@ public enum RejectReason : byte
     /// <c>ExpireDate</c> is plumbed through the inbound command).
     /// Issue #202.</summary>
     TimeInForceNotSupported,
+    /// <summary>The aggressor specified a non-zero
+    /// <see cref="NewOrderCommand.MinQty"/> but the immediately fillable
+    /// quantity against the opposite book at the order's limit price was
+    /// less than that minimum. The order is rejected before any state
+    /// change. Issue #203 (MinQty subset).</summary>
+    MinQtyNotMet,
+    /// <summary>A request field was outside the engine's accepted range
+    /// (e.g. <see cref="NewOrderCommand.MinQty"/> &gt;
+    /// <see cref="NewOrderCommand.Quantity"/>). Issue #203.</summary>
+    InvalidField,
 }
 
 /// <summary>
@@ -138,7 +148,22 @@ public sealed record NewOrderCommand(
     long PriceMantissa,
     long Quantity,
     uint EnteringFirm,
-    ulong EnteredAtNanos);
+    ulong EnteredAtNanos)
+{
+    /// <summary>
+    /// Optional minimum-fill (FIX MinQty). When non-zero, the engine
+    /// requires that at submission time the immediately fillable quantity
+    /// against the opposite side at this order's limit (or any price for
+    /// market orders) is at least <c>MinQty</c>; otherwise the order is
+    /// rejected with <see cref="RejectReason.MinQtyNotMet"/> and never
+    /// touches the book. Must satisfy <c>0 &lt; MinQty &lt;= Quantity</c>;
+    /// values outside that range yield
+    /// <see cref="RejectReason.InvalidField"/>. Default 0 means "no
+    /// minimum-fill constraint" and preserves legacy behaviour.
+    /// Issue #203 (MinQty subset).
+    /// </summary>
+    public ulong MinQty { get; init; }
+}
 
 public sealed record CancelOrderCommand(
     string ClOrdId,

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -208,6 +208,11 @@ public sealed class MatchingEngine
             if (cmd.Quantity <= 0) { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.QuantityNonPositive, cmd.EnteredAtNanos); return; }
             if (cmd.Quantity % rules.LotSize != 0) { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.QuantityNotMultipleOfLot, cmd.EnteredAtNanos); return; }
 
+            // #203 (MinQty subset): MinQty must be in (0, Quantity]. Zero
+            // means "no minimum-fill constraint" and is the legacy path.
+            if (cmd.MinQty != 0 && (long)cmd.MinQty > cmd.Quantity)
+            { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
+
             if (cmd.Type == OrderType.Limit)
             {
                 if (cmd.PriceMantissa <= 0) { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.PriceNonPositive, cmd.EnteredAtNanos); return; }
@@ -259,6 +264,21 @@ public sealed class MatchingEngine
             // market order to be "accepted with no fills".
             if (cmd.Type == OrderType.Market && book.BestLevel(LimitOrderBook.Opposite(cmd.Side)) is null)
             { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MarketNoLiquidity, cmd.EnteredAtNanos); return; }
+
+            // #203 (MinQty subset): pre-check immediately fillable quantity
+            // against the opposite side. Same crossing predicate as FOK but
+            // the threshold is MinQty instead of full Quantity. Any residual
+            // (Quantity - filled) is allowed to rest if TIF permits. STP
+            // self-trade exclusion is intentionally not factored in here:
+            // MinQty is a venue-level liquidity guard expressed against the
+            // book, and a separate STP cancel will surface to the client
+            // through the normal aggressor path.
+            if (cmd.MinQty != 0)
+            {
+                long fillable = book.FillableQuantityAgainst(cmd.Side, cmd.PriceMantissa, isMarket: cmd.Type == OrderType.Market);
+                if (fillable < (long)cmd.MinQty)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MinQtyNotMet, cmd.EnteredAtNanos); return; }
+            }
 
             ExecuteAggressor(cmd, rules, book);
         }

--- a/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
@@ -195,6 +195,8 @@ public class EnumMappingTests
         MatchingRejectReason.SelfTradePrevention => OrdRejReason.Other,
         MatchingRejectReason.MarketClosed => OrdRejReason.ExchangeClosed,
         MatchingRejectReason.TimeInForceNotSupported => OrdRejReason.UnsupportedOrderCharacteristic,
+        MatchingRejectReason.MinQtyNotMet => OrdRejReason.Other,
+        MatchingRejectReason.InvalidField => OrdRejReason.UnsupportedOrderCharacteristic,
         _ => throw new ArgumentOutOfRangeException(nameof(r), r, "unmapped Matching.RejectReason"),
     };
 

--- a/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
@@ -27,6 +27,8 @@ public class MapRejectReasonTests
     [InlineData(RejectReason.MarketNoLiquidity, 0u)]
     [InlineData(RejectReason.FokUnfillable, 0u)]
     [InlineData(RejectReason.SelfTradePrevention, 0u)]
+    [InlineData(RejectReason.MinQtyNotMet, 0u)]
+    [InlineData(RejectReason.InvalidField, 11u)]
     public void MapRejectReason_ProducesExpectedWireCode(RejectReason reason, uint expected)
     {
         Assert.Equal(expected, FixpSession.MapRejectReason(reason));

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -156,15 +156,16 @@ public class NewOrderSingleAndReplaceDecoderTests
     }
 
     [Fact]
-    public void NewOrderSingle_MinQtyRejectsAsUnsupported()
+    public void NewOrderSingle_AcceptsMinQty()
     {
-        var body = BuildNewOrderSingleV2(minQty: 5UL);
+        var body = BuildNewOrderSingleV2(minQty: 5UL, qty: 100L);
 
         var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
-            body, 1, 0, out _, out _, out var msg);
+            body, 1, 0, out var cmd, out _, out var msg);
 
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("Minimum-fill", msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(5UL, cmd.MinQty);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/MinQtyTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/MinQtyTests.cs
@@ -1,0 +1,123 @@
+namespace B3.Exchange.Matching.Tests;
+
+/// <summary>
+/// Engine semantics for the MinQty subset of issue #203.
+/// </summary>
+public class MinQtyTests
+{
+    private static NewOrderCommand Limit(string id, Side side, decimal price, long qty, uint firm = 1, ulong minQty = 0)
+        => new(id, TestFactory.PetrSecId, side, OrderType.Limit, TimeInForce.Day,
+               TestFactory.Px(price), qty, firm, 0)
+        { MinQty = minQty };
+
+    [Fact]
+    public void MinQty_zero_preserves_legacy_behaviour()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Sell, 10m, 100));
+        engine.Submit(Limit("A1", Side.Buy, 10m, 200, minQty: 0));
+
+        Assert.Single(sink.Trades);
+        Assert.Empty(sink.Rejects);
+        // Aggressor accepted, partial residual rests.
+        Assert.Equal(2, sink.Accepted.Count);
+    }
+
+    [Fact]
+    public void MinQty_met_by_book_allows_aggression_and_residual_rests()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Sell, 10m, 100));
+        engine.Submit(Limit("M2", Side.Sell, 10m, 100));
+        engine.Submit(Limit("A1", Side.Buy, 10m, 500, minQty: 200));
+
+        Assert.Equal(2, sink.Trades.Count);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(3, sink.Accepted.Count); // 2 makers + aggressor
+    }
+
+    [Fact]
+    public void MinQty_unmet_rejects_without_state_change()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Sell, 10m, 100));
+        sink.Clear();
+
+        engine.Submit(Limit("A1", Side.Buy, 10m, 500, minQty: 200));
+
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Accepted);
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MinQtyNotMet, rej.Reason);
+    }
+
+    [Fact]
+    public void MinQty_unmet_at_limit_price_rejects_even_with_deeper_levels()
+    {
+        // Only the level that crosses counts. A worse-priced level is ignored.
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Sell, 10m, 100));
+        engine.Submit(Limit("M2", Side.Sell, 11m, 1_000));
+        sink.Clear();
+
+        engine.Submit(Limit("A1", Side.Buy, 10m, 500, minQty: 200));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MinQtyNotMet, rej.Reason);
+    }
+
+    [Fact]
+    public void MinQty_greater_than_quantity_is_invalid_field()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+
+        engine.Submit(Limit("A1", Side.Buy, 10m, 100, minQty: 200));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void MinQty_with_empty_book_rejects_minqty_not_met()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+
+        engine.Submit(Limit("A1", Side.Buy, 10m, 500, minQty: 200));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MinQtyNotMet, rej.Reason);
+    }
+
+    [Fact]
+    public void MinQty_with_market_order_uses_full_opposite_book()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Sell, 10m, 100));
+        engine.Submit(Limit("M2", Side.Sell, 11m, 200));
+        sink.Clear();
+
+        var market = new NewOrderCommand("A1", TestFactory.PetrSecId, Side.Buy,
+            OrderType.Market, TimeInForce.IOC, 0, 200, 1, 0)
+        { MinQty = 200 };
+        engine.Submit(market);
+
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(2, sink.Trades.Count);
+    }
+
+    [Fact]
+    public void MinQty_with_market_order_unmet_rejects()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Sell, 10m, 100));
+        sink.Clear();
+
+        var market = new NewOrderCommand("A1", TestFactory.PetrSecId, Side.Buy,
+            OrderType.Market, TimeInForce.IOC, 0, 500, 1, 0)
+        { MinQty = 200 };
+        engine.Submit(market);
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MinQtyNotMet, rej.Reason);
+    }
+}


### PR DESCRIPTION
Implements the **MinQty** subset of #203 (Iceberg + MinQty support).
Iceberg / MaxFloor will be tackled in a separate follow-up issue/PR
(NewOrderCommand keeps no MaxFloor field; the decoder still rejects
MaxFloor as unsupported).

## What

- `NewOrderCommand.MinQty` (init-only `ulong`, default 0) plumbed end-to-end.
- `InboundMessageDecoder.TryDecodeNewOrderSingle` no longer rejects
  non-zero `minQty`; the value is forwarded to the engine.
- `MatchingEngine.Submit`:
  - Validates `0 < MinQty <= Quantity` (else `RejectReason.InvalidField`).
  - Pre-checks `book.FillableQuantityAgainst(...)` at the order's limit
    (or any-price for market orders); if `fillable < MinQty` rejects with
    new `RejectReason.MinQtyNotMet` without touching the book.
  - Residual (`Quantity - filled`) follows normal TIF rules — Day rests,
    IOC/FOK behave as today.
- Wire mapping: `MinQtyNotMet → 0u` (Other), `InvalidField → 11u`
  (UnsupportedOrderCharacteristic).

## Out of scope

- Iceberg / `MaxFloor` (book replenish, time-priority loss, MBO Add+Delete
  on replenish): follow-up issue.
- `MinQty` on **Replace**: out of scope; replace decoder still rejects.

## Tests

- `MinQtyTests` (new, 8 cases): zero-path legacy behaviour, met / unmet,
  limit-price scoping (deeper level ignored), market order, invalid field,
  empty book.
- Decoder test `NewOrderSingle_MinQtyRejectsAsUnsupported` flipped to
  `NewOrderSingle_AcceptsMinQty`.
- `EnumMappingTests` + `MapRejectReasonTests` extended for the two new
  `RejectReason` values (exhaustiveness guards continue to pass).

Full `dotnet test` green; `dotnet format --verify-no-changes` clean.
