### PR TITLE
M4: emit OpeningPrice_15 / ClosingPrice_17 on auction uncross (#231)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -142,6 +142,47 @@ public sealed partial class ChannelDispatcher
         Commit(nImb);
     }
 
+    /// <summary>
+    /// Onda M4 / issue #231: emits a single <c>OpeningPrice_15</c> or
+    /// <c>ClosingPrice_17</c> frame per uncross. The dispatcher injects
+    /// the configured <c>_tradeDate</c> (kept off the matching event so
+    /// the engine doesn't need calendar awareness), mirroring the
+    /// pattern used by <see cref="OnAuctionTopChanged"/>.
+    /// </summary>
+    public void OnAuctionPrint(in AuctionPrintEvent e)
+    {
+        AssertOnLoopThread();
+
+        if (e.Kind == AuctionPrintKind.Opening)
+        {
+            var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+                + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+                + B3.Umdf.WireEncoder.WireOffsets.OpeningPriceBlockLength);
+            int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteOpeningPriceFrame(
+                dst,
+                securityId: e.SecurityId,
+                priceMantissa: e.PriceMantissa,
+                tradeDate: _tradeDate,
+                mdEntryTimestampNanos: e.TransactTimeNanos,
+                rptSeq: e.RptSeq);
+            Commit(n);
+        }
+        else
+        {
+            var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+                + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+                + B3.Umdf.WireEncoder.WireOffsets.ClosingPriceBlockLength);
+            int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteClosingPriceFrame(
+                dst,
+                securityId: e.SecurityId,
+                priceMantissa: e.PriceMantissa,
+                tradeDate: _tradeDate,
+                mdEntryTimestampNanos: e.TransactTimeNanos,
+                rptSeq: e.RptSeq);
+            Commit(n);
+        }
+    }
+
     public void OnOrderCanceled(in OrderCanceledEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -196,6 +196,38 @@ public readonly record struct AuctionTopChangedEvent(
     uint RptSeq);
 
 /// <summary>
+/// Distinguishes the two auction-print kinds emitted by
+/// <see cref="MatchingEngine.UncrossAuction"/>: an opening uncross
+/// (Reserved → Open) yields <see cref="Opening"/>; a closing-call
+/// uncross (FinalClosingCall → Close) yields <see cref="Closing"/>.
+/// Issue #231 / Onda M4.
+/// </summary>
+public enum AuctionPrintKind : byte
+{
+    Opening = 0,
+    Closing = 1,
+}
+
+/// <summary>
+/// Fired exactly once per <see cref="MatchingEngine.UncrossAuction"/>
+/// call that printed at least one trade. Carries the cleared price
+/// (auction TOP) and total cleared volume across all uncross trades
+/// in this call. The integration layer fans out to UMDF
+/// <c>OpeningPrice_15</c> (kind=Opening) or <c>ClosingPrice_17</c>
+/// (kind=Closing). If the uncross drained no volume (no crossing in
+/// the book at TOP, or no TOP at all), no event is emitted — there
+/// is no "no-trade" auction print on the wire. Issue #231 / Onda M4.
+/// </summary>
+public readonly record struct AuctionPrintEvent(
+    long SecurityId,
+    AuctionPrintKind Kind,
+    long PriceMantissa,
+    long ClearedQuantity,
+    ulong TransactTimeNanos,
+    uint RptSeq);
+
+
+/// <summary>
 /// Fired when a stop order (StopLoss or StopLimit) is accepted by the
 /// engine and parked off-book in the per-instrument trigger book.
 /// Issue #214. Carries the original order parameters so the integration
@@ -336,4 +368,13 @@ public interface IMatchingEventSink
     /// <c>TheoreticalOpeningPrice_16</c> + <c>AuctionImbalance_19</c>.
     /// </summary>
     void OnAuctionTopChanged(in AuctionTopChangedEvent e) { }
+
+    /// <summary>
+    /// Optional event emitted exactly once per successful auction
+    /// uncross (issue #231 / Onda M4). Default no-op; production sink
+    /// fans out to UMDF <c>OpeningPrice_15</c> for an opening uncross
+    /// or <c>ClosingPrice_17</c> for a closing-call uncross. Skipped
+    /// when the uncross drained no volume.
+    /// </summary>
+    void OnAuctionPrint(in AuctionPrintEvent e) { }
 }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -267,9 +267,26 @@ public sealed class MatchingEngine
 
         var topState = ComputeAuctionTop(book);
         bool anyTrade = false;
