### PR TITLE
Accept V6 varData spec + honor Establish.NextSeqNo (#239)

### DIFF
--- a/src/B3.EntryPoint.Wire/EntryPointVarData.cs
+++ b/src/B3.EntryPoint.Wire/EntryPointVarData.cs
@@ -52,9 +52,13 @@ public static class EntryPointVarData
     public static ReadOnlySpan<Field> ExpectedFor(ushort templateId, ushort version) => (templateId, version) switch
     {
         (EntryPointFrameReader.TidSimpleNewOrder, 2) => SimpleNewOrderFields,
+        (EntryPointFrameReader.TidSimpleNewOrder, 6) => SimpleNewOrderFields,                           // #239
         (EntryPointFrameReader.TidSimpleModifyOrder, 2) => SimpleModifyOrderFields,
+        (EntryPointFrameReader.TidSimpleModifyOrder, 6) => SimpleModifyOrderFields,                     // #239
         (EntryPointFrameReader.TidNewOrderSingle, 2) => NewOrderSingleFields,
+        (EntryPointFrameReader.TidNewOrderSingle, 6) => NewOrderSingleFields,                           // #239: EPC 0.8.0 stamps version=6
         (EntryPointFrameReader.TidOrderCancelReplaceRequest, 2) => OrderCancelReplaceFields,
+        (EntryPointFrameReader.TidOrderCancelReplaceRequest, 6) => OrderCancelReplaceFields,            // #239
         (EntryPointFrameReader.TidOrderCancelRequest, 0) => OrderCancelFields,
         (EntryPointFrameReader.TidNegotiate, 0) => NegotiateFields,
         (EntryPointFrameReader.TidEstablish, 0) => EstablishFields,

--- a/src/B3.Exchange.Gateway/FixpSession.Establish.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Establish.cs
@@ -83,6 +83,11 @@ public sealed partial class FixpSession
             }
             KeepAliveIntervalMs = (long)req.KeepAliveIntervalMillis;
             ApplyCodEstablishParams(in req);
+            // #239: honor peer-declared starting sequence (FIXP §4.5.3).
+            // EPC 0.8.0 may carry over a non-1 NextSeqNo across reconnects;
+            // rebase so the first inbound at NextSeqNo passes the in-order
+            // gap check instead of triggering NotApplied(1, NextSeqNo-1).
+            RebaseLastIncomingSeqNoFromEstablish(req.NextSeqNo);
             var ackFrame = new byte[EstablishAckEncoder.Total];
             EstablishAckEncoder.Encode(ackFrame, req.SessionId, req.SessionVerId,
                 req.TimestampNanos, req.KeepAliveIntervalMillis,
@@ -124,6 +129,8 @@ public sealed partial class FixpSession
 
         KeepAliveIntervalMs = (long)req.KeepAliveIntervalMillis;
         ApplyCodEstablishParams(in req);
+        // #239: honor peer-declared starting sequence (FIXP §4.5.3).
+        RebaseLastIncomingSeqNoFromEstablish(req.NextSeqNo);
         var ack = new byte[EstablishAckEncoder.Total];
         EstablishAckEncoder.Encode(ack, req.SessionId, req.SessionVerId,
             req.TimestampNanos, req.KeepAliveIntervalMillis,
@@ -166,5 +173,29 @@ public sealed partial class FixpSession
         await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.Unspecified,
             step.LogReason).ConfigureAwait(false);
         return false;
+    }
+
+    /// <summary>
+    /// #239: applies the FIXP §4.5.3 rule that a peer's Establish
+    /// declares the next inbound business <c>MsgSeqNum</c> it will
+    /// send. We rebase <see cref="LastIncomingSeqNo"/> to
+    /// <c>NextSeqNo - 1</c> so the in-order check in
+    /// <see cref="TryAcceptBusinessHeaderMsgSeqNum"/> treats the very
+    /// first business message at <c>NextSeqNo</c> as in-order rather
+    /// than emitting <c>NotApplied(1, NextSeqNo - 1)</c>. Skipped when
+    /// <paramref name="peerNextSeqNo"/> is 0 (validator already
+    /// rejected) or 1 (default; nothing to rebase).
+    ///
+    /// This matches the EPC 0.8.0 client behaviour: it carries an
+    /// SDK-internal seq counter across reconnects and signals the
+    /// continuation point on Establish, instead of restarting from 1.
+    /// </summary>
+    private void RebaseLastIncomingSeqNoFromEstablish(uint peerNextSeqNo)
+    {
+        if (peerNextSeqNo <= 1) return;
+        if (peerNextSeqNo - 1 > LastIncomingSeqNo)
+        {
+            LastIncomingSeqNo = peerNextSeqNo - 1;
+        }
     }
 }

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -130,8 +130,12 @@ public sealed partial class FixpSession : IAsyncDisposable
     /// <summary>Highest inbound application <c>MsgSeqNum</c> accepted on
     /// this session. Zero until the first inbound application message is
     /// processed. Used to populate <c>EstablishAck.lastIncomingSeqNo</c>
