### PR TITLE
M5: expire unfilled GoodForAuction/AtClose post-uncross (#232)

### DIFF
--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -132,6 +132,11 @@ public enum CancelReason : byte
     /// <summary>Resting order cancelled by an OrderMassActionRequest
     /// (template 701 → ER_Cancel; spec §4.8 / #GAP-19).</summary>
     MassCancel,
+    /// <summary>Resting <see cref="TimeInForce.GoodForAuction"/> or
+    /// <see cref="TimeInForce.AtClose"/> order that did not participate
+    /// in the uncross is removed when the auction phase resolves.
+    /// Issue #232 / Onda M5.</summary>
+    AuctionExpired,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -118,6 +118,15 @@ internal sealed class LimitOrderBook
 
     public bool TryGet(long orderId, out RestingOrder order) => _byOrderId.TryGetValue(orderId, out order!);
 
+    /// <summary>
+    /// Snapshot of all resting orders, taken eagerly so callers can mutate
+    /// the book (cancel orders) while iterating. Used by the auction
+    /// expiration sweep in <see cref="MatchingEngine.UncrossAuction"/> to
+    /// find <see cref="TimeInForce.GoodForAuction"/> /
+    /// <see cref="TimeInForce.AtClose"/> survivors. Issue #232 / Onda M5.
+    /// </summary>
+    public IReadOnlyList<RestingOrder> SnapshotOrders() => _byOrderId.Values.ToList();
+
     private SortedDictionary<long, PriceLevel> SideMap(Side side) => side == Side.Buy ? _bids : _asks;
 
     public void Insert(RestingOrder o)

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -289,6 +289,24 @@ public sealed class MatchingEngine
                 RptSeq: NextRptSeq()));
         }
 
+        // M5 (issue #232): expire any survivor whose TIF was bound to
+        // the auction phase we are leaving. GoodForAuction lives in
+        // Reserved only; AtClose lives in FinalClosingCall only.
+        // Anything left on the book after the drain is, by definition,
+        // unfilled and must NOT carry over into the continuous phase.
+        // Day / Gtc / Gtd survive the transition unchanged.
+        // Snapshot first (the cancel mutates _byOrderId) then iterate.
+        var expiringTif = fromOpening
+            ? TimeInForce.GoodForAuction
+            : TimeInForce.AtClose;
+        foreach (var resting in book.SnapshotOrders())
+        {
+            if (resting.Tif == expiringTif)
+            {
+                EmitCanceled(book, resting, txnNanos, CancelReason.AuctionExpired);
+            }
+        }
+
         // M2 hook: the drain mutated the book — recompute and emit a
         // final TheoreticalOpeningPrice/Imbalance frame (typically
         // HasTop=false now since the crossing volume was consumed).

--- a/tests/B3.Exchange.Matching.Tests/AuctionUncrossTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/AuctionUncrossTests.cs
@@ -49,7 +49,11 @@ public class AuctionUncrossTests
         Assert.Single(sink.Filled);
         Assert.Single(sink.QtyReduced);
         Assert.Equal(200, sink.QtyReduced[0].NewRemainingQuantity);
-        Assert.Equal(1, eng.OrderCount(PetrSecId));
+        // M5 (#232): GoodForAuction residual that did not fully fill at
+        // the uncross is expired before the phase transitions to Open.
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+        var expired = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.AuctionExpired, expired.Reason);
     }
 
     [Fact]
@@ -92,7 +96,11 @@ public class AuctionUncrossTests
         Assert.False(any);
         Assert.Empty(sink.Trades);
         Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
-        Assert.Equal(1, eng.OrderCount(PetrSecId)); // Buy survives.
+        // M5 (#232): GoodForAuction order that did not participate in
+        // any uncross trade is expired on the phase transition.
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+        var expired = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.AuctionExpired, expired.Reason);
     }
 
     [Fact]
@@ -253,5 +261,110 @@ public class AuctionUncrossTests
         Assert.False(any);
         Assert.Empty(sink.AuctionPrints);
         Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
