### PR TITLE
L4 #217: buffer passive ExecutionReports for Suspended FIXP sessions

### DIFF
--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -285,7 +285,13 @@ public sealed partial class FixpSession : IAsyncDisposable
             retxBuffer: _retxBuffer,
             outboundLock: _outboundLock,
             nowNanos: () => _nowNanos(),
-            isOpen: () => IsOpen,
+            // Use IsRegistered (not IsOpen) so that passive ERs delivered while
+            // the session is Suspended (transport down, but session-state alive)
+            // are still encoded, sequenced, and appended to the FIXP retransmit
+            // ring. The TryEnqueueFrame inside AppendAndEnqueueLocked silently
+            // fails when the transport is dead; the buffered frame is replayed
+            // on a subsequent Establish + RetransmitRequest. Issue #217 / L4.
+            isOpen: () => IsRegistered,
             close: Close);
         _retransmitController = new FixpRetransmitController(
             sessionId: () => SessionId,

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -22,8 +22,11 @@ namespace B3.Exchange.Gateway;
 ///
 /// <para>If the session is no longer registered (peer disconnected
 /// between the inbound command and the engine emitting the event) the
-/// report is dropped silently. Phase 3 (Suspended sessions) will route
-/// these into a retransmission ring instead.</para>
+/// report is dropped silently. While the session is merely
+/// <c>Suspended</c> the session is still registered, so the report is
+/// still encoded; the encoder appends to the FIXP retransmit ring even
+/// though the (dead) transport rejects it, and the frame is replayed on
+/// re-Establish (issue #217 / Onda L · L4).</para>
 ///
 /// <para>Thread-safety: invoked from any
 /// <see cref="ChannelDispatcher"/> dispatch thread; the registry lookup

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -143,11 +143,12 @@ public sealed class HostRouter : IInboundCommandSink
     {
         // Drop every ownership entry held for this session across every
         // channel so passive fills against its resting orders stop trying
-        // to route to a disconnected peer. The orders themselves stay on
-        // the book — they ARE the book — but ER_Trade / ER_Cancel for them
-        // will be dropped in the dispatcher's OnTrade/OnOrderCanceled when
-        // the local registry no longer resolves them (Phase 3 / #69 will
-        // replace this with routing into a Suspended-session retx ring).
+        // to route to a disconnected peer. Note: this is invoked only on
+        // **terminal** close (FixpSession.CloseLocked); Suspend does NOT
+        // reach here, so passive ERs delivered during Suspended state are
+        // routed normally to the still-registered FixpSession and buffered
+        // into its FIXP retransmit ring for replay on re-Establish (issue
+        // #217 / Onda L · L4).
         int total = 0;
         foreach (var disp in _allDispatchers)
             total += disp.EvictSessionLocal(session);

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionPassiveErBufferingTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionPassiveErBufferingTests.cs
@@ -1,0 +1,187 @@
+using ContractsSessionId = B3.Exchange.Contracts.SessionId;
+using B3.Exchange.Contracts;
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Side = B3.Exchange.Matching.Side;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #217 (Onda L · L4): passive ExecutionReports delivered to a
+/// FIXP session that is currently <see cref="FixpState.Suspended"/> must
+/// be buffered into the session's FIXP retransmit ring rather than
+/// silently dropped, so a subsequent <c>Establish</c> + <c>RetransmitRequest</c>
+/// from the reattaching peer can replay them as part of normal recovery.
+/// </summary>
+public class FixpSessionPassiveErBufferingTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) => true;
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) => true;
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) => true;
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static async Task<(TcpListener tcp, NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        return (tcp, new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static TradeEvent MakeTrade(uint tradeId = 7, long restingOrderId = 12345)
+        => new TradeEvent(
+            SecurityId: 1001,
+            TradeId: tradeId,
+            PriceMantissa: 100_0000,
+            Quantity: 50,
+            AggressorSide: Side.Buy,
+            AggressorOrderId: 99,
+            AggressorClOrdId: "AGGR-1",
+            AggressorFirm: 13,
+            RestingOrderId: restingOrderId,
+            RestingFirm: 7,
+            TransactTimeNanos: 1_700_000_000_000_000_000UL,
+            RptSeq: 1);
+
+    [Fact]
+    public async Task PassiveTrade_WhileSuspended_AppendsToRetransmitRing()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new NoOpEngineSink();
+            var session = new FixpSession(
+                connectionId: 7001, enteringFirm: 7, sessionId: 217,
+                stream: serverStream, sink: sink,
+                logger: NullLogger<FixpSession>.Instance);
+            session.Start();
+
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+            Assert.Equal(FixpState.Established, session.State);
+            int depthBefore = session.RetxBufferDepth;
+
+            // Drop the client side → session demotes Established → Suspended.
+            client.Close();
+            await TestUtil.WaitUntilAsync(() => session.State == FixpState.Suspended, TimeSpan.FromSeconds(3));
+            Assert.False(session.IsOpen, "transport should be down while Suspended");
+            Assert.True(session.IsRegistered, "session must remain registered while Suspended");
+
+            // L4 contract: a passive ER routed to the suspended session must
+            // be encoded + appended to the retransmit ring (the underlying
+            // TryEnqueueFrame on the dead transport will silently fail).
+            var trade = MakeTrade(tradeId: 7, restingOrderId: 12345);
+            bool result = session.WriteExecutionReportTrade(
+                trade, isAggressor: false, ownerOrderId: 12345,
+                clOrdIdValue: 5555, leavesQty: 0, cumQty: 50);
+
+            // The transport rejection bubbles up as `false`, but the frame
+            // is in the ring — verify by depth growth.
+            Assert.False(result, "TryEnqueueFrame must fail when transport is down");
+            Assert.Equal(depthBefore + 1, session.RetxBufferDepth);
+
+            // A second passive event also accrues.
+            var trade2 = MakeTrade(tradeId: 8, restingOrderId: 12345);
+            session.WriteExecutionReportTrade(trade2, isAggressor: false, ownerOrderId: 12345,
+                clOrdIdValue: 5555, leavesQty: 0, cumQty: 100);
+            Assert.Equal(depthBefore + 2, session.RetxBufferDepth);
+
+            session.Close("test-cleanup");
+        }
+        finally
+        {
+            client.Dispose();
+            serverStream.Dispose();
+            tcp.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task PassiveCancel_WhileSuspended_AppendsToRetransmitRing()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new NoOpEngineSink();
+            var session = new FixpSession(
+                connectionId: 7002, enteringFirm: 7, sessionId: 218,
+                stream: serverStream, sink: sink,
+                logger: NullLogger<FixpSession>.Instance);
+            session.Start();
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+
+            client.Close();
+            await TestUtil.WaitUntilAsync(() => session.State == FixpState.Suspended, TimeSpan.FromSeconds(3));
+            int depthBefore = session.RetxBufferDepth;
+
+            var canceled = new OrderCanceledEvent(
+                SecurityId: 1001,
+                OrderId: 999,
+                Side: Side.Sell,
+                PriceMantissa: 101_0000,
+                RemainingQuantityAtCancel: 25,
+                TransactTimeNanos: 1_700_000_000_000_000_000UL,
+                Reason: CancelReason.MassCancel,
+                RptSeq: 2);
+            session.WriteExecutionReportCancel(canceled, clOrdIdValue: 5555, origClOrdIdValue: 0);
+            Assert.Equal(depthBefore + 1, session.RetxBufferDepth);
+
+            session.Close("test-cleanup");
+        }
+        finally
+        {
+            client.Dispose();
+            serverStream.Dispose();
+            tcp.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task PassiveTrade_AfterTerminalClose_IsDropped()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new NoOpEngineSink();
+            var session = new FixpSession(
+                connectionId: 7003, enteringFirm: 7, sessionId: 219,
+                stream: serverStream, sink: sink,
+                logger: NullLogger<FixpSession>.Instance);
+            session.Start();
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+            int depthBefore = session.RetxBufferDepth;
+
+            // Force terminal close (not Suspend).
+            session.Close("test-terminal");
+            Assert.False(session.IsRegistered);
+
+            var trade = MakeTrade();
+            bool result = session.WriteExecutionReportTrade(
+                trade, isAggressor: false, ownerOrderId: 12345,
+                clOrdIdValue: 5555, leavesQty: 0, cumQty: 50);
+            Assert.False(result);
+            // No buffering once terminal — IsRegistered is false.
+            Assert.Equal(depthBefore, session.RetxBufferDepth);
+        }
+        finally
+        {
+            client.Dispose();
+            serverStream.Dispose();
+            tcp.Stop();
+        }
+    }
+}


