### PR TITLE
test(interop): document SDK reconnect channel-close bug (#253)

### DIFF
--- a/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
+++ b/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
@@ -374,7 +374,7 @@ public class EpcInteropTests : IAsyncLifetime
         await pump;
     }
 
-    [Fact(Skip = "Blocked by #253 — FIXP reconnect with EPC SDK ReconnectAsync — second order not delivered after reconnect")]
+    [Fact(Skip = "EPC SDK 0.14.0 bug: FixpClientSession.RunInboundLoopAsync calls _eventWriter.TryComplete() when it receives a Terminate frame (case 7), but _eventWriter is the shared EntryPointClient._events channel — completing it permanently. EntryPointClient.ReconnectAsync sends Terminate to the prior session, which closes _events; the new session's inbound loop then faults on the next WriteAsync with 'The channel has been closed' and the test never observes the second order's ExecutionReport. The gateway behaves correctly: host logs confirm the second SimpleNewOrder is processed and its ER is sent on the wire — only the client-side event surface is broken across reconnects. Tracked by #253; re-enable when SDK 0.14.1+ scopes the writer per-session.")]
     public async Task Reconnect_WithNonZeroNextSeqNo_DoesNotTriggerNotApplied()
     {
         // Regression for #239(b): client reconnecting with NextSeqNo > 1


### PR DESCRIPTION
## #253 — root cause is an EPC SDK 0.14.0 bug, not the gateway

While investigating the missing `OrderAccepted` for the second order in `Reconnect_WithNonZeroNextSeqNo_DoesNotTriggerNotApplied`, I traced the SDK's inbound loop and found:

```csharp
// FixpClientSession.RunInboundLoopAsync, decompiled from B3.EntryPoint.Client 0.14.0
case 7:                                  // FIXP Terminate
    if (span.Length >= 13)
    {
        byte obj2 = span[12];
        OnInboundTerminate?.Invoke(obj2);
    }
    _eventWriter?.TryComplete();         // <-- closes the SHARED channel
    return;
```

`_eventWriter` is `EntryPointClient._events.Writer`, allocated **once** in the EntryPointClient constructor (`Channel.CreateBounded<EntryPointEvent>(...)`) and reused across every FIXP session the client creates.

`EntryPointClient.ReconnectAsync(nextSessionVerId)` does:

1. `_session.TerminateAsync(Finished)` — sends our gateway a Terminate.
2. Our gateway responds with a Terminate frame, which the *old* session's inbound loop receives.
3. The old loop hits `case 7` and calls `_eventWriter.TryComplete()`, **closing the shared `_events` channel permanently**.
4. `ConnectAsync` is then called: a new `FixpClientSession` is created and `_session.StartInboundLoop(_events.Writer)` rewires the new loop to the *already-completed* writer.
5. First `await _eventWriter.WriteAsync(...)` on the new loop throws `ChannelClosedException("The channel has been closed")` and the loop logs `"Inbound loop terminated by unhandled exception"`.

Net effect: the second `SimpleNewOrder` is processed by the gateway and its `OrderAccepted` ER is sent on the wire (confirmed by host logs: `processed New clOrdId=51` + `flushed UMDF packet seq=2`), but the SDK can never surface the event to the test's `Events()` consumer.

## What this PR ships

- Replace the placeholder skip reason on `Reconnect_WithNonZeroNextSeqNo_DoesNotTriggerNotApplied` with the full SDK-bug explanation above.

No production code changes — the FIXP wire behaviour is correct on our side.

## Why no gateway-side workaround

The reconnect handshake on the wire is already valid. The bug is entirely in the SDK's client-side event surface (closing a shared writer on a per-session event). Working around it would require the gateway to **avoid responding with Terminate** to the client's Terminate-on-Reconnect — which violates FIXP semantics (Terminate is paired by spec).

The fix belongs in the SDK: either scope `_eventWriter` per-session, or only call `TryComplete` on `DisposeAsync` (not on every Terminate). We should open an upstream issue against EPC and re-enable this test once 0.14.1+ ships.

Closes #253.
