### PR TITLE
feat(persistence): snapshot throttling policy (#267)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -92,6 +92,20 @@ public sealed partial class ChannelDispatcher
         {
             _logger.LogError(ex, "channel {ChannelNumber} dispatch loop terminated unexpectedly", ChannelNumber);
         }
+        finally
+        {
+            // Issue #267: ensure any throttle-deferred state is durable
+            // before the loop thread exits. Operator commands always
+            // force-persist, so this only matters when regular order
+            // commands have been deferred.
+            try { FlushPendingSnapshotOnShutdown(); }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: final shutdown snapshot flush failed",
+                    ChannelNumber);
+            }
+        }
     }
 
     private void RecordHeartbeat()
@@ -171,6 +185,15 @@ public sealed partial class ChannelDispatcher
         /// <see cref="ChannelDispatcher.KillForTesting"/>.
         /// </summary>
         public void Kill() => _disp.KillForTesting();
+
+        /// <summary>
+        /// Test seam for the cooperative-shutdown final snapshot flush
+        /// (issue #267). Production code never calls this directly —
+        /// it runs from the loop's <c>finally</c> block. Tests that
+        /// drive the dispatcher via <see cref="DrainInbound"/> bypass
+        /// the loop and so must trigger the shutdown hook explicitly.
+        /// </summary>
+        public void FlushPendingSnapshotOnShutdown() => _disp.FlushPendingSnapshotOnShutdown();
     }
 
     public async ValueTask DisposeAsync()

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -39,7 +39,9 @@ public sealed partial class ChannelDispatcher
             // BumpVersion publishes ChannelReset_11 and clears engine
             // state. Persist post-flush so a crash after the reset cannot
             // resurrect the pre-reset book on next boot.
-            OnAfterCommandFlushed();
+            // Issue #267: operator commands always force-persist, bypassing
+            // the throttle policy.
+            OnAfterCommandFlushed(force: true);
             return;
         }
 
@@ -49,7 +51,7 @@ public sealed partial class ChannelDispatcher
             // Persist after publishing TradeBust_57 so the consumed RptSeq
             // (engine.AllocateNextRptSeq) survives restart — otherwise a
             // restart would re-issue the same RptSeq for a different event.
-            OnAfterCommandFlushed();
+            OnAfterCommandFlushed(force: true);
             return;
         }
 
@@ -60,7 +62,7 @@ public sealed partial class ChannelDispatcher
             // _phaseById map (captured into EngineStateSnapshot.Phases)
             // and any RptSeq advance from SecurityStatus_3 emission
             // survive restart.
-            OnAfterCommandFlushed();
+            OnAfterCommandFlushed(force: true);
             return;
         }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -252,10 +252,33 @@ public sealed partial class ChannelDispatcher
     /// Captures the channel state and forwards it to the persister
     /// best-effort — exceptions are logged and swallowed so persistence
     /// failure never crashes the dispatcher.
+    ///
+    /// <para>Issue #267: when <paramref name="force"/> is <c>false</c>
+    /// (regular order-flow commands) the persist may be skipped per the
+    /// configured <see cref="SnapshotThrottlePolicy"/>; the dispatcher
+    /// then marks itself dirty so cooperative shutdown will flush a
+    /// final snapshot. Operator commands set <paramref name="force"/>
+    /// to <c>true</c> so SequenceVersion bumps, TradeBust replays and
+    /// trading-phase changes always persist immediately.</para>
     /// </summary>
