### PR TITLE
#204: Replace honors TIF/OrdType per EntryPoint spec

### DIFF
--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -71,42 +71,28 @@ internal static partial class InboundMessageDecoder
         if (!TryClassifyOrdType(ordTypeByte, out var ordType, out var ordTypeUnsupported))
         {
             message = ordTypeUnsupported is not null
-                ? $"OrdType={ordTypeByte:X2} not supported (only Limit on replace)"
+                ? $"OrdType={ordTypeByte:X2} not supported (only Market, Limit)"
                 : $"invalid OrdType={ordTypeByte}";
             return ordTypeUnsupported is not null
                 ? InboundDecodeOutcome.UnsupportedFeature
                 : InboundDecodeOutcome.DecodeError;
         }
-        // Replace path can only carry through Limit semantics — the
-        // engine's ReplaceOrderCommand has no Type field and reuses the
-        // resting order's existing type. Reject Market replace requests
-        // explicitly so we don't silently lie about what we did.
-        if (ordType != OrderType.Limit)
-        {
-            message = "Market replace not supported (only Limit replace)";
-            return InboundDecodeOutcome.UnsupportedFeature;
-        }
-        // TimeInForce on this template is optional in the schema (null =
-        // '\0'), meaning "do not change". Anything else than null or Day
-        // would request a TIF transition the engine cannot perform on
-        // a resting order, so reject with BMR rather than silently
-        // accepting and applying the wrong semantics.
+        // #204: TimeInForce on this template is optional; absence means
+        // "preserve the resting order's original TIF". When present, any
+        // value the engine accepts on a NewOrderSingle is allowed here.
+        TimeInForce? newTif = null;
         if (tifByte != TimeInForceOptionalNull)
         {
-            if (!TryClassifyTif(tifByte, out var tif, out var tifUnsupported))
+            if (!TryClassifyTif(tifByte, out var tifValue, out var tifUnsupported))
             {
                 message = tifUnsupported is not null
-                    ? $"TimeInForce={(char)tifByte} not supported on replace (omit or use Day)"
+                    ? $"TimeInForce={(char)tifByte} not supported"
                     : $"invalid TimeInForce={tifByte}";
                 return tifUnsupported is not null
                     ? InboundDecodeOutcome.UnsupportedFeature
                     : InboundDecodeOutcome.DecodeError;
             }
-            if (tif != TimeInForce.Day)
-            {
-                message = "TIF change on replace not supported (omit or use Day)";
-                return InboundDecodeOutcome.UnsupportedFeature;
-            }
+            newTif = tifValue;
         }
         if (stopPx != PriceNull)
         {
@@ -148,19 +134,29 @@ internal static partial class InboundMessageDecoder
             message = "OrderCancelReplaceRequest requires either OrderID or OrigClOrdID";
             return InboundDecodeOutcome.DecodeError;
         }
-        if (priceMantissa == PriceNull)
+        // Limit replace requires a price; Market replace ignores price (the
+        // engine zero-fills it before processing).
+        if (ordType == OrderType.Limit && priceMantissa == PriceNull)
         {
             message = "OrderCancelReplaceRequest requires Price (replace cannot remove price)";
             return InboundDecodeOutcome.DecodeError;
         }
 
