### PR TITLE
L3a #216: UMDF packet retransmit buffer + dispatcher plumbing

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Packet.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Packet.cs
@@ -37,12 +37,24 @@ public sealed partial class ChannelDispatcher
             System.Runtime.InteropServices.MemoryMarshal.Write(
                 _packetBuf.AsSpan(B3.Umdf.WireEncoder.WireOffsets.PacketHeaderSequenceVersionOffset, 2),
                 in newVer);
+            // Issue #216 (L3a): the (version, seq) tuple identifies a
+            // packet uniquely; once version bumps, the previously-stored
+            // packets address a now-stale namespace and would mislead a
+            // gap-fill responder. Wipe the ring before appending under
+            // the new version.
+            _retxBuffer?.Reset();
         }
         Volatile.Write(ref _sequenceNumber, _sequenceNumber + 1);
         ulong now = _nowNanos();
         B3.Umdf.WireEncoder.UmdfWireEncoder.PatchPacketHeader(
             _packetBuf.AsSpan(0, B3.Umdf.WireEncoder.WireOffsets.PacketHeaderSize), _sequenceNumber, now);
         _packetSink.Publish(ChannelNumber, _packetBuf.AsSpan(0, _packetWritten));
+        // Issue #216 (L3a): retain a deep-copied snapshot of the just-
+        // published incremental packet for the future retransmit
+        // responder (L3b). Snapshot/instrumentdef feeds are NOT routed
+        // through here — they reach the wire via the host-owned
+        // CountingUdpPacketSinkDecorator, by design.
+        _retxBuffer?.Append(_sequenceNumber, _packetBuf.AsSpan(0, _packetWritten));
         LogPacketFlushed(ChannelNumber, _sequenceNumber, _packetWritten);
         _metrics?.IncPacketsOut();
         // Issue #174: per-feed packet/byte throughput. The incremental feed

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -104,6 +104,12 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// <see cref="SequenceVersion"/>. Safe to read from any thread.</summary>
     public uint SequenceNumber => Volatile.Read(ref _sequenceNumber);
 
+    /// <summary>Issue #216 (Onda L · L3a): exposes the per-channel UMDF
+    /// retransmit ring (or <c>null</c> when buffering is disabled). The
+    /// future TCP retransmit responder (L3b) reads through this; tests
+    /// inspect it to verify <c>FlushPacket</c> appends.</summary>
+    public UmdfPacketRetransmitBuffer? RetransmitBuffer => _retxBuffer;
+
     /// <summary>
     /// Pending work-items in the bounded inbound channel. Snapshot value;
     /// safe to read from any thread (the underlying <see cref="System.Threading.Channels.Channel{T}"/>
@@ -123,6 +129,11 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly ChannelMetrics? _metrics;
     private readonly BoundedSessionFirmCounters? _sessionFirmCounters;
     private readonly OrderRegistry _orders = new();
+    /// <summary>Issue #216 (Onda L · L3a): per-channel UMDF retransmit
+    /// ring. Populated on each <c>FlushPacket</c> for the incremental
+    /// feed only. <c>null</c> when retransmit buffering is disabled
+    /// (host config <c>umdfRetransmit.bufferSize=0</c>).</summary>
+    private readonly UmdfPacketRetransmitBuffer? _retxBuffer;
 
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
@@ -172,7 +183,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         ILogger<ChannelDispatcher> logger,
         Func<ulong>? nowNanos = null, ushort tradeDate = 0, int inboundCapacity = DefaultInboundCapacity,
         ChannelMetrics? metrics = null,
-        BoundedSessionFirmCounters? sessionFirmCounters = null)
+        BoundedSessionFirmCounters? sessionFirmCounters = null,
+        UmdfPacketRetransmitBuffer? retxBuffer = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -184,6 +196,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _tradeDate = tradeDate;
         _metrics = metrics;
         _sessionFirmCounters = sessionFirmCounters;
+        _retxBuffer = retxBuffer;
         // Direct field writes are safe here: ctor runs on the constructing
         // thread before Start() and before any other thread can observe the
         // instance. No memory barrier is needed.

