### PR TITLE
L2: Market-with-leftover-as-Limit (#215)

### DIFF
--- a/src/B3.Exchange.Contracts/Enums.cs
+++ b/src/B3.Exchange.Contracts/Enums.cs
@@ -23,6 +23,13 @@ public enum OrderType : byte
     Limit = 2,
     StopLoss = 3,
     StopLimit = 4,
+    /// <summary>
+    /// Market with leftover-as-limit (FIX OrdType 'K' / B3
+    /// MARKET_WITH_LEFTOVER_AS_LIMIT). Sweeps the opposite side like a
+    /// Market; any unfilled remainder rests at the last execution price
+    /// as a Day Limit. Issue #215.
+    /// </summary>
+    MarketWithLeftover = 5,
 }
 
 /// <summary>Time-in-force. Wire-neutral mirror of FIX tag 59.</summary>

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -58,6 +58,7 @@ internal static class ExecutionReportEncoder
     private const byte OrdTypeLimit = (byte)'2';
     private const byte OrdTypeStopLoss = (byte)'3';
     private const byte OrdTypeStopLimit = (byte)'4';
+    private const byte OrdTypeMwl = (byte)'K';
     private const byte TifDay = (byte)'0';
     private const byte TifIoc = (byte)'3';
     private const byte TifFok = (byte)'4';
@@ -74,6 +75,7 @@ internal static class ExecutionReportEncoder
         Matching.OrderType.Limit => OrdTypeLimit,
         Matching.OrderType.StopLoss => OrdTypeStopLoss,
         Matching.OrderType.StopLimit => OrdTypeStopLimit,
+        Matching.OrderType.MarketWithLeftover => OrdTypeMwl,
         _ => OrdTypeLimit,
     };
     private static byte EncodeTif(Matching.TimeInForce t) => t switch

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -134,7 +134,9 @@ internal static partial class InboundMessageDecoder
             return InboundDecodeOutcome.UnsupportedFeature;
         }
 
-        long enginePrice = ordType == OrderType.Market ? 0L : (priceMantissa == PriceNull ? 0L : priceMantissa);
+        long enginePrice = (ordType == OrderType.Market || ordType == OrderType.MarketWithLeftover)
+            ? 0L
+            : (priceMantissa == PriceNull ? 0L : priceMantissa);
         long engineStopPx = isStop ? stopPx : 0L;
 
         cmd = new NewOrderCommand(

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -93,7 +93,7 @@ internal static partial class InboundMessageDecoder
             case (byte)'2': type = OrderType.Limit; return true;
             case (byte)'3': type = OrderType.StopLoss; return true;
             case (byte)'4': type = OrderType.StopLimit; return true;
-            case (byte)'K': // MARKET_WITH_LEFTOVER_AS_LIMIT
+            case (byte)'K': type = OrderType.MarketWithLeftover; return true;
             case (byte)'W': // RLP
             case (byte)'P': // PEGGED_MIDPOINT
                 type = default;

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -22,7 +22,7 @@ public enum Side : byte { Buy, Sell }
 /// </summary>
 public enum TimeInForce : byte { Day, IOC, FOK, Gtc, Gtd, AtClose, GoodForAuction }
 
-public enum OrderType : byte { Limit, Market, StopLoss, StopLimit }
+public enum OrderType : byte { Limit, Market, StopLoss, StopLimit, MarketWithLeftover }
 
 /// <summary>
 /// Per-instrument trading phase (gap-functional §5 / #201). The values

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -262,12 +262,23 @@ public sealed class MatchingEngine
                 if (cmd.PriceMantissa % rules.TickSizeMantissa != 0)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.PriceNotOnTick, cmd.EnteredAtNanos); return; }
             }