+        long enginePrice = ordType == OrderType.Market
+            ? 0L
+            : priceMantissa;
+
         cmd = new ReplaceOrderCommand(
             ClOrdId: clOrdId.ToString(),
             SecurityId: secId,
             OrderId: (long)orderId,
-            NewPriceMantissa: priceMantissa,
+            NewPriceMantissa: enginePrice,
             NewQuantity: qty,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            NewOrdType = ordType,
+            NewTif = newTif,
+        };
         return InboundDecodeOutcome.Success;
     }
 }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -187,7 +187,25 @@ public sealed record ReplaceOrderCommand(
     long OrderId,
     long NewPriceMantissa,
     long NewQuantity,
-    ulong EnteredAtNanos);
+    ulong EnteredAtNanos)
+{
+    /// <summary>
+    /// New order type for the replacement. <c>null</c> means "preserve
+    /// the resting order's type" (always <see cref="OrderType.Limit"/>
+    /// for an order that is on the book). Setting <c>OrderType.Market</c>
+    /// turns the priority-loss path into a market aggressor that consumes
+    /// liquidity and never rests; <see cref="NewTif"/> must then be
+    /// IOC or FOK. Issue #204.
+    /// </summary>
+    public OrderType? NewOrdType { get; init; }
+
+    /// <summary>
+    /// New TIF for the replacement. <c>null</c> means "preserve the
+    /// resting order's original TIF". Issue #204 (was previously hard-
+    /// coded to <see cref="TimeInForce.Day"/>).
+    /// </summary>
+    public TimeInForce? NewTif { get; init; }
+}
 
 /// <summary>
 /// Cross order command (NewOrderCross template 106 / spec §4.6.1 / §16.1.5).

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -14,6 +14,15 @@ internal sealed class RestingOrder
     public required uint EnteringFirm { get; init; }
     public required ulong InsertTimestampNanos { get; init; }
 
+    /// <summary>
+    /// TIF the order was originally accepted with (Day or Gtc — the only
+    /// TIFs that can rest). Tracked so a subsequent
+    /// <see cref="ReplaceOrderCommand"/> that omits TIF on the wire
+    /// preserves the resting order's original TIF instead of silently
+    /// downgrading to <see cref="TimeInForce.Day"/>. Issue #204.
+    /// </summary>
+    public TimeInForce Tif { get; init; } = TimeInForce.Day;
+
     public long RemainingQuantity;
     public PriceLevel? Level;
     public RestingOrder? Prev;

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -386,13 +386,52 @@ public sealed class MatchingEngine
             // Validate new params *before* mutating.
             if (cmd.NewQuantity <= 0) { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.QuantityNonPositive, cmd.EnteredAtNanos); return; }
             if (cmd.NewQuantity % rules.LotSize != 0) { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.QuantityNotMultipleOfLot, cmd.EnteredAtNanos); return; }
-            if (cmd.NewPriceMantissa <= 0) { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.PriceNonPositive, cmd.EnteredAtNanos); return; }
-            if (cmd.NewPriceMantissa < rules.MinPriceMantissa || cmd.NewPriceMantissa > rules.MaxPriceMantissa)
-            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.PriceOutOfBand, cmd.EnteredAtNanos); return; }
-            if (cmd.NewPriceMantissa % rules.TickSizeMantissa != 0)
-            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.PriceNotOnTick, cmd.EnteredAtNanos); return; }
 
-            bool priorityKept = cmd.NewPriceMantissa == resting.PriceMantissa
+            // #204: effective Type/TIF — null means "preserve original".
+            // The resting order is by construction Limit (Market never rests),
+            // so the only meaningful Type override is Limit -> Market, which
+            // turns the priority-loss path into a market aggressor.
+            var effectiveType = cmd.NewOrdType ?? OrderType.Limit;
+            var effectiveTif = cmd.NewTif ?? resting.Tif;
+
+            // Phase gating — same rules as a brand-new order. A replace that
+            // lands during a trading halt must be rejected before mutating
+            // the resting order; if the new TIF is incompatible with the
+            // current phase the replace is treated like a new order would be.
+            var phase = _phaseById[cmd.SecurityId];
+            if (effectiveTif == TimeInForce.Gtd)
+            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.TimeInForceNotSupported, cmd.EnteredAtNanos); return; }
+            var requiredPhase = effectiveTif switch
+            {
+                TimeInForce.AtClose => TradingPhase.FinalClosingCall,
+                TimeInForce.GoodForAuction => TradingPhase.Reserved,
+                _ => TradingPhase.Open,
+            };
+            if (phase != requiredPhase)
+            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.MarketClosed, cmd.EnteredAtNanos); return; }
+
+            // Market replace must be IOC/FOK (cannot rest); price is ignored
+            // in the aggressor path but we still validate it for Limit.
+            if (effectiveType == OrderType.Market)
+            {
+                if (effectiveTif != TimeInForce.IOC && effectiveTif != TimeInForce.FOK)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.MarketNotImmediateOrCancel, cmd.EnteredAtNanos); return; }
+            }
+            else
+            {
+                if (cmd.NewPriceMantissa <= 0) { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.PriceNonPositive, cmd.EnteredAtNanos); return; }
+                if (cmd.NewPriceMantissa < rules.MinPriceMantissa || cmd.NewPriceMantissa > rules.MaxPriceMantissa)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.PriceOutOfBand, cmd.EnteredAtNanos); return; }
+                if (cmd.NewPriceMantissa % rules.TickSizeMantissa != 0)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.PriceNotOnTick, cmd.EnteredAtNanos); return; }
+            }
+
+            // Priority-keep is only possible if Type/TIF are unchanged: a Type
+            // or TIF transition is by definition a logical re-entry (the order
+            // semantics differ), so we must DEL+NEW.
+            bool priorityKept = effectiveType == OrderType.Limit
+                                && effectiveTif == resting.Tif
+                                && cmd.NewPriceMantissa == resting.PriceMantissa
                                 && cmd.NewQuantity <= resting.RemainingQuantity;
 
             if (priorityKept)
