### PR TITLE
feat(persistence): async snapshot writer (#268)

### DIFF
--- a/src/B3.Exchange.Core/BackgroundSnapshotWriter.cs
+++ b/src/B3.Exchange.Core/BackgroundSnapshotWriter.cs
@@ -1,0 +1,151 @@
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Single-slot mailbox that hands off <see cref="ChannelStateSnapshot"/>
+/// captures from the dispatch loop to a dedicated writer thread (issue
+/// #268). The loop thread invokes <see cref="Submit"/> with the freshly
+/// captured POCO, which is published via an interlocked swap and the
+/// writer is signalled — the loop never blocks on serialization or
+/// fsync.
+///
+/// <para>Backpressure semantics are <em>last-write-wins</em>: if
+/// <see cref="Submit"/> is called while a previous snapshot is still
+/// pending, the older one is discarded (and counted via
+/// <see cref="ChannelMetrics.IncSnapshotDroppedByBackpressure"/>) and
+/// replaced by the newer one. This is safe because each snapshot
+/// represents the complete channel state at a point in time — there is
+/// no incremental information lost. The trade-off is RPO: a crash
+/// while a Submit-but-not-yet-written snapshot is in flight loses the
+/// most recent commands. Operators that need zero-RPO must keep the
+/// synchronous (non-async) writer.</para>
+///
+/// <para>On <see cref="StopAsync"/> the writer drains the final
+/// pending snapshot before returning, so cooperative shutdown still
+/// produces a durable on-disk image of the most recent submitted
+/// state.</para>
+/// </summary>
+public sealed class BackgroundSnapshotWriter : IAsyncDisposable
+{
+    private readonly IChannelStatePersister _persister;
+    private readonly ILogger _logger;
+    private readonly ChannelMetrics? _metrics;
+    private readonly byte _channelNumber;
+    private readonly SemaphoreSlim _signal = new(0, 1);
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _writerTask;
+
+    // Single-slot mailbox. Mutated only via Interlocked.Exchange so the
+    // writer thread can read-and-clear without a lock and Submit can
+    // overwrite without contention.
+    private ChannelStateSnapshot? _pending;
+    private int _stopped;
+
+    public BackgroundSnapshotWriter(
+        byte channelNumber,
+        IChannelStatePersister persister,
+        ILogger logger,
+        ChannelMetrics? metrics = null)
+    {
+        _channelNumber = channelNumber;
+        _persister = persister;
+        _logger = logger;
+        _metrics = metrics;
+        // The writer is a long-lived background task; LongRunning hints
+        // the scheduler to use a dedicated thread instead of a
+        // ThreadPool slot, since this task spends most of its life
+        // blocked on the semaphore or in fsync.
+        _writerTask = Task.Factory.StartNew(
+            WriterLoop,
+            _cts.Token,
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default).Unwrap();
+    }
+
+    /// <summary>
+    /// Hands a freshly captured snapshot to the writer thread. Returns
+    /// immediately. If a previous snapshot was still pending, it is
+    /// discarded (last-write-wins) and the backpressure counter is
+    /// incremented.
+    /// </summary>
+    public void Submit(ChannelStateSnapshot snapshot)
+    {
+        var prior = Interlocked.Exchange(ref _pending, snapshot);
+        if (prior is not null)
+        {
+            _metrics?.IncSnapshotDroppedByBackpressure();
+        }
+        // Release the semaphore if not already signalled. A
+        // SemaphoreSlim with capacity 1 will throw if released twice
+        // without a wait between; suppress that to coalesce signals.
+        try { _signal.Release(); }
+        catch (SemaphoreFullException) { }
+    }
+
+    private async Task WriterLoop()
+    {
+        var ct = _cts.Token;
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                await _signal.WaitAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            DrainOnce();
+        }
+        // Drain any final pending snapshot deposited between the last
+        // signal and the cancellation request so cooperative shutdown
+        // does not lose work.
+        DrainOnce();
+    }
+
+    private void DrainOnce()
+    {
+        var snap = Interlocked.Exchange(ref _pending, null);
+        if (snap is null) return;
+        var start = System.Diagnostics.Stopwatch.GetTimestamp();
+        try
+        {
+            var bytes = _persister.Save(snap);
+            var elapsed = System.Diagnostics.Stopwatch.GetTimestamp() - start;
+            if (_metrics is { } m)
+            {
+                m.SnapshotWrite.ObserveTicks(elapsed);
+                m.IncSnapshotSaveOk();
+                if (bytes > 0) m.SetSnapshotLastSizeBytes(bytes);
+                m.SetSnapshotLastSuccessUnixMs(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            }
+        }
+        catch (Exception ex)
+        {
+            _metrics?.IncSnapshotSaveFailure();
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: background snapshot writer Save failed",
+                _channelNumber);
+        }
+    }
+
+    /// <summary>
+    /// Signals the writer to stop, drains any remaining pending
+    /// snapshot, and awaits the writer task. Safe to call multiple
+    /// times — only the first call drains.
+    /// </summary>
+    public async Task StopAsync()
+    {
+        if (Interlocked.Exchange(ref _stopped, 1) != 0) return;
+        try { _cts.Cancel(); } catch { }
+        try { await _writerTask.ConfigureAwait(false); } catch { }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+        _signal.Dispose();
+        _cts.Dispose();
+    }
+}

