### PR TITLE
Accept RoutingInstruction=0 as default (#241)

### DIFF
--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -113,7 +113,7 @@ internal static partial class InboundMessageDecoder
             // #211: iceberg accepted on NewOrderSingle. The engine validates
             // MaxFloor in (0, Quantity] / lot multiple / Limit + Day|Gtc.
         }
-        if (routing != RoutingInstructionNull)
+        if (routing != RoutingInstructionNull && routing != RoutingInstructionDefault)
         {
             message = $"RoutingInstruction={routing} not supported";
             return InboundDecodeOutcome.UnsupportedFeature;

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -109,7 +109,7 @@ internal static partial class InboundMessageDecoder
             message = "Minimum-fill orders not supported (MinQty must be NULL)";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (routing != RoutingInstructionNull)
+        if (routing != RoutingInstructionNull && routing != RoutingInstructionDefault)
         {
             message = $"RoutingInstruction={routing} not supported";
             return InboundDecodeOutcome.UnsupportedFeature;

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -19,6 +19,12 @@ namespace B3.Exchange.Gateway;
 internal static partial class InboundMessageDecoder
 {
     private const byte RoutingInstructionNull = 255;
+    // #241: B3.EntryPoint.Client 0.8.0 has no public surface to set
+    // RoutingInstruction, so it always emits the .NET enum default (0).
+    // 0 is not one of the schema's defined non-null values (1..4) and
+    // is treated here as synonymous with NULL — i.e. "no special
+    // routing", which is exactly what we already do for the NULL byte.
+    private const byte RoutingInstructionDefault = 0;
     private const byte TimeInForceOptionalNull = 0; // schema null = '\0'
 
     private const long PriceNull = long.MinValue;

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -237,6 +237,46 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Contains("RoutingInstruction", msg);
     }
 
+    /// <summary>
+    /// #241: B3.EntryPoint.Client 0.8.0 has no public surface to set
+    /// RoutingInstruction so it always emits the .NET enum default 0.
+    /// 0 is not a schema-defined non-null value (1..4) and must be
+    /// treated as synonymous with NULL — accept silently, do not reject.
+    /// </summary>
+    [Theory]
+    [InlineData((byte)0)]   // EPC 0.8.0 SDK default
+    [InlineData((byte)255)] // explicit NULL
+    public void NewOrderSingle_RoutingInstructionDefaultOrNull_IsAccepted(byte routing)
+    {
+        var body = BuildNewOrderSingleV2(routing: routing);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+    }
+
+    /// <summary>
+    /// Same default-vs-null acceptance for the Cancel/Replace path —
+    /// EPC 0.8.0's Replace surface has the same gap as the new-order
+    /// surface, so a Replace on an existing order also carries
+    /// routing=0.
+    /// </summary>
+    [Theory]
+    [InlineData((byte)0)]
+    [InlineData((byte)255)]
+    public void OrderCancelReplace_RoutingInstructionDefaultOrNull_IsAccepted(byte routing)
+    {
+        var body = BuildOrderCancelReplaceV2(routing: routing);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 1, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+    }
+
     [Theory]
     [InlineData((byte)'W')] // RLP
     [InlineData((byte)'P')] // PEGGED_MIDPOINT


### PR DESCRIPTION
Closes #241.

Third interop bug discovered in the same partner end-to-end run (after #237 and #239). Post-#239, B3.EntryPoint.Client 0.8.0's `NewOrderSingle` parses cleanly but every order is business-rejected:

```
warn: B3.Exchange.Gateway.FixpSession[0] business reject (unsupported feature)
       template=102 text=RoutingInstruction=0 not supported
```

## Root cause

EPC 0.8.0 has no public surface to set `RoutingInstruction` — verified by inspecting the SDK's order-submission shapes (`NewOrderSingleData`, `NewOrderRequest`, `SimpleNewOrderRequest`, `NewOrderCrossRequest` — none expose the field). The SDK therefore emits the .NET enum default `0`, which is **not** one of the schema's defined non-null values:

```
RETAIL_LIQUIDITY_TAKER = 1
WAIVED_PRIORITY        = 2
BROKER_ONLY            = 3
BROKER_ONLY_REMOVAL    = 4
```

(`NULL = 255`.) The decoder treated anything `!= 255` as "non-default", which lumped the SDK's `0` in with real routing instructions and rejected the order.

## Fix

Treat `0` as synonymous with NULL — i.e. "no special routing", which is the existing behavior for the NULL byte. Matches industry practice for SBE-defaulted enums and unblocks the partner without touching the wire schema or introducing any new business behavior. Applied to both:

- `InboundMessageDecoder.NewOrderSingle.cs` (template 102)
- `InboundMessageDecoder.OrderCancelReplace.cs` (template 104)

Other inbound templates (Simple*) do not carry `RoutingInstruction`.

Real non-null values (`1..4`) still BMR with the same `RoutingInstruction=N not supported` text — the legacy `NewOrderSingle_RoutingInstructionRejectsAsUnsupported` test still covers that path with `routing=1`.

## Tests

- `NewOrderSingle_RoutingInstructionDefaultOrNull_IsAccepted` — `[Theory]` over `routing ∈ {0, 255}`, both Success.
- `OrderCancelReplace_RoutingInstructionDefaultOrNull_IsAccepted` — same theory for the Replace path.
- Existing rejection test for `routing=1` retained.

Full suite green: 763+ tests pass. `dotnet format --verify-no-changes` clean.

## Notes

This is the third interop bug found in the same `slice/integration-real-stack-v2` run. The partner's ask to publish the EPC↔matching compatibility matrix (carried forward from #236) is tracked in #238 and remains open. Adding a CI-side coverage path that exercises an EPC submit-and-execute against the matching repo would prevent further surprises downstream — worth a follow-up issue if not already filed.