@@ -420,15 +459,16 @@ public sealed class MatchingEngine
             EmitCanceled(book, resting, cmd.EnteredAtNanos, CancelReason.ReplaceLostPriority);
 
             // Build a synthetic NewOrderCommand for the replacement and process
-            // it through the normal aggressor path. TIF=Day so unfilled
-            // remainder rests (this matches FIX OrderCancelReplace semantics).
+            // it through the normal aggressor path. Type/TIF come from the
+            // explicit replace overrides (or the resting order's originals
+            // when omitted by the caller). Issue #204.
             var replacement = new NewOrderCommand(
                 ClOrdId: cmd.ClOrdId,
                 SecurityId: cmd.SecurityId,
                 Side: side,
-                Type: OrderType.Limit,
-                Tif: TimeInForce.Day,
-                PriceMantissa: cmd.NewPriceMantissa,
+                Type: effectiveType,
+                Tif: effectiveTif,
+                PriceMantissa: effectiveType == OrderType.Market ? 0L : cmd.NewPriceMantissa,
                 Quantity: cmd.NewQuantity,
                 EnteringFirm: resting.EnteringFirm,
                 EnteredAtNanos: cmd.EnteredAtNanos);
@@ -580,7 +620,7 @@ public sealed class MatchingEngine
             return;
         }
 
-        // Day order with remainder rests on the book.
+        // Day/GTC order with remainder rests on the book.
         var resting = new RestingOrder
         {
             OrderId = aggressorOrderIdForTrades,
@@ -590,6 +630,7 @@ public sealed class MatchingEngine
             EnteringFirm = cmd.EnteringFirm,
             InsertTimestampNanos = cmd.EnteredAtNanos,
             RemainingQuantity = aggressorRemaining,
+            Tif = cmd.Tif,
         };
         book.Insert(resting);
         _sink.OnOrderAccepted(new OrderAcceptedEvent(

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -388,29 +388,39 @@ public class NewOrderSingleAndReplaceDecoderTests
     }
 
     [Fact]
-    public void OrderCancelReplace_MarketRejectsAsUnsupported()
+    public void OrderCancelReplace_MarketAccepted()
     {
-        var body = BuildOrderCancelReplaceV2(ordType: (byte)'1');
+        // #204: Market replace is supported; price is ignored by the engine
+        // for market orders, so the decoder zero-fills it.
+        var body = BuildOrderCancelReplaceV2(ordType: (byte)'1', tif: (byte)'3');
 
         var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
-            body, 0UL, out _, out _, out _, out var msg);
+            body, 0UL, out var cmd, out _, out _, out var msg);
 
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("Market replace", msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(OrderType.Market, cmd.NewOrdType);
+        Assert.Equal(TimeInForce.IOC, cmd.NewTif);
+        Assert.Equal(0L, cmd.NewPriceMantissa);
     }
 
     [Theory]