--- a/src/B3.Exchange.Core/UmdfPacketRetransmitBuffer.cs
+++ b/src/B3.Exchange.Core/UmdfPacketRetransmitBuffer.cs
@@ -1,0 +1,210 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Per-channel bounded ring buffer of recently-published UMDF incremental
+/// packets, keyed by the packet's <c>SequenceNumber</c> (uint).
+///
+/// <para>Issue #216 (Onda L · L3a): infrastructure half. The dispatcher
+/// appends every successfully-published incremental packet here so that a
+/// future TCP retransmit responder (L3b) can serve gap-fill requests
+/// without replaying through the matching engine. The snapshot and
+/// instrumentdef feeds are NOT buffered here — they have their own
+/// recovery story (snapshot rotation / SequenceVersion bump).</para>
+///
+/// <para>Stored bytes are deep-copied on <see cref="Append"/> because the
+/// dispatcher reuses its outgoing packet buffer between flushes; mutating
+/// the original after publish must not corrupt the retained snapshot.
+/// Consumers receive newly-allocated arrays from <see cref="TryGet"/> and
+/// <see cref="TryGetRange"/> so concurrent readers cannot trip on a
+/// reader-side mutation either.</para>
+///
+/// <para>Producer (<see cref="Append"/>, <see cref="Reset"/>) is the
+/// dispatcher's single loop thread. Readers (<see cref="TryGet"/>,
+/// <see cref="TryGetRange"/>, <see cref="FirstAvailableSeqOrZero"/>,
+/// <see cref="LastSeqOrZero"/>, <see cref="Count"/>) may run from any
+/// thread — the buffer takes its own lock so a range query observes a
+/// consistent snapshot of seq window + payloads.</para>
+///
+/// <para>When the ring is full, the oldest entry is evicted (FIFO);
+/// <see cref="Evictions"/> counts how many drops have happened over the
+/// dispatcher's lifetime. <see cref="Reset"/> wipes the ring and is
+/// invoked when the dispatcher's <c>SequenceVersion</c> rolls over —
+/// the (version, seq) tuple is the real identity, so a new version
+/// invalidates everything stored against the previous one.</para>
+/// </summary>
+public sealed class UmdfPacketRetransmitBuffer
+{
+    /// <summary>Cap inherited from <see cref="RetransmitBufferDefaults"/>;
+    /// default 65 536 packets keeps the buffer well under 100 MiB even at
+    /// the 1 400-byte UMDF packet ceiling.</summary>
+    public int Capacity { get; }
+
+    private readonly object _lock = new();
+    private readonly byte[]?[] _packets;
+    private readonly uint[] _seqs;
+    private int _head;        // next write slot
+    private int _count;
+    private long _evictions;
+
+    public UmdfPacketRetransmitBuffer(int capacity)
+    {
+        if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity), "capacity must be > 0");
+        Capacity = capacity;
+        _packets = new byte[]?[capacity];
+        _seqs = new uint[capacity];
+    }
+
+    /// <summary>Number of packets currently retained.</summary>
+    public int Count { get { lock (_lock) return _count; } }
+
+    /// <summary>Total number of FIFO evictions since construction
+    /// (monotonic). Useful as a metrics gauge for sizing the ring.</summary>
+    public long Evictions { get { lock (_lock) return _evictions; } }
+
+    /// <summary>Lowest <c>SequenceNumber</c> currently retained, or
+    /// 0 when the buffer is empty.</summary>
+    public uint FirstAvailableSeqOrZero
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (_count == 0) return 0u;
+                int oldest = (_head - _count + Capacity) % Capacity;
+                return _seqs[oldest];
+            }
+        }
+    }
+
+    /// <summary>Highest <c>SequenceNumber</c> currently retained, or
+    /// 0 when the buffer is empty. Note: a real packet could legitimately
+    /// have sequence 0 only at startup (the dispatcher emits its first
+    /// packet with seq 1), so the sentinel is unambiguous in practice.</summary>
+    public uint LastSeqOrZero
+    {
+        get
+        {
+            lock (_lock)
+            {
+                if (_count == 0) return 0u;
+                int newest = (_head - 1 + Capacity) % Capacity;
+                return _seqs[newest];
+            }
+        }
+    }
+
+    /// <summary>Append a packet. Bytes are deep-copied. When the ring is
+    /// full the oldest entry is dropped and <see cref="Evictions"/> is
+    /// incremented.</summary>
+    public void Append(uint sequenceNumber, ReadOnlySpan<byte> packet)
+    {
+        var copy = packet.ToArray();
+        lock (_lock)
+        {
+            if (_count == Capacity)
+            {
+                _evictions++;
+            }
+            else
+            {
+                _count++;
+            }
+            _packets[_head] = copy;
+            _seqs[_head] = sequenceNumber;
+            _head = (_head + 1) % Capacity;
+        }
+    }
+
+    /// <summary>Wipe the ring. Call on <c>SequenceVersion</c> rollover,
+    /// when the (version, seq) namespace changes and previously-stored
+    /// packets are no longer addressable.</summary>
+    public void Reset()
+    {
+        lock (_lock)
+        {
+            for (int i = 0; i < _packets.Length; i++) _packets[i] = null;
+            _head = 0;
+            _count = 0;
+            // _evictions intentionally retained — it is a lifetime
+            // counter, not a per-version counter; useful when sizing the
+            // ring across the whole process lifetime.
+        }
+    }
+
+    /// <summary>Look up a single packet by sequence number. Returns a
+    /// fresh byte[] copy (so the caller cannot mutate the stored entry).
+    /// Returns <c>false</c> when the seq is outside the current
+    /// retention window.</summary>
+    public bool TryGet(uint sequenceNumber, out byte[] packet)
+    {
+        lock (_lock)
+        {
+            if (_count == 0) { packet = Array.Empty<byte>(); return false; }
+            int oldest = (_head - _count + Capacity) % Capacity;
+            uint first = _seqs[oldest];
+            uint last = _seqs[(_head - 1 + Capacity) % Capacity];
+            if (sequenceNumber < first || sequenceNumber > last) { packet = Array.Empty<byte>(); return false; }
+            // Direct subtraction: seq numbers are stored monotonically,
+            // wrap-around is handled by the dispatcher resetting the ring
+            // before the version bump.
+            int offset = (int)(sequenceNumber - first);
+            int slot = (oldest + offset) % Capacity;
+            var stored = _packets[slot];
+            if (stored is null || _seqs[slot] != sequenceNumber)
+            {
+                // Defensive: shouldn't happen under append-only single-writer
+                // semantics, but if it does, fail safe rather than serve a
+                // stale slot.
+                packet = Array.Empty<byte>();
+                return false;
+            }
+            packet = (byte[])stored.Clone();
+            return true;
+        }
+    }
+
+    /// <summary>Look up an inclusive contiguous range
+    /// <c>[fromSeq..fromSeq+count-1]</c>. Returns <c>false</c> if any seq
+    /// in the range is missing (entirely outside the retention window or
+    /// straddling the lower edge); on success, <paramref name="packets"/>
+    /// holds <paramref name="count"/> fresh byte[] copies in seq order.
+    /// </summary>
+    public bool TryGetRange(uint fromSeq, int count, out byte[][] packets)
+    {
+        if (count <= 0) { packets = Array.Empty<byte[]>(); return false; }
+        lock (_lock)
+        {
+            if (_count == 0) { packets = Array.Empty<byte[]>(); return false; }
+            int oldest = (_head - _count + Capacity) % Capacity;
+            uint first = _seqs[oldest];
+            uint last = _seqs[(_head - 1 + Capacity) % Capacity];
+            uint endSeq = fromSeq + (uint)(count - 1);
+            if (fromSeq < first || endSeq > last) { packets = Array.Empty<byte[]>(); return false; }
+            var result = new byte[count][];
+            for (int i = 0; i < count; i++)
+            {
+                uint seq = fromSeq + (uint)i;
+                int slot = (oldest + (int)(seq - first)) % Capacity;
+                var stored = _packets[slot];
+                if (stored is null || _seqs[slot] != seq)
+                {
+                    packets = Array.Empty<byte[]>();
+                    return false;
+                }
+                result[i] = (byte[])stored.Clone();
+            }
+            packets = result;
+            return true;
+        }
+    }
+}
+
+/// <summary>Documented defaults for the UMDF retransmit ring sizing.</summary>
+public static class RetransmitBufferDefaults
+{
+    /// <summary>Default ring capacity (packets) when host config does not
+    /// override. 65 536 packets × ~1.4 KB worst-case = ~90 MiB ceiling
+    /// per channel; comfortable for the autopilot scenarios in this repo
+    /// without straining containerised memory limits.</summary>
+    public const int UmdfRingCapacity = 65_536;
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -146,6 +146,14 @@ public sealed class ExchangeHost : IAsyncDisposable
             // Capture the engine via a side-channel so we can build a snapshot
             // source that reads through the live book on the dispatcher thread.
             MatchingEngine? capturedEngine = null;
+            // Issue #216 (L3a): build the UMDF retransmit ring per channel
+            // unless the operator explicitly opted out via bufferSize=0.
+            UmdfPacketRetransmitBuffer? retxBuffer = null;
+            int retxCapacity = ch.UmdfRetransmit?.BufferSize ?? RetransmitBufferDefaults.UmdfRingCapacity;
+            if (retxCapacity > 0)
+            {
+                retxBuffer = new UmdfPacketRetransmitBuffer(retxCapacity);
+            }
             var disp = new ChannelDispatcher(
                 channelNumber: ch.ChannelNumber,
                 engineFactory: s =>
@@ -158,7 +166,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 outbound: gatewayRouter,
                 logger: _loggerFactory.CreateLogger<ChannelDispatcher>(),
                 metrics: channelMetrics,
-                sessionFirmCounters: _metrics.SessionFirmMessages);
+                sessionFirmCounters: _metrics.SessionFirmMessages,
+                retxBuffer: retxBuffer);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -226,6 +226,15 @@ public sealed class ChannelConfig
     [JsonPropertyName("instrumentDefinition")] public InstrumentDefinitionConfig? InstrumentDefinition { get; set; }
 
     /// <summary>
