### PR TITLE
feat(persistence): per-channel order book + counter snapshots (#260, phase 2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,13 @@ RUN apt-get update \
 WORKDIR /app
 COPY --from=build /app .
 
+# Issue #260: persistence snapshots (when the channel config opts in via
+# a `persistence.dataDir` block) are written here. Mount a durable volume
+# at this path (e.g. `-v b3matching-state:/var/lib/b3matching`) for
+# restart-safety; without a volume the directory lives inside the
+# container's writable layer and is wiped on `docker rm`.
+VOLUME ["/var/lib/b3matching"]
+
 # Default config is mounted into /app/config by docker-compose; override with
 # CMD if needed.
 EXPOSE 9876

--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -9,6 +9,7 @@
     <Project Path="src/B3.Exchange.Matching/B3.Exchange.Matching.csproj" />
     <Project Path="src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj" />
     <Project Path="src/B3.Exchange.Core/B3.Exchange.Core.csproj" />
+    <Project Path="src/B3.Exchange.Persistence/B3.Exchange.Persistence.csproj" />
     <Project Path="src/B3.Exchange.Host/B3.Exchange.Host.csproj" />
     <Project Path="src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj" />
   </Folder>
@@ -23,6 +24,7 @@
     <Project Path="tests/B3.EntryPoint.Wire.Tests/B3.EntryPoint.Wire.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Matching.Tests/B3.Exchange.Matching.Tests.csproj" />
+    <Project Path="tests/B3.Exchange.Persistence.Tests/B3.Exchange.Persistence.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj" />

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -192,6 +192,22 @@ Exposes:
   30, ~1.3 KB per chunk → fits a standard 1500-byte MTU). Omit the
   `snapshot` block to publish only the incremental feed (no bootstrap for
   mid-session consumers).
+* `persistence` *(optional, per channel — issue #260)* — enables order
+  book + counter persistence so a restart resumes with the live working
+  book, RptSeq, and order/trade-id allocators intact. When present, the
+  dispatcher writes an atomic JSON snapshot to
+  `{dataDir}/channel-{N}.snapshot` after every command flush and reloads
+  it on the dispatch loop's first turn.
+  * `dataDir` — directory holding the per-channel snapshot file. The host
+    creates it if missing. Mount a durable volume here in container
+    deployments (e.g. `/var/lib/b3matching` — see Dockerfile).
+  * Limitations *(out of scope for this PR; tracked separately)*: stop
+    orders, auction-top throttling state, the UMDF retransmit ring,
+    snapshot-rotator cursor, and FIXP session counters are not persisted.
+    Resting `OrderRegistry` ownership is restored as-is — passive fills
+    that arrive while the original session is still away are dropped on
+    the floor as before. Omit the `persistence` block to keep the legacy
+    stateless boot.
 
 ## Operability endpoints
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -30,6 +30,12 @@ public sealed partial class ChannelDispatcher
         // after the first in-thread call has latched the owner.
         _engine.BindToDispatchThread(_loopThread);
 
+        // Issue #260: rehydrate from disk (if a persister is wired) on the
+        // loop thread so the engine's owner-thread invariant is satisfied
+        // and CaptureState/RestoreState see the same Thread identity as
+        // every subsequent ProcessOne.
+        LoadPersistedStateOnLoopThread();
+
         // Heartbeat is recorded on every loop wakeup (whether triggered by
         // new work or by the periodic timeout) so a stuck/dead dispatch
         // thread is detected by /health/live within HeartbeatInterval +

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -248,6 +248,11 @@ public sealed partial class ChannelDispatcher
                 }
                 if (_metrics != null)
                     _metrics.OutboundEmit.ObserveTicks(System.Diagnostics.Stopwatch.GetTimestamp() - flushStart);