-    /// and to compute <c>EstablishReject.lastIncomingSeqNo</c>.</summary>
-    public uint LastIncomingSeqNo { get; private set; }
+    /// and to compute <c>EstablishReject.lastIncomingSeqNo</c>.
+    ///
+    /// Setter is <c>internal</c> so <see cref="ProcessEstablish"/> can
+    /// rebase it to <c>req.NextSeqNo - 1</c> when the peer signals a
+    /// non-1 starting sequence (issue #239 / FIXP §4.5.3).</summary>
+    public uint LastIncomingSeqNo { get; internal set; }
     /// <summary>Stable, transport-neutral identity of this session as seen
     /// by Core / Contracts. Routing key the Gateway uses to resolve
     /// outbound ExecutionReports back to this <see cref="FixpSession"/>.

--- a/tests/B3.Exchange.Gateway.Tests/EstablishNextSeqNoRebaseTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishNextSeqNoRebaseTests.cs
@@ -1,0 +1,159 @@
+using B3.Exchange.Contracts;
+using B3.EntryPoint.Wire;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// #239 (sub-issue 2): the gateway used to ignore peer-declared
+/// <c>Establish.NextSeqNo</c>, treating every fresh session as
+/// "expecting MsgSeqNum=1". B3.EntryPoint.Client 0.8.0 carries an
+/// SDK-internal seq counter across reconnects (e.g. NextSeqNo=15
+/// on the first business send), which made the gateway emit a
+/// <c>NotApplied(1, 14)</c> followed by — historically — closing
+/// the session.
+///
+/// FIXP §4.5.3: <c>Establish.NextSeqNo</c> is the next inbound
+/// business <c>MsgSeqNum</c> the peer will send. After acceptance,
+/// the gateway MUST rebase its expected-next counter so the very
+/// first business message at <c>NextSeqNo</c> is in-order.
+/// </summary>
+public class EstablishNextSeqNoRebaseTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue) => true;
+        public bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm) => true;
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm) => true;
+        public void OnDecodeError(SessionId session, string error) { }
+        public void OnSessionClosed(SessionId session) { }
+    }
+
+    private static async Task<(NetworkStream serverSide, TcpClient client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        tcp.Stop();
+        return (new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static byte[] BuildBody(uint headerSessionId, uint headerMsgSeqNum, int totalLen)
+    {
+        var body = new byte[totalLen];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), headerSessionId);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(4, 4), headerMsgSeqNum);
+        return body;
+    }
+
+    private static FixpSession NewStartedSession(NetworkStream server)
+    {
+        var session = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: server, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance);
+        session.Start();
+        session.ApplyTransition(FixpEvent.Negotiate);
+        session.ApplyTransition(FixpEvent.Establish);
+        return session;
+    }
+
+    private static async Task<byte[]?> TryReadFrameAsync(NetworkStream ns, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var head = new byte[EntryPointFrameReader.WireHeaderSize];
+        try
+        {
+            int read = 0;
+            while (read < head.Length)
+            {
+                int n = await ns.ReadAsync(head.AsMemory(read), cts.Token);
+                if (n <= 0) return null;
+                read += n;
+            }
+            ushort msgLen = BinaryPrimitives.ReadUInt16LittleEndian(head.AsSpan(0, 2));
+            int bodyLen = msgLen - EntryPointFrameReader.WireHeaderSize;
+            var body = new byte[bodyLen];
+            read = 0;
+            while (read < bodyLen)
+            {
+                int n = await ns.ReadAsync(body.AsMemory(read), cts.Token);
+                if (n <= 0) return null;
+                read += n;
+            }
+            var full = new byte[msgLen];
+            head.CopyTo(full, 0);
+            body.CopyTo(full, head.Length);
+            return full;
+        }
+        catch (OperationCanceledException) { return null; }
+    }
+
+    /// <summary>
+    /// After Establish rebases <c>LastIncomingSeqNo</c> to 14, an
+    /// inbound message at MsgSeqNum=15 is in-order: no NotApplied
+    /// is emitted and the session advances cleanly.
+    /// </summary>
+    [Fact]
+    public async Task FirstBusinessMessage_AtRebasedNextSeqNo_IsAcceptedWithoutNotApplied()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+            // Mimic ProcessEstablish: peer signaled NextSeqNo=15 →
+            // gateway rebases LastIncomingSeqNo = 14.
+            session.LastIncomingSeqNo = 14;
+
+            var body = BuildBody(100, headerMsgSeqNum: 15, totalLen: 82);
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(body));
+            Assert.Equal(15u, session.LastIncomingSeqNo);
+
+            var frame = await TryReadFrameAsync(client.GetStream(), TimeSpan.FromMilliseconds(150));
+            Assert.Null(frame); // no NotApplied — message was in-order
+            session.Close("test");
+        }
+        finally
+        {
+            client.Dispose();
+            await server.DisposeAsync();
+        }
+    }
+
+    /// <summary>
+    /// Without rebase, the same inbound at MsgSeqNum=15 would
+    /// trigger NotApplied(1, 14) — pin the legacy behavior so a
+    /// future regression that drops the rebase is caught loudly.
+    /// </summary>
+    [Fact]
+    public async Task FirstBusinessMessage_WithoutRebase_StillEmitsNotApplied()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewStartedSession(server);
+            // No rebase: LastIncomingSeqNo defaults to 0.
+
+            var body = BuildBody(100, headerMsgSeqNum: 15, totalLen: 82);
+            Assert.True(session.TryAcceptBusinessHeaderMsgSeqNum(body));
+
+            var frame = await TryReadFrameAsync(client.GetStream(), TimeSpan.FromMilliseconds(250));
+            Assert.NotNull(frame); // NotApplied was emitted
+            session.Close("test");
+        }
+        finally
+        {
+            client.Dispose();
+            await server.DisposeAsync();
+        }
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/VarDataV6AcceptanceTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/VarDataV6AcceptanceTests.cs
@@ -1,0 +1,66 @@
+using B3.EntryPoint.Wire;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// #239 (sub-issue 1): the inbound varData spec table only registered
+/// `(template, 2)` entries, so when the V6 header acceptance from
+/// #237 let `(102, 6)` past the header parser, the varData walker
+/// got an empty `Field[]` and reported "varData has 2 trailing
+/// byte(s) after declared fields" for the empty `[DeskID, Memo]`
+/// pair (`[0x00, 0x00]`) that EPC 0.8.0 always appends.
+///
+/// This test pins that the V6 entries map to the same field spec as
+/// V2 — the schema delta between V2 and V6 is purely additive
+/// optional fields in the fixed root block; the varData spec is
+/// unchanged.
+/// </summary>
+public class VarDataV6AcceptanceTests
+{
+    [Theory]
+    [InlineData(EntryPointFrameReader.TidNewOrderSingle, 2, 2)]              // [DeskID, Memo]
+    [InlineData(EntryPointFrameReader.TidNewOrderSingle, 6, 2)]              // #239: same as V2
+    [InlineData(EntryPointFrameReader.TidOrderCancelReplaceRequest, 2, 2)]
+    [InlineData(EntryPointFrameReader.TidOrderCancelReplaceRequest, 6, 2)]   // #239
+    [InlineData(EntryPointFrameReader.TidSimpleNewOrder, 2, 1)]              // [Memo]
+    [InlineData(EntryPointFrameReader.TidSimpleNewOrder, 6, 1)]              // #239
+    [InlineData(EntryPointFrameReader.TidSimpleModifyOrder, 2, 1)]
+    [InlineData(EntryPointFrameReader.TidSimpleModifyOrder, 6, 1)]           // #239
+    public void ExpectedFor_V2AndV6_ReturnSameFieldCount(ushort templateId, ushort version, int expectedFieldCount)
+    {
+        var spec = EntryPointVarData.ExpectedFor(templateId, version);
+        Assert.Equal(expectedFieldCount, spec.Length);
+    }
+
+    /// <summary>
+    /// The exact byte pattern reported in #239: 2 bytes of varData
+    /// = empty DeskID (length=0) + empty Memo (length=0). Must be
+    /// accepted (no trailing-bytes error) for both V2 and V6.
+    /// </summary>
+    [Theory]
+    [InlineData((ushort)2)]
+    [InlineData((ushort)6)]
+    public void NewOrderSingle_EmptyDeskIdAndMemo_AcceptsForBothVersions(ushort version)
+    {
+        var spec = EntryPointVarData.ExpectedFor(EntryPointFrameReader.TidNewOrderSingle, version);
+        // Empty DeskID prefix + empty Memo prefix.
+        ReadOnlySpan<byte> varData = stackalloc byte[] { 0x00, 0x00 };
+        var result = EntryPointVarData.ValidateDetailed(varData, spec);
+        Assert.True(result.IsOk, $"expected Ok, got {result.Kind}: {result.DebugMessage}");
+    }
+
+    /// <summary>
+    /// Prove the bug the way it manifested before the fix: when V6
+    /// is mapped to the empty spec (the bug), a 2-byte varData is
+    /// classified as a protocol error. Pin the validator semantics
+    /// so a future regression that drops V6 from the table is caught.
+    /// </summary>
+    [Fact]
+    public void EmptySpec_TwoByteVarData_IsProtocolError()
+    {
+        ReadOnlySpan<byte> varData = stackalloc byte[] { 0x00, 0x00 };
+        var result = EntryPointVarData.ValidateDetailed(varData, ReadOnlySpan<EntryPointVarData.Field>.Empty);
+        Assert.Equal(EntryPointVarData.FailureKind.ProtocolError, result.Kind);
+        Assert.Contains("trailing byte", result.DebugMessage);
+    }
+}


