### PR TITLE
Emit ER_Modify on priority-kept Replace (#251)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -59,6 +59,37 @@ public sealed partial class ChannelDispatcher
         Commit(n);
     }
 
+    public void OnOrderModified(in OrderModifiedEvent e)
+    {
+        AssertOnLoopThread();
+        // Issue #251: priority-kept Replace acknowledgment. The UMDF
+        // UPDATE frame was already buffered by OnOrderQuantityReduced
+        // earlier in this same dispatch turn; here we only emit the
+        // per-session ER_Modify back to the requester.
+        if (!_hasCurrentSession) return;
+        if (!_orders.TryResolve(e.OrderId, out var owner)) return;
+
+        // ClOrdID = requester's new id; OrigClOrdID = owner's previous
+        // ClOrdID (the one identifying the order before this Replace).
+        ulong newClOrdId = _currentClOrdId;
+        ulong origClOrdId = owner.ClOrdId;
+        _outbound.WriteExecutionReportModify(_currentSession,
+            e.SecurityId, e.OrderId,
+            clOrdIdValue: newClOrdId, origClOrdIdValue: origClOrdId,
+            side: e.Side, newPriceMantissa: e.NewPriceMantissa,
+            newRemainingQty: e.NewRemainingQuantity,
+            transactTimeNanos: e.TransactTimeNanos, rptSeq: e.RptSeq,
+            receivedTimeNanos: _currentReceivedTimeNanos);
+        _metrics?.IncExecutionReport(ExecutionReportKind.Replace);
+
+        // Refresh the canonical (Firm, ClOrdID) → OrderId index so
+        // subsequent Cancel/Modify by OrigClOrdID = newClOrdId resolve
+        // to this order. Owner stays unchanged; only the ClOrdID
+        // identity is rotated.
+        if (newClOrdId != 0 && newClOrdId != origClOrdId)
+            _orders.Reregister(e.OrderId, newClOrdId);
+    }
+
     public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -55,6 +55,29 @@ public sealed class OrderRegistry
     }
 
     /// <summary>
+    /// Updates the canonical entry for <paramref name="orderId"/> so it
+    /// owns <paramref name="newClOrdId"/> instead of its previous ClOrdId,
+    /// and refreshes the reverse <c>(Firm, ClOrdId)</c> index accordingly.
+    /// Used after a successful Replace ack so subsequent Cancel/Modify by
+    /// <c>OrigClOrdID = newClOrdId</c> resolves to this order. Issue #251.
+    /// Returns <c>false</c> when the entry no longer exists. Setting
+    /// <paramref name="newClOrdId"/> to <c>0</c> is treated as "no
+    /// change" and the call is a no-op.
+    /// </summary>
+    public bool Reregister(long orderId, ulong newClOrdId)
+    {
+        if (newClOrdId == 0) return false;
+        if (!_byOrderId.TryGetValue(orderId, out var owner)) return false;
+        if (owner.ClOrdId == newClOrdId) return true;
+        var updated = owner with { ClOrdId = newClOrdId };
+        _byOrderId[orderId] = updated;
+        if (owner.ClOrdId != 0)
+            _byClOrdId.TryRemove(new KeyValuePair<(uint, ulong), long>((owner.Firm, owner.ClOrdId), orderId));
+        _byClOrdId[(owner.Firm, newClOrdId)] = orderId;
+        return true;
+    }
+
+    /// <summary>
     /// Removes the entry for <paramref name="orderId"/> and the matching
     /// reverse <c>(Firm, ClOrdId)</c> index entry (if any).
     /// </summary>

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -290,6 +290,28 @@ public readonly record struct StopOrderCanceledEvent(
     uint RptSeq);
 
 /// <summary>