+                // Issue #260: persist post-flush so any consumer-visible
+                // event corresponds to a durable snapshot on disk before
+                // the next command is observed. Best-effort: failures are
+                // logged and swallowed by the helper.
+                OnAfterCommandFlushed();
             }
             else
             {

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -35,18 +35,32 @@ public sealed partial class ChannelDispatcher
         if (item.Kind == WorkKind.OperatorBumpVersion)
         {
             ProcessBumpVersion();
+            // Issue #260 follow-up (review feedback on PR #261): operator
+            // BumpVersion publishes ChannelReset_11 and clears engine
+            // state. Persist post-flush so a crash after the reset cannot
+            // resurrect the pre-reset book on next boot.
+            OnAfterCommandFlushed();
             return;
         }
 
         if (item.Kind == WorkKind.OperatorTradeBust)
         {
             ProcessTradeBust(item.TradeBust!);
+            // Persist after publishing TradeBust_57 so the consumed RptSeq
+            // (engine.AllocateNextRptSeq) survives restart — otherwise a
+            // restart would re-issue the same RptSeq for a different event.
+            OnAfterCommandFlushed();
             return;
         }
 
         if (item.Kind == WorkKind.OperatorSetTradingPhase)
         {
             ProcessSetTradingPhase(item.TradingPhase!);
+            // Persist after the phase mutation so the engine's per-symbol
+            // _phaseById map (captured into EngineStateSnapshot.Phases)
+            // and any RptSeq advance from SecurityStatus_3 emission
+            // survive restart.
+            OnAfterCommandFlushed();
             return;
         }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -1,0 +1,140 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging;
+using Side = B3.Exchange.Matching.Side;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Persistence facet of <see cref="ChannelDispatcher"/> (issue #260).
+/// Owns the snapshot/restore plumbing wired through
+/// <see cref="IChannelStatePersister"/>; integrates with
+/// <c>ProcessOne</c> via <see cref="OnAfterCommandFlushed"/> and with
+/// <c>RunLoopAsync</c> via <see cref="LoadPersistedStateOnLoopThread"/>.
+///
+/// <para>All state mutation paths assume single-threaded invocation on
+/// the dispatch loop thread (mirrors the engine's invariant). The
+/// persister itself is invoked synchronously inside the dispatch turn so
+/// any consumer-visible event has a corresponding durable snapshot before
+/// the next command is observed.</para>
+/// </summary>
+public sealed partial class ChannelDispatcher
+{
+    /// <summary>
+    /// Captures a full per-channel snapshot of dispatcher + engine state.
+    /// Invoked on the dispatch thread; safe to call between commands.
+    /// </summary>
+    public ChannelStateSnapshot CaptureChannelState()
+    {
+        AssertOnLoopThread();
+        var owners = new List<OrderOwnerSnapshot>(_orders.Count);
+        foreach (var entry in _orders.EnumerateAll())
+        {
+            owners.Add(new OrderOwnerSnapshot(
+                OrderId: entry.OrderId,
+                SessionValue: entry.State.Session.Value ?? string.Empty,
+                Firm: entry.State.Firm,
+                ClOrdId: entry.State.ClOrdId,
+                Side: entry.State.Side,
+                SecurityId: entry.State.SecurityId));
+        }
+        return new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: ChannelNumber,
+            SequenceNumber: _sequenceNumber,
+            SequenceVersion: _sequenceVersion,
+            Engine: _engine.CaptureState(),
+            Owners: owners);
+    }
+
+    /// <summary>
+    /// Restores dispatcher + engine state from <paramref name="snapshot"/>.
+    /// Must be invoked on the dispatch thread, before any command has been
+    /// processed. Refuses to overwrite a non-default state.
+    /// </summary>
+    public void RestoreChannelState(ChannelStateSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        AssertOnLoopThread();
+        if (snapshot.Version != ChannelStateSnapshot.CurrentVersion)
+            throw new InvalidOperationException(
+                $"channel {ChannelNumber}: snapshot schema version {snapshot.Version} unsupported (expected {ChannelStateSnapshot.CurrentVersion})");
+        if (snapshot.ChannelNumber != ChannelNumber)
+            throw new InvalidOperationException(
+                $"snapshot is for channel {snapshot.ChannelNumber}, not {ChannelNumber}");
+        if (_orders.Count != 0)
+            throw new InvalidOperationException("RestoreChannelState requires an empty OrderRegistry on the target dispatcher");
+
+        _engine.RestoreState(snapshot.Engine);
+
+        // Re-publish counters via the cross-thread-readable Volatile
+        // backing fields so the HTTP scrape sees the restored values
+        // immediately after the loop becomes ready.
+        Volatile.Write(ref _sequenceNumber, snapshot.SequenceNumber);
+        Volatile.Write(ref _sequenceVersion, snapshot.SequenceVersion);
+
+        foreach (var o in snapshot.Owners)
+        {
+            _orders.Register(o.OrderId, new SessionId(o.SessionValue), o.ClOrdId, o.Firm, o.Side, o.SecurityId);
+        }
+
+        _logger.LogInformation(
+            "channel {ChannelNumber}: restored snapshot — seq={SequenceNumber}/{SequenceVersion} owners={OwnerCount}",
+            ChannelNumber, snapshot.SequenceNumber, snapshot.SequenceVersion, snapshot.Owners.Count);
+    }
+
+    /// <summary>
+    /// Loads the persisted snapshot (when a persister is wired) and
+    /// applies it on the dispatch thread. Called from
+    /// <see cref="RunLoopAsync"/> immediately after
+    /// <c>BindToDispatchThread</c>, so the engine's owner thread is the
+    /// loop thread for both the restore and every subsequent dispatch.
+    /// Errors are logged and swallowed: a corrupt snapshot must not stop
+    /// the channel from accepting new orders (operators can fix the
+    /// underlying file or set <c>--reset-state</c>; future PR).
+    /// </summary>
+    private void LoadPersistedStateOnLoopThread()
+    {
+        if (_persister is null) return;
+        ChannelStateSnapshot? snapshot;
+        try
+        {
+            snapshot = _persister.TryLoad(ChannelNumber);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "channel {ChannelNumber}: persister TryLoad threw; starting from empty state", ChannelNumber);
+            return;
+        }
+        if (snapshot is null) return;
+        try
+        {
+            RestoreChannelState(snapshot);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "channel {ChannelNumber}: RestoreChannelState failed; channel may be partially restored", ChannelNumber);
+        }
+    }
+
+    /// <summary>
+    /// Hook invoked by <c>ProcessOne</c> after a successful flush.
+    /// Captures the channel state and forwards it to the persister
+    /// best-effort — exceptions are logged and swallowed so persistence
+    /// failure never crashes the dispatcher.
+    /// </summary>
+    private void OnAfterCommandFlushed()
+    {
+        if (_persister is null) return;
+        try
+        {
+            var snap = CaptureChannelState();
+            _persister.Save(snap);
+        }
+        catch (Exception ex)
+        {
+            _metrics?.IncDispatcherCrashes();
+            _logger.LogError(ex, "channel {ChannelNumber}: persister Save failed", ChannelNumber);
+        }
+    }
+}

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -27,9 +27,28 @@ public sealed partial class ChannelDispatcher
     public ChannelStateSnapshot CaptureChannelState()
     {
         AssertOnLoopThread();
-        var owners = new List<OrderOwnerSnapshot>(_orders.Count);
+        // Issue #260 follow-up (review feedback on PR #261): only owners
+        // for orders that the engine considers resting belong in the
+        // snapshot. Stop orders also live in _orders but are intentionally
+        // omitted from EngineStateSnapshot (they do not match against the
+        // limit book). Persisting them would resurrect phantom OrigClOrdID
+        // mappings on restore (cancels would resolve to non-existent
+        // engine orders). Compute the engine-resting set first, then
+        // filter.
+        var engineSnap = _engine.CaptureState();
+        var restingIds = new HashSet<long>();
+        foreach (var book in engineSnap.Books)
+            foreach (var o in book.Orders)
+                restingIds.Add(o.OrderId);
+        var owners = new List<OrderOwnerSnapshot>(restingIds.Count);
+        int dropped = 0;
         foreach (var entry in _orders.EnumerateAll())
         {
+            if (!restingIds.Contains(entry.OrderId))
+            {
+                dropped++;
+                continue;
+            }
             owners.Add(new OrderOwnerSnapshot(
                 OrderId: entry.OrderId,
                 SessionValue: entry.State.Session.Value ?? string.Empty,
@@ -38,12 +57,18 @@ public sealed partial class ChannelDispatcher
                 Side: entry.State.Side,
                 SecurityId: entry.State.SecurityId));
         }
+        if (dropped > 0)
+        {
+            _logger.LogDebug(
+                "channel {ChannelNumber}: snapshot dropped {Dropped} non-resting owners (stops/in-flight)",
+                ChannelNumber, dropped);
+        }
         return new ChannelStateSnapshot(
             Version: ChannelStateSnapshot.CurrentVersion,
             ChannelNumber: ChannelNumber,
             SequenceNumber: _sequenceNumber,
             SequenceVersion: _sequenceVersion,
-            Engine: _engine.CaptureState(),
+            Engine: engineSnap,
             Owners: owners);
     }
 
@@ -51,6 +76,14 @@ public sealed partial class ChannelDispatcher
     /// Restores dispatcher + engine state from <paramref name="snapshot"/>.
     /// Must be invoked on the dispatch thread, before any command has been
     /// processed. Refuses to overwrite a non-default state.
+    ///
+    /// <para>Issue #260 follow-up (review feedback on PR #261): all
+    /// structural validation runs <em>before</em> any mutation so the
+    /// engine cannot end up half-restored. If validation fails the
+    /// snapshot is rejected with no side effects; if engine/registry
+    /// rebuild fails after validation, the exception is propagated and
+    /// the channel must fail-closed (the loop terminates → heartbeat
+    /// goes stale → <c>/health/live</c> trips).</para>
     /// </summary>
     public void RestoreChannelState(ChannelStateSnapshot snapshot)
     {
@@ -64,6 +97,8 @@ public sealed partial class ChannelDispatcher
                 $"snapshot is for channel {snapshot.ChannelNumber}, not {ChannelNumber}");
         if (_orders.Count != 0)
             throw new InvalidOperationException("RestoreChannelState requires an empty OrderRegistry on the target dispatcher");
+
+        ValidateSnapshotStructure(snapshot);
 
         _engine.RestoreState(snapshot.Engine);
 
@@ -84,14 +119,54 @@ public sealed partial class ChannelDispatcher
     }
 
     /// <summary>
+    /// Pure-read structural validation of <paramref name="snapshot"/>.
+    /// Throws <see cref="InvalidOperationException"/> with a precise
+    /// reason when the snapshot is malformed (duplicate orderIds across
+    /// books, owners referencing orderIds not present in any book, etc.).
+    /// Runs before any mutation so RestoreChannelState is all-or-nothing.
+    /// </summary>
+    private static void ValidateSnapshotStructure(ChannelStateSnapshot snapshot)
+    {
+        var seenOrderIds = new HashSet<long>();
+        foreach (var book in snapshot.Engine.Books)
+        {
+            foreach (var o in book.Orders)
+            {
+                if (o.RemainingQuantity <= 0)
+                    throw new InvalidOperationException(
+                        $"snapshot orderId {o.OrderId} on securityId {book.SecurityId} has non-positive remainingQuantity {o.RemainingQuantity}");
+                if (!seenOrderIds.Add(o.OrderId))
+                    throw new InvalidOperationException(
+                        $"snapshot contains duplicate orderId {o.OrderId} (in book for securityId {book.SecurityId})");
+                if (o.OrderId >= snapshot.Engine.NextOrderId)
+                    throw new InvalidOperationException(
+                        $"snapshot orderId {o.OrderId} is >= NextOrderId {snapshot.Engine.NextOrderId} (would collide with future allocations)");
+            }
+        }
+        foreach (var owner in snapshot.Owners)
+        {
+            if (!seenOrderIds.Contains(owner.OrderId))
+                throw new InvalidOperationException(
+                    $"snapshot owner refers to orderId {owner.OrderId} which is not present in any restored book");
+        }
+    }
+
+    /// <summary>
     /// Loads the persisted snapshot (when a persister is wired) and
     /// applies it on the dispatch thread. Called from
     /// <see cref="RunLoopAsync"/> immediately after
     /// <c>BindToDispatchThread</c>, so the engine's owner thread is the
     /// loop thread for both the restore and every subsequent dispatch.
