### PR TITLE
Accept FIXP NewOrderSingle/CancelReplace V6 from EPC 0.8.0 (#236)

### DIFF
--- a/src/B3.EntryPoint.Wire/EntryPointFrameReader.cs
+++ b/src/B3.EntryPoint.Wire/EntryPointFrameReader.cs
@@ -102,10 +102,14 @@ public static class EntryPointFrameReader
     public static int ExpectedInboundBlockLength(ushort templateId, ushort version) => (templateId, version) switch
     {
         (TidSimpleNewOrder, 2) => 82,            // SimpleNewOrderV2.MESSAGE_SIZE
+        (TidSimpleNewOrder, 6) => 82,            // SimpleNewOrder root V6 (no schema delta vs V2; SDK 0.8.0 stamps version=6). #236
         (TidSimpleModifyOrder, 2) => 98,         // SimpleModifyOrderV2.MESSAGE_SIZE
+        (TidSimpleModifyOrder, 6) => 98,         // SimpleModifyOrder root V6 (no schema delta vs V2). #236
         (TidNewOrderSingle, 2) => 125,           // NewOrderSingleV2.MESSAGE_SIZE
+        (TidNewOrderSingle, 6) => 133,           // NewOrderSingle root V6 (+strategyID@125, +tradingSubAccount@129). Decoder ignores trailing fields. #236
         (TidNewOrderCross, 6) => 84,             // NewOrderCross.MESSAGE_SIZE (root V6, group + varData follow)
         (TidOrderCancelReplaceRequest, 2) => 142, // OrderCancelReplaceRequestV2.MESSAGE_SIZE
+        (TidOrderCancelReplaceRequest, 6) => 150, // OrderCancelReplaceRequest root V6 (+strategyID@142, +tradingSubAccount@146). Decoder ignores trailing fields. #236
         (TidOrderCancelRequest, 0) => 76,        // OrderCancelRequest.MESSAGE_SIZE (V6 base)
         (TidOrderMassActionRequest, 6) => 52,    // OrderMassActionRequestData.MESSAGE_SIZE (V6 base, no varData)
         (TidSequence, 0) => 4,                   // Sequence: nextSeqNo (uint32). messageType is constant.

--- a/tests/B3.Exchange.Gateway.Tests/V6TemplateAcceptanceTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/V6TemplateAcceptanceTests.cs
@@ -1,0 +1,140 @@
+using System.Buffers.Binary;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// #236: B3.EntryPoint.Client 0.8.0 stamps inbound business templates
+/// with schema version=6 (the schema's root version) — including
+/// templates whose root V6 size differs from V2 only by appended
+/// optional fields (NewOrderSingle: +strategyID, +tradingSubAccount;
+/// OrderCancelReplaceRequest: same +8). Previously the header parser
+/// only knew (102, 2)/(104, 2)/(100, 2)/(101, 2), so every business
+/// message from EPC 0.8.0 was rejected as UnsupportedTemplate →
+/// DECODING_ERROR Terminate.
+///
+/// The decoder reads only V2-stable offsets, so accepting V6 bodies
+/// is a forward-compatible no-op for the engine. These tests pin the
+/// new acceptance table entries and prove a 133-byte V6 NewOrderSingle
+/// body decodes through <see cref="InboundMessageDecoder"/> with the
+/// trailing strategyID/tradingSubAccount silently ignored.
+///
+/// Native V6 decoding (mapping strategyID/tradingSubAccount into the
+/// engine command) is tracked as a follow-up — see issue body for
+/// the migration plan.
+/// </summary>
+public class V6TemplateAcceptanceTests
+{
+    [Theory]
+    [InlineData(EntryPointFrameReader.TidNewOrderSingle, 2, 125)]
+    [InlineData(EntryPointFrameReader.TidNewOrderSingle, 6, 133)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelReplaceRequest, 2, 142)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelReplaceRequest, 6, 150)]
+    [InlineData(EntryPointFrameReader.TidSimpleNewOrder, 2, 82)]
+    [InlineData(EntryPointFrameReader.TidSimpleNewOrder, 6, 82)]
+    [InlineData(EntryPointFrameReader.TidSimpleModifyOrder, 2, 98)]
+    [InlineData(EntryPointFrameReader.TidSimpleModifyOrder, 6, 98)]
+    public void HeaderParser_AcceptsV2AndV6BlockLengths(ushort templateId, ushort version, int expectedBlockLength)
+    {
+        Assert.Equal(expectedBlockLength, EntryPointFrameReader.ExpectedInboundBlockLength(templateId, version));
+    }
+
+    [Fact]
+    public void HeaderParser_RejectsUnknownVersion()
+    {
+        Assert.Equal(-1, EntryPointFrameReader.ExpectedInboundBlockLength(
+            EntryPointFrameReader.TidNewOrderSingle, version: 99));
+    }
+
+    /// <summary>
+    /// Builds a 133-byte V6 NewOrderSingle body (V2 fixed fields plus
+    /// the appended strategyID@125 + tradingSubAccount@129) and asserts
+    /// the decoder produces a clean <see cref="NewOrderCommand"/>,
+    /// silently ignoring the trailing fields.
+    /// </summary>
+    [Fact]
+    public void V6NewOrderSingleBody_DecodesAsV2_AppendedFieldsIgnored()
+    {
+        var body = BuildV6NewOrderSingleBody(
+            clOrdId: 7777,
+            secId: 123_456,
+            sideBuy: true,
+            qty: 100,
+            priceMantissa: 105_000,
+            strategyId: 99,
+            tradingSubAccount: 88);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, enteringFirm: 1, enteredAtNanos: 0,
+            out var cmd, out var clOrdIdValue, out var message);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(message);
+        Assert.Equal(7777UL, clOrdIdValue);
+        Assert.Equal(123_456L, cmd.SecurityId);
+        Assert.Equal(Side.Buy, cmd.Side);
+        Assert.Equal(OrderType.Limit, cmd.Type);
+        Assert.Equal(100L, cmd.Quantity);
+        Assert.Equal(105_000L, cmd.PriceMantissa);
+    }
+
+    /// <summary>
+    /// Same body trimmed to 125 bytes (V2 layout) must keep decoding
+    /// identically — V2 clients are still supported.
+    /// </summary>
+    [Fact]
+    public void V2NewOrderSingleBody_StillDecodes()
+    {
+        var v6 = BuildV6NewOrderSingleBody(
+            clOrdId: 4242, secId: 999, sideBuy: false, qty: 50,
+            priceMantissa: 200_000, strategyId: 0, tradingSubAccount: 0);
+        var v2 = v6.AsSpan(0, 125).ToArray();
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            v2, enteringFirm: 1, enteredAtNanos: 0,
+            out var cmd, out var clOrdIdValue, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(4242UL, clOrdIdValue);
+        Assert.Equal(999L, cmd.SecurityId);
+        Assert.Equal(Side.Sell, cmd.Side);
+        Assert.Equal(50L, cmd.Quantity);
+    }
+
+    private static byte[] BuildV6NewOrderSingleBody(
+        ulong clOrdId, long secId, bool sideBuy, ulong qty, long priceMantissa,
+        int strategyId, uint tradingSubAccount)
+    {
+        // Layout matches NewOrderSingleOffsets in
+        // InboundMessageDecoder.NewOrderSingle.cs. V6 root MESSAGE_SIZE = 133.
+        var body = new byte[133];
+
+        // BusinessHeader (16 bytes) — sendingTime(8) + msgSeqNum(4) + possRetransFlag(1) + pad(3)
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(0, 8), 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(8, 4), 1);
+        body[12] = 0;
+
+        body[19] = 0; // MmProtectionReset
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(20, 8), clOrdId);
+        // Account@28..SecurityID@48 zero-fill is fine (not read).
+        body[47] = 0; // Stp
+        BinaryPrimitives.WriteInt64LittleEndian(body.AsSpan(48, 8), secId);
+        body[56] = sideBuy ? (byte)'1' : (byte)'2';                                            // Side ASCII
+        body[57] = (byte)'2';                                                                  // OrdType = Limit (ASCII)
+        body[58] = (byte)'0';                                                                  // TimeInForce = Day (ASCII)
+        body[59] = 255;                                                                        // RoutingInstruction null
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(60, 8), qty);                     // OrderQty
+        BinaryPrimitives.WriteInt64LittleEndian(body.AsSpan(68, 8), priceMantissa);            // PriceMantissa
+        BinaryPrimitives.WriteInt64LittleEndian(body.AsSpan(76, 8), long.MinValue);            // StopPxMantissa null
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(84, 8), 0);                       // MinQty
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(92, 8), 0);                       // MaxFloor
+        BinaryPrimitives.WriteUInt16LittleEndian(body.AsSpan(105, 2), 0);                      // ExpireDate null
+
+        // V6-appended fields (offsets 125, 129) — must be tolerated.
+        BinaryPrimitives.WriteInt32LittleEndian(body.AsSpan(125, 4), strategyId);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(129, 4), tradingSubAccount);
+
+        return body;
+    }
+}