-            else // Market
+            else if (cmd.Type == OrderType.Market)
             {
                 // Market orders must be IOC or FOK. Day/Gtc/Gtd/AtClose/GoodForAuction
                 // are all resting TIFs that can't apply to a market order.
                 if (cmd.Tif != TimeInForce.IOC && cmd.Tif != TimeInForce.FOK)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MarketNotImmediateOrCancel, cmd.EnteredAtNanos); return; }
+            }
+            else // MarketWithLeftover (#215)
+            {
+                // MWL must be Day TIF: the unfilled remainder rests on the
+                // book as a Day Limit at the last execution price.
+                if (cmd.Tif != TimeInForce.Day)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
+                // MWL never carries a Price on the wire — the resting price
+                // is derived from the last executed trade.
+                if (cmd.PriceMantissa != 0)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
             }
 
             var book = _booksById[cmd.SecurityId];
@@ -276,7 +287,7 @@ public sealed class MatchingEngine
             // if insufficient. Same crossing predicate as the actual match path.
             if (cmd.Tif == TimeInForce.FOK)
             {
-                long fillable = book.FillableQuantityAgainst(cmd.Side, cmd.PriceMantissa, isMarket: cmd.Type == OrderType.Market);
+                long fillable = book.FillableQuantityAgainst(cmd.Side, cmd.PriceMantissa, isMarket: IsMarketLike(cmd.Type));
                 if (fillable < cmd.Quantity)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.FokUnfillable, cmd.EnteredAtNanos); return; }
 
@@ -284,7 +295,7 @@ public sealed class MatchingEngine
                 // would be prevented from matching, so reject FOK as unfillable if any exist.
                 if (_stp != SelfTradePrevention.None)
                 {
-                    bool isMarketOrder = cmd.Type == OrderType.Market;
+                    bool isMarketOrder = IsMarketLike(cmd.Type);
                     foreach (var level in book.OppositeLevels(cmd.Side))
                     {
                         if (!isMarketOrder && !LimitOrderBook.PriceCrosses(cmd.Side, level.PriceMantissa, cmd.PriceMantissa))
@@ -301,9 +312,10 @@ public sealed class MatchingEngine
                 }
             }
 
-            // Market order with empty opposite book: reject early — we never want a
-            // market order to be "accepted with no fills".
-            if (cmd.Type == OrderType.Market && book.BestLevel(LimitOrderBook.Opposite(cmd.Side)) is null)
+            // Market / MWL with empty opposite book: reject early — neither type
+            // should ever be "accepted with no fills" (MWL would have nothing
+            // to anchor the leftover-as-Limit price to).
+            if (IsMarketLike(cmd.Type) && book.BestLevel(LimitOrderBook.Opposite(cmd.Side)) is null)
             { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MarketNoLiquidity, cmd.EnteredAtNanos); return; }
 
             // #203 (MinQty subset): pre-check immediately fillable quantity
@@ -316,7 +328,7 @@ public sealed class MatchingEngine
             // through the normal aggressor path.
             if (cmd.MinQty != 0)
             {
-                long fillable = book.FillableQuantityAgainst(cmd.Side, cmd.PriceMantissa, isMarket: cmd.Type == OrderType.Market);
+                long fillable = book.FillableQuantityAgainst(cmd.Side, cmd.PriceMantissa, isMarket: IsMarketLike(cmd.Type));
                 if (fillable < (long)cmd.MinQty)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.MinQtyNotMet, cmd.EnteredAtNanos); return; }
             }
@@ -543,11 +555,21 @@ public sealed class MatchingEngine
     private void ExecuteAggressor(NewOrderCommand cmd, InstrumentTradingRules rules, LimitOrderBook book)
         => ExecuteAggressorWithOrderId(cmd, rules, book, _nextOrderId++);
 