-    /// Errors are logged and swallowed: a corrupt snapshot must not stop
-    /// the channel from accepting new orders (operators can fix the
-    /// underlying file or set <c>--reset-state</c>; future PR).
+    ///
+    /// <para>Issue #260 follow-up (review feedback on PR #261): a
+    /// corrupt/partial snapshot is fatal. We rethrow so the dispatch
+    /// loop exits, the heartbeat goes stale and <c>/health/live</c>
+    /// trips — that is preferable to silently running the channel with
+    /// a half-restored book (would risk duplicate IDs, missing
+    /// ownership, incorrect future matching). Operators must remove
+    /// or repair the snapshot file (or use a future <c>--reset-state</c>
+    /// flag) before restarting. <c>TryLoad</c>-time IO failures are
+    /// also fatal for the same reason.</para>
     /// </summary>
     private void LoadPersistedStateOnLoopThread()
     {
@@ -103,8 +178,10 @@ public sealed partial class ChannelDispatcher
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "channel {ChannelNumber}: persister TryLoad threw; starting from empty state", ChannelNumber);
-            return;
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: persister TryLoad threw — failing channel closed",
+                ChannelNumber);
+            throw;
         }
         if (snapshot is null) return;
         try
@@ -113,7 +190,10 @@ public sealed partial class ChannelDispatcher
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "channel {ChannelNumber}: RestoreChannelState failed; channel may be partially restored", ChannelNumber);
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: RestoreChannelState failed — failing channel closed (snapshot must be repaired or removed)",
+                ChannelNumber);
+            throw;
         }
     }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -135,6 +135,14 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// (host config <c>umdfRetransmit.bufferSize=0</c>).</summary>
     private readonly UmdfPacketRetransmitBuffer? _retxBuffer;
 
+    /// <summary>
+    /// Optional state persister (issue #260). When non-null, the dispatcher
+    /// loads any persisted snapshot at loop entry and writes a fresh
+    /// snapshot after every command flush. <c>null</c> ⇒ stateless boot
+    /// (legacy behaviour).
+    /// </summary>
+    private readonly IChannelStatePersister? _persister;
+
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
     private SessionId _currentSession;
@@ -184,7 +192,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         Func<ulong>? nowNanos = null, ushort tradeDate = 0, int inboundCapacity = DefaultInboundCapacity,
         ChannelMetrics? metrics = null,
         BoundedSessionFirmCounters? sessionFirmCounters = null,
-        UmdfPacketRetransmitBuffer? retxBuffer = null)
+        UmdfPacketRetransmitBuffer? retxBuffer = null,
+        IChannelStatePersister? persister = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -197,6 +206,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _metrics = metrics;
         _sessionFirmCounters = sessionFirmCounters;
         _retxBuffer = retxBuffer;
+        _persister = persister;
         // Direct field writes are safe here: ctor runs on the constructing
         // thread before Start() and before any other thread can observe the
         // instance. No memory barrier is needed.

--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -1,0 +1,68 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Matching;
+using Side = B3.Exchange.Matching.Side;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Persistable view of a single per-channel order ownership tuple
+/// (issue #260). One entry per resting order; the persister captures these
+/// alongside the engine snapshot so <see cref="OrderRegistry"/> can be
+/// rebuilt and PASSIVE-side execution reports keep routing to the original
+/// session after a restart (assuming the same session reconnects).
+/// </summary>
+public sealed record OrderOwnerSnapshot(
+    long OrderId,
+    string SessionValue,
+    uint Firm,
+    ulong ClOrdId,
+    Side Side,
+    long SecurityId);
+
+/// <summary>
+/// Per-channel persistable state captured by
+/// <see cref="ChannelDispatcher.CaptureChannelState"/> and consumed by
+/// <see cref="ChannelDispatcher.RestoreChannelState"/>. Wraps the
+/// engine-owned <see cref="EngineStateSnapshot"/> and adds the
+/// dispatcher-owned counters and per-order ownership index.
+///
+/// <para><b>Out of scope (v1):</b> the UMDF retransmit ring, snapshot
+/// rotator cursor, and any in-flight buffered packet are NOT persisted
+/// — restored channels emit fresh packets at <c>SequenceNumber+1</c> with
+/// the previous <c>SequenceVersion</c>; consumers that miss the gap
+/// recover via the snapshot feed.</para>
+/// </summary>
+public sealed record ChannelStateSnapshot(
+    /// <summary>Snapshot schema version. Bumped on incompatible layout
+    /// changes so old snapshots can be detected and rejected on load.</summary>
+    int Version,
+    byte ChannelNumber,
+    uint SequenceNumber,
+    ushort SequenceVersion,
+    EngineStateSnapshot Engine,
+    IReadOnlyList<OrderOwnerSnapshot> Owners)
+{
+    public const int CurrentVersion = 1;
+}
+
+/// <summary>
+/// Pluggable persistence sink for per-channel matching state (issue #260).
+/// Production wires <c>FileChannelStatePersister</c> from
+/// <c>B3.Exchange.Persistence</c>; tests use in-memory fakes.
+///
+/// <para>All methods are invoked on the channel's dispatch thread (single
+/// writer). Implementations MUST treat <see cref="Save"/> as best-effort
+/// and never throw — exceptions are swallowed and logged by the dispatcher
+/// so a transient disk error does not crash the engine.</para>
+/// </summary>
+public interface IChannelStatePersister
+{
+    /// <summary>Loads the most recent persisted snapshot for the
+    /// channel, or <c>null</c> when none exists / load failed.</summary>
+    ChannelStateSnapshot? TryLoad(byte channelNumber);
+
+    /// <summary>Persists <paramref name="snapshot"/> atomically.
+    /// Implementations should perform tmp-write + fsync + rename so a
+    /// crash mid-write never leaves a partial file on disk.</summary>
+    void Save(ChannelStateSnapshot snapshot);
+}

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -36,6 +36,21 @@ public sealed class OrderRegistry
 
     public int Count => _byOrderId.Count;
 
+    /// <summary>
+    /// Enumerates every (OrderId, OrderState) tuple currently registered.
+    /// Snapshot semantics: the underlying
+    /// <see cref="ConcurrentDictionary{TKey, TValue}"/> enumerator is
+    /// weakly consistent, which is acceptable here because the only
+    /// caller (<see cref="ChannelDispatcher.CaptureChannelState"/>) runs
+    /// on the dispatch thread — the single writer — so concurrent
+    /// mutation is impossible during enumeration. Issue #260.
+    /// </summary>
+    public IEnumerable<(long OrderId, OrderState State)> EnumerateAll()
+    {
+        foreach (var kv in _byOrderId)
+            yield return (kv.Key, kv.Value);
+    }
+
     public void Register(long orderId, SessionId session, ulong clOrdId, uint firm, Side side, long securityId)
     {
         _byOrderId[orderId] = new OrderState(session, clOrdId, firm, side, securityId);

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Persistence\B3.Exchange.Persistence.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -4,6 +4,7 @@ using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -167,7 +168,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 logger: _loggerFactory.CreateLogger<ChannelDispatcher>(),
                 metrics: channelMetrics,
                 sessionFirmCounters: _metrics.SessionFirmMessages,
-                retxBuffer: retxBuffer);
+                retxBuffer: retxBuffer,
+                persister: BuildPersister(ch));
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -411,6 +413,26 @@ public sealed class ExchangeHost : IAsyncDisposable
         var local = localInterface != null ? IPAddress.Parse(localInterface) : null;
         return new MulticastUdpPacketSink(IPAddress.Parse(host), port,
             _loggerFactory.CreateLogger<MulticastUdpPacketSink>(), local, ttl);