+        long clearedQty = 0;
         if (topState.HasTop)
         {
-            anyTrade = DrainAtTopPrice(book, topState.TopPriceMantissa, txnNanos);
+            anyTrade = DrainAtTopPrice(book, topState.TopPriceMantissa, txnNanos, out clearedQty);
+        }
+
+        // M4 (issue #231): emit a single OpeningPrice/ClosingPrice
+        // print before the post-drain TOP recomputation. Only fired
+        // when at least one trade printed — there is no "empty"
+        // auction print on the wire. The integration sink picks the
+        // UMDF template based on Kind.
+        if (anyTrade)
+        {
+            _sink.OnAuctionPrint(new AuctionPrintEvent(
+                SecurityId: securityId,
+                Kind: fromOpening ? AuctionPrintKind.Opening : AuctionPrintKind.Closing,
+                PriceMantissa: topState.TopPriceMantissa,
+                ClearedQuantity: clearedQty,
+                TransactTimeNanos: txnNanos,
+                RptSeq: NextRptSeq()));
         }
 
         // M2 hook: the drain mutated the book — recompute and emit a
@@ -305,9 +322,10 @@ public sealed class MatchingEngine
     /// <see cref="TradeEvent"/> per pair; iceberg replenishment runs
     /// in-place. Returns <c>true</c> if at least one trade printed.
     /// </summary>
-    private bool DrainAtTopPrice(LimitOrderBook book, long topPrice, ulong txnNanos)
+    private bool DrainAtTopPrice(LimitOrderBook book, long topPrice, ulong txnNanos, out long clearedQuantity)
     {
         bool anyTrade = false;
+        clearedQuantity = 0;
         while (true)
         {
             var bidLevel = book.BestLevel(Side.Buy);
@@ -344,6 +362,7 @@ public sealed class MatchingEngine
                 TransactTimeNanos: txnNanos,
                 RptSeq: NextRptSeq()));
             anyTrade = true;
+            clearedQuantity += tradeQty;
 
             buy.RemainingQuantity -= tradeQty;
             sell.RemainingQuantity -= tradeQty;

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -714,6 +714,99 @@ public static class UmdfWireEncoder
         return total;
     }
 