### PR DESCRIPTION
Closes #236.

## Problem

A partner using `B3.EntryPoint.Client 0.8.0` (downstream `B3TradingPlatform slice/integration-real-stack-v2`) reports that every business message after FIXP Establish is rejected and the session is terminated with code 15 (`UnrecognizedMessage`).

Server log on the issue:
```
inbound decode error from session conn-: unsupported template=102 version=6
decode-error:UnsupportedTemplate
```

## Root cause

`EntryPointFrameReader.ExpectedInboundBlockLength` only registered `(102, 2)`, `(104, 2)`, `(100, 2)`, `(101, 2)`. EPC 0.8.0 stamps the schema's root version (`version=6`), so the header parser returns -1 → `UnsupportedTemplate` → `DECODING_ERROR` Terminate.

## V2 → V6 schema diff (verified against generated SBE)

| Template | V2 size | V6 size | Delta |
|----------|---------|---------|-------|
| `NewOrderSingle` (102) | 125 | 133 | +`strategyID`@125 (int), +`tradingSubAccount`@129 (uint) |
| `OrderCancelReplaceRequest` (104) | 142 | 150 | +`strategyID`@142, +`tradingSubAccount`@146 |
| `SimpleNewOrder` (100) | 82 | 82 | no schema change |
| `SimpleModifyOrder` (101) | 98 | 98 | no schema change |