-    private void OnAfterCommandFlushed()
+    private void OnAfterCommandFlushed(bool force = false)
     {
         if (_persister is null) return;
+        long nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (!force)
+        {
+            // First-ever call: no prior persist → treat msSinceLastSave
+            // as 0 so a configured MinIntervalMs grace window applies
+            // from boot rather than triggering immediately.
+            long sinceMs = _lastPersistUnixMs == 0 ? 0 : nowMs - _lastPersistUnixMs;
+            if (!_snapshotThrottle.ShouldPersist(_commandsSincePersist + 1, sinceMs))
+            {
+                _commandsSincePersist++;
+                _pendingDirty = true;
+                _metrics?.IncSnapshotSkippedByThrottle();
+                return;
+            }
+        }
         var start = System.Diagnostics.Stopwatch.GetTimestamp();
         try
         {
@@ -267,8 +290,11 @@ public sealed partial class ChannelDispatcher
                 m.SnapshotWrite.ObserveTicks(elapsed);
                 m.IncSnapshotSaveOk();
                 if (bytes > 0) m.SetSnapshotLastSizeBytes(bytes);
-                m.SetSnapshotLastSuccessUnixMs(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                m.SetSnapshotLastSuccessUnixMs(nowMs);
             }
+            _commandsSincePersist = 0;
+            _lastPersistUnixMs = nowMs;
+            _pendingDirty = false;
         }
         catch (Exception ex)
         {
@@ -276,5 +302,18 @@ public sealed partial class ChannelDispatcher
             _metrics?.IncDispatcherCrashes();
             _logger.LogError(ex, "channel {ChannelNumber}: persister Save failed", ChannelNumber);
         }
+    }
+
+    /// <summary>
+    /// Forces a final snapshot if the throttle policy has accumulated
+    /// pending state (issue #267). Called from the cooperative shutdown
+    /// path so a quiet period after the last command flush does not
+    /// silently lose work that the throttle deferred.
+    /// </summary>
+    internal void FlushPendingSnapshotOnShutdown()
+    {
+        if (_persister is null) return;
+        if (!_pendingDirty) return;
+        OnAfterCommandFlushed(force: true);
     }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -142,6 +142,12 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// (legacy behaviour).
     /// </summary>
     private readonly IChannelStatePersister? _persister;
+    private readonly SnapshotThrottlePolicy _snapshotThrottle;
+    // Throttle bookkeeping (issue #267). Mutated only on the dispatch
+    // loop thread → no Interlocked needed.
+    private long _commandsSincePersist;
+    private long _lastPersistUnixMs;
+    private bool _pendingDirty;
 
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private int _packetWritten;
@@ -193,7 +199,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         ChannelMetrics? metrics = null,
         BoundedSessionFirmCounters? sessionFirmCounters = null,
         UmdfPacketRetransmitBuffer? retxBuffer = null,
-        IChannelStatePersister? persister = null)
+        IChannelStatePersister? persister = null,
+        SnapshotThrottlePolicy? snapshotThrottle = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -207,6 +214,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _sessionFirmCounters = sessionFirmCounters;
         _retxBuffer = retxBuffer;
         _persister = persister;
+        _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
         // Direct field writes are safe here: ctor runs on the constructing
         // thread before Start() and before any other thread can observe the
         // instance. No memory barrier is needed.

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -164,6 +164,9 @@ public sealed class ChannelMetrics
     public long SnapshotRestoreFailures => Interlocked.Read(ref _snapshotRestoreFailures);
     public long SnapshotLastSizeBytes => Interlocked.Read(ref _snapshotLastSizeBytes);
     public long SnapshotLastSuccessUnixMs => Interlocked.Read(ref _snapshotLastSuccessUnixMs);
+    private long _snapshotSkippedByThrottle;
+    public long SnapshotSkippedByThrottle => Interlocked.Read(ref _snapshotSkippedByThrottle);
+    public void IncSnapshotSkippedByThrottle() => Interlocked.Increment(ref _snapshotSkippedByThrottle);
 
     public void IncSnapshotSaveOk() => Interlocked.Increment(ref _snapshotSavesOk);
     public void IncSnapshotSaveFailure() => Interlocked.Increment(ref _snapshotSaveFailures);
@@ -439,6 +442,9 @@ public sealed class MetricsRegistry
         EmitGauge(sb, "exch_snapshot_last_success_unixms",
             "Unix time (milliseconds) of the most recent successful snapshot persist; 0 if no snapshot has been persisted yet. Use with rate(now() - this) for staleness alerts.",
             channels, c => c.SnapshotLastSuccessUnixMs);
+        EmitCounter(sb, "exch_snapshot_skipped_by_throttle_total",
+            "Total snapshot persists deferred by the SnapshotThrottlePolicy (issue #267). The dispatcher tracks the deferred state and forces a final flush at cooperative shutdown so quiet periods do not lose work.",
+            channels, c => c.SnapshotSkippedByThrottle);
 
         // Issue #174: throughput counters. Bounded labels (msg_type ≤ 6,
         // exec_type ≤ 7, feed = 3) — safe to ship per-channel.

