### PR TITLE
L5 #218: NewOrderCross full semantics

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -125,13 +125,71 @@ public sealed partial class ChannelDispatcher
                         // per-leg ClOrdID. The packet buffer accumulates
                         // both legs' UMDF events and flushes once at the
                         // end of this dispatch turn.
+                        //
+                        // Issue #218 (Onda L · L5): respect
+                        // CrossPrioritization (BuyPrioritized / None →
+                        // Buy first; SellPrioritized → Sell first), and
+                        // implement CrossType=AgainstBook by inserting a
+                        // sweep phase before the cross prints internally.
                         var cross = item.Cross!;
-                        _metrics?.IncOrdersIn();
-                        _currentClOrdId = cross.BuyClOrdIdValue;
-                        _engine.Submit(cross.Buy);
-                        _metrics?.IncOrdersIn();
-                        _currentClOrdId = cross.SellClOrdIdValue;
-                        _engine.Submit(cross.Sell);
+                        bool buyFirst = cross.CrossPrioritization != CrossPrioritization.SellPrioritized;
+                        var prioLeg = buyFirst ? cross.Buy : cross.Sell;
+                        ulong prioClOrd = buyFirst ? cross.BuyClOrdIdValue : cross.SellClOrdIdValue;
+                        var otherLeg = buyFirst ? cross.Sell : cross.Buy;
+                        ulong otherClOrd = buyFirst ? cross.SellClOrdIdValue : cross.BuyClOrdIdValue;
+
+                        if (cross.CrossType == CrossType.AgainstBook && cross.MaxSweepQty > 0)
+                        {
+                            // Phase 1: prioritized leg sweeps the opposing
+                            // public book at cross price (or better) up to
+                            // min(MaxSweepQty, OrderQty) via Limit IOC.
+                            // Any leftover from the cap is canceled (IOC).
+                            long sweepQty = Math.Min(cross.MaxSweepQty, prioLeg.Quantity);
+                            var sweepLeg = prioLeg with
+                            {
+                                Type = B3.Exchange.Matching.OrderType.Limit,
+                                Tif = B3.Exchange.Matching.TimeInForce.IOC,
+                                Quantity = sweepQty,
+                            };
+                            _metrics?.IncOrdersIn();
+                            _currentClOrdId = prioClOrd;
+                            _crossSweepFilledQty = 0;
+                            _engine.Submit(sweepLeg);
+                            long swept = _crossSweepFilledQty.GetValueOrDefault();
+                            _crossSweepFilledQty = null;
+
+                            // Phase 2: residual prioritized leg as the
+                            // original Limit Day at cross price; rests on
+                            // the book ready for the other leg to cross.
+                            long residual = prioLeg.Quantity - swept;
+                            if (residual > 0)
+                            {
+                                _metrics?.IncOrdersIn();
+                                _currentClOrdId = prioClOrd;
+                                _engine.Submit(prioLeg with { Quantity = residual });
+                            }
+
+                            // Phase 3: the other leg at full OrderQty —
+                            // crosses against the resting prioritized
+                            // residual; any remainder rests on the book
+                            // (price-time priority handles the rest).
+                            _metrics?.IncOrdersIn();
+                            _currentClOrdId = otherClOrd;
+                            _engine.Submit(otherLeg);
+                        }
+                        else
+                        {
+                            // AON cross (default): existing behavior. The
+                            // prioritized side rests, the other side
+                            // crosses against it → 1 internal trade at
+                            // cross price.
+                            _metrics?.IncOrdersIn();
+                            _currentClOrdId = prioClOrd;
+                            _engine.Submit(prioLeg);
+                            _metrics?.IncOrdersIn();
+                            _currentClOrdId = otherClOrd;
+                            _engine.Submit(otherLeg);
+                        }
                         break;
                     }
                 case WorkKind.MassCancel:

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -155,6 +155,11 @@ public sealed partial class ChannelDispatcher
     public void OnTrade(in TradeEvent e)
     {
         AssertOnLoopThread();
+        // Issue #218 (Onda L · L5): when a cross sweep phase is active,
+        // accumulate the aggressor's filled qty so the loop can decide how
+        // much of the prioritized leg remains for the internal print.
+        if (_crossSweepFilledQty.HasValue)
+            _crossSweepFilledQty = _crossSweepFilledQty.Value + e.Quantity;
         var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
             + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
             + B3.Umdf.WireEncoder.WireOffsets.TradeBlockLength);

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -143,6 +143,15 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     private ulong _currentReceivedTimeNanos = ulong.MaxValue;
 
