### PR TITLE
test(interop): bump EPC SDK to 0.14.1 and unskip OCRR + reconnect tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.0" />
+    <PackageVersion Include="B3.EntryPoint.Client" Version="0.14.1" />
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="SbeSourceGenerator" Version="1.6.1" />

--- a/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
+++ b/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
@@ -197,7 +197,7 @@ public class EpcInteropTests : IAsyncLifetime
         // hardcodes OrigClOrdID = null (SDK bug, not gateway).
     }
 
-    [Fact(Skip = "EPC SDK 0.14.0 bug: OrderCancelReplace encoder writes StopPx at offset 84 which overwrites OrigClOrdID (also at offset 84 per the OrderCancelReplaceRequestData struct). The encoder's hand-written explicit offsets for StopPx/MinQty/MaxFloor/AccountType/ExpireDate are all -8 from the struct's declared FieldOffsets. As a result OrigClOrdID never reaches the wire and the gateway correctly rejects 'requires either OrderID or OrigClOrdID'. Tracked by #252; re-enable when the SDK ships a fix or our gateway gets a OrigClOrdID-via-RAM-clobber heuristic.")]
+    [Fact]
     public async Task NewOrderSingleV6_Submit_Replace_Cancel_RoundTrips()
     {
         // Drives template 102 (NewOrderSingle V6) + template 104
@@ -374,7 +374,7 @@ public class EpcInteropTests : IAsyncLifetime
         await pump;
     }
 
-    [Fact(Skip = "EPC SDK 0.14.0 bug: FixpClientSession.RunInboundLoopAsync calls _eventWriter.TryComplete() when it receives a Terminate frame (case 7), but _eventWriter is the shared EntryPointClient._events channel — completing it permanently. EntryPointClient.ReconnectAsync sends Terminate to the prior session, which closes _events; the new session's inbound loop then faults on the next WriteAsync with 'The channel has been closed' and the test never observes the second order's ExecutionReport. The gateway behaves correctly: host logs confirm the second SimpleNewOrder is processed and its ER is sent on the wire — only the client-side event surface is broken across reconnects. Tracked by #253; re-enable when SDK 0.14.1+ scopes the writer per-session.")]
+    [Fact]
     public async Task Reconnect_WithNonZeroNextSeqNo_DoesNotTriggerNotApplied()
     {
         // Regression for #239(b): client reconnecting with NextSeqNo > 1


### PR DESCRIPTION
Bumps `B3.EntryPoint.Client` to **0.14.1**, which ships the upstream fixes for the two SDK bugs that had forced us to skip interop tests in #248 / #252 / #253.

## What 0.14.1 fixes

- [pedrosakuma/B3EntryPointClient#145](https://github.com/pedrosakuma/B3EntryPointClient/issues/145) (via PR #147 there) — OCRR encoder used hand-coded `BinaryPrimitives.Write*` at offsets that were -8 from the SBE struct's `[FieldOffset]`s, causing `StopPx` to overwrite `OrigClOrdID`. Replaced by the generated setters. **Closes #252.**
- [pedrosakuma/B3EntryPointClient#144](https://github.com/pedrosakuma/B3EntryPointClient/issues/144) (via PR #146 there) — shared `_events` channel no longer gets `TryComplete()`d on session-level Terminate, so `ReconnectAsync` produces a usable session. **Closes #253.**

## Changes

- `Directory.Packages.props`: `B3.EntryPoint.Client` 0.14.0 → 0.14.1.
- `tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs`: removed `Skip` from `NewOrderSingleV6_Submit_Replace_Cancel_RoundTrips` and `Reconnect_WithNonZeroNextSeqNo_DoesNotTriggerNotApplied`.

## Validation

```
dotnet build -c Release            # 0 warnings, 0 errors
dotnet test  -c Release            # 853+ passed, 0 skipped (was 2 skipped)
dotnet format --verify-no-changes  # clean
```

Both previously-skipped tests now pass against 0.14.1 — proving the upstream fixes are correct end-to-end through our gateway.

Closes #252
Closes #253