+    /// <summary>
+    /// <c>OpenCloseSettlFlag.DAILY</c> = 0 — schema enum value (byte 0,
+    /// NOT the ASCII digit '0'). Used for OpeningPrice_15 (daily-open)
+    /// and ClosingPrice_17 (daily-close).
+    /// </summary>
+    public const byte OpenCloseSettlFlagDaily = 0;
+
+    /// <summary>
+    /// Writes <c>OpeningPrice_15</c> (V16). Returns total bytes.
+    /// Emitted exactly once per opening uncross that printed at least
+    /// one trade (Onda M4 / issue #231). The ECP's <c>NetChgPrevDay</c>
+    /// is always written as NULL (long.MinValue) — net-change vs the
+    /// previous-day close is a downstream concern.
+    /// </summary>
+    public static int WriteOpeningPriceFrame(
+        Span<byte> dst,
+        long securityId,
+        long priceMantissa,
+        ushort tradeDate,
+        ulong mdEntryTimestampNanos,
+        uint rptSeq)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.OpeningPriceBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.OpeningPrice_15Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.OpeningPriceBlockLength);
+        body.Clear();
+
+        MemoryMarshal.Write(body.Slice(WireOffsets.OpeningPriceBodySecurityIdOffset, 8), in securityId);
+        // MatchEventIndicator overlays SecurityExchange at offset 8 — left zeroed.
+        body[WireOffsets.OpeningPriceBodyMdUpdateActionOffset] = 0; // NEW
+        body[WireOffsets.OpeningPriceBodyOpenCloseSettlFlagOffset] = OpenCloseSettlFlagDaily;
+        MemoryMarshal.Write(body.Slice(WireOffsets.OpeningPriceBodyMdEntryPxOffset, 8), in priceMantissa);
+        long netChgNull = long.MinValue;
+        MemoryMarshal.Write(body.Slice(WireOffsets.OpeningPriceBodyNetChgPrevDayOffset, 8), in netChgNull);
+        MemoryMarshal.Write(body.Slice(WireOffsets.OpeningPriceBodyTradeDateOffset, 2), in tradeDate);
+        MemoryMarshal.Write(body.Slice(WireOffsets.OpeningPriceBodyMdEntryTimestampOffset, 8), in mdEntryTimestampNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.OpeningPriceBodyRptSeqOffset, 4), in rptSeq);
+
+        return total;
+    }
+
+    /// <summary>
+    /// Writes <c>ClosingPrice_17</c> (V16). Returns total bytes.
+    /// Emitted exactly once per closing-call uncross that printed at
+    /// least one trade (Onda M4 / issue #231). <c>LastTradeDate</c> is
+    /// written as NULL — it is informational metadata for cases where
+    /// the close carries forward a price from a previous trading day,
+    /// which the simulator does not currently model.
+    /// </summary>
+    public static int WriteClosingPriceFrame(
+        Span<byte> dst,
+        long securityId,
+        long priceMantissa,
+        ushort tradeDate,
+        ulong mdEntryTimestampNanos,
+        uint rptSeq)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.ClosingPriceBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.ClosingPrice_17Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.ClosingPriceBlockLength);
+        body.Clear();
+
+        MemoryMarshal.Write(body.Slice(WireOffsets.ClosingPriceBodySecurityIdOffset, 8), in securityId);
+        // MatchEventIndicator overlays SecurityExchange at offset 8 — left zeroed.
+        body[WireOffsets.ClosingPriceBodyOpenCloseSettlFlagOffset] = OpenCloseSettlFlagDaily;
+        MemoryMarshal.Write(body.Slice(WireOffsets.ClosingPriceBodyMdEntryPxOffset, 8), in priceMantissa);
+        ushort lastTradeDateNull = 0;
+        MemoryMarshal.Write(body.Slice(WireOffsets.ClosingPriceBodyLastTradeDateOffset, 2), in lastTradeDateNull);
+        MemoryMarshal.Write(body.Slice(WireOffsets.ClosingPriceBodyTradeDateOffset, 2), in tradeDate);
+        MemoryMarshal.Write(body.Slice(WireOffsets.ClosingPriceBodyMdEntryTimestampOffset, 8), in mdEntryTimestampNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.ClosingPriceBodyRptSeqOffset, 4), in rptSeq);
+
+        return total;
+    }
+
     private static void WriteFramingHeader(Span<byte> dst, int totalFrameLength)
     {
         ushort messageLength = checked((ushort)totalFrameLength);

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -199,6 +199,44 @@ public static class WireOffsets
     public const int AuctionImbalanceBodyMdEntryTimestampOffset = 20;
     public const int AuctionImbalanceBodyRptSeqOffset = 28;
 
+    // ---- OpeningPrice_15 (V16) — Onda M4 / issue #231 ----
+    // Body layout (BLOCK_LENGTH=44, but only 42 declared bytes; the trailing
+    // 2 bytes are SBE alignment padding written as zero): securityID@0
+    // (long); securityExchange@8 shares offset with matchEventIndicator@8
+    // (byte); mDUpdateAction@9 (byte, NEW=0); openCloseSettlFlag@10
+    // (byte, '0'=DailyOpen); mDEntryPx@12 (long mantissa, /10000);
+    // netChgPrevDay@20 (long PriceOffset8Optional, long.MinValue = NULL);
+    // tradeDate@28 (ushort LocalMktDate); mDEntryTimestamp@30 (ulong nanos);
+    // rptSeq@38 (uint, 0 = NULL).
+    public const int OpeningPriceBlockLength = 44;
+    public const int OpeningPriceBodySecurityIdOffset = 0;
+    public const int OpeningPriceBodyMatchEventIndicatorOffset = 8;
+    public const int OpeningPriceBodyMdUpdateActionOffset = 9;
+    public const int OpeningPriceBodyOpenCloseSettlFlagOffset = 10;
+    public const int OpeningPriceBodyMdEntryPxOffset = 12;
+    public const int OpeningPriceBodyNetChgPrevDayOffset = 20;
+    public const int OpeningPriceBodyTradeDateOffset = 28;
+    public const int OpeningPriceBodyMdEntryTimestampOffset = 30;
+    public const int OpeningPriceBodyRptSeqOffset = 38;
+
+    // ---- ClosingPrice_17 (V16) — Onda M4 / issue #231 ----
+    // Body layout (BLOCK_LENGTH=MESSAGE_SIZE=36): securityID@0 (long);
+    // securityExchange@8 shares offset with matchEventIndicator@8 (byte);
+    // openCloseSettlFlag@9 (byte, '0'=DailyClose); mDEntryPx@12 (long
+    // Price8 mantissa, /10000); lastTradeDate@20 (ushort, 0 = NULL);
+    // tradeDate@22 (ushort LocalMktDate); mDEntryTimestamp@24 (ulong nanos);
+    // rptSeq@32 (uint, 0 = NULL). Note: ClosingPrice_17's MDUpdateAction is
+    // a constant in the schema (NEW), so it is NOT in the body.
+    public const int ClosingPriceBlockLength = 36;
+    public const int ClosingPriceBodySecurityIdOffset = 0;
+    public const int ClosingPriceBodyMatchEventIndicatorOffset = 8;
+    public const int ClosingPriceBodyOpenCloseSettlFlagOffset = 9;
+    public const int ClosingPriceBodyMdEntryPxOffset = 12;
+    public const int ClosingPriceBodyLastTradeDateOffset = 20;
+    public const int ClosingPriceBodyTradeDateOffset = 22;
+    public const int ClosingPriceBodyMdEntryTimestampOffset = 24;
+    public const int ClosingPriceBodyRptSeqOffset = 32;
+
     // ---- ChannelReset_11 (V16) ----
     // Body: MatchEventIndicator @0 (4 bytes — UMDF wire treats the bitset as
     // a 4-byte block, see schema offset="4" on MDEntryTimestamp), then

--- a/tests/B3.Exchange.Matching.Tests/AuctionUncrossTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/AuctionUncrossTests.cs
@@ -181,4 +181,77 @@ public class AuctionUncrossTests
         var trade = Assert.Single(sink.Trades);
         Assert.Equal(Side.Sell, trade.AggressorSide);
     }
