### PR TITLE
feat(persistence): persist untriggered stop orders (#262)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -1,6 +1,7 @@
 using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
+using OrderType = B3.Exchange.Matching.OrderType;
 using Side = B3.Exchange.Matching.Side;
 
 namespace B3.Exchange.Core;
@@ -28,18 +29,19 @@ public sealed partial class ChannelDispatcher
     {
         AssertOnLoopThread();
         // Issue #260 follow-up (review feedback on PR #261): only owners
-        // for orders that the engine considers resting belong in the
-        // snapshot. Stop orders also live in _orders but are intentionally
-        // omitted from EngineStateSnapshot (they do not match against the
-        // limit book). Persisting them would resurrect phantom OrigClOrdID
-        // mappings on restore (cancels would resolve to non-existent
-        // engine orders). Compute the engine-resting set first, then
-        // filter.
+        // for orders that the engine considers live belong in the snapshot.
+        // Issue #262: stops are now persisted, so the "live" set is
+        // (resting in books) ∪ (parked stops). Owners for stop orders can
+        // therefore be persisted; owners for in-flight or fully-filled
+        // orders are still dropped.
         var engineSnap = _engine.CaptureState();
         var restingIds = new HashSet<long>();
         foreach (var book in engineSnap.Books)
             foreach (var o in book.Orders)
                 restingIds.Add(o.OrderId);
+        if (engineSnap.Stops is { } stops)
+            foreach (var s in stops)
+                restingIds.Add(s.OrderId);
         var owners = new List<OrderOwnerSnapshot>(restingIds.Count);
         int dropped = 0;
         foreach (var entry in _orders.EnumerateAll())
@@ -60,7 +62,7 @@ public sealed partial class ChannelDispatcher
         if (dropped > 0)
         {
             _logger.LogDebug(
-                "channel {ChannelNumber}: snapshot dropped {Dropped} non-resting owners (stops/in-flight)",
+                "channel {ChannelNumber}: snapshot dropped {Dropped} non-resting owners (in-flight)",
                 ChannelNumber, dropped);
         }
         return new ChannelStateSnapshot(
@@ -143,11 +145,40 @@ public sealed partial class ChannelDispatcher
                         $"snapshot orderId {o.OrderId} is >= NextOrderId {snapshot.Engine.NextOrderId} (would collide with future allocations)");
             }
         }
+        // Issue #262: validate stop records in the same id namespace as
+        // book orders — engine OrderIds are unique across (books ∪ stops).
+        if (snapshot.Engine.Stops is { } stops)
+        {
+            foreach (var s in stops)
+            {
+                if (s.Quantity <= 0)
+                    throw new InvalidOperationException(
+                        $"snapshot stop orderId {s.OrderId} has non-positive quantity {s.Quantity}");
+                if (s.StopPxMantissa <= 0)
+                    throw new InvalidOperationException(
+                        $"snapshot stop orderId {s.OrderId} has non-positive stopPx {s.StopPxMantissa}");
+                if (s.StopType != OrderType.StopLoss && s.StopType != OrderType.StopLimit)
+                    throw new InvalidOperationException(
+                        $"snapshot stop orderId {s.OrderId} has non-stop OrderType {s.StopType}");
+                if (s.StopType == OrderType.StopLimit && s.LimitPriceMantissa <= 0)
+                    throw new InvalidOperationException(
+                        $"snapshot stop orderId {s.OrderId} (StopLimit) has non-positive limit price {s.LimitPriceMantissa}");
+                if (s.StopType == OrderType.StopLoss && s.LimitPriceMantissa != 0)
+                    throw new InvalidOperationException(
+                        $"snapshot stop orderId {s.OrderId} (StopLoss) must not carry a limit price (got {s.LimitPriceMantissa})");
+                if (!seenOrderIds.Add(s.OrderId))
+                    throw new InvalidOperationException(
+                        $"snapshot contains duplicate orderId {s.OrderId} (stop on securityId {s.SecurityId})");
+                if (s.OrderId >= snapshot.Engine.NextOrderId)
+                    throw new InvalidOperationException(
+                        $"snapshot stop orderId {s.OrderId} is >= NextOrderId {snapshot.Engine.NextOrderId}");
+            }
+        }
         foreach (var owner in snapshot.Owners)
         {
             if (!seenOrderIds.Contains(owner.OrderId))
                 throw new InvalidOperationException(
-                    $"snapshot owner refers to orderId {owner.OrderId} which is not present in any restored book");
+                    $"snapshot owner refers to orderId {owner.OrderId} which is not present in any restored book or stop");
         }
     }
 

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -7,18 +7,26 @@ namespace B3.Exchange.Matching;
 /// transient artefacts (auction-top throttling, in-flight dispatch flags)
 /// off the wire — those are recomputed lazily after restore.
 ///