+    }
+
+    /// <summary>
+    /// Builds the per-channel persister (issue #260). Returns
+    /// <c>null</c> when the channel has no <c>persistence</c> block,
+    /// preserving the legacy stateless boot for configs that haven't
+    /// opted in.
+    /// </summary>
+    private IChannelStatePersister? BuildPersister(ChannelConfig ch)
+    {
+        if (ch.Persistence is null) return null;
+        if (string.IsNullOrWhiteSpace(ch.Persistence.DataDir))
+        {
+            _logger.LogWarning("channel {ChannelNumber}: persistence.dataDir is empty; skipping persister",
+                ch.ChannelNumber);
+            return null;
+        }
+        return new FileChannelStatePersister(
+            ch.Persistence.DataDir,
+            _loggerFactory.CreateLogger<FileChannelStatePersister>());
     }
 
     private FirmRegistry BuildFirmRegistry()

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -241,6 +241,27 @@ public sealed class ChannelConfig
     /// gap detection) without external network-shaping tools.
     /// </summary>
     [JsonPropertyName("chaos")] public ChaosConfigJson? Chaos { get; set; }
+
+    /// <summary>
+    /// Optional per-channel persistence (issue #260). When present, the
+    /// dispatcher loads any existing snapshot from
+    /// <see cref="PersistenceConfig.DataDir"/>/<c>channel-{N}.snapshot</c>
+    /// at boot and persists a fresh snapshot after every command flush so
+    /// a restart resumes with the working order book + RptSeq + counters
+    /// intact. Omit to keep the legacy stateless boot.
+    /// </summary>
+    [JsonPropertyName("persistence")] public PersistenceConfig? Persistence { get; set; }
+}
+
+/// <summary>
+/// Per-channel persistence config (issue #260). The host creates
+/// <see cref="DataDir"/> if missing and writes one snapshot file per
+/// channel. Operators must mount a durable volume at this path
+/// (e.g. <c>/var/lib/b3matching</c>) for restart-safety to be meaningful.
+/// </summary>
+public sealed class PersistenceConfig
+{
+    [JsonPropertyName("dataDir")] public string DataDir { get; set; } = "";
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -1,0 +1,43 @@
+namespace B3.Exchange.Matching;
+
+/// <summary>
+/// Engine-level snapshot consumed by the persistence layer (issue #260).
+/// Captures every piece of <see cref="MatchingEngine"/> state required to
+/// restore a working order book across a process restart, while leaving
+/// transient artefacts (auction-top throttling, in-flight dispatch flags)
+/// off the wire — those are recomputed lazily after restore.
+///
+/// <para><b>Out of scope (v1):</b> stop orders (<c>_stopsBySymbol</c>) and
+/// auction indicative throttling (<c>_auctionTopById</c>) — restoring these
+/// safely would require replaying the trigger price stream. Operators that
+/// rely on them should drain in-flight stops before restart; the omission
+/// is documented in <c>docs/EXCHANGE-SIMULATOR.md</c>.</para>
+/// </summary>
+public sealed record EngineStateSnapshot(
+    long NextOrderId,
+    uint NextTradeId,
+    uint RptSeq,
+    IReadOnlyList<EngineStateSnapshot.PhaseEntry> Phases,
+    IReadOnlyList<EngineStateSnapshot.BookSnapshot> Books)
+{
+    public sealed record PhaseEntry(long SecurityId, TradingPhase Phase);
+
+    public sealed record BookSnapshot(long SecurityId, IReadOnlyList<RestingOrderRecord> Orders);
+}
+
+/// <summary>
+/// Persistable view of a single resting order — superset of
+/// <see cref="RestingOrderView"/> that also carries the iceberg/Tif fields
+/// required to faithfully rebuild a <c>RestingOrder</c> on restore.
+/// </summary>
+public sealed record RestingOrderRecord(
+    long OrderId,
+    string ClOrdId,
+    Side Side,
+    long PriceMantissa,
+    long RemainingQuantity,
+    uint EnteringFirm,
+    ulong InsertTimestampNanos,
+    TimeInForce Tif,
+    long MaxFloor,
+    long HiddenQuantity);

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -228,6 +228,63 @@ internal sealed class LimitOrderBook
         }
     }
 