--- a/src/B3.Exchange.Core/SnapshotThrottlePolicy.cs
+++ b/src/B3.Exchange.Core/SnapshotThrottlePolicy.cs
@@ -1,0 +1,66 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Configures how aggressively <see cref="ChannelDispatcher"/> persists
+/// channel snapshots after each flushed command (issue #267). The default
+/// (<see cref="AlwaysPersist"/>) preserves the PR #261 behaviour — every
+/// command flush triggers an immediate snapshot — and is appropriate for
+/// low-throughput operator deployments where RPO must be zero. Higher-
+/// throughput channels can throttle snapshots by command count, time
+/// since last successful persist, or both (whichever fires first).
+///
+/// <para>Operator commands (BumpVersion / TradeBust / SetTradingPhase)
+/// always persist immediately regardless of policy — they are
+/// low-frequency, high-consequence events whose effect on
+/// <c>SequenceVersion</c>/<c>RptSeq</c>/trading phase must survive a
+/// crash even if the throttle window has not elapsed.</para>
+///
+/// <para>The dispatcher tracks a <c>_pendingDirty</c> flag whenever it
+/// skips a persist; on cooperative shutdown the loop forces a final
+/// snapshot so a quiet period does not silently lose the most recent
+/// commands.</para>
+/// </summary>
+public sealed record SnapshotThrottlePolicy
+{
+    /// <summary>
+    /// Persist after <em>every</em> command (default; matches PR #261
+    /// behaviour). Equivalent to <c>EveryNCommands = 1</c>,
+    /// <c>MinIntervalMs = 0</c>.
+    /// </summary>
+    public static readonly SnapshotThrottlePolicy AlwaysPersist =
+        new() { EveryNCommands = 1, MinIntervalMs = 0 };
+
+    /// <summary>
+    /// Persist after this many non-operator commands have been flushed
+    /// since the last successful persist. <c>0</c> disables the
+    /// command-count trigger entirely (rely solely on
+    /// <see cref="MinIntervalMs"/>); <c>1</c> persists every command.
+    /// </summary>
+    public int EveryNCommands { get; init; } = 1;
+
+    /// <summary>
+    /// Persist when the wall-clock time since the last successful persist
+    /// reaches this many milliseconds. <c>0</c> disables the time
+    /// trigger entirely (rely solely on <see cref="EveryNCommands"/>).
+    /// Evaluated at command-flush boundaries — does not require its own
+    /// timer.
+    /// </summary>
+    public int MinIntervalMs { get; init; } = 0;
+
+    /// <summary>
+    /// Returns <c>true</c> if a non-operator flush should persist now
+    /// given the per-channel counters, or <c>false</c> if the snapshot
+    /// should be skipped (and the dispatcher should mark itself dirty so
+    /// shutdown forces a final flush).
+    /// </summary>
+    public bool ShouldPersist(long commandsSinceLastSave, long msSinceLastSave)
+    {
+        if (EveryNCommands > 0 && commandsSinceLastSave >= EveryNCommands) return true;
+        if (MinIntervalMs > 0 && msSinceLastSave >= MinIntervalMs) return true;
+        // Defensive: both knobs disabled would mean "never persist on
+        // the command path"; treat that as the legacy behaviour rather
+        // than silently breaking durability.
+        if (EveryNCommands <= 0 && MinIntervalMs <= 0) return true;
+        return false;
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -169,7 +169,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 metrics: channelMetrics,
                 sessionFirmCounters: _metrics.SessionFirmMessages,
                 retxBuffer: retxBuffer,
-                persister: BuildPersister(ch));
+                persister: BuildPersister(ch),
+                snapshotThrottle: ch.Persistence?.Throttle?.ToPolicy());
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -262,6 +262,30 @@ public sealed class ChannelConfig
 public sealed class PersistenceConfig
 {
     [JsonPropertyName("dataDir")] public string DataDir { get; set; } = "";
+
+    /// <summary>
+    /// Optional snapshot throttling (issue #267). Absent or both fields
+    /// zero means "persist after every command flush" — the PR #261
+    /// default. Provide either <c>everyN</c> (commands), <c>minIntervalMs</c>
+    /// (wall-clock), or both (whichever fires first triggers the persist).
+    /// Operator commands always force-persist regardless of throttle.
+    /// </summary>
+    [JsonPropertyName("throttle")] public SnapshotThrottleConfig? Throttle { get; set; }
+}
+
+/// <summary>
+/// JSON projection of <see cref="B3.Exchange.Core.SnapshotThrottlePolicy"/>.
+/// </summary>
+public sealed class SnapshotThrottleConfig
+{
+    [JsonPropertyName("everyN")] public int EveryNCommands { get; set; } = 1;
+    [JsonPropertyName("minIntervalMs")] public int MinIntervalMs { get; set; }
+
+    public B3.Exchange.Core.SnapshotThrottlePolicy ToPolicy() => new()
+    {
+        EveryNCommands = EveryNCommands,
+        MinIntervalMs = MinIntervalMs,
+    };
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -75,7 +75,8 @@ public class ChannelDispatcherPersistenceTests
     private static ChannelDispatcher BuildDispatcher(
         IChannelStatePersister persister,
         out NoOpOutbound outbound,
-        ChannelMetrics? metrics = null)
+        ChannelMetrics? metrics = null,
+        SnapshotThrottlePolicy? throttle = null)
     {
         outbound = new NoOpOutbound();
         var localOutbound = outbound;
@@ -87,7 +88,8 @@ public class ChannelDispatcherPersistenceTests
             outbound: localOutbound,
             logger: NullLogger<ChannelDispatcher>.Instance,
             metrics: metrics,
-            persister: persister);
+            persister: persister,
+            snapshotThrottle: throttle);
     }
 
     [Fact]