+    /// Optional UMDF retransmit ring sizing (issue #216 / Onda L · L3a).
+    /// When omitted, the default ring size is used. Set
+    /// <c>bufferSize=0</c> to disable retransmit buffering entirely (the
+    /// dispatcher will not retain published packets and any future
+    /// retransmit responder will report an empty window).
+    /// </summary>
+    [JsonPropertyName("umdfRetransmit")] public UmdfRetransmitConfig? UmdfRetransmit { get; set; }
+
+    /// <summary>
     /// Optional chaos injection on the incremental UDP sink (issue #119).
     /// When omitted or all probabilities are 0, the sink is unmodified.
     /// Used to exercise the consumer's recovery paths (snapshot bootstrap,
@@ -367,4 +376,18 @@ public static class HostConfigLoader
             throw new InvalidOperationException("HostConfig.Channels is empty");
         return cfg;
     }
+}
+
+/// <summary>
+/// Per-channel UMDF retransmit ring sizing (issue #216 / Onda L · L3a).
+/// </summary>
+public sealed class UmdfRetransmitConfig
+{
+    /// <summary>
+    /// Ring capacity in packets. <c>null</c> uses the default
+    /// (<see cref="B3.Exchange.Core.RetransmitBufferDefaults.UmdfRingCapacity"/>);
+    /// <c>0</c> disables the ring entirely (no buffer is allocated and
+    /// the dispatcher publishes without retaining packets).
+    /// </summary>
+    [JsonPropertyName("bufferSize")] public int? BufferSize { get; set; }
 }

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs
@@ -1,0 +1,177 @@
+using System.Runtime.InteropServices;
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Umdf.WireEncoder;
+using Microsoft.Extensions.Logging.Abstractions;
+using Side = B3.Exchange.Matching.Side;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Core.Tests;
+
+/// <summary>
+/// Issue #216 (Onda L · L3a) integration tests: verify that the
+/// <see cref="ChannelDispatcher"/> appends each published incremental
+/// packet into its <see cref="UmdfPacketRetransmitBuffer"/>, that
+/// retrieved bytes byte-equal what the packet sink received, and that a
+/// <c>SequenceVersion</c> bump wipes the ring before continuing.
+/// </summary>
+public class ChannelDispatcherRetxBufferTests
+{
+    private const long Petr = 900_000_000_001L;
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Petr,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Packets.Add(packet.ToArray());
+    }
+
+    private sealed class FakeSession
+    {
+        private static int _nextId;
+        public SessionId Id { get; } = new("rb" + System.Threading.Interlocked.Increment(ref _nextId));
+        public uint EnteringFirm => 7;
+    }
+
+    private sealed class NoopOutbound : ICoreOutbound
+    {
+        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportReject(SessionId session, in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue) => true;
+    }
+
+    private static (ChannelDispatcher disp, RecordingPacketSink pkt, UmdfPacketRetransmitBuffer ring) NewDispatcherWithRing(int capacity = 16)
+    {
+        var pkt = new RecordingPacketSink();
+        var ring = new UmdfPacketRetransmitBuffer(capacity);
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: new NoopOutbound(),
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL,
+            tradeDate: 19_000,
+            retxBuffer: ring);
+        return (disp, pkt, ring);
+    }
+
+    private static void DrainInbound(ChannelDispatcher disp) => disp.CreateTestProbe().DrainInbound();
+
+    [Fact]
+    public void Constructor_NoBuffer_RetransmitBufferIsNull()
+    {
+        var pkt = new RecordingPacketSink();
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: new NoopOutbound(),
+            logger: NullLogger<ChannelDispatcher>.Instance);
+        Assert.Null(disp.RetransmitBuffer);
+    }
+
+    [Fact]
+    public void FlushPacket_AppendsExactBytesToRingKeyedBySequenceNumber()
+    {
+        var (disp, pkt, ring) = NewDispatcherWithRing();
+        var s = new FakeSession();
+
+        disp.EnqueueNewOrder(
+            new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, s.EnteringFirm, 1_000UL),
+            s.Id, s.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        Assert.Same(ring, disp.RetransmitBuffer);
+        var sentPacket = Assert.Single(pkt.Packets);
+        Assert.Equal(1, ring.Count);
+        Assert.Equal(1u, ring.FirstAvailableSeqOrZero);
+        Assert.Equal(1u, ring.LastSeqOrZero);
+        Assert.True(ring.TryGet(1u, out var stored));
+        Assert.Equal(sentPacket, stored);
+    }
+
+    [Fact]
+    public void FlushPacket_MultiplePackets_RetainedInOrderUntilEviction()
+    {
+        var (disp, pkt, ring) = NewDispatcherWithRing(capacity: 3);
+        var s = new FakeSession();
+
+        for (int i = 0; i < 5; i++)
+        {
+            disp.EnqueueNewOrder(
+                new NewOrderCommand("o" + i, Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m + i * 0.01m), 100, s.EnteringFirm, (ulong)(1_000 + i)),
+                s.Id, s.EnteringFirm, clOrdIdValue: (ulong)(1 + i));
+            DrainInbound(disp);
+        }
+
+        Assert.Equal(5, pkt.Packets.Count);
+        Assert.Equal(3, ring.Count);
+        Assert.Equal(2L, ring.Evictions);
+        Assert.Equal(3u, ring.FirstAvailableSeqOrZero);
+        Assert.Equal(5u, ring.LastSeqOrZero);
+
+        for (uint seq = 3; seq <= 5; seq++)
+        {
+            Assert.True(ring.TryGet(seq, out var stored));
+            Assert.Equal(pkt.Packets[(int)(seq - 1)], stored);
+        }
+        Assert.False(ring.TryGet(1u, out _));
+        Assert.False(ring.TryGet(2u, out _));
+    }
+
+    [Fact]
+    public void FlushPacket_SequenceVersionRollover_ResetsRingBeforeAppendingNewVersionPacket()
+    {
+        var (disp, pkt, ring) = NewDispatcherWithRing();
+        var s = new FakeSession();
+
+        // Pre-populate the ring on version 1 with one real packet.
+        disp.EnqueueNewOrder(
+            new NewOrderCommand("pre", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, s.EnteringFirm, 1_000UL),
+            s.Id, s.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        Assert.Equal(1, ring.Count);
+        long baselineEvictions = ring.Evictions;
+
+        // Force the next FlushPacket to roll the SequenceVersion.
+        disp.TestSetSequenceNumber(uint.MaxValue);
+
+        disp.EnqueueNewOrder(
+            new NewOrderCommand("post", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(11m), 100, s.EnteringFirm, 2_000UL),
+            s.Id, s.EnteringFirm, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+
+        // After rollover: ring was wiped, then the new packet was
+        // appended under the new (version, seq) tuple.
+        Assert.Equal((ushort)2, disp.SequenceVersion);
+        Assert.Equal(1u, disp.SequenceNumber);
+        Assert.Equal(1, ring.Count);
+        Assert.Equal(1u, ring.FirstAvailableSeqOrZero);
+        Assert.Equal(1u, ring.LastSeqOrZero);
+        // Pre-rollover packet is no longer addressable.
+        Assert.True(ring.TryGet(1u, out var stored));
+        var lastSent = pkt.Packets[^1];
+        Assert.Equal(lastSent, stored);
+        // SequenceVersion in the wire packet header now reads 2.
+        Assert.Equal((ushort)2, MemoryMarshal.Read<ushort>(stored.AsSpan(2, 2)));
+        // Reset preserves the lifetime evictions counter.
+        Assert.Equal(baselineEvictions, ring.Evictions);
+    }
+}

--- a/tests/B3.Exchange.Core.Tests/UmdfPacketRetransmitBufferTests.cs
+++ b/tests/B3.Exchange.Core.Tests/UmdfPacketRetransmitBufferTests.cs
@@ -1,0 +1,150 @@
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Core.Tests;
+
+/// <summary>
+/// Issue #216 (Onda L · L3a) unit tests for the per-channel UMDF
+/// retransmit ring. Cover append/lookup/range, FIFO eviction, deep-copy
+/// isolation (mutating the input span or the returned array does not
+/// corrupt stored entries), and <c>Reset</c> behaviour invoked on
+/// <c>SequenceVersion</c> rollover.
+/// </summary>
+public class UmdfPacketRetransmitBufferTests
+{
+    [Fact]
+    public void Append_ThenTryGet_ReturnsCopyOfStoredBytes()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 4);
+        var pkt1 = new byte[] { 1, 2, 3 };
+        var pkt2 = new byte[] { 4, 5, 6, 7 };
+        buf.Append(seq1, pkt1);
+        buf.Append(seq2, pkt2);
+
+        Assert.Equal(2, buf.Count);
+        Assert.Equal(seq1, buf.FirstAvailableSeqOrZero);
+        Assert.Equal(seq2, buf.LastSeqOrZero);
+
+        Assert.True(buf.TryGet(seq1, out var got1));
+        Assert.Equal(pkt1, got1);
+        Assert.True(buf.TryGet(seq2, out var got2));
+        Assert.Equal(pkt2, got2);
+    }
+
+    [Fact]
+    public void TryGet_OutsideWindow_ReturnsFalse()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 4);
+        buf.Append(10u, new byte[] { 0xAA });
+        buf.Append(11u, new byte[] { 0xBB });
+
+        Assert.False(buf.TryGet(9u, out _));   // below window
+        Assert.False(buf.TryGet(12u, out _));  // above window
+        Assert.False(new UmdfPacketRetransmitBuffer(capacity: 2).TryGet(1u, out _)); // empty
+    }
+
+    [Fact]
+    public void Append_BeyondCapacity_EvictsOldestFifo()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 3);
+        buf.Append(1u, new byte[] { 1 });
+        buf.Append(2u, new byte[] { 2 });
+        buf.Append(3u, new byte[] { 3 });
+        buf.Append(4u, new byte[] { 4 });
+        buf.Append(5u, new byte[] { 5 });
+
+        Assert.Equal(3, buf.Count);
+        Assert.Equal(2L, buf.Evictions);
+        Assert.Equal(3u, buf.FirstAvailableSeqOrZero);
+        Assert.Equal(5u, buf.LastSeqOrZero);
+        Assert.False(buf.TryGet(1u, out _));
+        Assert.False(buf.TryGet(2u, out _));
+        Assert.True(buf.TryGet(3u, out var p3)); Assert.Equal(new byte[] { 3 }, p3);
+        Assert.True(buf.TryGet(4u, out var p4)); Assert.Equal(new byte[] { 4 }, p4);
+        Assert.True(buf.TryGet(5u, out var p5)); Assert.Equal(new byte[] { 5 }, p5);
+    }
+
+    [Fact]
+    public void Append_DeepCopiesInput_SubsequentMutationsDoNotCorruptStorage()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 2);
+        var src = new byte[] { 0x10, 0x20, 0x30 };
+        buf.Append(1u, src);
+        // Mutate the source after Append — stored copy must be unaffected.
+        src[0] = 0xFF;
+        src[1] = 0xFF;
+        Assert.True(buf.TryGet(1u, out var got));
+        Assert.Equal(new byte[] { 0x10, 0x20, 0x30 }, got);
+    }
+
+    [Fact]
+    public void TryGet_ReturnsFreshCopy_CallerMutationsDoNotCorruptStorage()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 2);
+        buf.Append(1u, new byte[] { 0x01, 0x02 });
+        Assert.True(buf.TryGet(1u, out var first));
+        first[0] = 0x99;
+        // Second lookup must see the original bytes, not the caller mutation.
+        Assert.True(buf.TryGet(1u, out var second));
+        Assert.Equal(new byte[] { 0x01, 0x02 }, second);
+    }
+
+    [Fact]
+    public void TryGetRange_ReturnsContiguousCopiesInOrder()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 8);
+        for (uint i = 1; i <= 5; i++) buf.Append(i, new byte[] { (byte)i });
+
+        Assert.True(buf.TryGetRange(fromSeq: 2u, count: 3, out var packets));
+        Assert.Equal(3, packets.Length);
+        Assert.Equal(new byte[] { 2 }, packets[0]);
+        Assert.Equal(new byte[] { 3 }, packets[1]);
+        Assert.Equal(new byte[] { 4 }, packets[2]);
+    }
+
+    [Fact]
+    public void TryGetRange_PartiallyOutsideWindow_ReturnsFalse()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 4);
+        for (uint i = 10; i <= 12; i++) buf.Append(i, new byte[] { (byte)i });
+
+        Assert.False(buf.TryGetRange(fromSeq: 9u, count: 2, out _));   // straddles lower edge
+        Assert.False(buf.TryGetRange(fromSeq: 12u, count: 2, out _));  // straddles upper edge
+        Assert.False(buf.TryGetRange(fromSeq: 11u, count: 0, out _));  // count must be > 0
+    }
+
+    [Fact]
+    public void Reset_ClearsRing_PreservesEvictionsCounter()
+    {
+        var buf = new UmdfPacketRetransmitBuffer(capacity: 2);
+        buf.Append(1u, new byte[] { 1 });
+        buf.Append(2u, new byte[] { 2 });
+        buf.Append(3u, new byte[] { 3 }); // evicts seq 1
+        Assert.Equal(1L, buf.Evictions);
+
+        buf.Reset();
+
+        Assert.Equal(0, buf.Count);
+        Assert.Equal(0u, buf.FirstAvailableSeqOrZero);
+        Assert.Equal(0u, buf.LastSeqOrZero);
+        Assert.False(buf.TryGet(2u, out _));
+        Assert.False(buf.TryGet(3u, out _));
+        // Eviction counter is a lifetime monotonic gauge; not reset.
+        Assert.Equal(1L, buf.Evictions);
+
+        // After reset, append re-establishes a fresh window.
+        buf.Append(100u, new byte[] { 0xAB });
+        Assert.True(buf.TryGet(100u, out var got));
+        Assert.Equal(new byte[] { 0xAB }, got);
+        Assert.Equal(100u, buf.FirstAvailableSeqOrZero);
+    }
+
+    [Fact]
+    public void Constructor_ZeroOrNegativeCapacity_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UmdfPacketRetransmitBuffer(0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new UmdfPacketRetransmitBuffer(-1));
+    }
+
+    private const uint seq1 = 100u;
+    private const uint seq2 = 101u;
+}