+    /// <summary>
+    /// When non-null, the dispatcher is processing the sweep phase of a
+    /// <see cref="WorkKind.Cross"/> with <c>CrossType=AgainstBook</c>: each
+    /// <see cref="OnTrade"/> on this aggressor's side accrues into the
+    /// captured value so the loop can compute the residual qty for the
+    /// internal print phase. Issue #218 (Onda L · L5).
+    /// </summary>
+    private long? _crossSweepFilledQty;
+
     private SnapshotRotator? _snapshotRotator;
 
     private readonly CancellationTokenSource _cts = new();

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderCross.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderCross.cs
@@ -96,19 +96,54 @@ internal static partial class InboundMessageDecoder
             message = "NewOrderCross requires positive OrderQty";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (crossTypeByte != 255)
+
+        // CrossType: null/255 → AllOrNone (default). Wire values 1
+        // (AllOrNone) and 4 (AgainstBook) accepted; 7/8 (VWAP /
+        // ClosingPrice — auction-tied) deferred to a future wave.
+        // Issue #218 (Onda L · L5).
+        CrossType crossTypeEnum;
+        if (crossTypeByte == 255 || crossTypeByte == (byte)CrossType.AllOrNone)
         {
-            message = "unsupported NewOrderCross CrossType (only null/AON cross supported)";
+            crossTypeEnum = CrossType.AllOrNone;
+        }
+        else if (crossTypeByte == (byte)CrossType.AgainstBook)
+        {
+            crossTypeEnum = CrossType.AgainstBook;
+        }
+        else
+        {
+            message = $"unsupported NewOrderCross CrossType={crossTypeByte} (auction-tied variants deferred)";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (crossPriByte != 255)
+
+        // CrossPrioritization: null/255 → None. Wire 0/1/2 mapped directly.
+        CrossPrioritization crossPriEnum;
+        if (crossPriByte == 255 || crossPriByte == (byte)CrossPrioritization.None)
         {
-            message = "unsupported NewOrderCross CrossPrioritization (only null supported)";
+            crossPriEnum = CrossPrioritization.None;
+        }
+        else if (crossPriByte == (byte)CrossPrioritization.BuyPrioritized
+            || crossPriByte == (byte)CrossPrioritization.SellPrioritized)
+        {
+            crossPriEnum = (CrossPrioritization)crossPriByte;
+        }
+        else
+        {
+            message = $"invalid NewOrderCross CrossPrioritization={crossPriByte}";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (maxSweepQty != 0)
+
+        // MaxSweepQty: only meaningful when CrossType == AgainstBook;
+        // otherwise it must be zero/null (defensive).
+        if (maxSweepQty > long.MaxValue)
         {
-            message = "unsupported NewOrderCross MaxSweepQty (sweep semantics not implemented)";
+            message = $"NewOrderCross MaxSweepQty={maxSweepQty} exceeds long.MaxValue";
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        long maxSweepQtySigned = (long)maxSweepQty;
+        if (crossTypeEnum != CrossType.AgainstBook && maxSweepQtySigned > 0)
+        {
+            message = "NewOrderCross MaxSweepQty requires CrossType=AgainstBook";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
 
@@ -222,7 +257,12 @@ internal static partial class InboundMessageDecoder
             Quantity: qty,
             EnteringFirm: sessionFirm,
             EnteredAtNanos: enteredAtNanos);
-        cross = new CrossOrderCommand(buy, sell, buyClOrd, sellClOrd, crossId);
+        cross = new CrossOrderCommand(buy, sell, buyClOrd, sellClOrd, crossId)
+        {
+            CrossType = crossTypeEnum,
+            CrossPrioritization = crossPriEnum,
+            MaxSweepQty = maxSweepQtySigned,
+        };
         return InboundDecodeOutcome.Success;
     }
 }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -244,13 +244,89 @@ public sealed record ReplaceOrderCommand(
 /// turn so the cross cannot be split, dropped half-way, or interleaved with
 /// other producers (Self-Trading Prevention is tracked separately as #14;
 /// without STP both legs cross naturally on the book).
+///
+/// <para>Issue #218 (Onda L · L5) extended this with <see cref="CrossType"/>,
+/// <see cref="CrossPrioritization"/>, and <see cref="MaxSweepQty"/>. The
+/// defaults reproduce the pre-#218 behavior (AllOrNone cross between the
+/// two legs, Buy submitted first, no book interaction).</para>
 /// </summary>
 public sealed record CrossOrderCommand(
     NewOrderCommand Buy,
     NewOrderCommand Sell,
     ulong BuyClOrdIdValue,
     ulong SellClOrdIdValue,
-    ulong CrossId);
+    ulong CrossId)
+{
+    /// <summary>Spec §16.1.5 / SBE enum <c>CrossType</c>. Default
+    /// <see cref="CrossType.AllOrNone"/> reproduces the pre-#218 behavior:
+    /// the two legs cross internally with no public-book interaction.
+    /// <see cref="CrossType.AgainstBook"/> activates the
+    /// <see cref="MaxSweepQty"/> sweep phase. Auction-related variants
+    /// (VWAP, ClosingPrice) are deferred and rejected at the decoder.</summary>
+    public CrossType CrossType { get; init; } = CrossType.AllOrNone;
+
+    /// <summary>Spec §16.1.5 / SBE enum <c>CrossPrioritization</c>. Controls
+    /// which leg submits first into the engine (and therefore which leg
+    /// gets to sweep first when <see cref="CrossType"/> is
+    /// <see cref="Matching.CrossType.AgainstBook"/>).
+    /// <see cref="CrossPrioritization.None"/> (default) treats Buy as the
+    /// implicitly prioritized side, matching pre-#218 submission order.</summary>
+    public CrossPrioritization CrossPrioritization { get; init; } = CrossPrioritization.None;
+
+    /// <summary>When <see cref="CrossType"/> is
+    /// <see cref="Matching.CrossType.AgainstBook"/>, the prioritized leg may
+    /// sweep up to this many shares against the opposing public book at the
+    /// cross price (or better) before the residual prints internally with
+    /// the other leg. Zero (default) means "no sweep" — equivalent to
+    /// AllOrNone semantics for the residual phase.</summary>
+    public long MaxSweepQty { get; init; } = 0;
+}
+
+/// <summary>
+/// NewOrderCross <c>CrossType</c> values per the EntryPoint SBE schema
+/// (b3-entrypoint-messages-8.4.2.xml). Wire byte values are preserved so
+/// the decoder can map directly. Issue #218 (Onda L · L5).
+/// </summary>
+public enum CrossType : byte
+{
+    /// <summary>Cross prints atomically between the two parties with no
+    /// public-book interaction. Wire value 1 — also the in-engine default
+    /// when the inbound message omits CrossType (null on the wire).</summary>
+    AllOrNone = 1,
+
+    /// <summary>Prioritized leg sweeps the opposing public book up to
+    /// <see cref="CrossOrderCommand.MaxSweepQty"/> shares at the cross
+    /// price (or better) before the residual prints internally between
+    /// the two cross legs. Wire value 4.</summary>
+    AgainstBook = 4,
+
+    /// <summary>VWAP cross — auction-tied, deferred. Wire value 7.</summary>
+    VwapCross = 7,
+
+    /// <summary>Closing-price cross — auction-tied, deferred. Wire value 8.</summary>
+    ClosingPriceCross = 8,
+}
+
+/// <summary>
+/// NewOrderCross <c>CrossPrioritization</c> values per the EntryPoint SBE
+/// schema. Wire byte values preserved. Issue #218 (Onda L · L5).
+/// </summary>
+public enum CrossPrioritization : byte
+{
+    /// <summary>No explicit prioritization. The engine treats this as
+    /// Buy-prioritized (Buy leg submits first), matching pre-#218
+    /// behavior. Wire value 0 — also the in-engine default when the
+    /// inbound message omits CrossPrioritization (null on the wire).</summary>
+    None = 0,
+
+    /// <summary>Buy leg submits first; sweeps before the Sell leg under
+    /// <see cref="CrossType.AgainstBook"/>. Wire value 1.</summary>
+    BuyPrioritized = 1,
+
+    /// <summary>Sell leg submits first; sweeps before the Buy leg under
+    /// <see cref="CrossType.AgainstBook"/>. Wire value 2.</summary>
+    SellPrioritized = 2,
+}
 
 /// <summary>
 /// Mass-cancel command (OrderMassActionRequest template 701, spec §4.8 /

--- a/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
+++ b/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
@@ -1,0 +1,240 @@
+using B3.Exchange.Contracts;
+using Side = B3.Exchange.Matching.Side;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+using B3.Exchange.Gateway;
+using B3.Exchange.Instruments;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Core.Tests;
+
+/// <summary>
+/// Issue #218 (Onda L · L5) integration tests for the dispatcher's
+/// expanded NewOrderCross handling: <see cref="CrossPrioritization"/>
+/// affects submission order and <see cref="CrossType.AgainstBook"/> with
+/// <see cref="CrossOrderCommand.MaxSweepQty"/> sweeps the opposing public
+/// book before printing the residual internally between the two legs.
+/// </summary>
+public class CrossOrderSemanticsTests
+{
+    private const long Petr = 900_000_000_001L;
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Petr,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Packets.Add(packet.ToArray());
+    }
+
+    private sealed class FakeSession
+    {
+        private static int _nextId;
+        public B3.Exchange.Contracts.SessionId Id { get; } = new("cs" + System.Threading.Interlocked.Increment(ref _nextId));
+        public uint EnteringFirm { get; init; } = 7;
+        public List<TradeEvent> Trades { get; } = new();
+        public List<bool> TradeIsAggressor { get; } = new();
+        public List<OrderAcceptedEvent> News { get; } = new();
+        public List<OrderCanceledEvent> Cancels { get; } = new();
+        public FakeSession(RecordingOutbound o) { o.Register(this); }
+    }
+
+    private sealed class RecordingOutbound : ICoreOutbound
+    {
+        private readonly Dictionary<B3.Exchange.Contracts.SessionId, FakeSession> _sessions = new();
+        public void Register(FakeSession s) => _sessions[s.Id] = s;
+
+        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        {
+            if (_sessions.TryGetValue(session, out var s)) s.News.Add(e);
+            return true;
+        }
+
+        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
+        {
+            if (_sessions.TryGetValue(session, out var s)) { s.Trades.Add(e); s.TradeIsAggressor.Add(isAggressor); }
+            return true;
+        }
+
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty)
+        {
+            if (_sessions.TryGetValue(ownerSession, out var s)) { s.Trades.Add(e); s.TradeIsAggressor.Add(false); }
+            return true;
+        }
+
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+        {
+            if (_sessions.TryGetValue(ownerSession, out var s)) s.Cancels.Add(e);
+            return true;
+        }
+
+        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
+
+        public bool WriteExecutionReportReject(SessionId session, in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue) => true;
+    }
+
+    private static (ChannelDispatcher disp, RecordingPacketSink pkt, RecordingOutbound outbound) NewDispatcher()
+    {
+        var pkt = new RecordingPacketSink();
+        var outbound = new RecordingOutbound();
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL, tradeDate: 19_000);
+        return (disp, pkt, outbound);
+    }
+
+    private static void DrainInbound(ChannelDispatcher disp) => disp.CreateTestProbe().DrainInbound();
+
+    private static NewOrderCommand Buy(long qty, decimal price, ulong clOrdId = 1UL)
+        => new("B" + clOrdId, Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(price), qty, 7, 1_000UL);
+    private static NewOrderCommand Sell(long qty, decimal price, ulong clOrdId = 2UL)
+        => new("S" + clOrdId, Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(price), qty, 7, 1_000UL);
+
+    [Fact]
+    public void Aon_NoPrioritization_BuyRestsThenSellCrossesInternally()
+    {
+        // Default behavior path: AON cross + None prioritization → Buy
+        // submits first and rests, Sell crosses against it → 1 internal trade.
+        var (disp, _, outbound) = NewDispatcher();
+        var s = new FakeSession(outbound);
+        var cross = new CrossOrderCommand(Buy(100, 10m), Sell(100, 10m), 1UL, 2UL, CrossId: 999UL);
+        disp.EnqueueCross(cross, s.Id, s.EnteringFirm);
+        DrainInbound(disp);
+
+        // Buy News (rests) + 1 Trade event delivered to BOTH aggressor (Sell)
+        // and resting (Buy) — both legs are owned by the same FakeSession.
+        Assert.Single(s.News);
+        Assert.Equal(2, s.Trades.Count); // aggressor + passive
+        Assert.Equal(Px(10m), s.Trades[0].PriceMantissa);
+        Assert.Equal(100, s.Trades[0].Quantity);
+    }
+
+    [Fact]
+    public void Aon_SellPrioritized_SellRestsThenBuyCrosses()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var s = new FakeSession(outbound);
+        var cross = new CrossOrderCommand(Buy(100, 10m), Sell(100, 10m), 1UL, 2UL, 999UL)
+        {
+            CrossPrioritization = CrossPrioritization.SellPrioritized,
+        };
+        disp.EnqueueCross(cross, s.Id, s.EnteringFirm);
+        DrainInbound(disp);
+
+        // The single News event must be the Sell leg (rested first).
+        Assert.Single(s.News);
+        Assert.Equal(Side.Sell, s.News[0].Side);
+        // 1 internal trade still happens.
+        Assert.Equal(2, s.Trades.Count);
+    }
+
+    [Fact]
+    public void AgainstBook_NoOpposingLiquidity_BehavesLikeAon()
+    {
+        // AgainstBook + MaxSweepQty=50, but the opposing book is empty:
+        // sweep IOC executes nothing, residual = full qty, internal print
+        // takes the entire cross qty.
+        var (disp, _, outbound) = NewDispatcher();
+        var s = new FakeSession(outbound);
+        var cross = new CrossOrderCommand(Buy(100, 10m), Sell(100, 10m), 1UL, 2UL, 999UL)
+        {
+            CrossType = CrossType.AgainstBook,
+            MaxSweepQty = 50,
+        };
+        disp.EnqueueCross(cross, s.Id, s.EnteringFirm);
+        DrainInbound(disp);
+
+        // No external book → sweep produced 0 trades; residual = 100; the
+        // other leg crosses for 100 internally.
+        var internalTrades = s.Trades.Where(t => t.Quantity == 100).ToList();
+        Assert.NotEmpty(internalTrades);
+        // Residual sell leg is fully consumed by internal print → no
+        // resting sell remains. The buy cross-residual rested first then
+        // was filled by sell — final: book empty, no News for sell rests.
+    }
+
+    [Fact]
+    public void AgainstBook_WithExternalLiquidity_SweepsBookThenPrintsResidual()
+    {
+        // External seller resting at a better price than the cross.
+        var (disp, _, outbound) = NewDispatcher();
+        var external = new FakeSession(outbound);
+        var crosser = new FakeSession(outbound);
+
+        // External Sell 100 @ 9.99 (better than cross price 10.00 for the buyer).
+        // Use multiples of lot size (100) — engine rejects fractional lots.
+        disp.EnqueueNewOrder(
+            new NewOrderCommand("EXT", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(9.99m), 100, external.EnteringFirm, 1_000UL),
+            external.Id, external.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        Assert.Single(external.News);
+
+        // Cross Buy=Sell=200 @ 10.00 with MaxSweepQty=100, Buy prioritized:
+        // Phase 1: Buy IOC 100 @ 10 sweeps the external sell 100 @ 9.99.
+        // Phase 2: Buy residual 100 @ 10 rests (book empty after sweep).
+        // Phase 3: Sell 200 @ 10 fills 100 internally vs the rested Buy and
+        // 100 rests on the sell side.
+        var cross = new CrossOrderCommand(Buy(200, 10m, 10UL), Sell(200, 10m, 11UL), 10UL, 11UL, 999UL)
+        {
+            CrossType = CrossType.AgainstBook,
+            CrossPrioritization = CrossPrioritization.BuyPrioritized,
+            MaxSweepQty = 100,
+        };
+        disp.EnqueueCross(cross, crosser.Id, crosser.EnteringFirm);
+        DrainInbound(disp);
+
+        // External resting seller got hit for 100 at 9.99.
+        var externalFills = external.Trades.Where(t => t.PriceMantissa == Px(9.99m)).ToList();
+        Assert.Single(externalFills);
+        Assert.Equal(100, externalFills[0].Quantity);
+
+        // The crosser sees: (a) sweep aggressor fill of 100 at 9.99,
+        // (b) internal cross prints at 10.00 between the two cross legs.
+        var crosserSweepFills = crosser.Trades.Where(t => t.PriceMantissa == Px(9.99m)).ToList();
+        Assert.Single(crosserSweepFills);
+        Assert.Equal(100, crosserSweepFills[0].Quantity);
+
+        var crosserInternalFills = crosser.Trades.Where(t => t.PriceMantissa == Px(10m)).ToList();
+        // Internal print: residual buy of 100 against sell leg of 200 →
+        // emitted as aggressor Trade (sell aggressing) AND passive Trade
+        // (buy resting) on the same FakeSession (crosser owns both legs).
+        Assert.NotEmpty(crosserInternalFills);
+        Assert.Contains(crosserInternalFills, t => t.Quantity == 100);
+    }
+
+    [Fact]
+    public void AgainstBook_MaxSweepQtyZero_StillBehavesLikeAon()
+    {
+        // Defensive: AgainstBook with MaxSweepQty=0 falls through to the
+        // AON path (no sweep phase performed).
+        var (disp, _, outbound) = NewDispatcher();
+        var s = new FakeSession(outbound);
+        var cross = new CrossOrderCommand(Buy(100, 10m), Sell(100, 10m), 1UL, 2UL, 999UL)
+        {
+            CrossType = CrossType.AgainstBook,
+            MaxSweepQty = 0,
+        };
+        disp.EnqueueCross(cross, s.Id, s.EnteringFirm);
+        DrainInbound(disp);
+
+        Assert.Single(s.News);
+        Assert.Equal(2, s.Trades.Count);
+        Assert.Equal(100, s.Trades[0].Quantity);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs
@@ -160,28 +160,63 @@ public class NewOrderCrossDecoderTests
     }
 
     [Fact]
-    public void UnsupportedFeature_NonNullCrossType()
+    public void Success_AcceptsCrossType_AllOrNone()
     {
-        var body = BuildCross(crossType: 1); // any non-null
+        // Issue #218 (Onda L · L5): wire CrossType=1 (AllOrNone) is now
+        // accepted; prior to L5 this was rejected as UnsupportedFeature.
+        var body = BuildCross(crossType: 1);
         var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
-            body, SessionFirm, 1UL, out _, out _, out var msg);
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("CrossType", msg);
+            body, SessionFirm, 1UL, out var cross, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(CrossType.AllOrNone, cross.CrossType);
     }
 
     [Fact]