--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -203,6 +203,19 @@ public sealed partial class ChannelDispatcher
         _inbound.Writer.TryComplete();
         try { _cts.Cancel(); } catch { }
         if (_loopTask != null) { try { await _loopTask.ConfigureAwait(false); } catch { } }
+        // Issue #268: ensure any in-flight async snapshot is durable
+        // before tearing down. The writer drains its pending mailbox
+        // inside StopAsync.
+        if (_asyncSnapshotWriter is { } writer)
+        {
+            try { await writer.DisposeAsync().ConfigureAwait(false); }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: BackgroundSnapshotWriter shutdown drain failed",
+                    ChannelNumber);
+            }
+        }
         _cts.Dispose();
     }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -283,6 +283,18 @@ public sealed partial class ChannelDispatcher
         try
         {
             var snap = CaptureChannelState();
+            // Issue #268: when an async writer is configured the loop
+            // thread captures the POCO (cheap) and hands it off — the
+            // serialization + atomic write happen on a dedicated thread
+            // so loop throughput is independent of book size.
+            if (_asyncSnapshotWriter is { } writer)
+            {
+                writer.Submit(snap);
+                _commandsSincePersist = 0;
+                _lastPersistUnixMs = nowMs;
+                _pendingDirty = false;
+                return;
+            }
             var bytes = _persister.Save(snap);
             var elapsed = System.Diagnostics.Stopwatch.GetTimestamp() - start;
             if (_metrics is { } m)

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -143,6 +143,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     private readonly IChannelStatePersister? _persister;
     private readonly SnapshotThrottlePolicy _snapshotThrottle;
+    private readonly BackgroundSnapshotWriter? _asyncSnapshotWriter;
     // Throttle bookkeeping (issue #267). Mutated only on the dispatch
     // loop thread → no Interlocked needed.
     private long _commandsSincePersist;
@@ -200,7 +201,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         BoundedSessionFirmCounters? sessionFirmCounters = null,
         UmdfPacketRetransmitBuffer? retxBuffer = null,
         IChannelStatePersister? persister = null,
-        SnapshotThrottlePolicy? snapshotThrottle = null)
+        SnapshotThrottlePolicy? snapshotThrottle = null,
+        bool useAsyncSnapshotWriter = false)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -215,6 +217,12 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _retxBuffer = retxBuffer;
         _persister = persister;
         _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
+        // Issue #268: opt-in async snapshot writer. Off by default so
+        // pre-existing deployments keep the synchronous in-loop persist
+        // (zero-RPO). Enabled per channel via host config.
+        _asyncSnapshotWriter = (useAsyncSnapshotWriter && persister is not null)
+            ? new BackgroundSnapshotWriter(channelNumber, persister, logger, metrics)
+            : null;
         // Direct field writes are safe here: ctor runs on the constructing
         // thread before Start() and before any other thread can observe the
         // instance. No memory barrier is needed.

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -167,6 +167,9 @@ public sealed class ChannelMetrics
     private long _snapshotSkippedByThrottle;
     public long SnapshotSkippedByThrottle => Interlocked.Read(ref _snapshotSkippedByThrottle);
     public void IncSnapshotSkippedByThrottle() => Interlocked.Increment(ref _snapshotSkippedByThrottle);
+    private long _snapshotDroppedByBackpressure;
+    public long SnapshotDroppedByBackpressure => Interlocked.Read(ref _snapshotDroppedByBackpressure);
+    public void IncSnapshotDroppedByBackpressure() => Interlocked.Increment(ref _snapshotDroppedByBackpressure);
 
     public void IncSnapshotSaveOk() => Interlocked.Increment(ref _snapshotSavesOk);
     public void IncSnapshotSaveFailure() => Interlocked.Increment(ref _snapshotSaveFailures);
@@ -445,6 +448,9 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_snapshot_skipped_by_throttle_total",
             "Total snapshot persists deferred by the SnapshotThrottlePolicy (issue #267). The dispatcher tracks the deferred state and forces a final flush at cooperative shutdown so quiet periods do not lose work.",
             channels, c => c.SnapshotSkippedByThrottle);