-/// <para><b>Out of scope (v1):</b> stop orders (<c>_stopsBySymbol</c>) and
-/// auction indicative throttling (<c>_auctionTopById</c>) — restoring these
-/// safely would require replaying the trigger price stream. Operators that
-/// rely on them should drain in-flight stops before restart; the omission
-/// is documented in <c>docs/EXCHANGE-SIMULATOR.md</c>.</para>
+/// <para><b>Out of scope:</b> auction indicative throttling
+/// (<c>_auctionTopById</c>) — restoring it safely would require replaying
+/// the trigger price stream and the omission only causes one transient
+/// duplicate frame post-restart. Operators that depend on auction
+/// throttling should drain in-flight indicative state before restart;
+/// the limitation is documented in <c>docs/EXCHANGE-SIMULATOR.md</c>.</para>
+///
+/// <para>Stop orders (<c>_stopsBySymbol</c> / <c>_stopById</c>) are
+/// persisted as of issue #262: the optional <see cref="Stops"/> list
+/// carries every untriggered stop. Old snapshots that pre-date #262
+/// deserialise with <see cref="Stops"/> null → treated as empty, so the
+/// schema remains backward compatible without a version bump.</para>
 /// </summary>
 public sealed record EngineStateSnapshot(
     long NextOrderId,
     uint NextTradeId,
     uint RptSeq,
     IReadOnlyList<EngineStateSnapshot.PhaseEntry> Phases,
-    IReadOnlyList<EngineStateSnapshot.BookSnapshot> Books)
+    IReadOnlyList<EngineStateSnapshot.BookSnapshot> Books,
+    IReadOnlyList<RestingStopRecord>? Stops = null)
 {
     public sealed record PhaseEntry(long SecurityId, TradingPhase Phase);
 
@@ -41,3 +49,24 @@ public sealed record RestingOrderRecord(
     TimeInForce Tif,
     long MaxFloor,
     long HiddenQuantity);
+
+/// <summary>
+/// Persistable view of a single untriggered stop order (issue #262). Mirrors
+/// the engine's private <c>RestingStop</c>: enough fields to faithfully
+/// reconstruct the parked order so that future trigger evaluations and
+/// cancels behave exactly as before the restart. <see cref="LimitPriceMantissa"/>
+/// is zero for <see cref="OrderType.StopLoss"/> and the limit price for
+/// <see cref="OrderType.StopLimit"/>.
+/// </summary>
+public sealed record RestingStopRecord(
+    long OrderId,
+    string ClOrdId,
+    long SecurityId,
+    Side Side,
+    OrderType StopType,
+    TimeInForce Tif,
+    long StopPxMantissa,
+    long LimitPriceMantissa,
+    long Quantity,
+    uint EnteringFirm,
+    ulong EnteredAtNanos);

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -146,7 +146,32 @@ public sealed class MatchingEngine
             var orders = kv.Value.EnumerateAllOrdersForSnapshot().ToList();
             books.Add(new EngineStateSnapshot.BookSnapshot(kv.Key, orders));
         }
-        return new EngineStateSnapshot(_nextOrderId, _nextTradeId, _rptSeq, phases, books);
+        // Issue #262: untriggered stops are persisted so a restart no
+        // longer silently loses parked StopLoss/StopLimit orders.
+        // Iterate _stopsBySymbol (instead of _stopById) so the per-symbol
+        // arrival order is preserved on restore — that order is observable
+        // when multiple stops trigger off the same trade and otherwise
+        // would scramble across restarts.
+        var stops = new List<RestingStopRecord>(_stopById.Count);
+        foreach (var kv in _stopsBySymbol)
+        {
+            foreach (var s in kv.Value)
+            {
+                stops.Add(new RestingStopRecord(
+                    OrderId: s.OrderId,
+                    ClOrdId: s.ClOrdId,
+                    SecurityId: s.SecurityId,
+                    Side: s.Side,
+                    StopType: s.StopType,
+                    Tif: s.Tif,
+                    StopPxMantissa: s.StopPxMantissa,
+                    LimitPriceMantissa: s.LimitPriceMantissa,
+                    Quantity: s.Quantity,
+                    EnteringFirm: s.EnteringFirm,
+                    EnteredAtNanos: s.EnteredAtNanos));
+            }
+        }
+        return new EngineStateSnapshot(_nextOrderId, _nextTradeId, _rptSeq, phases, books, stops);
     }
 
     /// <summary>