+
+    // ---------------- Onda M · M4 (issue #231) — auction prints ----------------
+
+    /// <summary>
+    /// Reserved → Open uncross that prints emits exactly one
+    /// <c>AuctionPrintEvent</c> with <c>Kind=Opening</c>, the cleared
+    /// price (auction TOP), and total cleared volume.
+    /// </summary>
+    [Fact]
+    public void Uncross_OpeningWithCrossing_EmitsSingleOpeningPrint()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 200, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 200, 12, 6001));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        var print = Assert.Single(sink.AuctionPrints);
+        Assert.Equal(AuctionPrintKind.Opening, print.Kind);
+        Assert.Equal(PetrSecId, print.SecurityId);
+        Assert.Equal(200L, print.ClearedQuantity);
+        Assert.Equal(7000UL, print.TransactTimeNanos);
+        // Same TOP-tiebreak rule as M3 trade-price: lowest crossing price.
+        Assert.Equal(Px(10.00m), print.PriceMantissa);
+    }
+
+    /// <summary>
+    /// FinalClosingCall → Close uncross that prints emits a
+    /// <c>Kind=Closing</c> event with cleared volume aggregated across
+    /// all trades in the uncross.
+    /// </summary>
+    [Fact]
+    public void Uncross_ClosingWithCrossing_EmitsSingleClosingPrint_AggregatesVolume()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.FinalClosingCall, 5000);
+        // Two buy makers, two sell makers — uncross drains all four.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("b2", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10.05m), 200, 11, 6001));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.AtClose, Px(10.00m), 100, 12, 6002));
+        eng.Submit(new NewOrderCommand("s2", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.AtClose, Px(10.00m), 200, 12, 6003));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Close, 7000);
+
+        var print = Assert.Single(sink.AuctionPrints);
+        Assert.Equal(AuctionPrintKind.Closing, print.Kind);
+        Assert.Equal(300L, print.ClearedQuantity);
+        Assert.Equal(Px(10.00m), print.PriceMantissa);
+    }
+
+    /// <summary>
+    /// Uncross with no crossing in the book emits NO auction print —
+    /// "no print on no trade". Phase still transitions.
+    /// </summary>
+    [Fact]
+    public void Uncross_NoCrossing_EmitsNoAuctionPrint()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        // Bid below ask — no crossing.
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(9.95m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 12, 6001));
+        sink.Clear();
+
+        bool any = eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        Assert.False(any);
+        Assert.Empty(sink.AuctionPrints);
+        Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
+    }
 }

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -46,6 +46,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<StopOrderTriggeredEvent> StopTriggered => Events.OfType<StopOrderTriggeredEvent>().ToList();
     public List<StopOrderCanceledEvent> StopCanceled => Events.OfType<StopOrderCanceledEvent>().ToList();
     public List<AuctionTopChangedEvent> AuctionTops => Events.OfType<AuctionTopChangedEvent>().ToList();