+    /// <summary>
+    /// Persistence-friendly enumeration of every resting order on this book
+    /// (issue #260). Yields in price-time priority and includes iceberg /
+    /// TimeInForce fields that <see cref="RestingOrderView"/> intentionally
+    /// hides. Used only by the snapshot capture path.
+    /// </summary>
+    public IEnumerable<RestingOrderRecord> EnumerateAllOrdersForSnapshot()
+    {
+        foreach (var side in new[] { Side.Buy, Side.Sell })
+        {
+            foreach (var kv in SideMap(side))
+            {
+                for (var o = kv.Value.Head; o is not null; o = o.Next)
+                {
+                    yield return new RestingOrderRecord(
+                        OrderId: o.OrderId,
+                        ClOrdId: o.ClOrdId,
+                        Side: o.Side,
+                        PriceMantissa: o.PriceMantissa,
+                        RemainingQuantity: o.RemainingQuantity,
+                        EnteringFirm: o.EnteringFirm,
+                        InsertTimestampNanos: o.InsertTimestampNanos,
+                        Tif: o.Tif,
+                        MaxFloor: o.MaxFloor,
+                        HiddenQuantity: o.HiddenQuantity);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Inserts a resting order rebuilt from a snapshot (issue #260).
+    /// Insertion happens at the back of the price level, so callers MUST
+    /// feed records in the order produced by
+    /// <see cref="EnumerateAllOrdersForSnapshot"/> (price-time priority)
+    /// to preserve FIFO ordering across restart.
+    /// </summary>
+    public void RestoreOrder(RestingOrderRecord record)
+    {
+        if (record.RemainingQuantity <= 0)
+            throw new ArgumentException("RemainingQuantity must be positive", nameof(record));
+        var order = new RestingOrder
+        {
+            OrderId = record.OrderId,
+            ClOrdId = record.ClOrdId,
+            Side = record.Side,
+            PriceMantissa = record.PriceMantissa,
+            EnteringFirm = record.EnteringFirm,
+            InsertTimestampNanos = record.InsertTimestampNanos,
+            Tif = record.Tif,
+            MaxFloor = record.MaxFloor,
+            HiddenQuantity = record.HiddenQuantity,
+            RemainingQuantity = record.RemainingQuantity,
+        };
+        Insert(order);
+    }
+
     public static Side Opposite(Side s) => s == Side.Buy ? Side.Sell : Side.Buy;
 
     public static bool PriceCrosses(Side aggressorSide, long oppositePrice, long aggressorLimit)

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -123,6 +123,85 @@ public sealed class MatchingEngine
     public SelfTradePrevention SelfTradePrevention => _stp;
 
     /// <summary>
+    /// Captures the engine's resumable state for persistence (issue #260).
+    /// Counters, per-instrument trading phase and every resting order in
+    /// every book are included; transient artefacts (auction-top
+    /// throttling, dispatch flags, stop-order book) are intentionally
+    /// omitted — see <see cref="EngineStateSnapshot"/> remarks.
+    ///
+    /// <para>Must be invoked from the dispatch thread (matching the
+    /// engine's single-thread invariant); cannot run mid-dispatch.</para>
+    /// </summary>
+    public EngineStateSnapshot CaptureState()
+    {
+        AssertOnOwnerThread();
+        if (_dispatching)
+            throw new InvalidOperationException("CaptureState called from inside a sink callback. Snapshots must not interleave with engine dispatch.");
+        var phases = new List<EngineStateSnapshot.PhaseEntry>(_phaseById.Count);
+        foreach (var kv in _phaseById)
+            phases.Add(new EngineStateSnapshot.PhaseEntry(kv.Key, kv.Value));
+        var books = new List<EngineStateSnapshot.BookSnapshot>(_booksById.Count);
+        foreach (var kv in _booksById)
+        {
+            var orders = kv.Value.EnumerateAllOrdersForSnapshot().ToList();
+            books.Add(new EngineStateSnapshot.BookSnapshot(kv.Key, orders));
+        }
+        return new EngineStateSnapshot(_nextOrderId, _nextTradeId, _rptSeq, phases, books);
+    }
+
+    /// <summary>
+    /// Restores engine state previously produced by <see cref="CaptureState"/>
+    /// (issue #260). The engine MUST be freshly constructed (all books
+    /// empty, counters at their defaults) — restore refuses to overwrite a
+    /// non-empty state to avoid silently merging an old snapshot on top of
+    /// live state. Phases and books are matched by SecurityId; unknown
+    /// SecurityIds in the snapshot are ignored with a warning so an
+    /// instrument removed from the channel config does not break boot.
+    /// </summary>
+    public void RestoreState(EngineStateSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        AssertOnOwnerThread();
+        if (_dispatching)
+            throw new InvalidOperationException("cannot restore state while a command is being dispatched");
+        if (_nextOrderId != 1 || _nextTradeId != 1 || _rptSeq != 0)
+            throw new InvalidOperationException("RestoreState requires a freshly constructed engine");
+        foreach (var book in _booksById.Values)
+        {
+            if (book.OrderCount != 0)
+                throw new InvalidOperationException("RestoreState requires empty books on the target engine");
+        }
+
+        _nextOrderId = snapshot.NextOrderId;
+        _nextTradeId = snapshot.NextTradeId;
+        _rptSeq = snapshot.RptSeq;
+        foreach (var p in snapshot.Phases)
+        {
+            if (_phaseById.ContainsKey(p.SecurityId))
+                _phaseById[p.SecurityId] = p.Phase;
+            else
+                _logger.LogWarning("RestoreState: ignoring phase entry for unknown securityId {SecurityId}", p.SecurityId);
+        }
+        int restored = 0;
+        foreach (var b in snapshot.Books)
+        {
+            if (!_booksById.TryGetValue(b.SecurityId, out var book))
+            {
+                _logger.LogWarning("RestoreState: ignoring book for unknown securityId {SecurityId} ({OrderCount} orders dropped)",
+                    b.SecurityId, b.Orders.Count);
+                continue;
+            }
+            foreach (var o in b.Orders)
+            {
+                book.RestoreOrder(o);
+                restored++;
+            }
+        }
+        _logger.LogInformation("RestoreState complete: nextOrderId={NextOrderId} nextTradeId={NextTradeId} rptSeq={RptSeq} restingOrders={RestingOrders}",
+            _nextOrderId, _nextTradeId, _rptSeq, restored);
+    }
+
+    /// <summary>
     /// Allocates and returns the next <c>RptSeq</c> value without emitting
     /// any matching event. Designed for the operator-triggered trade-bust
     /// replay path (issue #15) where the dispatcher synthesises a

--- a/src/B3.Exchange.Persistence/B3.Exchange.Persistence.csproj
+++ b/src/B3.Exchange.Persistence/B3.Exchange.Persistence.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Exchange.Persistence</RootNamespace>
+    <AssemblyName>B3.Exchange.Persistence</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+</Project>

--- a/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
+++ b/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Persistence;
+
+/// <summary>
+/// File-system backed implementation of
+/// <see cref="IChannelStatePersister"/> (issue #260). One snapshot file per
+/// channel under <see cref="DataDirectory"/>:
+/// <c>channel-{N}.snapshot</c>, written atomically via
+/// tmp + fsync + rename so a crash mid-write can never leave a partial file.
+///
+/// <para>Serialization uses System.Text.Json with enums-as-strings for
+/// debuggability — operators can <c>cat</c> a snapshot and read it. The
+/// extra cost (vs binary) is bounded: typical snapshots are a few KB to a
+/// few MB and serialization happens once per command flush, off the
+/// hot UMDF send path.</para>
+///
+/// <para><b>Atomicity:</b> on POSIX <see cref="File.Move(string, string, bool)"/>
+/// uses <c>rename(2)</c>, which is atomic on the same filesystem. We
+/// fsync the tmp file's data before rename and fsync the parent directory
+/// after rename so an abrupt power-loss is recoverable.</para>
+/// </summary>
+public sealed class FileChannelStatePersister : IChannelStatePersister
+{
+    private const string SnapshotFileNameFormat = "channel-{0}.snapshot";
+    private const string TempFileNameFormat = "channel-{0}.snapshot.tmp";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        // Easier to diff/read in incident review. The marginal size cost
+        // is negligible for files of this scale.
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+
+    private readonly string _dataDir;
+    private readonly ILogger<FileChannelStatePersister> _logger;
+
+    public string DataDirectory => _dataDir;
+
+    public FileChannelStatePersister(string dataDirectory, ILogger<FileChannelStatePersister> logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
+        ArgumentNullException.ThrowIfNull(logger);
+        _dataDir = Path.GetFullPath(dataDirectory);
+        _logger = logger;
+        Directory.CreateDirectory(_dataDir);
+    }
+
+    public ChannelStateSnapshot? TryLoad(byte channelNumber)
+    {
+        var path = SnapshotPath(channelNumber);
+        if (!File.Exists(path)) return null;
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            var snapshot = JsonSerializer.Deserialize<ChannelStateSnapshot>(fs, JsonOptions);
+            if (snapshot is null)
+            {
+                _logger.LogWarning("channel {ChannelNumber}: snapshot deserialized to null at {Path}", channelNumber, path);
+                return null;
+            }
+            _logger.LogInformation("channel {ChannelNumber}: loaded snapshot from {Path} (seq={SequenceNumber}/{SequenceVersion}, owners={OwnerCount})",
+                channelNumber, path, snapshot.SequenceNumber, snapshot.SequenceVersion, snapshot.Owners.Count);
+            return snapshot;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "channel {ChannelNumber}: failed to load snapshot at {Path}; ignoring", channelNumber, path);
+            return null;
+        }
+    }
+
+    public void Save(ChannelStateSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        var path = SnapshotPath(snapshot.ChannelNumber);
+        var tmp = TempPath(snapshot.ChannelNumber);
+        try
+        {
+            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                JsonSerializer.Serialize(fs, snapshot, JsonOptions);
+                fs.Flush(flushToDisk: true);
+            }
+            // File.Move uses rename(2) on POSIX → atomic within the same
+            // filesystem. overwrite=true so the previous snapshot is
+            // replaced in place.
+            File.Move(tmp, path, overwrite: true);
+            FsyncDirectory(_dataDir);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "channel {ChannelNumber}: failed to persist snapshot to {Path}", snapshot.ChannelNumber, path);
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
+            throw;
+        }
+    }
+
+    private string SnapshotPath(byte channelNumber)
+        => Path.Combine(_dataDir, string.Format(System.Globalization.CultureInfo.InvariantCulture, SnapshotFileNameFormat, channelNumber));
+
+    private string TempPath(byte channelNumber)
+        => Path.Combine(_dataDir, string.Format(System.Globalization.CultureInfo.InvariantCulture, TempFileNameFormat, channelNumber));
+
+    /// <summary>
+    /// Ensures the parent directory entry for the renamed file is durable.
+    /// On Linux the BCL exposes no portable directory-fsync; we fall back
+    /// to opening the directory with <see cref="FileOptions.WriteThrough"/>
+    /// semantics where supported. Failures are non-fatal — they only widen
+    /// the crash-loss window for the very last rename.
+    /// </summary>
+    private static void FsyncDirectory(string dir)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+        try
+        {
+            // Open with O_DIRECTORY|O_RDONLY equivalent and call fsync.
+            // SafeFileHandle path keeps us off P/Invoke for portability.
+            using var dirHandle = File.OpenHandle(dir, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, FileOptions.None);
+            RandomAccess.FlushToDisk(dirHandle);
+        }
+        catch
+        {
+            // Best-effort. On filesystems that reject fsync(directory) this
+            // throws EINVAL; the snapshot file itself is already durable.
+        }
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/B3.Exchange.Persistence.Tests.csproj
+++ b/tests/B3.Exchange.Persistence.Tests/B3.Exchange.Persistence.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Exchange.Contracts\B3.Exchange.Contracts.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.Persistence\B3.Exchange.Persistence.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -1,0 +1,169 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using RejectEvent = B3.Exchange.Matching.RejectEvent;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+using OrderType = B3.Exchange.Matching.OrderType;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Integration tests for the dispatcher-level persistence cycle
+/// (issue #260): Save invoked after each command flush, Restore rebuilds
+/// engine + OrderRegistry + sequence counters.
+/// </summary>
+public class ChannelDispatcherPersistenceTests
+{
+    private const long Sec = 900_000_000_001L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class NoOpOutbound : ICoreOutbound
+    {
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportReject(SessionId s, in RejectEvent e, ulong c) => true;
+    }
+
+    /// <summary>
+    /// In-memory persister capturing every Save and forwarding loads to
+    /// the most recent snapshot stored. Mirrors
+    /// <see cref="FileChannelStatePersister"/> semantics without touching
+    /// the disk.
+    /// </summary>
+    private sealed class InMemoryPersister : IChannelStatePersister
+    {
+        public Dictionary<byte, ChannelStateSnapshot> Last { get; } = new();
+        public int SaveCount { get; private set; }
+
+        public ChannelStateSnapshot? TryLoad(byte channelNumber)
+            => Last.TryGetValue(channelNumber, out var s) ? s : null;
+
+        public void Save(ChannelStateSnapshot snapshot)
+        {
+            SaveCount++;
+            Last[snapshot.ChannelNumber] = snapshot;
+        }
+    }
+
+    private static ChannelDispatcher BuildDispatcher(
+        IChannelStatePersister persister,
+        out NoOpOutbound outbound)
+    {
+        outbound = new NoOpOutbound();
+        var localOutbound = outbound;
+        return new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s,
+                NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: localOutbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            persister: persister);
+    }
+
+    [Fact]
+    public void SaveInvokedAfterEveryCommandFlush_PersistsBookAndOwners()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("10101");
+
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-1", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, 1000UL),
+            session, enteringFirm: 100, clOrdIdValue: 0xAAAA));
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-2", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 200, 100, 2000UL),
+            session, enteringFirm: 100, clOrdIdValue: 0xBBBB));
+        probe.DrainInbound();
+
+        Assert.Equal(2, persister.SaveCount);
+        var snap = persister.TryLoad(84);
+        Assert.NotNull(snap);
+        Assert.Equal(2, snap!.Engine.Books.Single().Orders.Count);
+        Assert.Equal(2, snap.Owners.Count);
+        Assert.All(snap.Owners, o => Assert.Equal("10101", o.SessionValue));
+        Assert.Contains(snap.Owners, o => o.ClOrdId == 0xAAAA);
+        Assert.Contains(snap.Owners, o => o.ClOrdId == 0xBBBB);
+        Assert.True(snap.Engine.NextOrderId >= 3);
+    }
+
+    [Fact]
+    public void RestoreChannelState_RebuildsBookOwnersAndCounters()
+    {
+        var persister = new InMemoryPersister();
+        // Round 1: build state in dispatcher A.
+        var dispA = BuildDispatcher(persister, out _);
+        var probe = dispA.CreateTestProbe();
+        var session = new SessionId("20201");
+        Assert.True(dispA.EnqueueNewOrder(
+            new NewOrderCommand("CL-X", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 300, 200, 1000UL),
+            session, enteringFirm: 200, clOrdIdValue: 0xCCCC));
+        probe.DrainInbound();
+
+        // Round 2: brand-new dispatcher with same persister; explicitly
+        // call RestoreChannelState to mimic what RunLoopAsync's
+        // LoadPersistedStateOnLoopThread does on real boot.
+        var dispB = BuildDispatcher(persister, out _);
+        var loaded = persister.TryLoad(84);
+        Assert.NotNull(loaded);
+        dispB.RestoreChannelState(loaded!);
+
+        // OrigClOrdID lookup resolves through the rebuilt OrderRegistry.
+        Assert.True(dispB.TryResolveByClOrdId(firm: 200, origClOrdId: 0xCCCC,
+            out var orderId, out var securityId));
+        Assert.NotEqual(0, orderId);
+        Assert.Equal(Sec, securityId);
+
+        // Sequence counters survive round-trip.
+        Assert.Equal(dispA.SequenceNumber, dispB.SequenceNumber);
+        Assert.Equal(dispA.SequenceVersion, dispB.SequenceVersion);
+        Assert.Equal(1, dispB.OrderRegistryCount);
+    }
+
+    [Fact]
+    public void RestoreChannelState_RejectsMismatchedChannelNumber()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var snap = new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 99,  // dispatcher is 84
+            SequenceNumber: 0, SequenceVersion: 1,
+            Engine: new EngineStateSnapshot(1, 1, 0,
+                Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+                Array.Empty<EngineStateSnapshot.BookSnapshot>()),
+            Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -166,4 +166,144 @@ public class ChannelDispatcherPersistenceTests
 
         Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
     }
