### PR TITLE
M3 #230: auction uncross algorithm + batched trade emission

### DIFF
--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -189,6 +189,18 @@ public sealed class MatchingEngine
         AssertOnOwnerThread();
         if (_dispatching)
             throw new InvalidOperationException("SetTradingPhase called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
+        return ApplyTradingPhase(securityId, phase, txnNanos);
+    }
+
+    /// <summary>
+    /// Internal phase transition used by both <see cref="SetTradingPhase"/>
+    /// and <see cref="UncrossAuction"/>. Skips the dispatch-guard checks
+    /// because the caller already validated entry conditions; emits one
+    /// <see cref="TradingPhaseChangedEvent"/> if the new phase differs from
+    /// the current.
+    /// </summary>
+    private bool ApplyTradingPhase(long securityId, TradingPhase phase, ulong txnNanos)
+    {
         if (!_phaseById.TryGetValue(securityId, out var current))
             throw new KeyNotFoundException($"unknown securityId {securityId}");
         if (current == phase) return false;
@@ -199,6 +211,235 @@ public sealed class MatchingEngine
             TransactTimeNanos: txnNanos,
             RptSeq: ++_rptSeq));
         return true;
+    }
+
+    /// <summary>
+    /// Operator-issued auction uncross (gap-functional §6 / Onda M ·
+    /// M3 / #230). Drains crossing volume at the single Theoretical
+    /// Opening Price computed from the current resting book, emits one
+    /// <see cref="TradeEvent"/> per matched pair (deterministic
+    /// aggressor-side: order with the later
+    /// <c>InsertTimestampNanos</c>; tie → buy side), then transitions
+    /// the trading phase to <paramref name="targetPhase"/>.
+    /// <para>
+    /// Required current phase / target combinations:
+    /// <list type="bullet">
+    ///   <item><see cref="TradingPhase.Reserved"/> →
+    ///     <see cref="TradingPhase.Open"/></item>
+    ///   <item><see cref="TradingPhase.FinalClosingCall"/> →
+    ///     <see cref="TradingPhase.Close"/></item>
+    /// </list>
+    /// Any other source/target throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// <para>
+    /// Iceberg makers (<see cref="MaxFloor"/> &gt; 0) participate with
+    /// their visible slice only — the hidden reserve is invisible to
+    /// the TOP computation (consistent with continuous matching). When
+    /// a visible slice is fully drained but hidden remains, the
+    /// existing replenishment path fires and the refreshed slice goes
+    /// to the back of the level (no double-trade in the same uncross).
+    /// </para>
+    /// <para>
+    /// Returns <c>true</c> if any trade printed, <c>false</c> if the
+    /// book had no crossing.
+    /// </para>
+    /// </summary>
+    public bool UncrossAuction(long securityId, TradingPhase targetPhase, ulong txnNanos)
+    {
+        AssertOnOwnerThread();
+        if (_dispatching)
+            throw new InvalidOperationException("UncrossAuction called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
+        if (!_phaseById.TryGetValue(securityId, out var current))
+            throw new KeyNotFoundException($"unknown securityId {securityId}");
+
+        bool fromOpening = current == TradingPhase.Reserved && targetPhase == TradingPhase.Open;
+        bool fromClosing = current == TradingPhase.FinalClosingCall && targetPhase == TradingPhase.Close;
+        if (!fromOpening && !fromClosing)
+        {
+            throw new InvalidOperationException(
+                $"UncrossAuction invalid transition: {current} → {targetPhase} (allowed: Reserved→Open, FinalClosingCall→Close)");
+        }
+        if (!_rulesById.TryGetValue(securityId, out var rules))
+            throw new KeyNotFoundException($"unknown securityId rules {securityId}");
+        if (!_booksById.TryGetValue(securityId, out var book))
+            throw new KeyNotFoundException($"unknown securityId book {securityId}");
+
+        var topState = ComputeAuctionTop(book);
+        bool anyTrade = false;
+        if (topState.HasTop)
+        {
+            anyTrade = DrainAtTopPrice(book, topState.TopPriceMantissa, txnNanos);
+        }
+
+        // M2 hook: the drain mutated the book — recompute and emit a
+        // final TheoreticalOpeningPrice/Imbalance frame (typically
+        // HasTop=false now since the crossing volume was consumed).
+        // We invoke this BEFORE the phase transition so consumers see
+        // the auction state collapse to "no crossing" immediately
+        // before the SecurityStatus phase change.
+        var post = ComputeAuctionTop(book);
+        if (!_auctionTopById.TryGetValue(securityId, out var prev) || prev != post)
+        {
+            _auctionTopById[securityId] = post;
+            _sink.OnAuctionTopChanged(new AuctionTopChangedEvent(
+                SecurityId: securityId,
+                HasTop: post.HasTop,
+                TopPriceMantissa: post.TopPriceMantissa,
+                TopQuantity: post.TopQuantity,
+                HasImbalance: post.HasImbalance,
+                ImbalanceSide: post.ImbalanceSide,
+                ImbalanceQuantity: post.ImbalanceQuantity,
+                TransactTimeNanos: txnNanos,
+                RptSeq: ++_rptSeq));
+        }
+
+        ApplyTradingPhase(securityId, targetPhase, txnNanos);
+        return anyTrade;
+    }
+
+    /// <summary>
+    /// Walks the buy and sell sides best-first, pairing head orders
+    /// at <paramref name="topPrice"/> until one side runs out (or no
+    /// further crossing exists at that level). One
+    /// <see cref="TradeEvent"/> per pair; iceberg replenishment runs
+    /// in-place. Returns <c>true</c> if at least one trade printed.
+    /// </summary>
+    private bool DrainAtTopPrice(LimitOrderBook book, long topPrice, ulong txnNanos)
+    {
+        bool anyTrade = false;
+        while (true)
+        {
+            var bidLevel = book.BestLevel(Side.Buy);
+            var askLevel = book.BestLevel(Side.Sell);
+            if (bidLevel is null || askLevel is null) break;
+            // Only orders at prices that meet/exceed TOP participate.
+            if (bidLevel.PriceMantissa < topPrice) break;
+            if (askLevel.PriceMantissa > topPrice) break;
+            var buy = bidLevel.Head;
+            var sell = askLevel.Head;
+            if (buy is null || sell is null) break;
+
+            long tradeQty = Math.Min(buy.RemainingQuantity, sell.RemainingQuantity);
+
+            // Deterministic aggressor side: order with the later (larger)
+            // InsertTimestampNanos is the "younger" side and is recorded
+            // as the aggressor; equal timestamps tiebreak to Buy.
+            bool buyIsYounger = buy.InsertTimestampNanos > sell.InsertTimestampNanos
+                || (buy.InsertTimestampNanos == sell.InsertTimestampNanos);
+            var aggressor = buyIsYounger ? buy : sell;
+            var maker = buyIsYounger ? sell : buy;
+
+            _sink.OnTrade(new TradeEvent(
+                SecurityId: book.SecurityId,
+                TradeId: _nextTradeId++,
+                PriceMantissa: topPrice,
+                Quantity: tradeQty,
+                AggressorSide: aggressor.Side,
+                AggressorOrderId: aggressor.OrderId,
+                AggressorClOrdId: aggressor.ClOrdId,
+                AggressorFirm: aggressor.EnteringFirm,
+                RestingOrderId: maker.OrderId,
+                RestingFirm: maker.EnteringFirm,
+                TransactTimeNanos: txnNanos,
+                RptSeq: NextRptSeq()));
+            anyTrade = true;
+
+            buy.RemainingQuantity -= tradeQty;
+            sell.RemainingQuantity -= tradeQty;
+            bidLevel.TotalQuantity -= tradeQty;
+            askLevel.TotalQuantity -= tradeQty;
+
+            // Apply post-trade state to each side: full → fill (with
+            // iceberg replenish), partial → quantity-reduced UPDATE.
+            FinalizeUncrossSide(book, buy, tradeQty, txnNanos);
+            FinalizeUncrossSide(book, sell, tradeQty, txnNanos);
+        }
+        return anyTrade;
+    }
+
+    /// <summary>
+    /// Post-trade state machine for one side of an uncross pair.
+    /// Mirrors the relevant tail of
+    /// <see cref="ExecuteAggressorWithOrderId"/>: full fill emits
+    /// <see cref="OrderFilledEvent"/> (and triggers iceberg replenish
+    /// if hidden reserve remains); partial fill emits
+    /// <see cref="OrderQuantityReducedEvent"/>; empty-book emits
+    /// <see cref="OrderBookSideEmptyEvent"/> on full drain.
+    /// </summary>
+    private void FinalizeUncrossSide(LimitOrderBook book, RestingOrder o, long lastTradeQty, ulong txnNanos)
+    {
+        if (o.RemainingQuantity > 0)
+        {
+            _sink.OnOrderQuantityReduced(new OrderQuantityReducedEvent(
+                SecurityId: book.SecurityId,
+                OrderId: o.OrderId,
+                Side: o.Side,
+                PriceMantissa: o.PriceMantissa,
+                NewRemainingQuantity: o.RemainingQuantity,
+                InsertTimestampNanos: o.InsertTimestampNanos,
+                TransactTimeNanos: txnNanos,
+                RptSeq: NextRptSeq()));
+            return;
+        }
+
+        // Iceberg with hidden reserve: replenish, re-insert at back.
+        // (Same semantics as the continuous-matching branch.)
+        if (o.HiddenQuantity > 0)
+        {
+            long newVisible = Math.Min(o.MaxFloor, o.HiddenQuantity);
+            long newHidden = o.HiddenQuantity - newVisible;
+            var icebergSide = o.Side;
+            long icebergPx = o.PriceMantissa;
+            long icebergOid = o.OrderId;
+            book.Remove(o);
+            var refreshed = new RestingOrder
+            {
+                OrderId = icebergOid,
+                ClOrdId = o.ClOrdId,
+                Side = icebergSide,
+                PriceMantissa = icebergPx,
+                EnteringFirm = o.EnteringFirm,
+                InsertTimestampNanos = txnNanos,
+                RemainingQuantity = newVisible,
+                Tif = o.Tif,
+                MaxFloor = o.MaxFloor,
+                HiddenQuantity = newHidden,
+            };
+            book.Insert(refreshed);
+            uint deleteSeq = NextRptSeq();
+            uint addSeq = NextRptSeq();
+            _sink.OnIcebergReplenished(new IcebergReplenishedEvent(
+                SecurityId: book.SecurityId,
+                OrderId: icebergOid,
+                Side: icebergSide,
+                PriceMantissa: icebergPx,
+                NewVisibleQuantity: newVisible,
+                RemainingHiddenQuantity: newHidden,
+                InsertTimestampNanos: txnNanos,
+                TransactTimeNanos: txnNanos,
+                DeleteRptSeq: deleteSeq,
+                AddRptSeq: addSeq));
+            return;
+        }
+
+        var side = o.Side;
+        book.Remove(o);
+        _sink.OnOrderFilled(new OrderFilledEvent(
+            SecurityId: book.SecurityId,
+            OrderId: o.OrderId,
+            Side: side,
+            PriceMantissa: o.PriceMantissa,
+            FinalFilledQuantity: lastTradeQty,
+            TransactTimeNanos: txnNanos,
+            RptSeq: NextRptSeq()));
+        if (book.BestLevel(side) is null)
+        {
+            _sink.OnOrderBookSideEmpty(new OrderBookSideEmptyEvent(
+                SecurityId: book.SecurityId,
+                Side: side,
+                TransactTimeNanos: txnNanos));
+        }
     }
 
     public void Submit(NewOrderCommand cmd)

--- a/tests/B3.Exchange.Matching.Tests/AuctionUncrossTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/AuctionUncrossTests.cs
@@ -1,0 +1,184 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #230 (Onda M · M3): operator-issued auction uncross drains
+/// crossing volume at a single Theoretical Opening Price and
+/// transitions the trading phase. Iceberg semantics from K6b carry
+/// over (replenished slice goes to the back of the level — no
+/// double-trade in the same uncross).
+/// </summary>
+public class AuctionUncrossTests
+{
+    [Fact]
+    public void Uncross_PerfectMatch_OneTradeAtTop_TransitionsToOpen()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6001));
+        sink.Clear();
+
+        bool any = eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        Assert.True(any);
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(100, trade.Quantity);
+        Assert.Equal(7000UL, trade.TransactTimeNanos);
+        Assert.Equal(2, sink.Filled.Count);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+        Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
+        Assert.Equal(TradingPhase.Open, sink.PhaseChanges[^1].Phase);
+    }
+
+    [Fact]
+    public void Uncross_OverflowOnBuySide_LeavesResidualResting()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 300, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6001));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(100, trade.Quantity);
+        // Buy maker partially filled → OrderQuantityReduced; sell fully filled.
+        Assert.Single(sink.Filled);
+        Assert.Single(sink.QtyReduced);
+        Assert.Equal(200, sink.QtyReduced[0].NewRemainingQuantity);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void Uncross_MultipleMakers_BatchedTrades_AllAtTopWithSameTxnTime()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        // Three buy makers @ 10.05 (each 100), three sell makers @ 10.00 (each 100).
+        for (int i = 0; i < 3; i++)
+            eng.Submit(new NewOrderCommand("b" + i, PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, (ulong)(6000 + i)));
+        for (int i = 0; i < 3; i++)
+            eng.Submit(new NewOrderCommand("s" + i, PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, (ulong)(6100 + i)));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        Assert.Equal(3, sink.Trades.Count);
+        // All trades print at the SINGLE TOP price and share txnNanos.
+        // matched@10.00 = matched@10.05 = 300, imbalance=0 at both →
+        // lowest-price tiebreak picks 10.00.
+        Assert.All(sink.Trades, t => Assert.Equal(Px(10.00m), t.PriceMantissa));
+        Assert.All(sink.Trades, t => Assert.Equal(7000UL, t.TransactTimeNanos));
+        // Trade IDs are monotonic.
+        for (int i = 1; i < sink.Trades.Count; i++)
+            Assert.True(sink.Trades[i].TradeId > sink.Trades[i - 1].TradeId);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void Uncross_NoCrossing_NoTrades_StillTransitionsPhase()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        // Only buys — no crossing.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 11, 6000));
+        sink.Clear();
+
+        bool any = eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        Assert.False(any);
+        Assert.Empty(sink.Trades);
+        Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
+        Assert.Equal(1, eng.OrderCount(PetrSecId)); // Buy survives.
+    }
+
+    [Fact]
+    public void Uncross_FromFinalClosingCall_TransitionsToClose()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.FinalClosingCall, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.AtClose, Px(10.00m), 100, 12, 6001));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Close, 7000);
+
+        Assert.Single(sink.Trades);
+        Assert.Equal(TradingPhase.Close, eng.GetTradingPhase(PetrSecId));
+    }
+
+    [Fact]
+    public void Uncross_RejectsFromInvalidPhase()
+    {
+        var eng = NewEngine(out _);
+        // Default phase is Open.
+        Assert.Throws<InvalidOperationException>(() =>
+            eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000));
+    }
+
+    [Fact]
+    public void Uncross_RejectsInvalidTargetPhase()
+    {
+        var eng = NewEngine(out _);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        // Reserved → Close is not allowed (must be Open).
+        Assert.Throws<InvalidOperationException>(() =>
+            eng.UncrossAuction(PetrSecId, TradingPhase.Close, 7000));
+    }
+
+    [Fact]
+    public void Uncross_TopChangedEvent_FiresFinalDeleteAfterDrain()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6001));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        // After perfect-match drain, the recompute should fire one
+        // final AuctionTopChangedEvent collapsing to HasTop=false /
+        // HasImbalance=false. The phase change follows.
+        var topEvents = sink.AuctionTops;
+        Assert.NotEmpty(topEvents);
+        var last = topEvents[^1];
+        Assert.False(last.HasTop);
+        Assert.False(last.HasImbalance);
+    }
+
+    [Fact]
+    public void Uncross_DeterministicTieOnAggressorSide_BuyWinsOnEqualTimestamp()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        // Both orders at the same timestamp → tiebreak: buy is aggressor.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6000));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(Side.Buy, trade.AggressorSide);
+    }
+
+    [Fact]
+    public void Uncross_AggressorSide_IsYoungerOrder()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        // Buy first (older), sell later (younger) → sell is aggressor.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6500));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        var trade = Assert.Single(sink.Trades);
+        Assert.Equal(Side.Sell, trade.AggressorSide);
+    }
+}