+    public List<AuctionPrintEvent> AuctionPrints => Events.OfType<AuctionPrintEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -61,4 +62,5 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnStopOrderTriggered(in StopOrderTriggeredEvent e) => Events.Add(e);
     public void OnStopOrderCanceled(in StopOrderCanceledEvent e) => Events.Add(e);
     public void OnAuctionTopChanged(in AuctionTopChangedEvent e) => Events.Add(e);
+    public void OnAuctionPrint(in AuctionPrintEvent e) => Events.Add(e);
 }

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -464,6 +464,53 @@ public class UmdfWireEncoderTests
         Assert.Null(rdr.Data.MDEntrySize);
     }
 
+    // ---- Onda M4 (issue #231) — OpeningPrice_15 / ClosingPrice_17 ----
+
+    [Fact]
+    public void OpeningPrice_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WriteOpeningPriceFrame(buf,
+            securityId: 900_000_000_001L,
+            priceMantissa: 100_500L,
+            tradeDate: 9000,
+            mdEntryTimestampNanos: 1_700_000_000_000_000_000UL,
+            rptSeq: 7);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.OpeningPriceBlockLength, n);
+        Assert.True(OpeningPrice_15Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.OpeningPriceBlockLength), out var rdr));
+        Assert.Equal(900_000_000_001L, (long)(ulong)rdr.Data.SecurityID);
+        Assert.Equal(MDUpdateAction.NEW, rdr.Data.MDUpdateAction);
+        Assert.Equal(OpenCloseSettlFlag.DAILY, rdr.Data.OpenCloseSettlFlag);
+        Assert.Equal(100_500L, rdr.Data.MDEntryPx.Mantissa);
+        Assert.Equal((ushort)9000, rdr.Data.TradeDate.Value);
+        Assert.Equal(7u, rdr.Data.RptSeq);
+        // NetChgPrevDay always written as NULL (long.MinValue).
+        Assert.Null(rdr.Data.NetChgPrevDay.Mantissa);
+    }
+
+    [Fact]
+    public void ClosingPrice_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WriteClosingPriceFrame(buf,
+            securityId: 900_000_000_002L,
+            priceMantissa: 99_750L,
+            tradeDate: 9001,
+            mdEntryTimestampNanos: 1_700_000_000_000_000_001UL,
+            rptSeq: 8);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.ClosingPriceBlockLength, n);
+        Assert.True(ClosingPrice_17Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.ClosingPriceBlockLength), out var rdr));
+        Assert.Equal(900_000_000_002L, (long)(ulong)rdr.Data.SecurityID);
+        Assert.Equal(OpenCloseSettlFlag.DAILY, rdr.Data.OpenCloseSettlFlag);
+        Assert.Equal(99_750L, rdr.Data.MDEntryPx.Mantissa);
+        Assert.Equal((ushort)9001, rdr.Data.TradeDate.Value);
+        Assert.Equal(8u, rdr.Data.RptSeq);
+        // LastTradeDate always written as NULL.
+        Assert.Null(rdr.Data.LastTradeDate);
+    }
+
     [Fact]
     public void Encoder_ThrowsOnSmallBuffer()
     {


### PR DESCRIPTION
Onda M · M4 — emit `OpeningPrice_15` / `ClosingPrice_17` UMDF frames on auction uncross. Builds on M3 (#235).

Tracked in #231.

## Engine (`B3.Exchange.Matching`)

- `Events.cs`: new `AuctionPrintKind` enum (`Opening`/`Closing`) and `AuctionPrintEvent` record-struct (`SecurityId`, `Kind`, `PriceMantissa`, `ClearedQuantity`, `TransactTimeNanos`, `RptSeq`).
- `MatchingEngine.UncrossAuction`: emits exactly one `AuctionPrintEvent` per uncross **that printed at least one trade** — no "empty" auction prints on the wire. Fired BEFORE the post-drain `TheoreticalOpeningPrice` recomputation and BEFORE the `SecurityStatus` phase change, so consumers see (cleared price, cleared volume) → TOP collapses → phase changes in that order.
- `DrainAtTopPrice` gains an `out long clearedQuantity` so the engine aggregates total cleared volume across all uncross trades for the print.

EOD `Open→Close` path (no auction) is **out of scope** for M4 — this PR only covers auction-driven prints.

## Wire encoder (`B3.Umdf.WireEncoder`)

- `WriteOpeningPriceFrame` / `WriteClosingPriceFrame` in `UmdfWireEncoder.cs`, with field offsets in `WireOffsets.cs`.
- Both write `OpenCloseSettlFlag = DAILY` (schema enum value `0`, **not** the ASCII digit `'0'` — separate constant `OpenCloseSettlFlagDaily = 0` documents this).
- `NetChgPrevDay` (OpeningPrice) and `LastTradeDate` (ClosingPrice) are always written as their NULL sentinels — net-change vs prev-day close is a downstream concern and the simulator does not model multi-day carries.
- Layout notes:
  - `OpeningPrice_15`: `BLOCK_LENGTH = 44` with 2 trailing bytes of SBE alignment padding after `rptSeq@38`, written as zero.
  - `ClosingPrice_17`: `BLOCK_LENGTH = MESSAGE_SIZE = 36`. The schema marks `MDUpdateAction` as a constant (NEW), so it is **not** in the body.

## Dispatcher (`B3.Exchange.Core`)

- `ChannelDispatcher.OnAuctionPrint` picks Opening vs Closing template based on event `Kind` and injects the dispatcher's configured `_tradeDate` (kept off the engine event so matching doesn't need calendar awareness — same pattern as `OnAuctionTopChanged`).

## Tests (5 new)

- `AuctionUncrossTests`:
  - `Uncross_OpeningWithCrossing_EmitsSingleOpeningPrint`
  - `Uncross_ClosingWithCrossing_EmitsSingleClosingPrint_AggregatesVolume`
  - `Uncross_NoCrossing_EmitsNoAuctionPrint`
- `UmdfWireEncoderTests`:
  - `OpeningPrice_Roundtrip`
  - `ClosingPrice_Roundtrip`
- `RecordingSink.AuctionPrints` accessor added.

Full suite: 861 passed, 1 skipped, 0 failed. `dotnet format --verify-no-changes` clean.

## Follow-ups (not in this PR)

- EOD `Open → Close` path with no auction.
- `HostConfig` per-instrument ref-price seed.
- M5: GoodForAuction / AtClose survivors handling.