The existing `InboundMessageDecoder.NewOrderSingle/.OrderCancelReplace` paths read only V2-stable offsets (max `ExpireDate@105` for `NewOrderSingle`, `ExpireDate@122` for CRR). Accepting a longer V6 body is a forward-compatible no-op: the trailing `strategyID`/`tradingSubAccount` are silently ignored.

## Fix

Mini change to `ExpectedInboundBlockLength`: add 4 new `(templateId, 6)` entries with the correct V6 sizes. No decoder changes.

## Tests

`tests/B3.Exchange.Gateway.Tests/V6TemplateAcceptanceTests.cs`:

- `HeaderParser_AcceptsV2AndV6BlockLengths` — pins the table for all 8 `(template, version)` combos.
- `HeaderParser_RejectsUnknownVersion` — sentinel for unrelated versions still returns -1.
- `V6NewOrderSingleBody_DecodesAsV2_AppendedFieldsIgnored` — feeds a 133-byte V6 body (with `strategyID`/`tradingSubAccount` populated at offsets 125/129) through `InboundMessageDecoder.TryDecodeNewOrderSingle` and asserts a clean `Success` outcome with the V2-stable fields parsed correctly.
- `V2NewOrderSingleBody_StillDecodes` — same body trimmed to 125 bytes still decodes; legacy V2 clients keep working.

Full suite green: 763+ tests pass. `dotnet format --verify-no-changes` clean.

## Follow-up

Tracked as a separate issue (linked below): native V6 decoding — map `strategyID`/`tradingSubAccount` into `NewOrderCommand`, review every other inbound template's schema-version policy, and decide whether to migrate `NewOrderSingle`/`OrderCancelReplaceRequest` to V6 base (the rest of the codebase — `NewOrderCross`, `OrderCancelRequest`, `OrderMassActionRequest`, all outbound ER — is already V6 base).