### PR DESCRIPTION
Implements **L3a** of issue #216 (Onda L · L3): the per-channel UMDF
retransmit ring infrastructure. **No TCP listener / wire request format
yet** — that is L3b, deferred and tracked separately so the wire format
can be coordinated with the consumer repo.

## What ships

### `UmdfPacketRetransmitBuffer` (new)
Bounded FIFO ring keyed by uint `SequenceNumber`. Public API:
- `Append(seq, ReadOnlySpan<byte> packet)` — deep-copies on input.
- `TryGet(seq, out byte[])` — returns a fresh copy, never the stored array.
- `TryGetRange(fromSeq, count, out byte[][])` — contiguous, in seq order.
- `Reset()` — wipes the ring (called on `SequenceVersion` rollover).
- Read-only: `Count`, `Capacity`, `Evictions`, `FirstAvailableSeqOrZero`, `LastSeqOrZero`.

Producer (`Append`/`Reset`) is the dispatcher's single loop thread; readers may run from any thread — internal lock keeps each query a consistent snapshot.

### `ChannelDispatcher` wire-up
- New optional ctor parameter `UmdfPacketRetransmitBuffer? retxBuffer` (null = disabled, preserves all existing behaviour).
- Public read-only accessor `RetransmitBuffer`.
- `FlushPacket` appends each successfully-published incremental packet to the ring after `_packetSink.Publish`. Snapshot/instrumentdef feeds reach the wire via the host-owned `CountingUdpPacketSinkDecorator` and are intentionally NOT routed here — they have their own recovery story.
- On `SequenceVersion` rollover (uint overflow), the ring is reset before the new packet is appended: the `(version, seq)` tuple is the real packet identity, so previously-stored entries address a now-stale namespace.