-    public void UnsupportedFeature_NonNullCrossPrioritization()
+    public void Success_AcceptsCrossType_AgainstBook()
     {
-        var body = BuildCross(crossPri: 0);
+        // Issue #218 (Onda L · L5): wire CrossType=4 (AgainstBook).
+        var body = BuildCross(crossType: 4, maxSweepQty: 50UL);
         var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
-            body, SessionFirm, 1UL, out _, out _, out var msg);
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("CrossPrioritization", msg);
+            body, SessionFirm, 1UL, out var cross, out _, out _);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(CrossType.AgainstBook, cross.CrossType);
+        Assert.Equal(50L, cross.MaxSweepQty);
     }
 
     [Fact]
-    public void UnsupportedFeature_NonZeroMaxSweepQty()
+    public void UnsupportedFeature_AuctionCrossTypesDeferred()
     {
+        // Wire 7 (VWAP) and 8 (ClosingPrice) remain rejected — auction-tied.
+        foreach (byte ct in new byte[] { 7, 8 })
+        {
+            var body = BuildCross(crossType: ct);
+            var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+                body, SessionFirm, 1UL, out _, out _, out var msg);
+            Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+            Assert.Contains("CrossType", msg);
+        }
+    }
+
+    [Fact]
+    public void Success_AcceptsCrossPrioritization_All()
+    {
+        // Issue #218 (Onda L · L5): wire CrossPrioritization 0/1/2 all
+        // accepted; prior to L5 these were rejected as UnsupportedFeature.
+        foreach (byte cp in new byte[] { 0, 1, 2 })
+        {
+            var body = BuildCross(crossPri: cp);
+            var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+                body, SessionFirm, 1UL, out var cross, out _, out _);
+            Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+            Assert.Equal((CrossPrioritization)cp, cross.CrossPrioritization);
+        }
+    }
+
+    [Fact]
+    public void UnsupportedFeature_MaxSweepQtyWithoutAgainstBook()
+    {
+        // MaxSweepQty without CrossType=AgainstBook is rejected (defensive —
+        // the field is meaningless except in the sweep variant).
         var body = BuildCross(maxSweepQty: 50UL);
         var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
             body, SessionFirm, 1UL, out _, out _, out var msg);