+
+    [Fact]
+    public void OperatorBumpVersion_TriggersPersistence()
+    {
+        // Review feedback on PR #261 (issue #260): visible
+        // ChannelReset_11 must be durable — otherwise a crash after the
+        // reset would resurrect the pre-reset book on next boot.
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("30303");
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-1", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, 1000UL),
+            session, enteringFirm: 300, clOrdIdValue: 0xDDDD));
+        probe.DrainInbound();
+        var beforeBump = persister.SaveCount;
+
+        Assert.True(disp.EnqueueOperatorBumpVersion());
+        probe.DrainInbound();
+
+        Assert.True(persister.SaveCount > beforeBump,
+            "BumpVersion must trigger an additional Save");
+        var snap = persister.TryLoad(84);
+        Assert.NotNull(snap);
+        // Engine has been reset → no resting orders, no owners.
+        Assert.Empty(snap!.Engine.Books.Single().Orders);
+        Assert.Empty(snap.Owners);
+        // SequenceVersion bumped, SequenceNumber reset (then bumped to 1
+        // by the ChannelReset_11 packet).
+        Assert.True(snap.SequenceVersion >= 2);
+    }
+
+    [Fact]
+    public void OperatorSetTradingPhase_TriggersPersistence()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var probe = disp.CreateTestProbe();
+        var beforePhase = persister.SaveCount;
+
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Sec,
+            B3.Exchange.Matching.TradingPhase.Pause));
+        probe.DrainInbound();
+
+        Assert.True(persister.SaveCount > beforePhase,
+            "SetTradingPhase must trigger a Save so the new phase survives restart");
+        var snap = persister.TryLoad(84);
+        Assert.NotNull(snap);
+        Assert.Contains(snap!.Engine.Phases,
+            p => p.SecurityId == Sec && p.Phase == B3.Exchange.Matching.TradingPhase.Pause);
+    }
+
+    [Fact]
+    public void Capture_FiltersStopOrderOwners()
+    {
+        // Review feedback on PR #261: stop orders are registered in
+        // _orders but are intentionally absent from the engine snapshot.
+        // CaptureChannelState must filter them out so a restored
+        // dispatcher does not have phantom OrigClOrdID → OrderId
+        // mappings pointing at non-existent engine orders.
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("40404");
+
+        // One regular Limit order (lands in book) plus one Stop order
+        // (registers ownership but stays off-book).
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-LIMIT", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, 1000UL),
+            session, enteringFirm: 400, clOrdIdValue: 0xE001));
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-STOP", Sec, Side.Buy, OrderType.StopLoss,
+                TimeInForce.Day, Px(11.00m), 100, 100, 2000UL)
+            { StopPxMantissa = Px(10.50m) },
+            session, enteringFirm: 400, clOrdIdValue: 0xE002));
+        probe.DrainInbound();
+
+        var snap = persister.TryLoad(84);
+        Assert.NotNull(snap);
+        Assert.Single(snap!.Engine.Books.Single().Orders);
+        // Only the limit order's owner is persisted; the stop owner is
+        // dropped because no engine book contains its orderId.
+        Assert.Single(snap.Owners);
+        Assert.Equal(0xE001UL, snap.Owners.Single().ClOrdId);
+    }
+
+    [Fact]
+    public void Restore_RejectsSnapshotWithOrphanedOwners()
+    {
+        // Review feedback on PR #261: structural validation runs before
+        // any mutation so a bad snapshot cannot leave the engine
+        // half-restored.
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var snap = new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 84,
+            SequenceNumber: 5, SequenceVersion: 1,
+            Engine: new EngineStateSnapshot(2, 1, 0,
+                Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+                Array.Empty<EngineStateSnapshot.BookSnapshot>()),
+            Owners: new[]
+            {
+                new OrderOwnerSnapshot(
+                    OrderId: 99, SessionValue: "x", Firm: 1,
+                    ClOrdId: 0xAAAA, Side: Side.Buy, SecurityId: Sec),
+            });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
+        Assert.Contains("orderId 99", ex.Message);
+        // Engine must be untouched — counters at defaults.
+        Assert.Equal(0u, disp.SequenceNumber);
+        Assert.Equal((ushort)1, disp.SequenceVersion);
+        Assert.Equal(0, disp.OrderRegistryCount);
+    }
+
+    [Fact]
+    public void Restore_RejectsSnapshotWithDuplicateOrderId()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var dupOrder = new RestingOrderRecord(
+            OrderId: 1, ClOrdId: "x", Side: Side.Buy, PriceMantissa: Px(10.00m),
+            RemainingQuantity: 100, EnteringFirm: 1, InsertTimestampNanos: 0,
+            Tif: TimeInForce.Day, MaxFloor: 0, HiddenQuantity: 0);
+        var snap = new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 84,
+            SequenceNumber: 0, SequenceVersion: 1,
+            Engine: new EngineStateSnapshot(2, 1, 0,
+                Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+                new[] { new EngineStateSnapshot.BookSnapshot(Sec, new[] { dupOrder, dupOrder }) }),
+            Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
+        Assert.Contains("duplicate orderId", ex.Message);
+        Assert.Equal(0, disp.OrderRegistryCount);
+    }
 }

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelStatePersisterTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelStatePersisterTests.cs
@@ -1,0 +1,142 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+public class FileChannelStatePersisterTests
+{
+    [Fact]
+    public void RoundTrip_PreservesEveryField()
+    {
+        using var dir = new TempDir();
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance);
+
+        var snapshot = MakeRichSnapshot(channel: 84);
+
+        persister.Save(snapshot);
+        var loaded = persister.TryLoad(84);
+
+        Assert.NotNull(loaded);
+        Assert.Equal(snapshot.Version, loaded!.Version);
+        Assert.Equal(snapshot.ChannelNumber, loaded.ChannelNumber);
+        Assert.Equal(snapshot.SequenceNumber, loaded.SequenceNumber);
+        Assert.Equal(snapshot.SequenceVersion, loaded.SequenceVersion);
+        Assert.Equal(snapshot.Engine.NextOrderId, loaded.Engine.NextOrderId);
+        Assert.Equal(snapshot.Engine.NextTradeId, loaded.Engine.NextTradeId);
+        Assert.Equal(snapshot.Engine.RptSeq, loaded.Engine.RptSeq);
+        Assert.Equal(snapshot.Engine.Phases.Count, loaded.Engine.Phases.Count);
+        Assert.Equal(snapshot.Engine.Books.Count, loaded.Engine.Books.Count);
+
+        var origBook = snapshot.Engine.Books.Single();
+        var loadedBook = loaded.Engine.Books.Single();
+        Assert.Equal(origBook.SecurityId, loadedBook.SecurityId);
+        Assert.Equal(origBook.Orders.Count, loadedBook.Orders.Count);
+        for (int i = 0; i < origBook.Orders.Count; i++)
+            Assert.Equal(origBook.Orders[i], loadedBook.Orders[i]);
+
+        Assert.Equal(snapshot.Owners.Count, loaded.Owners.Count);
+        for (int i = 0; i < snapshot.Owners.Count; i++)
+            Assert.Equal(snapshot.Owners[i], loaded.Owners[i]);
+    }
+
+    [Fact]
+    public void TryLoad_ReturnsNull_WhenNoSnapshot()
+    {
+        using var dir = new TempDir();
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance);
+
+        Assert.Null(persister.TryLoad(99));
+    }
+
+    [Fact]
+    public void Save_OverwritesPreviousSnapshot_Atomically()
+    {
+        using var dir = new TempDir();
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance);
+
+        persister.Save(MakeRichSnapshot(channel: 7) with { SequenceNumber = 1 });
+        persister.Save(MakeRichSnapshot(channel: 7) with { SequenceNumber = 42 });
+
+        var loaded = persister.TryLoad(7);
+        Assert.NotNull(loaded);
+        Assert.Equal(42u, loaded!.SequenceNumber);
+        // tmp file must not leak
+        Assert.False(File.Exists(Path.Combine(dir.Path, "channel-7.snapshot.tmp")));
+    }
+
+    [Fact]
+    public void TryLoad_ReturnsNull_OnCorruptFile()
+    {
+        using var dir = new TempDir();
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance);
+
+        File.WriteAllText(Path.Combine(dir.Path, "channel-3.snapshot"), "{not json");
+
+        Assert.Null(persister.TryLoad(3));
+    }
+
+    private static ChannelStateSnapshot MakeRichSnapshot(byte channel)
+    {
+        var orders = new[]
+        {
+            new RestingOrderRecord(
+                OrderId: 1, ClOrdId: "C-1", Side: Side.Buy,
+                PriceMantissa: 100_000, RemainingQuantity: 200,
+                EnteringFirm: 100, InsertTimestampNanos: 1_000UL,
+                Tif: TimeInForce.Day, MaxFloor: 0, HiddenQuantity: 0),
+            new RestingOrderRecord(
+                OrderId: 2, ClOrdId: "C-2", Side: Side.Sell,
+                PriceMantissa: 105_000, RemainingQuantity: 50,
+                EnteringFirm: 200, InsertTimestampNanos: 2_000UL,
+                Tif: TimeInForce.Gtc, MaxFloor: 100, HiddenQuantity: 400),
+        };
+        var phases = new[]
+        {
+            new EngineStateSnapshot.PhaseEntry(900_000_000_001L, TradingPhase.Open),
+        };
+        var books = new[]
+        {
+            new EngineStateSnapshot.BookSnapshot(900_000_000_001L, orders),
+        };
+        var engine = new EngineStateSnapshot(
+            NextOrderId: 99, NextTradeId: 11, RptSeq: 17, Phases: phases, Books: books);
+        var owners = new[]
+        {
+            new OrderOwnerSnapshot(1, "10101", 100, 0xDEADBEEF, Side.Buy, 900_000_000_001L),
+            new OrderOwnerSnapshot(2, "20201", 200, 0xCAFEBABE, Side.Sell, 900_000_000_001L),
+        };
+        return new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: channel,
+            SequenceNumber: 1234,
+            SequenceVersion: 5,
+            Engine: engine,
+            Owners: owners);
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "b3xpersist-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); }
+            catch { /* best effort */ }
+        }
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/MatchingEngineRestoreTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/MatchingEngineRestoreTests.cs
@@ -1,0 +1,146 @@
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Verifies that <see cref="MatchingEngine.CaptureState"/> +
+/// <see cref="MatchingEngine.RestoreState"/> round-trips a working book
+/// preserving price-time priority, iceberg state and counters
+/// (issue #260).
+/// </summary>
+public class MatchingEngineRestoreTests
+{
+    private const long Sec = 900_000_000_001L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000.00m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private sealed class CountingSink : IMatchingEventSink
+    {
+        public List<long> AcceptedOrderIds { get; } = new();
+        public List<TradeEvent> Trades { get; } = new();
+        public void OnOrderAccepted(in OrderAcceptedEvent e) => AcceptedOrderIds.Add(e.OrderId);
+        public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) { }
+        public void OnOrderModified(in OrderModifiedEvent e) { }
+        public void OnOrderCanceled(in OrderCanceledEvent e) { }
+        public void OnOrderFilled(in OrderFilledEvent e) { }
+        public void OnTrade(in TradeEvent e) => Trades.Add(e);
+        public void OnReject(in RejectEvent e) { }
+        public void OnOrderMassCanceled(in OrderMassCanceledEvent e) { }
+        public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e) { }
+        public void OnTradingPhaseChanged(in TradingPhaseChangedEvent e) { }
+        public void OnIcebergReplenished(in IcebergReplenishedEvent e) { }
+        public void OnStopOrderAccepted(in StopOrderAcceptedEvent e) { }
+        public void OnStopOrderTriggered(in StopOrderTriggeredEvent e) { }
+        public void OnStopOrderCanceled(in StopOrderCanceledEvent e) { }
+        public void OnAuctionTopChanged(in AuctionTopChangedEvent e) { }
+        public void OnAuctionPrint(in AuctionPrintEvent e) { }
+    }
+
+    private static MatchingEngine NewEngine(out CountingSink sink)
+    {
+        sink = new CountingSink();
+        return new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance);
+    }
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    [Fact]
+    public void Restore_PreservesPriceTimePriority_AndCounters()
+    {
+        var src = NewEngine(out var srcSink);
+        // Three resting buys at the same price — FIFO order matters.
+        src.Submit(new NewOrderCommand("A", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(10.00m), 100, 100, 1000UL));
+        src.Submit(new NewOrderCommand("B", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(10.00m), 100, 200, 2000UL));
+        src.Submit(new NewOrderCommand("C", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(10.00m), 100, 300, 3000UL));
+        // One sell to consume one of the buys (orderId=1, ClOrdId=A)
+        src.Submit(new NewOrderCommand("X", Sec, Side.Sell, OrderType.Limit,
+            TimeInForce.IOC, Px(10.00m), 100, 999, 4000UL));
+        Assert.Single(srcSink.Trades);
+        var firstTrade = srcSink.Trades[0];
+
+        var snap = src.CaptureState();
+
+        // Re-create from snapshot in a fresh engine.
+        var dst = NewEngine(out var dstSink);
+        dst.RestoreState(snap);
+
+        Assert.Equal(src.PeekNextOrderId, dst.PeekNextOrderId);
+        Assert.Equal(src.CurrentRptSeq, dst.CurrentRptSeq);
+
+        // Resting buys after restore should be {B, C} (A was consumed).
+        var restingBuys = dst.EnumerateBook(Sec, Side.Buy).ToList();
+        Assert.Equal(2, restingBuys.Count);
+        Assert.Equal(2L, restingBuys[0].OrderId);  // B is first now
+        Assert.Equal(3L, restingBuys[1].OrderId);
+
+        // Submit a fresh sell that consumes them in FIFO order: B first.
+        dst.Submit(new NewOrderCommand("Y", Sec, Side.Sell, OrderType.Limit,
+            TimeInForce.IOC, Px(10.00m), 100, 999, 5000UL));
+        Assert.Single(dstSink.Trades);
+        Assert.Equal(2L, dstSink.Trades[0].RestingOrderId);  // B fills first
+
+        // OrderId allocator continues monotonically (no re-issuance).
+        // src ended with nextOrderId=5 (A,B,C,X consumed 1..4). After
+        // restore Y is allocated 5 and Z is allocated 6 — Z is the last
+        // accepted (Y is IOC and does not rest).
+        long preZ = dst.PeekNextOrderId;
+        dst.Submit(new NewOrderCommand("Z", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(9.50m), 100, 100, 6000UL));
+        var lastAccepted = dstSink.AcceptedOrderIds.Last();
+        Assert.Equal(preZ, lastAccepted);
+        Assert.Equal(preZ + 1, dst.PeekNextOrderId);
+    }
+
+    [Fact]
+    public void Restore_RefusesOnNonEmptyEngine()
+    {
+        var src = NewEngine(out _);
+        src.Submit(new NewOrderCommand("A", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(10.00m), 100, 100, 1000UL));
+        var snap = src.CaptureState();
+
+        var dst = NewEngine(out _);
+        dst.Submit(new NewOrderCommand("B", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(11.00m), 100, 100, 2000UL));
+
+        Assert.Throws<InvalidOperationException>(() => dst.RestoreState(snap));
+    }
+
+    [Fact]
+    public void Restore_PreservesIcebergFields()
+    {
+        var src = NewEngine(out _);
+        src.Submit(new NewOrderCommand("ICE", Sec, Side.Buy, OrderType.Limit,
+            TimeInForce.Day, Px(10.00m), 1000, 100, 1000UL)
+        { MaxFloor = 100 });
+
+        var snap = src.CaptureState();
+        var rec = snap.Books.Single().Orders.Single();
+        Assert.Equal(100L, rec.MaxFloor);
+        // 1000 total, 100 visible → 900 hidden.
+        Assert.Equal(900L, rec.HiddenQuantity);
+        Assert.Equal(100L, rec.RemainingQuantity);
+
+        var dst = NewEngine(out _);
+        dst.RestoreState(snap);
+        // Restored book exposes only the visible slice.
+        var view = dst.EnumerateBook(Sec, Side.Buy).Single();
+        Assert.Equal(100L, view.RemainingQuantity);
+    }
+}


