### PR TITLE
M1 #228: auction book accumulation in Reserved / FinalClosingCall

### DIFF
--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -336,6 +336,20 @@ public sealed class MatchingEngine
             // Issue #214: stop branch handled earlier (right after MinQty
             // range-check). Falling through here means cmd.Type is Limit
             // or Market.
+            //
+            // Issue #228 (Onda M · M1): during auction phases (Reserved /
+            // FinalClosingCall) the engine accepts the order onto the book
+            // but bypasses continuous matching entirely — no Trade_53 events
+            // are emitted until the operator-issued auction uncross (M3).
+            // The TIF gate above guarantees that only GoodForAuction (in
+            // Reserved) and AtClose (in FinalClosingCall) reach this path,
+            // and both are wire-restricted to Limit Order type, so we can
+            // rest cmd directly with cmd.PriceMantissa.
+            if (phase == TradingPhase.Reserved || phase == TradingPhase.FinalClosingCall)
+            {
+                RestForAuction(cmd, book);
+                return;
+            }
             ExecuteAggressor(cmd, rules, book);
         }
         finally { ExitDispatch(); }
@@ -554,6 +568,53 @@ public sealed class MatchingEngine
 
     private void ExecuteAggressor(NewOrderCommand cmd, InstrumentTradingRules rules, LimitOrderBook book)
         => ExecuteAggressorWithOrderId(cmd, rules, book, _nextOrderId++);
+
+    /// <summary>
+    /// Issue #228 (Onda M · M1): rest the order on the book without any
+    /// continuous-matching attempt. Called only when the instrument is in
+    /// an auction phase (<see cref="TradingPhase.Reserved"/> for opening
+    /// call, <see cref="TradingPhase.FinalClosingCall"/> for closing call).
+    /// Emits the same <see cref="OrderAcceptedEvent"/> that the regular
+    /// rest path emits, so UMDF <c>Order_MBO_50</c> add events are still
+    /// published — consumers see the auction book build up. Iceberg
+    /// (<see cref="NewOrderCommand.MaxFloor"/>) is honored so the visible
+    /// slice on the book matches the continuous-Open semantics from #211.
+    /// </summary>
+    private void RestForAuction(NewOrderCommand cmd, LimitOrderBook book)
+    {
+        long visible = cmd.Quantity;
+        long hidden = 0;
+        if (cmd.MaxFloor != 0 && (long)cmd.MaxFloor < cmd.Quantity)
+        {
+            visible = (long)cmd.MaxFloor;
+            hidden = cmd.Quantity - visible;
+        }
+        var resting = new RestingOrder
+        {
+            OrderId = _nextOrderId++,
+            ClOrdId = cmd.ClOrdId,
+            Side = cmd.Side,
+            PriceMantissa = cmd.PriceMantissa,
+            EnteringFirm = cmd.EnteringFirm,
+            InsertTimestampNanos = cmd.EnteredAtNanos,
+            RemainingQuantity = visible,
+            Tif = cmd.Tif,
+            MaxFloor = (long)cmd.MaxFloor,
+            HiddenQuantity = hidden,
+        };
+        book.Insert(resting);
+        _sink.OnOrderAccepted(new OrderAcceptedEvent(
+            SecurityId: book.SecurityId,
+            OrderId: resting.OrderId,
+            ClOrdId: cmd.ClOrdId,
+            Side: resting.Side,
+            PriceMantissa: resting.PriceMantissa,
+            RemainingQuantity: resting.RemainingQuantity,
+            EnteringFirm: resting.EnteringFirm,
+            InsertTimestampNanos: resting.InsertTimestampNanos,
+            RptSeq: NextRptSeq()));
+    }
+
 
     /// <summary>
     /// True when the order should walk the book ignoring its own price