@@ -171,6 +196,8 @@ public sealed class MatchingEngine
             if (book.OrderCount != 0)
                 throw new InvalidOperationException("RestoreState requires empty books on the target engine");
         }
+        if (_stopById.Count != 0)
+            throw new InvalidOperationException("RestoreState requires no parked stops on the target engine");
 
         _nextOrderId = snapshot.NextOrderId;
         _nextTradeId = snapshot.NextTradeId;
@@ -197,8 +224,41 @@ public sealed class MatchingEngine
                 restored++;
             }
         }
-        _logger.LogInformation("RestoreState complete: nextOrderId={NextOrderId} nextTradeId={NextTradeId} rptSeq={RptSeq} restingOrders={RestingOrders}",
-            _nextOrderId, _nextTradeId, _rptSeq, restored);
+        // Issue #262: rebuild parked stops. Snapshots predating #262 carry
+        // null Stops, treated as empty so older state files keep loading.
+        int restoredStops = 0;
+        if (snapshot.Stops is { } stopRecords)
+        {
+            foreach (var s in stopRecords)
+            {
+                if (!_stopsBySymbol.TryGetValue(s.SecurityId, out var bucket))
+                {
+                    _logger.LogWarning("RestoreState: ignoring stop orderId {OrderId} for unknown securityId {SecurityId}", s.OrderId, s.SecurityId);
+                    continue;
+                }
+                if (_stopById.ContainsKey(s.OrderId))
+                    throw new InvalidOperationException($"RestoreState: duplicate stop orderId {s.OrderId}");
+                var stop = new RestingStop
+                {
+                    OrderId = s.OrderId,
+                    ClOrdId = s.ClOrdId,
+                    Side = s.Side,
+                    StopType = s.StopType,
+                    Tif = s.Tif,
+                    StopPxMantissa = s.StopPxMantissa,
+                    LimitPriceMantissa = s.LimitPriceMantissa,
+                    Quantity = s.Quantity,
+                    EnteringFirm = s.EnteringFirm,
+                    EnteredAtNanos = s.EnteredAtNanos,
+                    SecurityId = s.SecurityId,
+                };
+                bucket.Add(stop);
+                _stopById.Add(s.OrderId, stop);
+                restoredStops++;
+            }
+        }
+        _logger.LogInformation("RestoreState complete: nextOrderId={NextOrderId} nextTradeId={NextTradeId} rptSeq={RptSeq} restingOrders={RestingOrders} restingStops={RestingStops}",
+            _nextOrderId, _nextTradeId, _rptSeq, restored, restoredStops);
     }
 
     /// <summary>
@@ -248,6 +308,17 @@ public sealed class MatchingEngine
         => _booksById[securityId].EnumerateOrders(side);
 
     public int OrderCount(long securityId) => _booksById[securityId].OrderCount;
+
+    /// <summary>
+    /// Total number of untriggered stop orders parked across every
+    /// instrument. Issue #262 — exposes a counter the persistence tests
+    /// and HTTP /metrics endpoint can read without snapshotting state.
+    /// Read on the engine's owner thread.
+    /// </summary>
+    public int StopOrderCount
+    {
+        get { AssertOnOwnerThread(); return _stopById.Count; }
+    }
 
     /// <summary>
     /// Current trading phase for the supplied security. Throws

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -220,27 +220,25 @@ public class ChannelDispatcherPersistenceTests
     }
 
     [Fact]