### PR DESCRIPTION
Closes #239.

Two distinct decode failures observed after #237's header-acceptance fix landed in production. Both fixed in this PR.

## Sub-issue 1 — `varData has 2 trailing byte(s) after declared fields`

**Root cause.** `EntryPointVarData.ExpectedFor` only registered `(template, 2)` entries. Once #237 let `(102, 6)` past the header parser, the varData walker received an empty `Field[]` and rejected the trivial 2-byte `[DeskID empty + Memo empty]` tail (`[0x00, 0x00]`) that EPC 0.8.0 always emits.

**Fix.** Mirror the V2 entries to V6 — the schema delta between V2 and V6 is purely additive optional fields in the **fixed root block**; the varData spec is unchanged.

```csharp
(TidSimpleNewOrder, 6) => SimpleNewOrderFields,                  // #239
(TidSimpleModifyOrder, 6) => SimpleModifyOrderFields,            // #239
(TidNewOrderSingle, 6) => NewOrderSingleFields,                  // #239
(TidOrderCancelReplaceRequest, 6) => OrderCancelReplaceFields,   // #239
```

## Sub-issue 2 — `inbound gap detected: expected=1 received=15`

**Root cause.** `FixpSession` ignored the FIXP §4.5.3 `Establish.NextSeqNo` field, so peers that carry an SDK-internal seq counter across reconnects (EPC 0.8.0 starts at e.g. 15 on reconnect) always triggered a `NotApplied(1, NextSeqNo-1)`.

