### PR TITLE
#238: V6-aware NewOrderSingle/OrderCancelReplace decoders + schema audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,38 @@ EntryPoint TCP listener (default port 9876).
 official B3 SBE schemas. The same files exist in `SbeB3UmdfConsumer`; keep
 them in sync when upgrading.
 
+### Inbound EntryPoint compatibility matrix
+
+The exchange parses the inbound SBE templates listed below. Any version
+not listed is rejected at the FIXP frame layer with `UnsupportedSchema` /
+`UnsupportedTemplate` and the session is terminated (`DECODING_ERROR`).
+See `B3.EntryPoint.Wire.EntryPointFrameReader.ExpectedInboundBlockLength`
+for the source of truth.
+
+| Template | ID | Versions accepted | Block size | Notes |
+|---|---:|---|---:|---|
+| `Negotiate` | 100 | V0 | 28 | FIXP session establishment. |
+| `Establish` | 101 | V0 | 42 | FIXP session establishment. |
+| `Terminate` | 102 | V0 | 13 | Peer-initiated graceful logout. |
+| `RetransmitRequest` | 103 | V0 | 20 | FIXP retransmission. |
+| `Sequence` | 104 | V0 | 4 | FIXP heartbeat / seq sync. |
+| `SimpleNewOrder` | 100 | V2, **V6** | 82 | V6 has the same wire layout as V2; SDK 0.8.0 stamps version=6 (issue #236 / #239). |
+| `SimpleModifyOrder` | 101 | V2, **V6** | 98 | Same as above. |
+| `NewOrderSingle` | 102 | V2 (125 B), **V6 (133 B)** | 125 / 133 | V6 appends `strategyID@125` (int32) and `tradingSubAccount@129` (uint32). Both fields are decoded; non-null values produce `BusinessMessageReject(33003)` because the engine has no strategy / sub-account routing (issue #238). |
+| `OrderCancelReplaceRequest` | 104 | V2 (142 B), **V6 (150 B)** | 142 / 150 | Same +8 trailer (`strategyID@142`, `tradingSubAccount@146`) and same reject-if-non-null policy. |
+| `OrderCancelRequest` | 105 | V6 (root version=0) | 76 | Native V6 layout; no V2 ancestor. |
+| `NewOrderCross` | 106 | V6 | 84 + group + varData | Native V6. |
+| `OrderMassActionRequest` | 701 | V6 | 52 | Native V6. |
+
+**Convention:** when an SDK bumps the schema version stamp **without**
+changing the wire layout, both versions are added to
+`ExpectedInboundBlockLength` with the same expected size. When the V6
+revision **adds** trailing optional fields (additive-only), the new
+larger size is added as a separate row and the decoder is updated to
+read or reject the trailer based on `body.Length`. We deliberately do
+**not** wildcard `blockLength &gt;= V2_size` — the explicit table
+catches accidental schema regressions in upstream consumers.
+
 ## License
 
 MIT — see `LICENSE`.

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -31,7 +31,17 @@ internal static partial class InboundMessageDecoder
         public const int MinQty = 84;             // ulong (0 == null)
         public const int MaxFloor = 92;           // ulong (0 == null)
         public const int ExpireDate = 105;        // ushort (0 == null)
+        // V6 trailer (BlockLength=133). Both fields use 0 as the SBE
+        // null sentinel. Currently the engine rejects non-null values
+        // with BMR(33003) since strategy routing / sub-account tagging
+        // aren't supported (issue #238).
+        public const int StrategyID = 125;        // int32 (0 == null)
+        public const int TradingSubAccount = 129; // uint32 (0 == null)
     }
+
+    // V2 root size (matches ExpectedInboundBlockLength). Bodies of this
+    // size carry no V6 trailer; bodies of size 133 carry it. See #238.
+    private const int NewOrderSingleV2BodySize = 125;
 
     /// <summary>
     /// Decodes a NewOrderSingleV2 (id=102) body for #GAP-15. Returns
@@ -132,6 +142,28 @@ internal static partial class InboundMessageDecoder
         {
             message = "ExpireDate not supported (only Day/IOC/FOK)";
             return InboundDecodeOutcome.UnsupportedFeature;
+        }
+
+        // #238: V6 root carries +strategyID@125 (int32, 0=null) and
+        // +tradingSubAccount@129 (uint32, 0=null). The body span has
+        // already been sliced to BlockLength by the FIXP dispatch, so
+        // the trailer is present iff body.Length > V2 size. Engine
+        // doesn't honor either field — surface a BMR rather than
+        // silently ignore so partners notice.
+        if (body.Length > NewOrderSingleV2BodySize)
+        {
+            int strategyId = MemoryMarshal.Read<int>(body.Slice(NewOrderSingleOffsets.StrategyID, 4));
+            uint tradingSubAccount = MemoryMarshal.Read<uint>(body.Slice(NewOrderSingleOffsets.TradingSubAccount, 4));
+            if (strategyId != 0)
+            {
+                message = $"StrategyID={strategyId} not supported";
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
+            if (tradingSubAccount != 0)
+            {
+                message = $"TradingSubAccount={tradingSubAccount} not supported";
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
         }
 
         long enginePrice = (ordType == OrderType.Market || ordType == OrderType.MarketWithLeftover)

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -26,7 +26,13 @@ internal static partial class InboundMessageDecoder
         public const int MinQty = 100;            // ulong (0 == null)
         public const int MaxFloor = 108;          // ulong (0 == null)
         public const int ExpireDate = 122;        // ushort (0 == null)
+        // V6 trailer (BlockLength=150). Same semantics as
+        // NewOrderSingle's trailer — see issue #238.
+        public const int StrategyID = 142;        // int32 (0 == null)
+        public const int TradingSubAccount = 146; // uint32 (0 == null)
     }
+
+    private const int OrderCancelReplaceV2BodySize = 142;
 
     /// <summary>
     /// Decodes an OrderCancelReplaceRequestV2 (id=104) body for #GAP-15.
@@ -128,6 +134,22 @@ internal static partial class InboundMessageDecoder
         {
             message = "ExpireDate not supported (only Day/IOC/FOK)";
             return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        // #238: V6 trailer reject — see NewOrderSingle decoder.
+        if (body.Length > OrderCancelReplaceV2BodySize)
+        {
+            int strategyId = MemoryMarshal.Read<int>(body.Slice(OrderCancelReplaceOffsets.StrategyID, 4));
+            uint tradingSubAccount = MemoryMarshal.Read<uint>(body.Slice(OrderCancelReplaceOffsets.TradingSubAccount, 4));
+            if (strategyId != 0)
+            {
+                message = $"StrategyID={strategyId} not supported";
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
+            if (tradingSubAccount != 0)
+            {
+                message = $"TradingSubAccount={tradingSubAccount} not supported";
+                return InboundDecodeOutcome.UnsupportedFeature;
+            }
         }
         if (orderId == 0 && origClOrdId == 0)
         {

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -567,4 +567,105 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
         Assert.Contains("ExpireDate", msg);
     }
+
+    // ---------------- #238: V6 trailer (StrategyID + TradingSubAccount) ----------------
+
+    private static byte[] BuildNewOrderSingleV6(
+        int strategyId = 0, uint tradingSubAccount = 0)
+    {
+        var v2 = BuildNewOrderSingleV2();
+        // V6 root is 133 bytes: V2 root (125) + strategyID(int32) + tradingSubAccount(uint32).
+        var body = new byte[133];
+        v2.CopyTo(body, 0);
+        Span<byte> s = body;
+        MemoryMarshal.Write(s.Slice(125, 4), in strategyId);
+        MemoryMarshal.Write(s.Slice(129, 4), in tradingSubAccount);
+        return body;
+    }
+
+    private static byte[] BuildOrderCancelReplaceV6(
+        int strategyId = 0, uint tradingSubAccount = 0)
+    {
+        var v2 = BuildOrderCancelReplaceV2();
+        var body = new byte[150];
+        v2.CopyTo(body, 0);
+        Span<byte> s = body;
+        MemoryMarshal.Write(s.Slice(142, 4), in strategyId);
+        MemoryMarshal.Write(s.Slice(146, 4), in tradingSubAccount);
+        return body;
+    }
+
+    [Fact]
+    public void NewOrderSingle_V6_NullTrailer_HappyPath()
+    {
+        var body = BuildNewOrderSingleV6();
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 7, 1_000_000UL, out var cmd, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(OrderType.Limit, cmd.Type);
+    }
+
+    [Fact]
+    public void NewOrderSingle_V6_StrategyID_Rejected()
+    {
+        var body = BuildNewOrderSingleV6(strategyId: 42);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 7, 1_000_000UL, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("StrategyID", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_V6_TradingSubAccount_Rejected()
+    {
+        var body = BuildNewOrderSingleV6(tradingSubAccount: 99u);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 7, 1_000_000UL, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("TradingSubAccount", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_V6_NullTrailer_HappyPath()
+    {
+        var body = BuildOrderCancelReplaceV6();
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out var cmd, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(42L, cmd.OrderId);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_V6_StrategyID_Rejected()
+    {
+        var body = BuildOrderCancelReplaceV6(strategyId: 7);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("StrategyID", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_V6_TradingSubAccount_Rejected()
+    {
+        var body = BuildOrderCancelReplaceV6(tradingSubAccount: 12345u);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out _, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("TradingSubAccount", msg);
+    }
 }

--- a/tests/B3.Exchange.Gateway.Tests/V6TemplateAcceptanceTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/V6TemplateAcceptanceTests.cs
@@ -48,13 +48,14 @@ public class V6TemplateAcceptanceTests
     }
 
     /// <summary>
-    /// Builds a 133-byte V6 NewOrderSingle body (V2 fixed fields plus
-    /// the appended strategyID@125 + tradingSubAccount@129) and asserts
-    /// the decoder produces a clean <see cref="NewOrderCommand"/>,
-    /// silently ignoring the trailing fields.
+    /// V6 NewOrderSingle body with non-null `strategyID` /
+    /// `tradingSubAccount` trailer is rejected with
+    /// <see cref="InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature"/>
+    /// rather than silently dropped (issue #238). Caller emits BMR and
+    /// keeps the session open.
     /// </summary>
     [Fact]
-    public void V6NewOrderSingleBody_DecodesAsV2_AppendedFieldsIgnored()
+    public void V6NewOrderSingleBody_AppendedFields_RejectedWithBmr()
     {
         var body = BuildV6NewOrderSingleBody(
             clOrdId: 7777,
@@ -67,16 +68,41 @@ public class V6TemplateAcceptanceTests
 
         var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
             body, enteringFirm: 1, enteredAtNanos: 0,
+            out _, out var clOrdIdValue, out var message);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal(7777UL, clOrdIdValue);
+        // The first non-null trailer field surfaced in the message
+        // (strategyID is checked before tradingSubAccount).
+        Assert.Contains("StrategyID", message);
+    }
+
+    /// <summary>
+    /// V6 NewOrderSingle body with NULL trailer (strategyID=0,
+    /// tradingSubAccount=0) decodes successfully — both fields are
+    /// SBE-null at value 0 (issue #238).
+    /// </summary>
+    [Fact]
+    public void V6NewOrderSingleBody_NullTrailer_Decodes()
+    {
+        var body = BuildV6NewOrderSingleBody(
+            clOrdId: 7777,
+            secId: 123_456,
+            sideBuy: true,
+            qty: 100,
+            priceMantissa: 105_000,
+            strategyId: 0,
+            tradingSubAccount: 0);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, enteringFirm: 1, enteredAtNanos: 0,
             out var cmd, out var clOrdIdValue, out var message);
 
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
         Assert.Null(message);
         Assert.Equal(7777UL, clOrdIdValue);
-        Assert.Equal(123_456L, cmd.SecurityId);
         Assert.Equal(Side.Buy, cmd.Side);
-        Assert.Equal(OrderType.Limit, cmd.Type);
         Assert.Equal(100L, cmd.Quantity);
-        Assert.Equal(105_000L, cmd.PriceMantissa);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #238. Follow-up to the partner mini-fix #239.

## Problem

#239 accepted schema version=6 in the FIXP header parser but kept the decoders reading only the V2 root, silently dropping the V6-appended fields:

| Template | V2 BlockLength | V6 BlockLength | Trailer |
|---|---:|---:|---|
| `NewOrderSingle` (102) | 125 | 133 | `strategyID@125` (int32, 0=null) + `tradingSubAccount@129` (uint32, 0=null) |
| `OrderCancelReplaceRequest` (104) | 142 | 150 | `strategyID@142` + `tradingSubAccount@146` |

Silent ignore is a footgun — a partner sets `strategyID` expecting strategy routing, the order behaves vanilla, and there is no diagnostic.

## Solution

Both decoders are now V6-aware via `body.Length`. When the trailer is present, both fields are read and any non-null value (SBE null sentinel = 0) produces `InboundDecodeOutcome.UnsupportedFeature`, surfacing as `BusinessMessageReject(33003)` — same pattern used today for `MmProtectionReset` / `SelfTradePreventionInstruction` / `ExpireDate`. Engine semantics are unchanged. Partners get a loud signal.

## Tests

- 6 new unit tests in `NewOrderSingleAndReplaceDecoderTests` covering V6 null-trailer happy path + non-null `StrategyID` + non-null `TradingSubAccount`, on both templates.
- `V6TemplateAcceptanceTests.V6NewOrderSingleBody_DecodesAsV2_AppendedFieldsIgnored` (added by #239 to assert silent-ignore) replaced by two tests asserting (a) reject-on-non-null trailer and (b) accept-on-null trailer.

## Docs

README §Schemas gains an **inbound EntryPoint compatibility matrix** enumerating every accepted `(template, version, blockLength)` tuple and the policy for additive trailers. Explicit table chosen over `blockLength >= V2_size` wildcard so accidental schema regressions in upstream consumers are caught at the FIXP frame layer.

## Test count

870 tests pass (was 864 — +6 new, 1 modified into 2).