--- a/tests/B3.Exchange.Matching.Tests/AuctionAccumulationTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/AuctionAccumulationTests.cs
@@ -1,0 +1,105 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #228 (Onda M · M1): in <see cref="TradingPhase.Reserved"/>
+/// (opening call) and <see cref="TradingPhase.FinalClosingCall"/>
+/// (closing call) the engine must accept new orders without running
+/// continuous matching — orders accumulate on the book until an
+/// operator-issued auction uncross (M3) clears them at a single price.
+/// </summary>
+public class AuctionAccumulationTests
+{
+    [Fact]
+    public void GoodForAuction_CrossingPair_DuringReserved_DoesNotTrade()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        sink.Clear();
+
+        // Buy @ 10.05 and Sell @ 10.00 would cross immediately during
+        // continuous Open — during the auction call they must rest in
+        // place and wait for uncrossing.
+        eng.Submit(new NewOrderCommand("buy", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("sell", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6001));
+
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(2, sink.Accepted.Count);
+        Assert.Equal(2, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void AtClose_CrossingPair_DuringFinalClosingCall_DoesNotTrade()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.FinalClosingCall, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("buy", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("sell", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.AtClose, Px(10.00m), 100, 12, 6001));
+
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(2, sink.Accepted.Count);
+        Assert.Equal(2, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void GoodForAuction_RestedOnAuctionBook_TradesOnceTransitionsToOpen()
+    {
+        // Verifies the transition path: orders accumulated in Reserved
+        // remain on the book after SetTradingPhase(Open) and a new
+        // crossing aggressor matches against them via the normal
+        // continuous-matching path. (M3 will replace this implicit
+        // path with an explicit uncrossing call, but M1 must not
+        // break it.)
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("rest", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 11, 6000));
+        Assert.Empty(sink.Trades);
+
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Open, 6500);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("agg", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10.00m), 100, 12, 7000));
+
+        Assert.Single(sink.Trades);
+        Assert.Equal(100, sink.Trades[0].Quantity);
+        Assert.Equal(Px(10.00m), sink.Trades[0].PriceMantissa);
+    }
+
+    [Fact]
+    public void GoodForAuction_Iceberg_RejectedByExistingTifGuard()
+    {
+        // #211 already restricts MaxFloor to Day/Gtc TIFs (an iceberg
+        // resting under GoodForAuction has no replenish opportunity
+        // because the order expires post-uncross). M1 does not relax
+        // that guard. This test pins the behavior so a future change
+        // to iceberg+auction must update both this test and #211.
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        sink.Clear();
+
+        eng.Submit(new NewOrderCommand("ice", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 500, 11, 6000)
+        { MaxFloor = 100 });
+
+        Assert.Single(sink.Rejects);
+        Assert.Empty(sink.Accepted);
+    }
+
+    [Fact]
+    public void OpenPhase_ContinuousMatchingPath_StillTrades()
+    {
+        // Sanity: the M1 branch must not affect the Open phase.
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("rest", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10.00m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("agg", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10.00m), 100, 12, 6001));
+
+        Assert.Single(sink.Trades);
+    }
+}


### PR DESCRIPTION
Implements **M1** of Onda M (auctions). In phases `Reserved` (opening
call) and `FinalClosingCall` (closing call), the matching engine now
accepts new orders without running continuous matching — they rest on
the book and wait for an operator-issued auction uncross (M3). UMDF
`Order_MBO_50` add events are still emitted so consumers see the
auction book build up. Zero `Trade_53` events fire while in an auction
phase.

## What changes

`MatchingEngine.Submit` (post-validation tail): when phase ∈ {Reserved,
FinalClosingCall}, divert to a new `RestForAuction(cmd, book)` helper
instead of `ExecuteAggressor`. The TIF gate (#202/K5) already
guarantees only `GoodForAuction` (in Reserved) and `AtClose` (in
FinalClosingCall) reach this branch, and both are wire-restricted to
`OrderType.Limit`, so we can rest `cmd` directly with its
`PriceMantissa`. Iceberg's existing #211 guard rejects `MaxFloor` for
non-Day/Gtc TIFs, so M1 also doesn't need to handle hidden quantity in
the auction path.

## Tests

`tests/B3.Exchange.Matching.Tests/AuctionAccumulationTests.cs` — 5
tests (all passing, full suite green):

- `GoodForAuction_CrossingPair_DuringReserved_DoesNotTrade` — buy
  10.05 + sell 10.00 in Reserved → both rest, zero trades.
- `AtClose_CrossingPair_DuringFinalClosingCall_DoesNotTrade` — same
  for closing call.
- `GoodForAuction_RestedOnAuctionBook_TradesOnceTransitionsToOpen` —
  resting GFA order survives the `Reserved → Open` transition and a
  fresh Day aggressor in Open matches against it via the normal
  continuous path. (M3 will replace this implicit transition with an
  explicit `UncrossAuction` call; M1 must not break this fallback.)
- `GoodForAuction_Iceberg_RejectedByExistingTifGuard` — pins the
  pre-existing #211 invariant that iceberg is incompatible with
  GoodForAuction.
- `OpenPhase_ContinuousMatchingPath_StillTrades` — sanity for the
  non-auction phase.

## Out of scope (later M phases)

- TOP / `TheoreticalOpeningPrice_16` / `AuctionImbalance_19` (M2 #229).
- Uncrossing algorithm + batched trade emission (M3 #230).
- `OpeningPrice_15` / `ClosingPrice_17` (M4 #231).
- `GoodForAuction` / `AtClose` survivor expiry post-uncross (M5 #232).

Refs #228, #6.