**Fix.** After accepting the Establish (in both legacy and strict-validator paths), rebase `LastIncomingSeqNo = NextSeqNo - 1` so the first business message at `NextSeqNo` is treated as in-order. The validator already enforces `NextSeqNo > 0`, so the rebase only acts on a peer-supplied value of 2 or higher.

```csharp
private void RebaseLastIncomingSeqNoFromEstablish(uint peerNextSeqNo)
{
    if (peerNextSeqNo <= 1) return;
    if (peerNextSeqNo - 1 > LastIncomingSeqNo)
        LastIncomingSeqNo = peerNextSeqNo - 1;
}
```

The `LastIncomingSeqNo` setter was changed from `private set` to `internal set` so the same-assembly Establish handler (and tests) can rebase. External callers cannot mutate it.

## Tests

- **`VarDataV6AcceptanceTests`** — 9 `[Theory]` rows pinning `(template, version) → field-count`; explicit reproduction of the empty `[DeskID, Memo] = [0x00, 0x00]` case for V2 and V6; legacy "empty spec rejects 2-byte trailer" test pinned so a future regression that drops V6 from the table is caught loudly.
- **`EstablishNextSeqNoRebaseTests`** — first inbound at `MsgSeqNum=15` after rebase is accepted with no `NotApplied`; without rebase, `NotApplied` is still emitted (legacy regression pin).

Full suite green: 763+ tests pass. `dotnet format --verify-no-changes` clean.

## Notes

- Follow-up #238 (native V6 decoding + schema-version audit) still applies — this PR only widens the parser/varData tables; it does not modernize the decoder pipeline.
- The strict `EstablishValidator` path is unchanged (it only rejects `NextSeqNo == 0`); the rebase happens after the validator returns Accept.
- Reattach / replay tests (`FixpSessionReattachReplayE2ETests`, `FixpSessionRetransmitTests`) all still pass — those scenarios use `NextSeqNo=1` or build the session with explicit seq positions, so the new rebase path is a no-op for them.
