### PR TITLE
K6b: Iceberg/MaxFloor on NewOrderSingle (#211)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -197,4 +197,38 @@ public sealed partial class ChannelDispatcher
             _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
         }
     }
+
+    public void OnIcebergReplenished(in IcebergReplenishedEvent e)
+    {
+        AssertOnLoopThread();
+        // #211: encode the replenish as a Delete + Add MBO frame pair for
+        // the same OrderID. The order's canonical state (and therefore the
+        // owning session/ClOrdID for ER routing) is intentionally NOT
+        // touched: the order is logically the same; only its position in
+        // the price-level queue changed. No ExecutionReport is emitted —
+        // the per-trade ER_Trade frames already covered the fills that
+        // exhausted the visible slice.
+        var entryType = e.Side == Side.Buy
+            ? B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeBid
+            : B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeOffer;
+
+        // 1. DeleteOrder for the consumed visible spot. Quantity is 0
+        //    because the slice was fully traded away (it's a "removed by
+        //    consumption" delete from the consumer's perspective).
+        var del = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.DeleteOrderBlockLength);
+        int dn = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteOrderDeletedFrame(del,
+            e.SecurityId, e.OrderId, entryType, 0L, e.DeleteRptSeq, e.TransactTimeNanos, e.PriceMantissa);
+        Commit(dn);
+
+        // 2. OrderAdded for the replenished slice at the back of the level.
+        var add = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.OrderBlockLength);
+        int an = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteOrderAddedFrame(add,
+            e.SecurityId, e.OrderId, entryType, e.PriceMantissa, e.NewVisibleQuantity,
+            e.AddRptSeq, e.InsertTimestampNanos);
+        Commit(an);
+    }
 }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -101,8 +101,8 @@ internal static partial class InboundMessageDecoder
         }
         if (maxFloor != 0)
         {
-            message = "Iceberg orders not supported (MaxFloor must be NULL)";
-            return InboundDecodeOutcome.UnsupportedFeature;
+            // #211: iceberg accepted on NewOrderSingle. The engine validates
+            // MaxFloor in (0, Quantity] / lot multiple / Limit + Day|Gtc.
         }
         if (routing != RoutingInstructionNull)
         {
@@ -139,6 +139,7 @@ internal static partial class InboundMessageDecoder
             EnteredAtNanos: enteredAtNanos)
         {
             MinQty = minQty,
+            MaxFloor = maxFloor,
         };
         return InboundDecodeOutcome.Success;
     }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -163,6 +163,25 @@ public sealed record NewOrderCommand(
     /// Issue #203 (MinQty subset).
     /// </summary>
     public ulong MinQty { get; init; }
+
+    /// <summary>
+    /// Optional iceberg visible quantity (FIX MaxFloor). When non-zero
+    /// and strictly less than <see cref="Quantity"/>, the engine exposes
+    /// only <c>MaxFloor</c> shares at a time on the book; on full
+    /// consumption of the visible slice the engine replenishes a new
+    /// visible slice from the hidden reserve and re-inserts the order at
+    /// the back of the same price level, losing time priority. Must
+    /// satisfy <c>0 &lt; MaxFloor &lt;= Quantity</c> and be a multiple of
+    /// the instrument's lot size; values outside that range yield
+    /// <see cref="RejectReason.InvalidField"/>. Iceberg requires
+    /// <see cref="OrderType.Limit"/> and a resting TIF
+    /// (<see cref="TimeInForce.Day"/> or <see cref="TimeInForce.Gtc"/>);
+    /// IOC/FOK/Market combinations are rejected with
+    /// <see cref="RejectReason.InvalidField"/>. <c>MaxFloor == Quantity</c>
+    /// is accepted as a no-op (degenerate iceberg with no hidden reserve).
+    /// Default 0 means "not an iceberg". Issue #211.
+    /// </summary>
+    public ulong MaxFloor { get; init; }
 }
 
 public sealed record CancelOrderCommand(

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -134,6 +134,34 @@ public readonly record struct OrderMassCanceledEvent(
     uint RptSeq);
 
 /// <summary>
+/// Fired when an iceberg order's visible slice is fully consumed by
+/// trades and a fresh visible slice is taken from the hidden reserve
+/// (issue #211). Carries the same <see cref="OrderId"/> as the
+/// original order — the order is logically still the same. The
+/// integration layer translates this to a UMDF
+/// <c>DeleteOrder_MBO_51</c> for the consumed spot followed by an
+/// <c>OrderAdded_MBO_50</c> for the replenished slice at the back of
+/// the same price level (time-priority loss). No
+/// <c>ExecutionReport</c> is emitted: the per-trade ER_Trade frames
+/// already covered the fills, and the order has not changed cumulative
+/// quantity or status from the client's perspective.
+/// <see cref="NewVisibleQuantity"/> is the size of the new exposed
+/// slice; <see cref="RemainingHiddenQuantity"/> is what is left in the
+/// reserve after this replenish (may be zero on the last replenish).
+/// </summary>
+public readonly record struct IcebergReplenishedEvent(
+    long SecurityId,
+    long OrderId,
+    Side Side,
+    long PriceMantissa,
+    long NewVisibleQuantity,
+    long RemainingHiddenQuantity,
+    ulong InsertTimestampNanos,
+    ulong TransactTimeNanos,
+    uint DeleteRptSeq,
+    uint AddRptSeq);
+
+/// <summary>
 /// Sink of matching events. Implementations MUST NOT call back into the engine
 /// from any of these methods — the engine is single-threaded per channel and
 /// reentrant commands corrupt internal linked lists.
@@ -169,4 +197,13 @@ public interface IMatchingEventSink
     /// <c>SecurityStatus_3</c>.
     /// </summary>
     void OnTradingPhaseChanged(in TradingPhaseChangedEvent e) { }
+
+    /// <summary>
+    /// Optional event emitted when an iceberg order replenishes its
+    /// visible slice from the hidden reserve. Default no-op so legacy
+    /// sinks compile; the production <c>ChannelDispatcher</c> overrides
+    /// it to emit a UMDF <c>DeleteOrder_MBO_51</c> + <c>OrderAdded_MBO_50</c>
+    /// pair for the same OrderID. Issue #211.
+    /// </summary>
+    void OnIcebergReplenished(in IcebergReplenishedEvent e) { }
 }

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -23,6 +23,25 @@ internal sealed class RestingOrder
     /// </summary>
     public TimeInForce Tif { get; init; } = TimeInForce.Day;
 