+    /// <summary>
+    /// True when the order should walk the book ignoring its own price
+    /// (Market and MarketWithLeftover #215). The two differ only in the
+    /// post-walk handling of any remainder (Market drops; MWL rests at
+    /// last-trade price).
+    /// </summary>
+    private static bool IsMarketLike(OrderType t)
+        => t == OrderType.Market || t == OrderType.MarketWithLeftover;
+
     private void ExecuteAggressorWithOrderId(NewOrderCommand cmd, InstrumentTradingRules rules,
         LimitOrderBook book, long aggressorOrderIdForTrades)
     {
         long aggressorRemaining = cmd.Quantity;
-        bool isMarket = cmd.Type == OrderType.Market;
+        bool isMarket = IsMarketLike(cmd.Type);
+        bool isMwl = cmd.Type == OrderType.MarketWithLeftover;
         long limitPx = cmd.PriceMantissa;
         bool stpAggressorCanceled = false;
         long lastTradePx = 0;
@@ -737,11 +759,22 @@ public sealed class MatchingEngine
 
             if (isMarket)
             {
-                // Market remainder → no resting (already validated MarketNoLiquidity
-                // upfront, but if the book emptied mid-walk we just stop here without
-                // further events for the aggressor — there is no resting order to
-                // cancel and we never emitted Accepted).
-                return;
+                if (isMwl && anyTrade)
+                {
+                    // #215 MWL: leftover rests as Day Limit at last-execution
+                    // price. Validation guaranteed Day TIF + Price=0 at submit
+                    // time; here we anchor the resting price to the last trade
+                    // and fall through to the standard resting code path.
+                    limitPx = lastTradePx;
+                }
+                else
+                {
+                    // Market remainder → no resting (already validated MarketNoLiquidity
+                    // upfront, but if the book emptied mid-walk we just stop here without
+                    // further events for the aggressor — there is no resting order to
+                    // cancel and we never emitted Accepted).
+                    return;
+                }
             }
 
             if (cmd.Tif == TimeInForce.IOC || cmd.Tif == TimeInForce.FOK)

--- a/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
@@ -67,6 +67,7 @@ public class EnumMappingTests
     [InlineData(MatchingOrderType.Market, ContractsOrderType.Market)]
     [InlineData(MatchingOrderType.StopLoss, ContractsOrderType.StopLoss)]
     [InlineData(MatchingOrderType.StopLimit, ContractsOrderType.StopLimit)]
+    [InlineData(MatchingOrderType.MarketWithLeftover, ContractsOrderType.MarketWithLeftover)]
     public void OrderType_MatchingToContracts(MatchingOrderType matching, ContractsOrderType expected)
     {
         Assert.Equal(expected, MapOrderType(matching));
@@ -75,8 +76,8 @@ public class EnumMappingTests
     [Fact]
     public void OrderType_AllValuesCovered()
     {
-        Assert.Equal(4, Enum.GetValues<MatchingOrderType>().Length);
-        Assert.Equal(4, Enum.GetValues<ContractsOrderType>().Length);
+        Assert.Equal(5, Enum.GetValues<MatchingOrderType>().Length);
+        Assert.Equal(5, Enum.GetValues<ContractsOrderType>().Length);
         foreach (var v in Enum.GetValues<MatchingOrderType>()) _ = MapOrderType(v);
     }
 
@@ -154,6 +155,7 @@ public class EnumMappingTests
         MatchingOrderType.Market => ContractsOrderType.Market,
         MatchingOrderType.StopLoss => ContractsOrderType.StopLoss,
         MatchingOrderType.StopLimit => ContractsOrderType.StopLimit,
+        MatchingOrderType.MarketWithLeftover => ContractsOrderType.MarketWithLeftover,
         _ => throw new ArgumentOutOfRangeException(nameof(t), t, "unmapped Matching.OrderType"),
     };
 

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -182,6 +182,22 @@ public class NewOrderSingleAndReplaceDecoderTests
     }
 
     [Fact]