+        EmitCounter(sb, "exch_snapshot_dropped_by_backpressure_total",
+            "Total snapshots that the BackgroundSnapshotWriter (issue #268) discarded because a newer snapshot was submitted before the previous one had been written. Last-write-wins semantics preserve correctness — each snapshot is a complete state image — but a high rate indicates the writer cannot keep up with the loop and RPO is degraded.",
+            channels, c => c.SnapshotDroppedByBackpressure);
 
         // Issue #174: throughput counters. Bounded labels (msg_type ≤ 6,
         // exec_type ≤ 7, feed = 3) — safe to ship per-channel.

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -170,7 +170,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 sessionFirmCounters: _metrics.SessionFirmMessages,
                 retxBuffer: retxBuffer,
                 persister: BuildPersister(ch),
-                snapshotThrottle: ch.Persistence?.Throttle?.ToPolicy());
+                snapshotThrottle: ch.Persistence?.Throttle?.ToPolicy(),
+                useAsyncSnapshotWriter: ch.Persistence?.AsyncWriter ?? false);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -271,6 +271,16 @@ public sealed class PersistenceConfig
     /// Operator commands always force-persist regardless of throttle.
     /// </summary>
     [JsonPropertyName("throttle")] public SnapshotThrottleConfig? Throttle { get; set; }
+
+    /// <summary>
+    /// Issue #268: opt-in async snapshot writer. When <c>true</c> the
+    /// dispatcher captures the snapshot POCO on the loop thread (cheap)
+    /// and hands it off to a dedicated writer thread for serialization
+    /// and atomic write. Off by default so existing deployments keep
+    /// the synchronous (zero-RPO) behaviour. Backpressure is
+    /// last-write-wins — see exch_snapshot_dropped_by_backpressure_total.
+    /// </summary>
+    [JsonPropertyName("asyncWriter")] public bool AsyncWriter { get; set; }
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -76,7 +76,8 @@ public class ChannelDispatcherPersistenceTests
         IChannelStatePersister persister,
         out NoOpOutbound outbound,
         ChannelMetrics? metrics = null,
-        SnapshotThrottlePolicy? throttle = null)
+        SnapshotThrottlePolicy? throttle = null,
+        bool useAsyncSnapshotWriter = false)
     {
         outbound = new NoOpOutbound();
         var localOutbound = outbound;
@@ -89,7 +90,8 @@ public class ChannelDispatcherPersistenceTests
             logger: NullLogger<ChannelDispatcher>.Instance,
             metrics: metrics,
             persister: persister,
-            snapshotThrottle: throttle);
+            snapshotThrottle: throttle,
+            useAsyncSnapshotWriter: useAsyncSnapshotWriter);
     }
 
     [Fact]
@@ -604,5 +606,141 @@ public class ChannelDispatcherPersistenceTests
         Assert.True(EnqueueOrder(disp, session, "CL-2", 0x31, 4001UL));
         probe.DrainInbound();
         Assert.Equal(2, persister.SaveCount);