-    public void Capture_FiltersStopOrderOwners()
+    public void Capture_PersistsStopOrderOwners()
     {
-        // Review feedback on PR #261: stop orders are registered in
-        // _orders but are intentionally absent from the engine snapshot.
-        // CaptureChannelState must filter them out so a restored
-        // dispatcher does not have phantom OrigClOrdID → OrderId
-        // mappings pointing at non-existent engine orders.
+        // Issue #262: stop orders are now persisted alongside book
+        // orders. Both the StopLoss and its owner must appear in the
+        // snapshot so a restored dispatcher resumes the parked stop and
+        // can route a future trigger / cancel back to the original
+        // session.
         var persister = new InMemoryPersister();
         var disp = BuildDispatcher(persister, out _);
         var probe = disp.CreateTestProbe();
         var session = new SessionId("40404");
 
-        // One regular Limit order (lands in book) plus one Stop order
-        // (registers ownership but stays off-book).
         Assert.True(disp.EnqueueNewOrder(
             new NewOrderCommand("CL-LIMIT", Sec, Side.Buy, OrderType.Limit,
                 TimeInForce.Day, Px(10.00m), 100, 100, 1000UL),
             session, enteringFirm: 400, clOrdIdValue: 0xE001));
         Assert.True(disp.EnqueueNewOrder(
             new NewOrderCommand("CL-STOP", Sec, Side.Buy, OrderType.StopLoss,
-                TimeInForce.Day, Px(11.00m), 100, 100, 2000UL)
+                TimeInForce.Day, 0, 100, 100, 2000UL)
             { StopPxMantissa = Px(10.50m) },
             session, enteringFirm: 400, clOrdIdValue: 0xE002));
         probe.DrainInbound();
@@ -248,10 +246,115 @@ public class ChannelDispatcherPersistenceTests
         var snap = persister.TryLoad(84);
         Assert.NotNull(snap);
         Assert.Single(snap!.Engine.Books.Single().Orders);
-        // Only the limit order's owner is persisted; the stop owner is
-        // dropped because no engine book contains its orderId.
-        Assert.Single(snap.Owners);
-        Assert.Equal(0xE001UL, snap.Owners.Single().ClOrdId);
+        Assert.NotNull(snap.Engine.Stops);
+        var stop = Assert.Single(snap.Engine.Stops!);
+        Assert.Equal(OrderType.StopLoss, stop.StopType);
+        Assert.Equal(Px(10.50m), stop.StopPxMantissa);
+        Assert.Equal(0L, stop.LimitPriceMantissa);
+        Assert.Equal(2, snap.Owners.Count);
+        Assert.Contains(snap.Owners, o => o.ClOrdId == 0xE001);
+        Assert.Contains(snap.Owners, o => o.ClOrdId == 0xE002);
+    }
+
+    [Fact]
+    public void RestoreChannelState_RebuildsParkedStops()
+    {
+        // Issue #262: after restore the engine must hold the parked
+        // stop, the OrderRegistry must contain its owner mapping, and
+        // a Cancel-by-orderId must succeed (proving the stop is fully
+        // wired up).
+        var persister = new InMemoryPersister();
+        var dispA = BuildDispatcher(persister, out _);
+        var probeA = dispA.CreateTestProbe();
+        var session = new SessionId("50505");
+
+        Assert.True(dispA.EnqueueNewOrder(
+            new NewOrderCommand("CL-STOPLIM", Sec, Side.Sell, OrderType.StopLimit,
+                TimeInForce.Day, Px(9.50m), 100, 100, 1000UL)
+            { StopPxMantissa = Px(9.80m) },
+            session, enteringFirm: 500, clOrdIdValue: 0xF001));
+        probeA.DrainInbound();
+
+        long stopOid;
+        {
+            var snap = persister.TryLoad(84);
+            Assert.NotNull(snap);
+            Assert.NotNull(snap!.Engine.Stops);
+            var s = Assert.Single(snap.Engine.Stops!);
+            Assert.Equal(OrderType.StopLimit, s.StopType);
+            stopOid = s.OrderId;
+        }
+
+        // Fresh dispatcher, restore, then cancel the parked stop by
+        // its engine OrderId — only succeeds if both _stopById and
+        // OrderRegistry were rebuilt.
+        var dispB = BuildDispatcher(persister, out _);
+        var probeB = dispB.CreateTestProbe();
+        var loaded = persister.TryLoad(84);
+        Assert.NotNull(loaded);
+        dispB.RestoreChannelState(loaded!);
+        Assert.Equal(1, dispB.OrderRegistryCount);
+
+        Assert.True(dispB.EnqueueCancel(
+            new CancelOrderCommand(ClOrdId: "CL-STOPLIM-C", SecurityId: Sec, OrderId: stopOid, EnteredAtNanos: 2000UL),
+            session, enteringFirm: 500, clOrdIdValue: 0xF002, origClOrdIdValue: 0xF001));
+        probeB.DrainInbound();
+
+        // After cancel the stop ownership is evicted; a fresh capture
+        // shows no parked stops and no orphan owner.
+        var post = dispB.CaptureChannelState();
+        Assert.True(post.Engine.Stops is null || post.Engine.Stops.Count == 0);
+        Assert.Empty(post.Owners);
+    }
+
+    [Fact]
+    public void Restore_RejectsSnapshotWithDuplicateStopOrderId()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var dupStop = new RestingStopRecord(
+            OrderId: 1, ClOrdId: "x", SecurityId: Sec, Side: Side.Buy,
+            StopType: OrderType.StopLoss, Tif: TimeInForce.Day,
+            StopPxMantissa: Px(10.50m), LimitPriceMantissa: 0,
+            Quantity: 100, EnteringFirm: 1, EnteredAtNanos: 0);
+        var snap = new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 84,
+            SequenceNumber: 0, SequenceVersion: 1,
+            Engine: new EngineStateSnapshot(2, 1, 0,
+                Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+                Array.Empty<EngineStateSnapshot.BookSnapshot>(),
+                new[] { dupStop, dupStop }),
+            Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
+        Assert.Contains("duplicate orderId", ex.Message);
+        Assert.Equal(0, disp.OrderRegistryCount);
+    }
+
+    [Fact]
+    public void Restore_RejectsStopLossWithLimitPrice()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var bad = new RestingStopRecord(
+            OrderId: 1, ClOrdId: "x", SecurityId: Sec, Side: Side.Buy,
+            StopType: OrderType.StopLoss, Tif: TimeInForce.Day,
+            StopPxMantissa: Px(10.50m), LimitPriceMantissa: Px(11.00m),
+            Quantity: 100, EnteringFirm: 1, EnteredAtNanos: 0);
+        var snap = new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 84,
+            SequenceNumber: 0, SequenceVersion: 1,
+            Engine: new EngineStateSnapshot(2, 1, 0,
+                Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+                Array.Empty<EngineStateSnapshot.BookSnapshot>(),
+                new[] { bad }),
+            Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
+        Assert.Contains("StopLoss", ex.Message);
+        Assert.Equal(0, disp.OrderRegistryCount);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #262.