+    public void NewOrderSingle_AcceptsMwl()
+    {
+        // #215: MARKET_WITH_LEFTOVER_AS_LIMIT (FIX 'K') decoded with
+        // engine Price=0 (resting price derived from last trade at runtime).
+        var body = BuildNewOrderSingleV2(ordType: (byte)'K', price: PriceNull, tif: (byte)'0');
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.NotNull(cmd);
+        Assert.Equal(OrderType.MarketWithLeftover, cmd.Type);
+        Assert.Equal(0L, cmd.PriceMantissa);
+    }
+
+    [Fact]
     public void NewOrderSingle_AcceptsMaxFloor()
     {
         // #211: iceberg accepted on NewOrderSingle. The decoder forwards
@@ -223,7 +239,6 @@ public class NewOrderSingleAndReplaceDecoderTests
 
     [Theory]
     [InlineData((byte)'W')] // RLP
-    [InlineData((byte)'K')] // MARKET_WITH_LEFTOVER_AS_LIMIT
     [InlineData((byte)'P')] // PEGGED_MIDPOINT
     public void NewOrderSingle_UnsupportedOrdTypeReturnsBmr(byte ordTypeByte)
     {

--- a/tests/B3.Exchange.Matching.Tests/MarketWithLeftoverTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/MarketWithLeftoverTests.cs
@@ -1,0 +1,103 @@
+namespace B3.Exchange.Matching.Tests;
+
+/// <summary>
+/// Engine semantics for MarketWithLeftoverAsLimit (FIX OrdType 'K' /
+/// issue #215). Validates: market-style sweeping of the opposite book,
+/// leftover-rests-as-Day-Limit at last execution price, validation
+/// rejects (TIF, Price, no-liquidity).
+/// </summary>
+public class MarketWithLeftoverTests
+{
+    private static NewOrderCommand Mwl(string id, Side side, long qty, uint firm = 1)
+        => new(id, TestFactory.PetrSecId, side, OrderType.MarketWithLeftover,
+               TimeInForce.Day, PriceMantissa: 0L, qty, firm, EnteredAtNanos: 0);
+
+    private static NewOrderCommand Limit(string id, Side side, decimal price, long qty,
+        TimeInForce tif = TimeInForce.Day, uint firm = 2)
+        => new(id, TestFactory.PetrSecId, side, OrderType.Limit, tif,
+               TestFactory.Px(price), qty, firm, EnteredAtNanos: 0);
+
+    [Fact]
+    public void Mwl_consumes_book_and_rests_remainder_at_last_trade_price()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Two ask levels: 100@10, 200@11. MWL buy 500 → consumes 300,
+        // last trade at 11 → 200 leftover rests as Day Limit Buy at 11.
+        engine.Submit(Limit("S1", Side.Sell, 10m, 100, firm: 9));
+        engine.Submit(Limit("S2", Side.Sell, 11m, 200, firm: 9));
+        sink.Clear();
+
+        engine.Submit(Mwl("MWL", Side.Buy, 500));
+
+        Assert.Equal(2, sink.Trades.Count);
+        Assert.Equal(TestFactory.Px(10m), sink.Trades[0].PriceMantissa);
+        Assert.Equal(TestFactory.Px(11m), sink.Trades[1].PriceMantissa);
+        var rested = Assert.Single(sink.Accepted);
+        Assert.Equal(TestFactory.Px(11m), rested.PriceMantissa);
+        Assert.Equal(200, rested.RemainingQuantity);
+        Assert.Equal(Side.Buy, rested.Side);
+    }
+
+    [Fact]
+    public void Mwl_fully_filled_emits_no_resting_order()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("S", Side.Sell, 10m, 500, firm: 9));
+        sink.Clear();
+
+        engine.Submit(Mwl("MWL", Side.Buy, 300));
+
+        Assert.Single(sink.Trades);
+        Assert.Equal(300, sink.Trades[0].Quantity);
+        Assert.Empty(sink.Accepted);
+    }
+
+    [Fact]
+    public void Mwl_with_empty_book_rejected_marketnoliquidity()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Mwl("MWL", Side.Buy, 100));
+        var r = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketNoLiquidity, r.Reason);
+    }
+
+    [Fact]
+    public void Mwl_with_non_day_tif_rejected()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(new NewOrderCommand("MWL", TestFactory.PetrSecId, Side.Buy,
+            OrderType.MarketWithLeftover, TimeInForce.IOC, PriceMantissa: 0L,
+            Quantity: 100, EnteringFirm: 1, EnteredAtNanos: 0));
+        var r = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, r.Reason);
+    }
+
+    [Fact]
+    public void Mwl_with_nonzero_price_rejected()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(new NewOrderCommand("MWL", TestFactory.PetrSecId, Side.Buy,
+            OrderType.MarketWithLeftover, TimeInForce.Day,
+            PriceMantissa: TestFactory.Px(10m),
+            Quantity: 100, EnteringFirm: 1, EnteredAtNanos: 0));
+        var r = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, r.Reason);
+    }
+
+    [Fact]
+    public void Mwl_leftover_can_be_traded_against_subsequent_aggressor()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(Limit("S1", Side.Sell, 10m, 100, firm: 9));
+        engine.Submit(Limit("S2", Side.Sell, 11m, 100, firm: 9));
+        engine.Submit(Mwl("MWL", Side.Buy, 300)); // 100@10 + 100@11; 100 rests @11 buy
+        sink.Clear();
+
+        // Sell aggressor at 11 hits the rested MWL leftover.
+        engine.Submit(Limit("AGG", Side.Sell, 11m, 100, firm: 5, tif: TimeInForce.IOC));
+
+        var t = Assert.Single(sink.Trades);
+        Assert.Equal(TestFactory.Px(11m), t.PriceMantissa);
+        Assert.Equal(100, t.Quantity);
+    }
+}