+/// Fired when a resting order has been successfully replaced by a client
+/// request and the replace kept priority (price unchanged, quantity reduced,
+/// type/TIF unchanged). The integration layer translates this into an
+/// <c>ExecutionReport_Modify</c> back to the requesting session. Issue #251.
+///
+/// <para>The matching engine emits this <em>in addition</em> to the
+/// <see cref="OrderQuantityReducedEvent"/> that drives the UMDF UPDATE
+/// frame, so that legacy sinks observing only book-level mutations stay
+/// unaffected. The integration layer overrides this method to write the
+/// per-session ER and to refresh the (Firm, ClOrdID) → OrderId index so
+/// subsequent Cancel/Modify by the new ClOrdID resolve correctly.</para>
+/// </summary>
+public readonly record struct OrderModifiedEvent(
+    long SecurityId,
+    long OrderId,
+    Side Side,
+    long NewPriceMantissa,
+    long NewRemainingQuantity,
+    ulong TransactTimeNanos,
+    uint RptSeq);
+
+/// <summary>
 /// from any of these methods — the engine is single-threaded per channel and
 /// reentrant commands corrupt internal linked lists.
 /// </summary>
@@ -301,6 +323,15 @@ public interface IMatchingEventSink
     void OnOrderFilled(in OrderFilledEvent e);
     void OnTrade(in TradeEvent e);
     void OnReject(in RejectEvent e);
+
+    /// <summary>
+    /// Optional event emitted right after the
+    /// <see cref="OrderQuantityReducedEvent"/> on a priority-kept Replace,
+    /// to drive the per-session <c>ExecutionReport_Modify</c>. Default
+    /// no-op so legacy sinks (matching unit tests, bench) compile
+    /// unchanged. Issue #251.
+    /// </summary>
+    void OnOrderModified(in OrderModifiedEvent e) { }
 
     /// <summary>
     /// Optional summary event emitted once per (SecurityId, Side) at the

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -825,6 +825,7 @@ public sealed class MatchingEngine
                 long delta = resting.RemainingQuantity - cmd.NewQuantity;
                 resting.RemainingQuantity = cmd.NewQuantity;
                 resting.Level!.TotalQuantity -= delta;
+                uint rptSeq = NextRptSeq();
                 _sink.OnOrderQuantityReduced(new OrderQuantityReducedEvent(
                     SecurityId: book.SecurityId,
                     OrderId: resting.OrderId,
@@ -833,7 +834,22 @@ public sealed class MatchingEngine
                     NewRemainingQuantity: cmd.NewQuantity,
                     InsertTimestampNanos: resting.InsertTimestampNanos,
                     TransactTimeNanos: cmd.EnteredAtNanos,
-                    RptSeq: NextRptSeq()));
+                    RptSeq: rptSeq));
+                // Issue #251: priority-kept Replace must also surface as
+                // an ExecutionReport_Modify on the requesting session.
+                // The book mutation is announced via the UMDF UPDATE
+                // emitted above; this second event is the per-session ack
+                // hook the integration layer translates into ER_Modify
+                // (no additional UMDF frame, so the same RptSeq is reused
+                // for ER_Modify's MDEntry correlation).
+                _sink.OnOrderModified(new OrderModifiedEvent(
+                    SecurityId: book.SecurityId,
+                    OrderId: resting.OrderId,
+                    Side: resting.Side,
+                    NewPriceMantissa: resting.PriceMantissa,
+                    NewRemainingQuantity: cmd.NewQuantity,
+                    TransactTimeNanos: cmd.EnteredAtNanos,
+                    RptSeq: rptSeq));
                 RecomputeAuctionTopIfApplicable(cmd.SecurityId, cmd.EnteredAtNanos);
                 return;
             }

--- a/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
+++ b/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
@@ -267,7 +267,7 @@ public class EpcInteropTests : IAsyncLifetime
         Assert.Contains(events, e => e is OrderCancelled);
     }
 
-    [Fact(Skip = "Blocked by #251 — gateway does not emit ER_Modify on priority-kept Replace")]
+    [Fact]
     public async Task SimpleModify_Submit_Modify_RoundTrips()
     {
         var sessionVerId = (uint)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -295,12 +295,14 @@ public class EpcInteropTests : IAsyncLifetime
             Side = Side.Buy,
             OrderType = SimpleOrderType.Limit,
             TimeInForce = SimpleTimeInForce.Day,
-            OrderQty = 100,
+            OrderQty = 200,
             Price = 32.0m,
         }, cts.Token);
 
         await WaitFor(events, l => l.OfType<OrderAccepted>().Any(), cts.Token);
 