+    /// <summary>
+    /// Iceberg visible-slice size (FIX MaxFloor). 0 means "not an iceberg"
+    /// and <see cref="HiddenQuantity"/> is always 0 in that case. When
+    /// non-zero, <see cref="RemainingQuantity"/> represents only the
+    /// visible portion currently exposed in the book; the hidden reserve
+    /// lives in <see cref="HiddenQuantity"/> and replenishes the visible
+    /// slice when it is fully consumed (the order is then re-inserted at
+    /// the back of the same price level, losing time priority).
+    /// Issue #211.
+    /// </summary>
+    public long MaxFloor { get; init; }
+
+    /// <summary>
+    /// Hidden iceberg reserve. Mutable: decreases each time a fresh
+    /// visible slice is taken from it. Always 0 when
+    /// <see cref="MaxFloor"/> is 0. Issue #211.
+    /// </summary>
+    public long HiddenQuantity;
+
     public long RemainingQuantity;
     public PriceLevel? Level;
     public RestingOrder? Prev;

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -213,6 +213,20 @@ public sealed class MatchingEngine
             if (cmd.MinQty != 0 && (long)cmd.MinQty > cmd.Quantity)
             { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
 
+            // #211: iceberg validation. MaxFloor in (0, Quantity], multiple
+            // of lot, and only meaningful for resting limit orders. Market
+            // / IOC / FOK / Gtd / AtClose / GoodForAuction would never let
+            // hidden qty replenish, so reject them.
+            if (cmd.MaxFloor != 0)
+            {
+                if ((long)cmd.MaxFloor > cmd.Quantity
+                    || (long)cmd.MaxFloor % rules.LotSize != 0)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
+                if (cmd.Type != OrderType.Limit
+                    || (cmd.Tif != TimeInForce.Day && cmd.Tif != TimeInForce.Gtc))
+                { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
+            }
+
             if (cmd.Type == OrderType.Limit)
             {
                 if (cmd.PriceMantissa <= 0) { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.PriceNonPositive, cmd.EnteredAtNanos); return; }
@@ -549,6 +563,66 @@ public sealed class MatchingEngine
 
                 if (maker.RemainingQuantity == 0)
                 {
+                    // #211: iceberg replenish — if the maker has hidden
+                    // reserve, the visible slice was just exhausted but
+                    // the order is not yet fully filled. Take a fresh
+                    // visible slice from the hidden reserve, re-insert
+                    // at the BACK of the same price level (time-priority
+                    // loss), and emit IcebergReplenishedEvent so the
+                    // sink can flush a paired Delete + Add MBO frame
+                    // for the same OrderID. The aggressor does NOT
+                    // re-cross the replenished slice in the same dispatch
+                    // (loop iterates via the pre-captured `next`), which
+                    // matches the spec's "loses time priority" guarantee.
+                    if (maker.HiddenQuantity > 0)
+                    {
+                        long newVisible = Math.Min(maker.MaxFloor, maker.HiddenQuantity);
+                        long newHidden = maker.HiddenQuantity - newVisible;
+                        var icebergSide = maker.Side;
+                        long icebergPx = maker.PriceMantissa;
+                        long icebergOid = maker.OrderId;
+                        // Atomically: remove from current spot, mutate
+                        // visible/hidden counters, re-insert at tail of
+                        // same level. The book.Remove + book.Insert pair
+                        // is correct even if this is the only order at
+                        // the level (Insert recreates the level).
+                        book.Remove(maker);
+                        maker.RemainingQuantity = newVisible;
+                        maker.HiddenQuantity = newHidden;
+                        // Reset insert timestamp to the trade time — the
+                        // replenished slice is logically a fresh entry at
+                        // the back of the queue.
+                        var refreshed = new RestingOrder
+                        {
+                            OrderId = icebergOid,
+                            ClOrdId = maker.ClOrdId,
+                            Side = icebergSide,
+                            PriceMantissa = icebergPx,
+                            EnteringFirm = maker.EnteringFirm,
+                            InsertTimestampNanos = cmd.EnteredAtNanos,
+                            RemainingQuantity = newVisible,
+                            Tif = maker.Tif,
+                            MaxFloor = maker.MaxFloor,
+                            HiddenQuantity = newHidden,
+                        };
+                        book.Insert(refreshed);
+                        uint deleteSeq = NextRptSeq();
+                        uint addSeq = NextRptSeq();
+                        _sink.OnIcebergReplenished(new IcebergReplenishedEvent(
+                            SecurityId: book.SecurityId,
+                            OrderId: icebergOid,
+                            Side: icebergSide,
+                            PriceMantissa: icebergPx,
+                            NewVisibleQuantity: newVisible,
+                            RemainingHiddenQuantity: newHidden,
+                            InsertTimestampNanos: cmd.EnteredAtNanos,
+                            TransactTimeNanos: cmd.EnteredAtNanos,
+                            DeleteRptSeq: deleteSeq,
+                            AddRptSeq: addSeq));
+                        maker = next;
+                        continue;
+                    }
+
                     // Maker fully filled → remove + OnOrderFilled.
                     long finalFilled = tradeQty; // For simplicity OrderFilledEvent reports
                                                  // the LAST trade's qty; downstream cares
@@ -621,6 +695,16 @@ public sealed class MatchingEngine
         }
 
         // Day/GTC order with remainder rests on the book.
+        // Day/GTC order with remainder rests on the book. For iceberg
+        // orders (#211), expose only the visible slice on the book and
+        // hold the rest as HiddenQuantity for replenish on consumption.
+        long visible = aggressorRemaining;
+        long hidden = 0;
+        if (cmd.MaxFloor != 0 && (long)cmd.MaxFloor < aggressorRemaining)
+        {
+            visible = (long)cmd.MaxFloor;
+            hidden = aggressorRemaining - visible;
+        }
         var resting = new RestingOrder
         {
             OrderId = aggressorOrderIdForTrades,
@@ -629,8 +713,10 @@ public sealed class MatchingEngine
             PriceMantissa = limitPx,
             EnteringFirm = cmd.EnteringFirm,
             InsertTimestampNanos = cmd.EnteredAtNanos,
-            RemainingQuantity = aggressorRemaining,
+            RemainingQuantity = visible,
             Tif = cmd.Tif,
+            MaxFloor = (long)cmd.MaxFloor,
+            HiddenQuantity = hidden,
         };
         book.Insert(resting);
         _sink.OnOrderAccepted(new OrderAcceptedEvent(

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -144,15 +144,18 @@ public class NewOrderSingleAndReplaceDecoderTests
     }
 
     [Fact]
-    public void NewOrderSingle_MaxFloorRejectsAsUnsupported()
+    public void NewOrderSingle_AcceptsMaxFloor()
     {
-        var body = BuildNewOrderSingleV2(maxFloor: 10UL);
+        // #211: iceberg accepted on NewOrderSingle. The decoder forwards
+        // MaxFloor to the engine; engine validates lot/multiple/Type/TIF.
+        var body = BuildNewOrderSingleV2(maxFloor: 10UL, qty: 100L);
 
         var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
-            body, 1, 0, out _, out _, out var msg);
+            body, 1, 0, out var cmd, out _, out var msg);
 
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("Iceberg", msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(10UL, cmd.MaxFloor);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/IcebergTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/IcebergTests.cs
@@ -1,0 +1,199 @@
+namespace B3.Exchange.Matching.Tests;
+
+/// <summary>
+/// Engine semantics for the Iceberg (MaxFloor) subset of issue #211.
+/// Validates: visible-only book exposure, replenish on visible exhaustion,
+/// time-priority loss after replenish, full consumption transitions to
+/// OrderFilled, validation of MaxFloor against quantity / lot / type / TIF.
+/// </summary>
+public class IcebergTests
+{
+    private static NewOrderCommand IcebergSell(string id, decimal price, long qty, ulong maxFloor,
+        TimeInForce tif = TimeInForce.Day, uint firm = 1)
+        => new(id, TestFactory.PetrSecId, Side.Sell, OrderType.Limit, tif,
+               TestFactory.Px(price), qty, firm, 0)
+        { MaxFloor = maxFloor };
+
+    private static NewOrderCommand BuyLimit(string id, decimal price, long qty,
+        TimeInForce tif = TimeInForce.Day, uint firm = 2)
+        => new(id, TestFactory.PetrSecId, Side.Buy, OrderType.Limit, tif,
+               TestFactory.Px(price), qty, firm, 0);
+
+    [Fact]
+    public void Iceberg_exposes_only_visible_slice_on_accept()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Total 1000, visible 200.
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 200));
+
+        var accept = sink.Accepted.Single();
+        Assert.Equal(200, accept.RemainingQuantity);
+    }
+
+    [Fact]
+    public void Iceberg_replenishes_visible_slice_when_exhausted()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 200));
+        sink.Clear();
+
+        // Aggressor buys exactly the visible slice → triggers replenish.
+        engine.Submit(BuyLimit("AGG", 10m, 200, tif: TimeInForce.IOC));
+
+        Assert.Single(sink.Trades);
+        Assert.Equal(200, sink.Trades[0].Quantity);
+        // Replenish event with new visible 200 and remaining hidden 600.
+        var rep = Assert.Single(sink.Replenishments);
+        Assert.Equal(200, rep.NewVisibleQuantity);
+        Assert.Equal(600, rep.RemainingHiddenQuantity);
+        // No OrderFilled (the iceberg is still alive).
+        Assert.Empty(sink.Filled);
+    }
+
+    [Fact]
+    public void Iceberg_replenish_loses_time_priority_at_same_level()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Iceberg first, then a regular order at the SAME price → iceberg
+        // is at head of queue.
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 200));
+        engine.Submit(new NewOrderCommand("REG", TestFactory.PetrSecId, Side.Sell,
+            OrderType.Limit, TimeInForce.Day, TestFactory.Px(10m), 300, 9, 0));
+        sink.Clear();
+
+        // First aggressor consumes iceberg's visible 200 → replenish puts
+        // iceberg at the BACK of the level (now after REG).
+        engine.Submit(BuyLimit("AGG1", 10m, 200, tif: TimeInForce.IOC));
+        Assert.Single(sink.Trades);
+        Assert.Equal(sink.Replenishments.Single().OrderId, sink.Trades[0].RestingOrderId);
+        sink.Clear();
+
+        // Second aggressor for 300 should hit REG first (now at head),
+        // not the replenished iceberg.
+        engine.Submit(BuyLimit("AGG2", 10m, 300, tif: TimeInForce.IOC));
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(300, trade.Quantity);
+        // The traded resting orderId must be REG, not the iceberg.
+        var iceOid = engine; // alias — we don't hold it; assert via Filled event
+        var filled = Assert.Single(sink.Filled);
+        Assert.Equal(trade.RestingOrderId, filled.OrderId);
+    }
+
+    [Fact]
+    public void Iceberg_final_consumption_emits_OrderFilled()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Total 300, visible 100 → 3 slices, third one has hidden 0 left.
+        engine.Submit(IcebergSell("ICE", 10m, 300, maxFloor: 100));
+        sink.Clear();
+
+        // Walk three visible slices: replenish twice, then final fill.
+        engine.Submit(BuyLimit("AGG1", 10m, 100, tif: TimeInForce.IOC));
+        engine.Submit(BuyLimit("AGG2", 10m, 100, tif: TimeInForce.IOC));
+        engine.Submit(BuyLimit("AGG3", 10m, 100, tif: TimeInForce.IOC));
+
+        Assert.Equal(3, sink.Trades.Count);
+        Assert.Equal(2, sink.Replenishments.Count);
+        // After the 3rd consumption, hidden was already 0 → OrderFilled.
+        var filled = Assert.Single(sink.Filled);
+        Assert.Equal(100, filled.FinalFilledQuantity);
+    }
+
+    [Fact]
+    public void Iceberg_partial_visible_consumption_only_reduces_quantity()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 300));
+        sink.Clear();
+
+        // Aggressor takes less than the visible slice → no replenish.
+        engine.Submit(BuyLimit("AGG", 10m, 100, tif: TimeInForce.IOC));
+
+        Assert.Single(sink.Trades);
+        Assert.Empty(sink.Replenishments);
+        var qr = Assert.Single(sink.QtyReduced);
+        Assert.Equal(200, qr.NewRemainingQuantity);
+    }
+
+    [Fact]
+    public void Iceberg_with_maxfloor_equal_to_quantity_acts_as_normal_order()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(IcebergSell("ICE", 10m, 200, maxFloor: 200));
+        sink.Clear();
+
+        engine.Submit(BuyLimit("AGG", 10m, 200, tif: TimeInForce.IOC));
+
+        // No hidden reserve → full consumption emits OrderFilled, no replenish.
+        Assert.Single(sink.Trades);
+        Assert.Empty(sink.Replenishments);
+        Assert.Single(sink.Filled);
+    }
+
+    [Fact]
+    public void Iceberg_with_maxfloor_greater_than_quantity_rejects_invalid_field()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(IcebergSell("ICE", 10m, 100, maxFloor: 200));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void Iceberg_with_non_lot_maxfloor_rejects_invalid_field()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // PETR4 LotSize=100; MaxFloor=150 violates lot multiple.
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 150));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void Iceberg_on_market_order_rejects()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(BuyLimit("M1", 10m, 100));
+        sink.Clear();
+
+        var market = new NewOrderCommand("ICE", TestFactory.PetrSecId, Side.Sell,
+            OrderType.Market, TimeInForce.IOC, 0, 1000, 1, 0)
+        { MaxFloor = 200 };
+        engine.Submit(market);
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void Iceberg_on_ioc_rejects()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 200, tif: TimeInForce.IOC));
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void Iceberg_aggressor_keeps_consuming_after_replenish_skip()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Iceberg 1000@10 visible 200, plus a regular 500@11.
+        engine.Submit(IcebergSell("ICE", 10m, 1000, maxFloor: 200));
+        engine.Submit(IcebergSell("REG", 11m, 500, maxFloor: 0));
+        sink.Clear();
+
+        // Buy 600 at 11 → consume iceberg visible 200 (replenish, but
+        // replenished slice not re-eligible in the same dispatch),
+        // then 400 against REG.
+        engine.Submit(BuyLimit("AGG", 11m, 600, tif: TimeInForce.IOC));
+
+        Assert.Equal(2, sink.Trades.Count);
+        Assert.Equal(200, sink.Trades[0].Quantity);
+        Assert.Equal(400, sink.Trades[1].Quantity);
+        Assert.Single(sink.Replenishments);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -41,6 +41,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<OrderMassCanceledEvent> MassCanceled => Events.OfType<OrderMassCanceledEvent>().ToList();
     public List<OrderBookSideEmptyEvent> BookSideEmpty => Events.OfType<OrderBookSideEmptyEvent>().ToList();
     public List<TradingPhaseChangedEvent> PhaseChanges => Events.OfType<TradingPhaseChangedEvent>().ToList();