-    [InlineData((byte)'3')] // IOC
-    [InlineData((byte)'4')] // FOK
-    public void OrderCancelReplace_NonDayTifRejectsAsUnsupported(byte tifByte)
+    [InlineData((byte)'3', TimeInForce.IOC)]
+    [InlineData((byte)'4', TimeInForce.FOK)]
+    public void OrderCancelReplace_NonDayTifAccepted(byte tifByte, TimeInForce expected)
     {
+        // #204: every TIF the engine accepts on a NewOrderSingle is now
+        // valid on replace too. The decoder propagates it as the optional
+        // ReplaceOrderCommand.NewTif so the engine can apply it on the
+        // priority-loss re-entry path.
         var body = BuildOrderCancelReplaceV2(tif: tifByte);
 
         var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
-            body, 0UL, out _, out _, out _, out var msg);
+            body, 0UL, out var cmd, out _, out _, out var msg);
 
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("TIF", msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(expected, cmd.NewTif);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/ReplaceTypeAndTifTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/ReplaceTypeAndTifTests.cs
@@ -1,0 +1,146 @@
+namespace B3.Exchange.Matching.Tests;
+
+/// <summary>
+/// Engine semantics for #204 — Replace honors TIF/OrdType per the
+/// EntryPoint OrderCancelReplaceRequest schema. Validates the
+/// priority-loss re-entry path uses the explicit overrides (or
+/// preserves the resting order's originals when the wire field is null).
+/// </summary>
+public class ReplaceTypeAndTifTests
+{
+    private static NewOrderCommand Limit(string id, Side side, decimal price, long qty,
+        TimeInForce tif = TimeInForce.Day, uint firm = 1)
+        => new(id, TestFactory.PetrSecId, side, OrderType.Limit, tif,
+               TestFactory.Px(price), qty, firm, 0);
+
+    [Fact]
+    public void Replace_with_no_overrides_preserves_original_tif_day()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Buy, 10m, 100));
+        var original = sink.Accepted.Single();
+        sink.Clear();
+
+        // Same price, smaller qty: priority preserved (no DEL+NEW).
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, TestFactory.Px(10m), 100, 0));
+
+        Assert.Empty(sink.Canceled);
+        Assert.Single(sink.QtyReduced);
+    }
+
+    [Fact]
+    public void Replace_to_ioc_drops_residual_after_partial_fill()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Resting buy at 10
+        engine.Submit(Limit("M1", Side.Buy, 10m, 500));
+        var original = sink.Accepted.Single();
+        // Counter-side liquidity at 11 (so price-up replace crosses)
+        engine.Submit(Limit("M2", Side.Sell, 11m, 100));
+        sink.Clear();
+
+        // Replace to price 11 with TIF=IOC: the original order is cancelled
+        // (priority lost) and the replacement crosses against M2 for 100,
+        // dropping the IOC remainder instead of resting.
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, TestFactory.Px(11m), 500, 0)
+        { NewTif = TimeInForce.IOC });
+
+        var cancel = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.ReplaceLostPriority, cancel.Reason);
+        Assert.Single(sink.Trades);
+        // No new accept: IOC remainder didn't rest.
+        Assert.Empty(sink.Accepted);
+    }
+
+    [Fact]
+    public void Replace_to_market_ioc_consumes_book_and_does_not_rest()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Buy, 10m, 500));
+        var original = sink.Accepted.Single();
+        engine.Submit(Limit("M2", Side.Sell, 11m, 100));
+        engine.Submit(Limit("M3", Side.Sell, 12m, 100));
+        sink.Clear();
+
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, 0, 200, 0)
+        { NewOrdType = OrderType.Market, NewTif = TimeInForce.IOC });
+
+        Assert.Single(sink.Canceled);
+        Assert.Equal(2, sink.Trades.Count);
+        Assert.Empty(sink.Accepted);
+    }
+
+    [Fact]
+    public void Replace_to_market_with_day_tif_rejects()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Buy, 10m, 100));
+        var original = sink.Accepted.Single();
+        sink.Clear();
+
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, 0, 100, 0)
+        { NewOrdType = OrderType.Market, NewTif = TimeInForce.Day });
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketNotImmediateOrCancel, rej.Reason);
+        Assert.Empty(sink.Canceled);
+    }
+
+    [Fact]
+    public void Replace_with_tif_change_loses_priority_even_at_same_price_and_qty()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Buy, 10m, 100, tif: TimeInForce.Day));
+        var original = sink.Accepted.Single();
+        sink.Clear();
+
+        // Counter-side empty so IOC replace will be cancelled with no fills,
+        // proving the order is gone (priority lost branch was taken).
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, TestFactory.Px(10m), 100, 0)
+        { NewTif = TimeInForce.IOC });
+
+        var cancel = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.ReplaceLostPriority, cancel.Reason);
+        // IOC remainder is silently dropped — no new accept.
+        Assert.Empty(sink.Accepted);
+        Assert.Empty(sink.Trades);
+    }
+
+    [Fact]
+    public void Replace_during_close_phase_rejects_market_closed()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Buy, 10m, 100));
+        var original = sink.Accepted.Single();
+        engine.SetTradingPhase(TestFactory.PetrSecId, TradingPhase.Close, 0);
+        sink.Clear();
+
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, TestFactory.Px(11m), 100, 0));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketClosed, rej.Reason);
+    }
+
+    [Fact]
+    public void Replace_with_omitted_tif_preserves_gtc()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("M1", Side.Buy, 10m, 100, tif: TimeInForce.Gtc));
+        var original = sink.Accepted.Single();
+        sink.Clear();
+
+        // Different price → priority lost path. NewTif null preserves GTC,
+        // so the replacement rests like a GTC order (residual stays on book).
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, TestFactory.Px(11m), 100, 0));
+
+        Assert.Single(sink.Canceled);
+        Assert.Single(sink.Accepted);
+    }
+}