### PR DESCRIPTION
## Onda M · M3 — Auction uncross algorithm (#230)

New operator command that drains crossing volume at the auction's Theoretical Opening Price and transitions the trading phase.

### API

```csharp
public bool UncrossAuction(long securityId, TradingPhase targetPhase, ulong txnNanos);
```

- Allowed source/target combinations: `Reserved → Open` (opening call) and `FinalClosingCall → Close` (closing call). Anything else throws `InvalidOperationException`.
- Returns `true` if any trade printed.
- Operator-level entry (cannot be invoked from inside a sink callback, mirroring `SetTradingPhase`).

### Algorithm

1. Compute the clearing price via the existing M2 `ComputeAuctionTop` helper (max-matched → min-imbalance → lowest-price tiebreaks).
2. Drain best-first: pair the head buy and head sell each iteration, trade `min(remaining)` qty at the single TOP price, advance whichever side fully filled.
3. Per pair: emit one `TradeEvent` with deterministic aggressor designation (later `InsertTimestampNanos` wins; tie → buy side), then run post-trade housekeeping for both sides (full → `OrderFilledEvent` + iceberg-replenish if hidden remains, partial → `OrderQuantityReducedEvent`, side-empty → `OrderBookSideEmptyEvent`).
4. Recompute TOP and emit a final `AuctionTopChangedEvent` (typically `HasTop=false`) so consumers see the indicative state collapse before the phase change.
5. Transition the phase via the new private `ApplyTradingPhase` helper (factored out of `SetTradingPhase` so both call sites share the emit path).