### PR DESCRIPTION
Closes part of #260 — phase 2 (order book + matching state, snapshot-only).

## Summary
Each `ChannelDispatcher` now writes an atomic JSON snapshot to disk
after every command flush and reloads it on the loop's first turn,
making the simulator restart-safe for the working order book and the
counters that drive UMDF/ER sequencing.

Persisted per channel:
- `MatchingEngine`: `_nextOrderId`, `_nextTradeId`, `_rptSeq`,
  per-instrument trading phase, every resting order (incl. iceberg /
  TIF / insert timestamp) per book, in price-time order.
- `ChannelDispatcher`: `SequenceNumber`, `SequenceVersion`,
  `OrderRegistry` (session+firm+ClOrdId+side+securityId per orderId),
  with the `(firm, ClOrdId) → orderId` lookup rebuilt on restore so
  Cancel/Replace by `OrigClOrdID` keeps working.

## Storage
`FileChannelStatePersister` writes
`{dataDir}/channel-{N}.snapshot` via tmp-file → fsync → atomic
rename → directory fsync. JSON (`System.Text.Json`,
`JsonStringEnumConverter`); save failures are logged and swallowed —
persistence never crashes the dispatcher.

## Config
New optional per-channel block:
```json
"persistence": { "dataDir": "/var/lib/b3matching" }
```
Omit to keep the legacy stateless boot. Dockerfile declares
`/var/lib/b3matching` as a volume.

## Out of scope (documented as known limitations)
- WAL between snapshots — granularity is one command.
- FIXP session counters / SessionVerId / admin reset endpoint
  (phase 1 of #260 covers these).
- Stop orders, auction-top throttling state, UMDF retransmit ring,
  snapshot-rotator cursor.

## Tests
10 new tests in `B3.Exchange.Persistence.Tests`:
- `MatchingEngineRestoreTests` — capture → restore preserves
  matching priority and counter monotonicity.
- `FileChannelStatePersisterTests` — atomic write, missing-file
  load, schema-version round-trip, idempotent overwrite.
- `ChannelDispatcherPersistenceTests` — Save fires after each
  command flush; restored dispatcher resolves `OrigClOrdID` and
  preserves `SequenceNumber`/`SequenceVersion`; mismatched
  channelNumber is rejected.

Full suite passes (the only flake is a pre-existing socket race in
`FixpSessionRetransmitTests.RetransmitReject_when_send_queue_too_small`,
present on `main` too).