@@ -496,5 +498,111 @@ public class ChannelDispatcherPersistenceTests
         var ex = Assert.Throws<InvalidOperationException>(() => disp.RestoreChannelState(snap));
         Assert.Contains("duplicate orderId", ex.Message);
         Assert.Equal(0, disp.OrderRegistryCount);
+    }
+
+    // -------- Issue #267: snapshot throttling --------
+
+    private static bool EnqueueOrder(ChannelDispatcher disp, SessionId session,
+        string clOrdId, ulong clOrdIdValue, ulong nanos)
+        => disp.EnqueueNewOrder(
+            new NewOrderCommand(clOrdId, Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, nanos),
+            session, enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    [Fact]
+    public void Throttle_EveryNCommands_SkipsBelowThreshold_PersistsAtThreshold()
+    {
+        var persister = new InMemoryPersister();
+        var metrics = new ChannelMetrics(channelNumber: 84);
+        var policy = new SnapshotThrottlePolicy { EveryNCommands = 3, MinIntervalMs = 0 };
+        var disp = BuildDispatcher(persister, out _, metrics, policy);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("70701");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0x1, 1000UL));
+        probe.DrainInbound();
+        Assert.Equal(0, persister.SaveCount);
+        Assert.Equal(1, metrics.SnapshotSkippedByThrottle);
+
+        Assert.True(EnqueueOrder(disp, session, "CL-2", 0x2, 1001UL));
+        probe.DrainInbound();
+        Assert.Equal(0, persister.SaveCount);
+        Assert.Equal(2, metrics.SnapshotSkippedByThrottle);
+
+        // Third command hits threshold → persists.
+        Assert.True(EnqueueOrder(disp, session, "CL-3", 0x3, 1002UL));
+        probe.DrainInbound();
+        Assert.Equal(1, persister.SaveCount);
+        Assert.Equal(2, metrics.SnapshotSkippedByThrottle);
+        Assert.Equal(1L, metrics.SnapshotSavesOk);
+    }
+
+    [Fact]
+    public void Throttle_OperatorCommands_AlwaysForcePersist()
+    {
+        var persister = new InMemoryPersister();
+        var metrics = new ChannelMetrics(channelNumber: 84);
+        // Effectively never persist regular commands during the test
+        // window: 1 000 commands or 24h, whichever comes first.
+        var policy = new SnapshotThrottlePolicy { EveryNCommands = 1000, MinIntervalMs = 86_400_000 };
+        var disp = BuildDispatcher(persister, out _, metrics, policy);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("70702");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0x10, 2000UL));
+        probe.DrainInbound();
+        Assert.Equal(0, persister.SaveCount);
+        Assert.Equal(1, metrics.SnapshotSkippedByThrottle);
+
+        // Operator command bypasses throttle.
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Sec, B3.Exchange.Matching.TradingPhase.Pause));
+        probe.DrainInbound();
+        Assert.Equal(1, persister.SaveCount);
+
+        // BumpVersion also forces.
+        Assert.True(disp.EnqueueOperatorBumpVersion());
+        probe.DrainInbound();
+        Assert.Equal(2, persister.SaveCount);
+    }
+
+    [Fact]
+    public void Throttle_PendingDirty_FlushedOnShutdown()
+    {
+        var persister = new InMemoryPersister();
+        var metrics = new ChannelMetrics(channelNumber: 84);
+        var policy = new SnapshotThrottlePolicy { EveryNCommands = 1000, MinIntervalMs = 86_400_000 };
+        var disp = BuildDispatcher(persister, out _, metrics, policy);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("70703");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0x20, 3000UL));
+        probe.DrainInbound();
+        Assert.Equal(0, persister.SaveCount);
+        Assert.Equal(1, metrics.SnapshotSkippedByThrottle);
+
+        // Cooperative shutdown drains pending dirty state.
+        probe.FlushPendingSnapshotOnShutdown();
+        Assert.Equal(1, persister.SaveCount);
+
+        // Calling again is a no-op (dirty cleared after force flush).
+        probe.FlushPendingSnapshotOnShutdown();
+        Assert.Equal(1, persister.SaveCount);
+    }
+
+    [Fact]
+    public void Throttle_DefaultPolicy_PersistsEveryCommand()
+    {
+        // Sanity: dispatcher constructed without an explicit throttle
+        // (BuildDispatcher passes null) preserves PR #261 behaviour —
+        // every command persists.
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("70704");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0x30, 4000UL));
+        Assert.True(EnqueueOrder(disp, session, "CL-2", 0x31, 4001UL));
+        probe.DrainInbound();
+        Assert.Equal(2, persister.SaveCount);
     }
 }