### Host config
- New optional `umdfRetransmit.bufferSize` per channel.
- Default = `RetransmitBufferDefaults.UmdfRingCapacity` (65 536 packets ≈ 90 MiB ceiling per channel at the 1 400-byte UMDF packet cap).
- `0` disables the ring entirely (no buffer allocated).

## Tests (13 new, all green; full suite passes)

`tests/B3.Exchange.Core.Tests/UmdfPacketRetransmitBufferTests.cs` — 9 unit tests covering the ring directly:
- Basic append + lookup; window edges (below/above/empty).
- FIFO eviction beyond capacity; evictions counter.
- Deep-copy isolation in both directions (input span post-mutation, returned array post-mutation).
- `TryGetRange` happy path and partial-window failure modes; rejects `count<=0`.
- `Reset` wipes ring but preserves the lifetime evictions counter.
- `Capacity` invariants.

`tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs` — 4 integration tests:
- `RetransmitBuffer` is `null` when not wired.
- Each `FlushPacket` appends bytes that byte-equal what the packet sink received, keyed by `SequenceNumber`.
- Rolling many packets past capacity produces matching FIFO eviction in the ring.
- `SequenceVersion` rollover via `TestSetSequenceNumber(uint.MaxValue)` resets the ring before the post-rollover packet is appended; lifetime evictions counter survives.

## Out of scope (L3b — deferred)

- TCP listener per channel.
- Request wire format (custom binary vs reuse FIXP `RetransmitRequest` over a separate transport — needs consumer-side coordination).
- Replayed-packet bracketing with `Sequence_2` markers.
- `SequenceReset_1` response on out-of-window requests.

A separate issue will be opened for L3b once the wire-format decision is made; this PR delivers the public ring API L3b will read through.

Refs #216.
