### PR TITLE
fix(#161): FIXP watchdog honors negotiated KeepAliveIntervalMs

### DIFF
--- a/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
@@ -33,8 +33,14 @@ public sealed partial class FixpSession
         var ownTransport = _transport;
         // Tick at a fraction of the smallest configured interval so we react
         // promptly without busy-polling. Capped to keep tests responsive.
-        int tickMs = Math.Max(1, Math.Min(_options.HeartbeatIntervalMs,
-            Math.Min(_options.IdleTimeoutMs, _options.TestRequestGraceMs)) / 4);
+        // Includes the (possibly negotiated) KeepAliveIntervalMs so that a
+        // sub-second client-requested interval drives the loop fast enough
+        // to actually send heartbeats inside the client's stale window
+        // (#161).
+        int hbiMs = EffectiveHeartbeatIntervalMs();
+        int idleMs = EffectiveIdleTimeoutMs();
+        int graceMs = _options.TestRequestGraceMs;
+        int tickMs = Math.Max(1, Math.Min(hbiMs, Math.Min(idleMs, graceMs)) / 4);
         try
         {
             while (!ct.IsCancellationRequested)
@@ -49,12 +55,21 @@ public sealed partial class FixpSession
                 long sinceIn = now - Volatile.Read(ref _lastInboundMs);
                 long sinceOut = now - ownTransport.LastOutboundTickMs;
 
+                // Re-resolve every tick: KeepAliveIntervalMs is committed
+                // by Establish and stays stable once set, but the watchdog
+                // may start ticking before Establish lands (during
+                // Negotiated state). Recomputing each tick keeps the
+                // thresholds correct across the state transition without
+                // restarting the loop. (#161)
+                hbiMs = EffectiveHeartbeatIntervalMs();
+                idleMs = EffectiveIdleTimeoutMs();
+
                 // Idle teardown: if a probe is outstanding and grace elapsed
                 // without any inbound, close. The grace clock starts from the
                 // moment the probe was sent (i.e. last outbound tick was
                 // bumped), so we measure the additional silence beyond
                 // idleTimeoutMs.
-                if (sinceIn >= (long)_options.IdleTimeoutMs + _options.TestRequestGraceMs &&
+                if (sinceIn >= (long)idleMs + graceMs &&
                     Volatile.Read(ref _probeOutstanding) == 1)
                 {
                     // Generation-aware close: another reattach could have
@@ -68,7 +83,7 @@ public sealed partial class FixpSession
                 // Probe (FIXP TestRequest equivalent): if we've been silent on
                 // the inbound side past the idle threshold and we haven't
                 // already sent a probe in this idle stretch, send one.
-                if (sinceIn >= _options.IdleTimeoutMs &&
+                if (sinceIn >= idleMs &&
                     Interlocked.CompareExchange(ref _probeOutstanding, 1, 0) == 0)
                 {
                     EnqueueSequence();
@@ -78,7 +93,7 @@ public sealed partial class FixpSession
                 // Regular heartbeat: only when no other outbound traffic has
                 // been sent within the heartbeat interval. This naturally
                 // suppresses heartbeats while ER traffic is flowing.
-                if (sinceOut >= _options.HeartbeatIntervalMs)
+                if (sinceOut >= hbiMs)
                 {
                     EnqueueSequence();
                 }
@@ -91,6 +106,41 @@ public sealed partial class FixpSession
             // unexpected error so the listener can drop the connection.
             Close("watchdog-error");
         }
+    }
+
+    /// <summary>
+    /// Resolves the effective server-side heartbeat interval. Once
+    /// <see cref="FixpSession.KeepAliveIntervalMs"/> is committed by an
+    /// Establish (negotiated by the client), the server honors that
+    /// value: heartbeats are emitted at most every keepAlive ms so the
+    /// client sees inbound liveness well inside its own stale window
+    /// (clients consider the peer stale at 1.5×keepAlive, see
+    /// <c>FixpClient.IsPeerStale</c>). Without the negotiated value
+    /// (e.g. mid-handshake) we fall back to the static option default.
+    /// (#161)
+    /// </summary>
+    private int EffectiveHeartbeatIntervalMs()
+    {
+        long negotiated = KeepAliveIntervalMs;
+        if (negotiated > 0)
+            return (int)Math.Min(int.MaxValue, negotiated);
+        return _options.HeartbeatIntervalMs;
+    }
+
+    /// <summary>
+    /// Resolves the effective inbound-silence threshold before the
+    /// watchdog probes the peer. When the client negotiated a keepAlive
+    /// interval, we mirror its own staleness logic and set the probe
+    /// threshold to 1.5×keepAlive — that is, we tolerate one missed
+    /// client heartbeat (clients send at keepAlive/2 cadence) before
+    /// asking the peer to prove it is still alive. (#161)
+    /// </summary>
+    private int EffectiveIdleTimeoutMs()
+    {
+        long negotiated = KeepAliveIntervalMs;
+        if (negotiated > 0)
+            return (int)Math.Min(int.MaxValue, negotiated + (negotiated / 2));
+        return _options.IdleTimeoutMs;
     }
 
     private void EnqueueSequence() => _retransmitController.EnqueueSequence();

--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -34,7 +34,7 @@ public class MultiSessionReplayTests
         throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
     }
 
-    [Fact(Skip = "Flake under FIXP watchdog 'peer stale' tear-down — #161")]
+    [Fact]
     public async Task TwoSessions_CrossingScript_LandsErTradesOnBothSides()
     {
         var sink = new CountingSink();


### PR DESCRIPTION
Closes #161.

## Root cause

Server-side `FixpSession` watchdog used static `_options.HeartbeatIntervalMs` (30s) and `_options.IdleTimeoutMs` (30s) and ignored the `KeepAliveIntervalMs` the client commits in Establish. With `FixpClientOptions.KeepAliveIntervalMillis` defaulting to 5000 ms, the client considers the peer stale at 7.5 s of inbound silence (`KeepAlive + KeepAlive/2`, see `FixpClient.IsPeerStale`) and tears the session down — but the server only emitted heartbeats every 30 s, guaranteeing tear-down whenever no application traffic flowed.

## Fix

Watchdog now resolves an effective heartbeat interval and idle threshold each tick:

- `EffectiveHeartbeatIntervalMs()` returns the negotiated `KeepAliveIntervalMs` once Establish lands, else falls back to `_options.HeartbeatIntervalMs`.
- `EffectiveIdleTimeoutMs()` returns `1.5 × KeepAliveIntervalMs` (mirrors the client's own staleness logic — tolerate one missed heartbeat), else falls back to `_options.IdleTimeoutMs`.

Re-resolving every tick lets the loop transition `Negotiated → Established` without a restart. Tests that open raw TCP without Establish keep the existing static-option semantics (`KeepAliveIntervalMs` stays 0 → fallback), so the `EntryPointHeartbeatTests` family is unaffected.

## Validation

Un-skips `MultiSessionReplayTests.TwoSessions_CrossingScript_LandsErTradesOnBothSides`, which was flaking under the old watchdog. Full suite green (866 passing, 0 skipped).