+    public List<IcebergReplenishedEvent> Replenishments => Events.OfType<IcebergReplenishedEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -51,4 +52,5 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnOrderMassCanceled(in OrderMassCanceledEvent e) => Events.Add(e);
     public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e) => Events.Add(e);
     public void OnTradingPhaseChanged(in TradingPhaseChangedEvent e) => Events.Add(e);
+    public void OnIcebergReplenished(in IcebergReplenishedEvent e) => Events.Add(e);
 }


### PR DESCRIPTION
## K6b — Iceberg / MaxFloor on NewOrderSingle (#211)

Last open item from Onda K. Adds iceberg-order support to the matching
engine via the `MaxFloor` field on `NewOrderSingle`.

### What changes

- `NewOrderCommand.MaxFloor` (0 = no iceberg).
- `RestingOrder` gains `MaxFloor` + `HiddenQuantity`; only the visible
  slice enters the book.
- Engine validates `MaxFloor`: must be `> 0`, `<= Quantity`, lot-multiple,
  and only on `Limit + (Day or Gtc)`. Violations → `InvalidField`.
- On full consumption of the visible slice while hidden remains > 0:
  - engine replenishes a fresh visible slice (same `OrderId`) at the
    tail of the level (loses time priority) and emits
    `IcebergReplenishedEvent`;
  - aggressor does **not** re-cross the replenished slice in the same
    dispatch (loop iterates pre-captured `next`);
  - sink emits paired `DeleteOrder` + `OrderAdded` MBO frames; no ER
    is generated and the canonical `OrderState` is untouched (logically
    the same order).
- `InboundMessageDecoder` no longer rejects `MaxFloor` on
  `NewOrderSingle`; it passes through to the engine. `MaxFloor` on
  `OrderCancelReplace` continues to be rejected (out of scope).

### Tests

11 new tests in `IcebergTests`:

- accept / visible-only split on book entry,
- single replenish,
- multi-replenish until exhaustion → final `OrderFilled`,
- partial visible consumption only reduces quantity,
- time-priority loss after replenish,
- `MaxFloor == Quantity` acts as a normal order,
- validation rejects: `MaxFloor > Quantity`, non-lot multiple,
  `Market`, `IOC`,
- aggressor keeps consuming other levels after the replenish skip.

Decoder unit test `NewOrderSingle_MaxFloorRejectsAsUnsupported` flipped
to `NewOrderSingle_AcceptsMaxFloor`.

Closes #211.