### PR DESCRIPTION
**Onda L · L4** — Buffer passive ExecutionReports for Suspended FIXP sessions.

Closes #217.

## Problem

Today, a passive `ExecutionReport` (resting order traded or canceled by another firm) routed at the GatewayRouter to a session whose transport had dropped — but whose FIXP state is still `Suspended` — was silently dropped, because `FixpOutboundEncoder._isOpen()` was wired to `FixpSession.IsOpen`, and `IsOpen = (_isOpen == 1) && _transport.IsOpen`. Suspending closes the transport (`Suspend → SuspendLocked`), so `IsOpen` flips false even though the session is still alive in the registry waiting for a re-Establish.

Net effect: a peer that disconnected while having resting orders missed every passive fill that occurred during its outage, even after a successful FIXP recovery handshake.

## Fix

Switch the encoder's "is alive enough to write?" predicate from `IsOpen` to `IsRegistered` (i.e. `_isOpen == 1`, transport-state-independent). This is exactly the right semantic: while the session is registered (`Established` or `Suspended`), encode + sequence + append-to-retransmit-ring; the existing `TryEnqueueFrame` on the dead transport silently returns `false` — and the buffered frame is now replayable on the next `Establish` + `RetransmitRequest`.

`AppendAndEnqueueLocked` already appends to the ring **before** enqueuing on the transport (per gpt-5.5 critique #9, comment in `FixpOutboundEncoder`), so no other change is needed there.

The retransmit responder (`FixpRetransmitController`) keeps its `IsOpen` predicate unchanged — it requires a live transport to respond.

## Acceptance

- ✅ Resting order placed by session A. A disconnects → session goes Suspended (`FixpSession.Suspend`).
- ✅ Session B aggresses A's order. The dispatcher resolves A as the owner (ownership preserved across Suspend — `OnSessionClosed` is only invoked from terminal `CloseLocked`, never from `SuspendLocked`).
- ✅ `WriteExecutionReportTrade(passive)` encodes + appends to A's `RetransmitBuffer`. Verified by `RetxBufferDepth` growth.
- ✅ A reconnects via `Establish` → `RetransmitRequest` → receives the queued ER via the existing FIXP retransmission path (already covered by `FixpSessionReattachReplayE2ETests`).
- ✅ Ownership is dropped on actual `Terminated` / `UnNegotiated` (unchanged: `HostRouter.OnSessionClosed` still evicts on terminal close).

## Tests

`tests/B3.Exchange.Gateway.Tests/FixpSessionPassiveErBufferingTests.cs` (new, 3 cases):

1. `PassiveTrade_WhileSuspended_AppendsToRetransmitRing` — Suspend → 2 passive `WriteExecutionReportTrade` calls → ring depth grows by 2; `WriteExecutionReportTrade` returns `false` (transport dead).
2. `PassiveCancel_WhileSuspended_AppendsToRetransmitRing` — same flow for `WriteExecutionReportCancel`.
3. `PassiveTrade_AfterTerminalClose_IsDropped` — terminal `Close()` → `IsRegistered=false` → write returns `false`, ring depth unchanged.

Plus stale-comment cleanups in `HostRouter.OnSessionClosed` and `GatewayRouter` docstring (referenced "Phase 3 / #69 will replace").

All 832+3 = 835 tests passing locally; format clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