### PR DESCRIPTION
Closes #267.

## What
Adds `SnapshotThrottlePolicy` so operators can defer snapshot writes on high-throughput channels by command count and/or wall-clock interval, while keeping the PR #261 'persist after every command' default for low-throughput / zero-RPO deployments.

## Design
- `EveryNCommands` + `MinIntervalMs` (whichever fires first triggers a persist).
- Operator commands (BumpVersion / TradeBust / SetTradingPhase) **always** force-persist regardless of policy — they are low-frequency, high-consequence events whose effect on `SequenceVersion`/`RptSeq`/trading phase must survive a crash even if the throttle window has not elapsed.
- Per-channel state (`_commandsSincePersist`, `_lastPersistUnixMs`, `_pendingDirty`) lives on the dispatch thread → no Interlocked needed.
- Cooperative shutdown (`RunLoopAsync` finally block) forces a final flush via `FlushPendingSnapshotOnShutdown` so a quiet period after the last command does not silently lose deferred work.
- New metric `exch_snapshot_skipped_by_throttle_total`.

## Config
```json
"persistence": {
  "dataDir": "/var/lib/b3matching",
  "throttle": { "everyN": 50, "minIntervalMs": 250 }
}
```
Both omitted/zero → legacy behaviour (every command persists).

## Tests
4 new tests in `ChannelDispatcherPersistenceTests`:
- `Throttle_EveryNCommands_SkipsBelowThreshold_PersistsAtThreshold`
- `Throttle_OperatorCommands_AlwaysForcePersist`
- `Throttle_PendingDirty_FlushedOnShutdown`
- `Throttle_DefaultPolicy_PersistsEveryCommand`

All 25 persistence tests pass; full suite green except the pre-existing flaky `MultiSessionReplayTests.TwoSessions_CrossingScript_LandsErTradesOnBothSides` (also failing on `main`).