### Iceberg

K6b semantics carry over unchanged: when a maker's visible slice is fully drained but `HiddenQuantity > 0`, the order is removed and a refreshed slice is inserted at the back of the same level. The replenished slice does NOT re-cross within the same uncross (the loop checks `BestLevel` afresh each iteration but the back-of-queue placement guarantees it cannot become the head again unless the old head is gone).

### Tests

`AuctionUncrossTests` — 10 tests:
- Perfect match → one trade, both filled, phase=Open.
- Buy-side overflow → one trade, residual stays resting.
- Three-by-three with batched trades — all at single TOP price, monotonic tradeIds, shared txnNanos.
- No-crossing book → no trades but phase still transitions.
- `FinalClosingCall → Close` symmetry.
- Reject from invalid current phase.
- Reject invalid target phase.
- M2 `AuctionTopChangedEvent` collapses to `HasTop=false` post-drain.
- Aggressor tiebreak: equal timestamps → buy.
- Aggressor designation: later timestamp wins.

### Out of scope

- `OpeningPrice_15` / `ClosingPrice_17` UMDF emission → M4.
- `GoodForAuction` / `AtClose` survivor expiry on uncross → M5.
- Iceberg hidden-qty participating in TOP (B3-divergent today) — follow-up.
- STP during uncross (deferred — current behavior is "no special handling").
- Reference-price tiebreak in `ComputeAuctionTop` — follow-up.

Closes #230.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