+        // Price unchanged + new qty (100) <= remaining (200) → priority kept
+        // path. Issue #251: gateway must surface ExecutionReport_Modify.
         await client.ReplaceSimpleAsync(new SimpleModifyRequest
         {
             ClOrdID = new ClOrdID(21),
@@ -309,8 +311,8 @@ public class EpcInteropTests : IAsyncLifetime
             Side = Side.Buy,
             OrderType = SimpleOrderType.Limit,
             TimeInForce = SimpleTimeInForce.Day,
-            OrderQty = 200,
-            Price = 31.95m,
+            OrderQty = 100,
+            Price = 32.0m,
         }, cts.Token);
 
         await WaitFor(events, l => l.OfType<OrderModified>().Any(), cts.Token);

--- a/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
@@ -42,6 +42,14 @@ public class CancelReplaceTests
         Assert.Equal(1000UL, u.InsertTimestampNanos); // priority preserved → original timestamp
         Assert.Equal(2000UL, u.TransactTimeNanos);
         Assert.Empty(sink.Canceled);
+        // Issue #251: priority-kept Replace also emits a per-session
+        // modify-ack hook with the same RptSeq as the UMDF UPDATE.
+        var m = Assert.Single(sink.Modified);
+        Assert.Equal(oid, m.OrderId);
+        Assert.Equal(Px(10m), m.NewPriceMantissa);
+        Assert.Equal(300, m.NewRemainingQuantity);
+        Assert.Equal(2000UL, m.TransactTimeNanos);
+        Assert.Equal(u.RptSeq, m.RptSeq);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -38,6 +38,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<OrderCanceledEvent> Canceled => Events.OfType<OrderCanceledEvent>().ToList();
     public List<OrderFilledEvent> Filled => Events.OfType<OrderFilledEvent>().ToList();
     public List<OrderQuantityReducedEvent> QtyReduced => Events.OfType<OrderQuantityReducedEvent>().ToList();
+    public List<OrderModifiedEvent> Modified => Events.OfType<OrderModifiedEvent>().ToList();
     public List<OrderMassCanceledEvent> MassCanceled => Events.OfType<OrderMassCanceledEvent>().ToList();
     public List<OrderBookSideEmptyEvent> BookSideEmpty => Events.OfType<OrderBookSideEmptyEvent>().ToList();
     public List<TradingPhaseChangedEvent> PhaseChanges => Events.OfType<TradingPhaseChangedEvent>().ToList();
@@ -50,6 +51,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
+    public void OnOrderModified(in OrderModifiedEvent e) => Events.Add(e);
     public void OnOrderCanceled(in OrderCanceledEvent e) => Events.Add(e);
     public void OnOrderFilled(in OrderFilledEvent e) => Events.Add(e);
     public void OnTrade(in TradeEvent e) => Events.Add(e);


### PR DESCRIPTION
Closes #251.

The matching engine's `Replace` path, when it kept book priority (price unchanged, quantity reduced, type/TIF unchanged), only emitted `OrderQuantityReducedEvent`. The integration layer turned that into a UMDF UPDATE frame but never wrote the per-session `ExecutionReport_Modify` the spec requires for any modify. EPC interop test `SimpleModify_Submit_Modify_RoundTrips` therefore saw `OrderAccepted` followed by nothing.

## Change

- New `OrderModifiedEvent` emitted by `MatchingEngine` alongside the existing `OrderQuantityReducedEvent` on the priority-kept Replace branch (same `RptSeq` so the ER's MDEntry correlates with the same UMDF UPDATE).
- New `OnOrderModified` hook on `IMatchingEventSink` (default no-op so legacy sinks compile).
- `ChannelDispatcher.OnOrderModified`: resolves owner via `OrderRegistry`, emits `ExecutionReport_Modify` with `(ClOrdID = requester's new id, OrigClOrdID = previous ClOrdID)`, and refreshes the `(Firm, ClOrdID) → OrderId` index via the new `OrderRegistry.Reregister` so subsequent Cancel/Modify by the new ClOrdID resolve.

## Tests

- Unskipped EPC interop `SimpleModify_Submit_Modify_RoundTrips` and reworked it to exercise the priority-kept branch (price unchanged, qty 200 → 100).
- Extended `Replace_QtyDecrease_PreservesPriority_EmitsQtyReduced` to assert the new event payload + shared RptSeq.
- All 4 EPC interop tests now pass; remaining 2 are still skipped against #252/#253.