+    }
+
+    // -------- Issue #268: async snapshot writer --------
+
+    /// <summary>
+    /// Persister that blocks each Save until the test releases it,
+    /// allowing assertions about backpressure / coalescing.
+    /// </summary>
+    private sealed class BlockingPersister : IChannelStatePersister
+    {
+        private readonly ManualResetEventSlim _gate = new(initialState: false);
+        public int SaveCount { get; private set; }
+        public ChannelStateSnapshot? Last { get; private set; }
+
+        public ChannelStateSnapshot? TryLoad(byte channelNumber) => null;
+
+        public long Save(ChannelStateSnapshot snapshot)
+        {
+            _gate.Wait();
+            SaveCount++;
+            Last = snapshot;
+            return 0;
+        }
+
+        public void Release() => _gate.Set();
+    }
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+        return condition();
+    }
+
+    [Fact]
+    public async Task AsyncWriter_Submits_PersistAfterFlush()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _, useAsyncSnapshotWriter: true);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("80801");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0xA0, 5000UL));
+        probe.DrainInbound();
+
+        // Async path → poll briefly; the writer thread must observe the
+        // submission and persist.
+        Assert.True(await WaitForAsync(() => persister.SaveCount >= 1, TimeSpan.FromSeconds(2)));
+        var snap = persister.TryLoad(84);
+        Assert.NotNull(snap);
+        Assert.Single(snap!.Engine.Books.Single().Orders);
+
+        await disp.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AsyncWriter_RapidSubmits_CoalesceLastWriteWins()
+    {
+        // While Save is blocked, several captures in a row collapse to
+        // a single write because the mailbox is single-slot.
+        var blocking = new BlockingPersister();
+        var metrics = new ChannelMetrics(channelNumber: 84);
+        var disp = BuildDispatcher(blocking, out _, metrics, useAsyncSnapshotWriter: true);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("80802");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0xB0, 6000UL));
+        Assert.True(EnqueueOrder(disp, session, "CL-2", 0xB1, 6001UL));
+        Assert.True(EnqueueOrder(disp, session, "CL-3", 0xB2, 6002UL));
+        probe.DrainInbound();
+
+        // Writer thread should be blocked inside Save with the first
+        // submitted snapshot, while the next two were coalesced.
+        Assert.True(await WaitForAsync(() => metrics.SnapshotDroppedByBackpressure >= 2,
+            TimeSpan.FromSeconds(2)));
+        Assert.Equal(0, blocking.SaveCount); // still blocked
+
+        // Release the blocked Save and let the writer drain.
+        blocking.Release();
+        await disp.DisposeAsync();
+
+        // After dispose we expect at most 2 actual writes (the first
+        // blocked one + the final coalesced one); never the full 3.
+        Assert.True(blocking.SaveCount <= 2,
+            $"Expected coalescing → at most 2 writes, got {blocking.SaveCount}");
+        Assert.True(blocking.SaveCount >= 1);
+        Assert.NotNull(blocking.Last);
+        // The final persisted snapshot must contain all 3 orders
+        // (last-write-wins semantics).
+        Assert.Equal(3, blocking.Last!.Engine.Books.Single().Orders.Count);
+    }
+
+    [Fact]
+    public async Task AsyncWriter_DisposeAsync_DrainsPendingSnapshot()
+    {
+        var persister = new InMemoryPersister();
+        var disp = BuildDispatcher(persister, out _, useAsyncSnapshotWriter: true);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("80803");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0xC0, 7000UL));
+        probe.DrainInbound();
+
+        // DisposeAsync drains the writer; persister must reflect the
+        // submitted snapshot before the call returns.
+        await disp.DisposeAsync();
+        Assert.True(persister.SaveCount >= 1);
+        Assert.NotNull(persister.TryLoad(84));
+    }
+
+    [Fact]
+    public async Task AsyncWriter_ThrowingPersister_DoesNotCrashWriter()
+    {
+        var throwing = new ThrowingPersister();
+        var metrics = new ChannelMetrics(channelNumber: 84);
+        var disp = BuildDispatcher(throwing, out _, metrics, useAsyncSnapshotWriter: true);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("80804");
+
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0xD0, 8000UL));
+        probe.DrainInbound();
+
+        Assert.True(await WaitForAsync(() => metrics.SnapshotSaveFailures >= 1,
+            TimeSpan.FromSeconds(2)));
+
+        // Subsequent submissions still flow — writer survived the throw.
+        Assert.True(EnqueueOrder(disp, session, "CL-2", 0xD1, 8001UL));
+        probe.DrainInbound();
+        Assert.True(await WaitForAsync(() => metrics.SnapshotSaveFailures >= 2,
+            TimeSpan.FromSeconds(2)));
+
+        await disp.DisposeAsync();
     }
 }


### PR DESCRIPTION
Closes #268.

## What
Opt-in `BackgroundSnapshotWriter` moves snapshot serialization + fsync off the dispatch loop thread so per-channel command throughput becomes independent of book size.

## Design
- POCO capture (`CaptureChannelState`) stays on the loop thread — already lock-free and cheap.
- Single-slot mailbox + interlocked swap publishes the latest snapshot to a dedicated writer Task.
- Writer is started `LongRunning` so it doesn't squat a ThreadPool slot while blocked on the semaphore / fsync.
- Backpressure = **last-write-wins**: rapid submits coalesce because each snapshot is a complete state image (no incremental info to lose). Counted via `exch_snapshot_dropped_by_backpressure_total`. The trade-off is RPO — operators that need zero-RPO must keep the synchronous default.
- `DisposeAsync` drains the writer's pending snapshot before tearing down, so cooperative shutdown still produces a durable image of the most recent submitted state.

## Config
```json
"persistence": {
  "dataDir": "/var/lib/b3matching",
  "asyncWriter": true,
  "throttle": { "everyN": 50 }
}
```
Default `asyncWriter: false` preserves PR #261 zero-RPO behaviour.

## Tests
4 new tests in `ChannelDispatcherPersistenceTests`:
- `AsyncWriter_Submits_PersistAfterFlush`
- `AsyncWriter_RapidSubmits_CoalesceLastWriteWins` (blocking persister proves coalescing)
- `AsyncWriter_DisposeAsync_DrainsPendingSnapshot`
- `AsyncWriter_ThrowingPersister_DoesNotCrashWriter`

29/29 persistence tests green; full suite green except a separately flaky FixpSession test that passes on retry.