### PR DESCRIPTION
Closes #204.

## What

`OrderCancelReplaceRequest` (template 104) can now carry full FIX
semantics for `OrdType` and `TimeInForce`, instead of being limited to
`Limit + Day`.

### Engine

- `ReplaceOrderCommand` gains optional `NewOrdType` and `NewTif`
  (init-only nullable). `null` = preserve the resting order's original.
- `RestingOrder.Tif` (init-only, default `Day`) is set from
  `cmd.Tif` on insert so that omitting TIF on replace preserves a GTC
  origin (instead of silently downgrading to Day).
- `Replace` now phase- and TIF-gates the request like a brand-new order
  (Gtd → `TimeInForceNotSupported`, AtClose requires
  `FinalClosingCall`, etc.). Market replace must be IOC/FOK.
- `priorityKept` additionally requires `Type == Limit` and TIF unchanged.
  Any Type/TIF transition forces DEL+NEW because the replacement is
  logically a new order and must lose time priority.
- The synthetic re-entry `NewOrderCommand` uses the effective Type/TIF.

### Decoder

- Drops the "Market replace not supported" and "TIF != Day" rejects.
- `Market` replace is accepted; the engine zero-fills price (price is
  ignored for market aggressors).
- Optional TIF byte (`'\0'`) → `NewTif = null`; otherwise the full
  K5 TIF set is accepted.
- Price is now only required for `Limit` replace.

## Out of scope

- `MaxFloor` / `MinQty` on replace remain rejected (deferred follow-up).
- `Side` / `SecurityID` change on replace remains unsupported (would
  be a new order).

## Tests

- New `ReplaceTypeAndTifTests` (7 cases): preserve-original, Day→IOC,
  Limit→Market+IOC, Market+Day rejection, TIF-change loses priority,
  phase-Close rejection, GTC preservation when TIF omitted.
- Decoder tests `OrderCancelReplace_MarketRejectsAsUnsupported` and
  `_NonDayTifRejectsAsUnsupported` flipped to positive `_Accepted`.

`dotnet test` 744/744 green; `dotnet format --verify-no-changes` clean.