### PR DESCRIPTION
Closes #215.

L2 of Onda L. Adds `OrderType.MarketWithLeftover` (FIX OrdType `'K'` / `MARKET_WITH_LEFTOVER_AS_LIMIT`).

## Behavior
- Walks the opposite book like a Market (ignores own price).
- Requires non-empty opposite side (`MarketNoLiquidity` reject otherwise — same as Market).
- Any unfilled remainder rests as a **Day Limit at the last executed trade price**.
- TIF must be `Day`; Price on the wire must be NULL (the resting price is derived at runtime from the last fill).

## Engine
- New `IsMarketLike` helper `(Market || MWL)` used by FOK/MinQty fillability checks, the `MarketNoLiquidity` reject, and the aggressor walk's crossing predicate.
- `ExecuteAggressorWithOrderId` already tracks `lastTradePx` (added for stop triggers in #214); for MWL with leftover + at least one trade, anchors `limitPx = lastTradePx` and falls through to the standard resting code path.
- `Submit()` validation: separate `elif` for MWL (Day TIF only, Price=0); the legacy `else // Market` branch stays IOC/FOK only.

## Gateway
- `TryClassifyOrdType`: `'K' → MarketWithLeftover` (removed from unsupported set).
- `NewOrderSingle` decoder: `enginePrice = 0` for both Market and MWL.
- `ExecutionReportEncoder.EncodeOrdType`: MWL → `'K'`.

## Contracts
- `OrderType.MarketWithLeftover = 5` (parity with Matching).

## Tests
- `MarketWithLeftoverTests` — 6 new cases covering sweep+rest, fully-filled, empty-book reject, non-Day TIF reject, non-zero Price reject, rested leftover trading against subsequent aggressor.
- `NewOrderSingle_AcceptsMwl` decoder test; `'K'` removed from the unsupported-OrdType test set.
- `EnumMappingTests` extended for the new OrderType value.

## Validation
- `dotnet build -c Release` ✅ 0 warnings/errors
- `dotnet test -c Release` ✅ 832 passed
- `dotnet format --verify-no-changes` ✅
