### PR TITLE
Fix #222: emit trailing securityDesc length prefix in SecurityDefinition_12

### DIFF
--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -291,7 +291,12 @@ public static class UmdfWireEncoder
     /// for the consumer's instrument pipeline (SecurityID, SecurityExchange,
     /// Symbol, SecurityType, TotNoRelatedSym, ISIN, optional ValidityTimestamp,
     /// optional MaturityDate). Trailing 9 bytes encode three empty groups
-    /// (NoUnderlyings, NoLegs, NoInstrAttribs).
+    /// (NoUnderlyings, NoLegs, NoInstrAttribs); the final byte is the
+    /// <c>securityDesc</c> TextEncoding length prefix, written as 0 (empty
+    /// description). The length prefix is mandatory even when no text is
+    /// attached — without it the consumer's generated
+    /// <c>SecurityDefinition_12DataReader</c> reads past the SBE message
+    /// boundary and throws (issue #222).
     /// </summary>
     public static int WriteSecurityDefinitionFrame(
         Span<byte> dst,

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -187,5 +187,13 @@ public static class WireOffsets
     // SecDef body emits three empty repeating-group headers
     // (NoUnderlyings, NoLegs, NoInstrAttribs) so consumer ReadGroups paths stay safe.
     public const int GroupSizeEncodingSize = 3;
-    public const int SecDefBodyTotal = SecDefBlockLength + GroupSizeEncodingSize * 3;
+    // Trailing var-data section: TextEncoding 'securityDesc' (uint8 length
+    // prefix + 0..250 UTF-8 bytes). Required by the consumer's generated
+    // SecurityDefinition_12DataReader — when omitted, TextEncoding.Create
+    // reads the next frame's first byte as the length and the slice runs
+    // past the SBE message boundary (issue #222). We always emit length=0
+    // (empty description) so the prefix is present even when no text is
+    // attached.
+    public const int SecDefSecurityDescLengthSize = 1;
+    public const int SecDefBodyTotal = SecDefBlockLength + GroupSizeEncodingSize * 3 + SecDefSecurityDescLengthSize;
 }

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -236,6 +236,38 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void SecurityDefinition_GeneratedReader_ReadsSecurityDescWithoutOverflow()
+    {
+        // Issue #222: prior to the trailing length-prefix fix, the
+        // generated SecurityDefinition_12Data reader's TextEncoding.Create
+        // call would slice past the SBE message buffer when the encoder
+        // omitted the securityDesc data section, throwing
+        // ArgumentOutOfRangeException. With the fix the reader observes a
+        // 0-length description and ReadGroups completes cleanly.
+        var buf = new byte[512];
+        int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(buf, securityId: 900_000_000_001L,
+            symbol: "PETR4", isin: "BRPETRACNPR6", securityTypeByte: 1, totNoRelatedSym: 1);
+
+        // Slice exactly to the encoded payload (excluding framing header)
+        // — that's what the consumer sees on the wire after stripping
+        // SOFH + SBE message header.
+        var sbeMessage = buf.AsSpan(WireOffsets.FramingHeaderSize, n - WireOffsets.FramingHeaderSize);
+        // Skip the SBE message header (8 bytes) — the V6 reader expects
+        // the slice to start at the block.
+        var bodyAndTail = sbeMessage.Slice(WireOffsets.SbeMessageHeaderSize);
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.TryParse(bodyAndTail,
+            blockLength: WireOffsets.SecDefBlockLength, out var rdr));
+
+        int descLen = -1;
+        rdr.ReadGroups(
+            (in B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.NoUnderlyingsData _) => { },
+            (in B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.NoLegsData _) => { },
+            (in B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.NoInstrAttribsData _) => { },
+            (B3.Umdf.Mbo.Sbe.V16.TextEncoding desc) => { descLen = desc.VarData.Length; });
+        Assert.Equal(0, descLen);
+    }
+
+    [Fact]
     public void SecurityDefinition_Roundtrip_BasicFields()
     {
         var buf = new byte[512];
@@ -252,6 +284,14 @@ public class UmdfWireEncoderTests
         Assert.Equal((byte)1, body[WireOffsets.SecDefSecurityTypeOffset]);
         Assert.Equal(3u, MemoryMarshal.Read<uint>(body.Slice(WireOffsets.SecDefTotNoRelatedSymOffset, 4)));
         Assert.Equal("BRPETRACNPR6", System.Text.Encoding.ASCII.GetString(body.Slice(WireOffsets.SecDefIsinNumberOffset, 12)));
+
+        // Issue #222: trailing byte after the three empty group headers is
+        // the securityDesc TextEncoding length prefix (uint8). Must be 0
+        // when no description is attached so the consumer's generated
+        // reader doesn't slice past the SBE message boundary.
+        int descLengthOffset = FrameOffset + WireOffsets.SecDefBlockLength + WireOffsets.GroupSizeEncodingSize * 3;
+        Assert.Equal((byte)0, buf[descLengthOffset]);
+        Assert.Equal(descLengthOffset + 1, n);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #222 — `SecurityDefinition_12` consumer-side `ArgumentOutOfRangeException`.

## Root cause

`UmdfWireEncoder.WriteSecurityDefinitionFrame` emitted the fixed block + the three empty group headers (`NoUnderlyings`, `NoLegs`, `NoInstrAttribs`) but **omitted the trailing `securityDesc` data section** entirely. Per the schema, `securityDesc` is a `TextEncoding` composite (uint8 length prefix + 0..250 UTF-8 bytes) and is mandatory in the wire layout — even when empty it must contribute its 1-byte length prefix.

The consumer's generated `SecurityDefinition_12DataReader.ReadGroups` calls `TextEncoding.Create(reader.Remaining)`. When the trailing length byte is absent, `reader.Remaining` either has zero bytes or, in a packed UMDF UDP datagram, contains the **next frame's first byte**. The reader interprets that byte as `length`, then `buffer.Slice(1, length)` slices past the SBE message boundary → `ArgumentOutOfRangeException`.

## Fix

`WireOffsets.SecDefBodyTotal` now includes a 1-byte `securityDesc` length prefix at the tail. `WriteSecurityDefinitionFrame` already calls `body.Clear()` over the full body, so the new byte is naturally written as `0` (length=0, empty description). No changes needed in callers — the constant flows through `InstrumentDefinitionPublisher`, `ExchangeHostE2ETests`, etc.

## Tests

Two assertions added to `B3.Umdf.WireEncoder.Tests`:

1. **`SecurityDefinition_Roundtrip_BasicFields`** — extended with an explicit byte-level check that the trailing length prefix is `0` and that the frame ends exactly there.
2. **`SecurityDefinition_GeneratedReader_ReadsSecurityDescWithoutOverflow`** (new) — drives the encoded frame through the *generated* `SecurityDefinition_12Data.TryParse` + `ReadGroups` path (the same code that was throwing on the consumer side) and asserts `desc.VarData.Length == 0` with no exception.

Without the fix, test (2) reproduces the consumer-side `ArgumentOutOfRangeException` from issue #222 inside `TextEncoding.Create`.

## Out of scope

- The consumer-side defensive clamp discussion (`B3MarketDataPlatform#12`) remains tracked there.
- VWAP/auction-tied `SecurityType` mappings are unrelated.

Closes #222.