### PR DESCRIPTION
Implements full NewOrderCross semantics (issue #218, Onda L · L5).

## Decoder (B3.Exchange.Gateway)
- `InboundMessageDecoder.NewOrderCross` now accepts:
  - `CrossType` ∈ {`AllOrNone`, `AgainstBook`} — wires 1, 4
  - `CrossPrioritization` ∈ {`None`, `BuyPrioritized`, `SellPrioritized`} — wires 0, 1, 2 (and SBE null 255 → `None`)
  - `MaxSweepQty` (only meaningful with `AgainstBook`)
- `CrossType` 7 (VWAP) and 8 (ClosingPriceCross) still rejected with `UnsupportedFeature` — auction-tied; deferred to a future wave.
- `MaxSweepQty > 0` without `AgainstBook` is a defensive `UnsupportedFeature` reject.

## Engine wiring (B3.Exchange.Core ChannelDispatcher)
- Honors `CrossPrioritization`: `SellPrioritized` submits the Sell leg first; otherwise Buy first.
- For `CrossType=AgainstBook` with `MaxSweepQty>0`, splits into 3 phases:
  1. Prioritized leg as `Limit IOC` capped at `min(MaxSweepQty, OrderQty)` — sweeps the opposing public book at cross price.
  2. Residual prioritized qty as the original `Limit Day` at cross price (rests).
  3. Other leg at full `OrderQty` — crosses internally against the rested residual; any remainder rests.
- New per-channel field `_crossSweepFilledQty` accumulates fills via the `OnTrade` sink while phase 1 runs, so the dispatcher knows exactly how much external liquidity was eaten before computing the residual.

## Contracts (B3.Exchange.Matching)
- `CrossOrderCommand` extended with `CrossType` (default `AllOrNone`), `CrossPrioritization` (default `None`), `MaxSweepQty` (default 0). Wire values preserved for direct mapping.

## Tests
- `tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs` — replaces the 3 old "blanket UnsupportedFeature" tests with 5 covering the new accepted/rejected matrix.
- `tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs` (new) — 5 dispatcher-level integration tests exercising AON default, prioritization swap, AgainstBook fallback when book is empty, AgainstBook sweep against external liquidity, and the `MaxSweepQty=0` degenerate case.

## MVP limitations
- Phase-3 residual rests asymmetrically when the opposing leg overflows after sweep; symmetric both-sides-cap semantics are out of scope here.
- VWAP / ClosingPrice crosses remain rejected; they fold into the auctions wave.

Closes #218.