## What

Stop orders (StopLoss / StopLimit) are now persisted in the channel snapshot and faithfully restored on boot. Previously they were silently dropped on restart (intentionally filtered in PR #261's review fix because the engine snapshot didn't carry them).

## Changes

- \`EngineStateSnapshot\` gains an optional \`Stops\` list (\`IReadOnlyList<RestingStopRecord>?\`, default null = empty). Schema stays at version 1 so snapshots written by PR #261 still load.
- \`MatchingEngine.CaptureState\` iterates \`_stopsBySymbol\` (preserves per-symbol arrival order) → emits \`RestingStopRecord[]\`.
- \`MatchingEngine.RestoreState\` rebuilds \`_stopsBySymbol\` + \`_stopById\`; pre-empty check now also requires zero parked stops.
- \`ChannelDispatcher.CaptureChannelState\` resting-id set widens to (books ∪ stops) so stop owners persist.
- \`ChannelDispatcher.ValidateSnapshotStructure\` validates stop records (positive qty/stopPx, type ∈ {StopLoss, StopLimit}, StopLimit requires limit > 0, StopLoss must not carry one, no duplicate orderId across books/stops, orderId < NextOrderId). All-or-nothing restore semantics from PR #261 preserved.
- \`MatchingEngine.StopOrderCount\` added for ops + test introspection.

## Tests (4 new, 18 total in B3.Exchange.Persistence.Tests)

- \`Capture_PersistsStopOrderOwners\` — replaces the old \`Capture_FiltersStopOrderOwners\` assertion (intentional inversion of behaviour).
- \`RestoreChannelState_RebuildsParkedStops\` — full round-trip; cancel-by-engine-OrderId after restore proves both engine and OrderRegistry are wired up.
- \`Restore_RejectsSnapshotWithDuplicateStopOrderId\`
- \`Restore_RejectsStopLossWithLimitPrice\`

## Verification

- \`dotnet build SbeB3Exchange.slnx -c Release\` — 0 warnings, 0 errors (TreatWarningsAsErrors).
- \`dotnet test SbeB3Exchange.slnx -c Release --no-build\` — all suites green.
- \`dotnet format --verify-no-changes\` — clean.

Part of the persistence roadmap. Next: #265 Prometheus metrics.