### PR TITLE
test(interop): document SDK OCRR encoder bug in skip reason (#252)

### DIFF
--- a/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
+++ b/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
@@ -197,7 +197,7 @@ public class EpcInteropTests : IAsyncLifetime
         // hardcodes OrigClOrdID = null (SDK bug, not gateway).
     }
 
-    [Fact(Skip = "Blocked by #252 — OrderCancelReplaceRequest (template 104) BusinessReject against EPC SDK 0.14.0 defaults")]
+    [Fact(Skip = "EPC SDK 0.14.0 bug: OrderCancelReplace encoder writes StopPx at offset 84 which overwrites OrigClOrdID (also at offset 84 per the OrderCancelReplaceRequestData struct). The encoder's hand-written explicit offsets for StopPx/MinQty/MaxFloor/AccountType/ExpireDate are all -8 from the struct's declared FieldOffsets. As a result OrigClOrdID never reaches the wire and the gateway correctly rejects 'requires either OrderID or OrigClOrdID'. Tracked by #252; re-enable when the SDK ships a fix or our gateway gets a OrigClOrdID-via-RAM-clobber heuristic.")]
     public async Task NewOrderSingleV6_Submit_Replace_Cancel_RoundTrips()
     {
         // Drives template 102 (NewOrderSingle V6) + template 104
@@ -244,7 +244,7 @@ public class EpcInteropTests : IAsyncLifetime
             OrderType = OrderType.Limit,
             TimeInForce = TimeInForce.Day,
             OrderQty = 100,
-            Price = 31.40m,
+            Price = 31.50m,
         }, cts.Token);
 
         await WaitFor(events, l => l.OfType<OrderModified>().Any(), cts.Token);


### PR DESCRIPTION
## #252 — root cause is an EPC SDK 0.14.0 OCRR encoder bug, not the gateway

While investigating the BusinessReject reported in #252, I decompiled the SDK's `OrderCancelReplaceRequestData` struct (`B3.Entrypoint.Fixp.Sbe.V6.OrderCancelReplaceRequestData`, `MESSAGE_SIZE = 150`, `TemplateId = 104`) and the SDK's hand-written `EncodeOrderCancelReplace` method.

The SBE-generated struct lays out:

| Field | Offset |
|---|---|
| `price` | 68 |
| `orderID` | 76 |
| `origClOrdID` | **84** |
| `stopPx` | **92** |
| `minQty` | **100** |
| `maxFloor` | **108** |
| `accountType` | **121** |
| `expireDate` | **122** |

But the SDK encoder writes:

```csharp
((OrderCancelReplaceRequestData)(ref value)).SetOrigClOrdID((ulong?)request.OrigClOrdID.Value);   // writes at struct offset 84
BinaryPrimitives.WriteInt64LittleEndian(MemoryMarshalAsBytes(ref value, 84, 8), long.MinValue);   // OVERWRITES OrigClOrdID with PriceNull
BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref value, 92, 8), request.MinQty.Value);    // wrong: should be 100
BinaryPrimitives.WriteUInt64LittleEndian(MemoryMarshalAsBytes(ref value, 100, 8), request.MaxFloor.Value); // wrong: should be 108
MemoryMarshalAsBytes(ref value, 113, 1)[0] = (byte)request.AccountType;                                    // wrong: should be 121
BinaryPrimitives.WriteUInt16LittleEndian(MemoryMarshalAsBytes(ref value, 114, 2), …);                      // wrong: should be 122
```

Every hand-written explicit offset for StopPx/MinQty/MaxFloor/AccountType/ExpireDate is **−8 bytes** off from the struct's declared `FieldOffsetAttribute`. The first symptom is the worst: `SetOrigClOrdID` correctly writes OrigClOrdID at offset 84, then the very next line clobbers it with `long.MinValue` (StopPx-as-null).

End result on the wire: `OrigClOrdID = 0` always. Our gateway then correctly fails `OrderID == 0 && OrigClOrdID == 0` and emits a BusinessReject. The reject is **correct behaviour** — there is no valid resting order to replace.

## What this PR ships

- Replace the previous placeholder skip reason on `NewOrderSingleV6_Submit_Replace_Cancel_RoundTrips` with the full SDK-bug explanation above so the next person looking at the failing interop test understands immediately why we can't patch this in the gateway.
- Adjust the test body to exercise priority-kept Replace (qty 200→100, price unchanged at 31.50) so when the SDK fix lands, the test naturally goes through the ER_Modify pipeline introduced in #251.

No production code changes — our V5 OCRR decoder matches the SBE-generated struct exactly.

## Why no gateway-side workaround

Trying to "rescue" `OrigClOrdID` from the SDK's clobbering would require either:
1. A heuristic that treats `StopPx == PriceNull && OrigClOrdID == 0` as "OrigClOrdID was clobbered, infer from session state" — fragile and impossible to reconcile with a future SDK fix.
2. A version-discriminated alternate offset map. But the bug isn't a layout difference; the SDK targets the same struct we decode, it just writes the wrong offsets. There's no consistent alternate layout we could decode with.

The right place to fix this is the SDK. We should open an upstream issue against EPC, then re-enable this test once 0.14.1+ ships.

Closes #252.
