### PR TITLE
Add second channel group (DRV) to bundled simulator configs (#225)

### DIFF
--- a/config/exchange-simulator.bridge.json
+++ b/config/exchange-simulator.bridge.json
@@ -53,6 +53,30 @@
         "port": 31084,
         "cadenceMs": 5000
       }
+    },
+    // Second channel group (DRV, ch 72) — mirrors the EQT shape on a
+    // distinct port range so consumers can validate multi-group
+    // dispatch over the bridge unicast wire (#225). Re-uses the same
+    // unicast hostname.
+    {
+      "channelNumber": 72,
+      "transport": "unicast",
+      "incrementalGroup": "marketdata",
+      "incrementalPort": 30072,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-drv.json",
+      "snapshot": {
+        "group": "marketdata",
+        "port": 30172,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 172,
+        "group": "marketdata",
+        "port": 31072,
+        "cadenceMs": 5000
+      }
     }
   ]
 }

--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -82,6 +82,33 @@
         "ttl": 1,
         "cadenceMs": 5000
       }
+    },
+    // Second channel group (DRV) — exercises the multi-group UMDF
+    // dispatch path end-to-end (#225). Real B3 always publishes at
+    // least EQT + DRV side-by-side; mirror that shape here so consumers
+    // can validate per-group ring + cross-group fan-in. The synthetic
+    // instruments under config/instruments-drv.json are placeholders.
+    {
+      "channelNumber": 72,
+      "incrementalGroup": "224.0.20.72",
+      "incrementalPort": 30072,
+      "ttl": 1,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-drv.json",
+      "snapshot": {
+        "group": "224.0.20.172",
+        "port": 30172,
+        "ttl": 1,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 172,
+        "group": "224.0.21.72",
+        "port": 31072,
+        "ttl": 1,
+        "cadenceMs": 5000
+      }
     }
   ]
 }

--- a/config/exchange-simulator.soak.json
+++ b/config/exchange-simulator.soak.json
@@ -43,6 +43,28 @@
         "ttl": 1,
         "cadenceMs": 5000
       }
+    },
+    {
+      "channelNumber": 72,
+      "incrementalGroup": "224.0.20.72",
+      "incrementalPort": 30072,
+      "ttl": 1,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-drv.json",
+      "snapshot": {
+        "group": "224.0.20.172",
+        "port": 30172,
+        "ttl": 1,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 172,
+        "group": "224.0.21.72",
+        "port": 31072,
+        "ttl": 1,
+        "cadenceMs": 5000
+      }
     }
   ]
 }

--- a/config/instruments-drv.json
+++ b/config/instruments-drv.json
@@ -1,0 +1,15 @@
+[
+  // Synthetic derivatives sample — token instruments to exercise the
+  // multi-channel-group dispatch path end-to-end (#225). NOT real B3
+  // contract specs; purely placeholders. SecurityIDs use the high-bit
+  // 901xxx prefix to stay disjoint from instruments-eqt.json (900xxx).
+  { "symbol": "DOLF99", "securityId": 901000000001, "tickSize": "0.5",
+    "lotSize": 1, "minPx": "0.5", "maxPx": "999999.5",
+    "currency": "BRL", "isin": "BRDOLF99F2026", "securityType": "FUT" },
+  { "symbol": "INDF99", "securityId": 901000000002, "tickSize": "5",
+    "lotSize": 1, "minPx": "5", "maxPx": "9999995",
+    "currency": "BRL", "isin": "BRINDF99F2026", "securityType": "FUT" },
+  { "symbol": "DI1F99", "securityId": 901000000003, "tickSize": "0.001",
+    "lotSize": 1, "minPx": "0.001", "maxPx": "999.999",
+    "currency": "BRL", "isin": "BRDI1F99F2026", "securityType": "FUT" }
+]

--- a/tests/B3.Exchange.Host.Tests/BundledConfigMultiGroupTests.cs
+++ b/tests/B3.Exchange.Host.Tests/BundledConfigMultiGroupTests.cs
@@ -1,0 +1,50 @@
+using B3.Exchange.Host;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Validates the bundled <c>config/exchange-simulator*.json</c> files
+/// declare the EQT (channel 84) + DRV (channel 72) groups required by
+/// the multi-group production topology (#225). Pure JSON-load smoke test
+/// — does not start the listener.
+/// </summary>
+public class BundledConfigMultiGroupTests
+{
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Theory]
+    [InlineData("config/exchange-simulator.json")]
+    [InlineData("config/exchange-simulator.bridge.json")]
+    [InlineData("config/exchange-simulator.soak.json")]
+    public void BundledConfig_DeclaresBothEqtAndDrvChannels(string relPath)
+    {
+        var cfg = HostConfigLoader.Load(ResolveRepoFile(relPath));
+
+        var channelNumbers = cfg.Channels.Select(c => c.ChannelNumber).ToHashSet();
+        Assert.Contains((byte)84, channelNumbers);
+        Assert.Contains((byte)72, channelNumbers);
+
+        var instrumentFiles = cfg.Channels
+            .Select(c => c.InstrumentsFile ?? string.Empty)
+            .ToList();
+        Assert.Contains(instrumentFiles, f => f.EndsWith("instruments-eqt.json", StringComparison.Ordinal));
+        Assert.Contains(instrumentFiles, f => f.EndsWith("instruments-drv.json", StringComparison.Ordinal));
+
+        // Per-channel UMDF L3 destinations must be disjoint to avoid
+        // collapsing two groups onto one socket.
+        var endpoints = cfg.Channels
+            .Select(c => $"{c.IncrementalGroup}:{c.IncrementalPort}")
+            .ToList();
+        Assert.Equal(endpoints.Count, endpoints.Distinct().Count());
+    }
+}


### PR DESCRIPTION
## Summary

Add the second UMDF channel group (DRV) alongside EQT in the three bundled `config/exchange-simulator*.json` files so operators booting from the shipped configs immediately exercise the multi-group dispatch path. Mirrors real B3 production topology where at minimum EQT + DRV are always live.

## Changes

- **`config/instruments-drv.json`** (new) — 3 synthetic futures (`DOLF99`, `INDF99`, `DI1F99`). Placeholders, NOT real B3 contract specs. SecurityID `901xxx` prefix is disjoint from the EQT `900xxx` range.
- **`config/exchange-simulator.json` + `…soak.json`** — second `ChannelConfig` on channel `72`, multicast group `224.0.20.72:30072` (snapshot `…20.172:30172`, instrumentDefinition channel `172` on `…21.72:31072`).
- **`config/exchange-simulator.bridge.json`** — same second group on the bridge unicast wire (`marketdata:30072` / `30172` / `31072`).
- **`BundledConfigMultiGroupTests`** (new) — asserts each bundled config declares both channels, references the right instruments file, and uses disjoint UMDF L3 endpoints.

## What's not changing

Engine/dispatcher/runtime code is untouched. The multi-group dispatch hot path is already covered end-to-end by `E2EConcurrentMultiChannelTests` (4 channels, concurrent traffic, monotonic per-channel sequences, no cross-talk). This PR just brings the bundled defaults in line with real-world topology.

## Verification

```
dotnet build SbeB3Exchange.slnx -c Release   # 0 warnings
dotnet test  SbeB3Exchange.slnx -c Release   # all green; +3 in BundledConfigMultiGroupTests
dotnet format … --verify-no-changes          # clean
```

Closes #225.