+    }
+
+    // ─── Onda M · M5 (issue #232) ─────────────────────────────────────
+    // Survivors of an auction call that did not match must NOT carry
+    // over into the continuous phase: GoodForAuction expires after the
+    // opening uncross, AtClose after the closing uncross.
+
+    /// <summary>
+    /// Multiple unfilled GoodForAuction orders all expire when Reserved
+    /// → Open. Each emits an OrderCanceledEvent with reason
+    /// AuctionExpired. Book is empty before phase flips.
+    /// </summary>
+    [Fact]
+    public void Uncross_Opening_ExpiresAllUnfilledGoodForAuction()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(9.95m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("b2", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(9.90m), 200, 11, 6001));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.10m), 100, 12, 6002));
+        sink.Clear();
+
+        bool any = eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        Assert.False(any);
+        Assert.Empty(sink.Trades);
+        Assert.Equal(3, sink.Canceled.Count);
+        Assert.All(sink.Canceled, c => Assert.Equal(CancelReason.AuctionExpired, c.Reason));
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+        Assert.Equal(TradingPhase.Open, eng.GetTradingPhase(PetrSecId));
+    }
+
+    /// <summary>
+    /// Closing-call analogue: AtClose survivors expire on Final →
+    /// Close transition. GoodForAuction left over from a previous
+    /// opening would have already been cleared, so this test only
+    /// exercises AtClose.
+    /// </summary>
+    [Fact]
+    public void Uncross_Closing_ExpiresAllUnfilledAtClose()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.FinalClosingCall, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(9.95m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.AtClose, Px(10.05m), 100, 12, 6001));
+        sink.Clear();
+
+        bool any = eng.UncrossAuction(PetrSecId, TradingPhase.Close, 7000);
+
+        Assert.False(any);
+        Assert.Empty(sink.Trades);
+        Assert.Equal(2, sink.Canceled.Count);
+        Assert.All(sink.Canceled, c => Assert.Equal(CancelReason.AuctionExpired, c.Reason));
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+        Assert.Equal(TradingPhase.Close, eng.GetTradingPhase(PetrSecId));
+    }
+
+    /// <summary>
+    /// Fully-filled GoodForAuction orders must not be double-cancelled:
+    /// they have already been removed from the book by the drain.
+    /// Asserts no AuctionExpired event is emitted for either side.
+    /// </summary>
+    [Fact]
+    public void Uncross_Opening_FullyFilledGoodForAuction_NotDoubleCanceled()
+    {
+        var eng = NewEngine(out var sink);
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5000);
+        eng.Submit(new NewOrderCommand("b1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.05m), 100, 11, 6000));
+        eng.Submit(new NewOrderCommand("s1", PetrSecId, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10.00m), 100, 12, 6001));
+        sink.Clear();
+
+        bool any = eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        Assert.True(any);
+        Assert.Single(sink.Trades);
+        Assert.Empty(sink.Canceled);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    /// <summary>
+    /// Mixed-TIF scenario: Day orders submitted in continuous Open
+    /// then carried into a Reserved auction call (operator-driven phase
+    /// transition) survive the uncross, while GoodForAuction siblings
+    /// expire. Pins the "do not over-expire" invariant: only
+    /// auction-bound TIFs are touched by the M5 sweep.
+    /// </summary>
+    [Fact]
+    public void Uncross_Opening_DayOrders_SurviveIntoContinuous()
+    {
+        var eng = NewEngine(out var sink);
+        // Day order submitted in Open (TIF gate accepts Day in Open).
+        eng.Submit(new NewOrderCommand("d1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.95m), 100, 11, 5500));
+        // Operator transitions to Reserved (intraday auction call).
+        eng.SetTradingPhase(PetrSecId, TradingPhase.Reserved, 5800);
+        // Auction-only sibling joins during Reserved.
+        eng.Submit(new NewOrderCommand("a1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(9.90m), 100, 11, 6001));
+        sink.Clear();
+
+        eng.UncrossAuction(PetrSecId, TradingPhase.Open, 7000);
+
+        // Only the GoodForAuction order is expired.
+        var expired = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.AuctionExpired, expired.Reason);
+        // Day order survives.
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
     }
 }


### PR DESCRIPTION
Closes #232. Onda M phase 5 — auction TIF survivors now expire at uncross.

## What

After `MatchingEngine.UncrossAuction` drains crossing volume at the TOP, sweep the residual book for orders bound to the auction phase being left:

| Transition | TIF expired |
|---|---|
| `Reserved` → `Open` | `GoodForAuction` |
| `FinalClosingCall` → `Close` | `AtClose` |

Each expired order emits `OrderCanceledEvent` with the new `CancelReason.AuctionExpired`. The sweep runs **before** the post-drain TOP recompute + phase transition, so consumers see the full auction-resolution batch in order:

```
trades → expirations → final TOP delete (HasTop=false) → SecurityStatus
```

`Day` / `Gtc` / `Gtd` survivors carried into the call (e.g. by an operator-driven intraday `Reserved` transition) are left untouched and roll into the continuous phase.

## Files

- `Commands.cs` — `CancelReason.AuctionExpired`.
- `LimitOrderBook.cs` — `SnapshotOrders()` helper (defensive copy so the cancel sweep can iterate without fighting `_byOrderId` mutation in `Remove`).
- `MatchingEngine.cs` — sweep block in `UncrossAuction`.
- `AuctionUncrossTests.cs` — 4 new M5 tests + 2 M3 tests fixed (residual now expected to be expired, not stay resting).

## Test count

865 tests pass (was 861 before M5; +4 new, 2 modified).
