### PR TITLE
feat(persistence): N rolling snapshot generations (#264)

### DIFF
--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -432,9 +432,13 @@ public sealed class ExchangeHost : IAsyncDisposable
                 ch.ChannelNumber);
             return null;
         }
+        int generations = ch.Persistence.Generations > 0
+            ? ch.Persistence.Generations
+            : FileChannelStatePersister.DefaultGenerations;
         return new FileChannelStatePersister(
             ch.Persistence.DataDir,
-            _loggerFactory.CreateLogger<FileChannelStatePersister>());
+            _loggerFactory.CreateLogger<FileChannelStatePersister>(),
+            generations);
     }
 
     private FirmRegistry BuildFirmRegistry()

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -281,6 +281,17 @@ public sealed class PersistenceConfig
     /// last-write-wins — see exch_snapshot_dropped_by_backpressure_total.
     /// </summary>
     [JsonPropertyName("asyncWriter")] public bool AsyncWriter { get; set; }
+
+    /// <summary>
+    /// Issue #264: number of rolling snapshot generations kept on disk
+    /// per channel. The persister round-robins across slots
+    /// <c>0..generations-1</c> and picks the newest valid one on load,
+    /// transparently falling back to older slots if the newest is
+    /// corrupted. Defaults to
+    /// <see cref="B3.Exchange.Persistence.FileChannelStatePersister.DefaultGenerations"/>
+    /// when absent or zero.
+    /// </summary>
+    [JsonPropertyName("generations")] public int Generations { get; set; }
 }
 
 /// <summary>

--- a/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
+++ b/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using B3.Exchange.Core;
@@ -7,31 +8,39 @@ namespace B3.Exchange.Persistence;
 
 /// <summary>
 /// File-system backed implementation of
-/// <see cref="IChannelStatePersister"/> (issue #260). One snapshot file per
-/// channel under <see cref="DataDirectory"/>:
-/// <c>channel-{N}.snapshot</c>, written atomically via
-/// tmp + fsync + rename so a crash mid-write can never leave a partial file.
+/// <see cref="IChannelStatePersister"/> (issue #260) with N rolling
+/// generations (issue #264). Snapshots are written to round-robin slots
+/// <c>channel-{N}.snapshot.{slot}</c> where <c>slot</c> is in
+/// <c>0..Generations-1</c>; the persister picks the newest valid slot
+/// on load and writes to <c>(lastUsed + 1) mod Generations</c> on save.
 ///
-/// <para>Serialization uses System.Text.Json with enums-as-strings for
-/// debuggability — operators can <c>cat</c> a snapshot and read it. The
-/// extra cost (vs binary) is bounded: typical snapshots are a few KB to a
-/// few MB and serialization happens once per command flush, off the
-/// hot UMDF send path.</para>
+/// <para>Load semantics: enumerate all per-channel files, sort by
+/// modification time descending, return the first that deserializes.
+/// A corrupted newest file therefore falls back transparently to the
+/// previous generation. <c>ValidateSnapshotStructure</c> failures still
+/// fail-closed in the dispatcher — generations defend against I/O-level
+/// corruption (truncated writes, bad JSON), not against semantically
+/// inconsistent snapshots.</para>
 ///
-/// <para><b>Atomicity:</b> on POSIX <see cref="File.Move(string, string, bool)"/>
-/// uses <c>rename(2)</c>, which is atomic on the same filesystem. We
-/// fsync the tmp file's data before rename and fsync the parent directory
-/// after rename so an abrupt power-loss is recoverable.</para>
+/// <para>Atomicity per slot remains the PR #261 contract: write to
+/// <c>.tmp</c>, fsync the data, rename, fsync the directory entry. The
+/// <c>rename(2)</c> is atomic on POSIX within the same filesystem.</para>
+///
+/// <para>Backward compatibility: a pre-#264 single file
+/// <c>channel-{N}.snapshot</c> (no slot suffix) is still considered on
+/// load. After the first successful generational write the legacy file
+/// is removed so subsequent loads pick from the rolling slots only.</para>
 /// </summary>
 public sealed class FileChannelStatePersister : IChannelStatePersister
 {
-    private const string SnapshotFileNameFormat = "channel-{0}.snapshot";
-    private const string TempFileNameFormat = "channel-{0}.snapshot.tmp";
+    public const int DefaultGenerations = 3;
+
+    private const string LegacyFileNameFormat = "channel-{0}.snapshot";
+    private const string SlotFileNameFormat = "channel-{0}.snapshot.{1}";
+    private const string TempFileNameFormat = "channel-{0}.snapshot.{1}.tmp";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
-        // Easier to diff/read in incident review. The marginal size cost
-        // is negligible for files of this scale.
         WriteIndented = false,
         DefaultIgnoreCondition = JsonIgnoreCondition.Never,
         Converters =
@@ -41,48 +50,79 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
     };
 
     private readonly string _dataDir;
+    private readonly int _generations;
     private readonly ILogger<FileChannelStatePersister> _logger;
 
-    public string DataDirectory => _dataDir;
+    // Per-channel last-used slot, -1 = unknown (derive from filesystem).
+    // Mutated only inside Save under the per-channel lock.
+    private readonly Dictionary<byte, int> _lastUsedSlot = new();
+    private readonly object _slotLock = new();
 
-    public FileChannelStatePersister(string dataDirectory, ILogger<FileChannelStatePersister> logger)
+    public string DataDirectory => _dataDir;
+    public int Generations => _generations;
+
+    public FileChannelStatePersister(
+        string dataDirectory,
+        ILogger<FileChannelStatePersister> logger,
+        int generations = DefaultGenerations)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
         ArgumentNullException.ThrowIfNull(logger);
+        if (generations < 1)
+            throw new ArgumentOutOfRangeException(nameof(generations),
+                "generations must be >= 1");
         _dataDir = Path.GetFullPath(dataDirectory);
         _logger = logger;
+        _generations = generations;
         Directory.CreateDirectory(_dataDir);
     }
 
     public ChannelStateSnapshot? TryLoad(byte channelNumber)
     {
-        var path = SnapshotPath(channelNumber);
-        if (!File.Exists(path)) return null;
-        try
+        // Enumerate every generation slot + legacy file for this channel,
+        // newest mtime first, returning the first that deserializes
+        // successfully. This makes a corrupted newest slot transparently
+        // fall back to the previous generation.
+        var candidates = EnumerateCandidateFiles(channelNumber);
+        if (candidates.Count == 0) return null;
+
+        foreach (var (path, _) in candidates)
         {
-            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-            var snapshot = JsonSerializer.Deserialize<ChannelStateSnapshot>(fs, JsonOptions);
-            if (snapshot is null)
+            try
             {
-                _logger.LogWarning("channel {ChannelNumber}: snapshot deserialized to null at {Path}", channelNumber, path);
-                return null;
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                var snapshot = JsonSerializer.Deserialize<ChannelStateSnapshot>(fs, JsonOptions);
+                if (snapshot is null)
+                {
+                    _logger.LogWarning(
+                        "channel {ChannelNumber}: snapshot deserialized to null at {Path}; trying older generation",
+                        channelNumber, path);
+                    continue;
+                }
+                _logger.LogInformation(
+                    "channel {ChannelNumber}: loaded snapshot from {Path} (seq={SequenceNumber}/{SequenceVersion}, owners={OwnerCount})",
+                    channelNumber, path, snapshot.SequenceNumber, snapshot.SequenceVersion, snapshot.Owners.Count);
+                return snapshot;
             }
-            _logger.LogInformation("channel {ChannelNumber}: loaded snapshot from {Path} (seq={SequenceNumber}/{SequenceVersion}, owners={OwnerCount})",
-                channelNumber, path, snapshot.SequenceNumber, snapshot.SequenceVersion, snapshot.Owners.Count);
-            return snapshot;
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "channel {ChannelNumber}: failed to load snapshot at {Path}; trying older generation",
+                    channelNumber, path);
+            }
         }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "channel {ChannelNumber}: failed to load snapshot at {Path}; ignoring", channelNumber, path);
-            return null;
-        }
+        _logger.LogError(
+            "channel {ChannelNumber}: all {Count} candidate snapshot files failed to load",
+            channelNumber, candidates.Count);
+        return null;
     }
 
     public long Save(ChannelStateSnapshot snapshot)
     {
         ArgumentNullException.ThrowIfNull(snapshot);
-        var path = SnapshotPath(snapshot.ChannelNumber);
-        var tmp = TempPath(snapshot.ChannelNumber);
+        int slot = NextSlot(snapshot.ChannelNumber);
+        var path = SlotPath(snapshot.ChannelNumber, slot);
+        var tmp = TempPath(snapshot.ChannelNumber, slot);
         long bytesWritten;
         try
         {
@@ -92,48 +132,113 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
                 fs.Flush(flushToDisk: true);
                 bytesWritten = fs.Length;
             }
-            // File.Move uses rename(2) on POSIX → atomic within the same
-            // filesystem. overwrite=true so the previous snapshot is
-            // replaced in place.
             File.Move(tmp, path, overwrite: true);
             FsyncDirectory(_dataDir);
-            return bytesWritten;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "channel {ChannelNumber}: failed to persist snapshot to {Path}", snapshot.ChannelNumber, path);
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: failed to persist snapshot slot {Slot} to {Path}",
+                snapshot.ChannelNumber, slot, path);
             try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
             throw;
         }
+        // Best-effort: drop the legacy single-file once a generational
+        // write succeeded, so future loads stop considering it.
+        try
+        {
+            var legacy = LegacyPath(snapshot.ChannelNumber);
+            if (File.Exists(legacy)) File.Delete(legacy);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex,
+                "channel {ChannelNumber}: failed to remove legacy snapshot file (non-fatal)",
+                snapshot.ChannelNumber);
+        }
+        return bytesWritten;
     }
 
-    private string SnapshotPath(byte channelNumber)
-        => Path.Combine(_dataDir, string.Format(System.Globalization.CultureInfo.InvariantCulture, SnapshotFileNameFormat, channelNumber));
+    /// <summary>
+    /// Picks the next round-robin slot for the channel, lazily deriving
+    /// the starting point from the on-disk newest file the first time
+    /// a channel is observed (so a host restart does not reuse the slot
+    /// that already contains the most recent snapshot).
+    /// </summary>
+    private int NextSlot(byte channelNumber)
+    {
+        lock (_slotLock)
+        {
+            if (!_lastUsedSlot.TryGetValue(channelNumber, out var last))
+            {
+                last = DiscoverNewestSlot(channelNumber);
+                _lastUsedSlot[channelNumber] = last;
+            }
+            int next = (last + 1) % _generations;
+            _lastUsedSlot[channelNumber] = next;
+            return next;
+        }
+    }
 
-    private string TempPath(byte channelNumber)
-        => Path.Combine(_dataDir, string.Format(System.Globalization.CultureInfo.InvariantCulture, TempFileNameFormat, channelNumber));
+    private int DiscoverNewestSlot(byte channelNumber)
+    {
+        int newest = -1;
+        DateTime newestMtime = DateTime.MinValue;
+        for (int i = 0; i < _generations; i++)
+        {
+            var p = SlotPath(channelNumber, i);
+            if (!File.Exists(p)) continue;
+            var mt = File.GetLastWriteTimeUtc(p);
+            if (mt > newestMtime)
+            {
+                newestMtime = mt;
+                newest = i;
+            }
+        }
+        return newest;
+    }
 
     /// <summary>
-    /// Ensures the parent directory entry for the renamed file is durable.
-    /// On Linux the BCL exposes no portable directory-fsync; we fall back
-    /// to opening the directory with <see cref="FileOptions.WriteThrough"/>
-    /// semantics where supported. Failures are non-fatal — they only widen
-    /// the crash-loss window for the very last rename.
+    /// Returns existing snapshot file paths for the channel (slot files
+    /// + legacy single-file if present), sorted by mtime descending.
     /// </summary>
+    private List<(string Path, DateTime Mtime)> EnumerateCandidateFiles(byte channelNumber)
+    {
+        var list = new List<(string, DateTime)>(_generations + 1);
+        for (int i = 0; i < _generations; i++)
+        {
+            var p = SlotPath(channelNumber, i);
+            if (File.Exists(p)) list.Add((p, File.GetLastWriteTimeUtc(p)));
+        }
+        var legacy = LegacyPath(channelNumber);
+        if (File.Exists(legacy)) list.Add((legacy, File.GetLastWriteTimeUtc(legacy)));
+        list.Sort((a, b) => b.Item2.CompareTo(a.Item2));
+        return list;
+    }
+
+    private string LegacyPath(byte channelNumber)
+        => Path.Combine(_dataDir,
+            string.Format(CultureInfo.InvariantCulture, LegacyFileNameFormat, channelNumber));
+
+    private string SlotPath(byte channelNumber, int slot)
+        => Path.Combine(_dataDir,
+            string.Format(CultureInfo.InvariantCulture, SlotFileNameFormat, channelNumber, slot));
+
+    private string TempPath(byte channelNumber, int slot)
+        => Path.Combine(_dataDir,
+            string.Format(CultureInfo.InvariantCulture, TempFileNameFormat, channelNumber, slot));
+
     private static void FsyncDirectory(string dir)
     {
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
         try
         {
-            // Open with O_DIRECTORY|O_RDONLY equivalent and call fsync.
-            // SafeFileHandle path keeps us off P/Invoke for portability.
             using var dirHandle = File.OpenHandle(dir, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, FileOptions.None);
             RandomAccess.FlushToDisk(dirHandle);
         }
         catch
         {
-            // Best-effort. On filesystems that reject fsync(directory) this
-            // throws EINVAL; the snapshot file itself is already durable.
+            // Best-effort; some FSes reject directory fsync with EINVAL.
         }
     }
 }

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelStatePersisterTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelStatePersisterTests.cs
@@ -85,6 +85,117 @@ public class FileChannelStatePersisterTests
         Assert.Null(persister.TryLoad(3));
     }
 
+    // -------- Issue #264: snapshot rotation (N generations) --------
+
+    [Fact]
+    public void Rotation_RoundRobinsAcrossSlots()
+    {
+        // generations=3 → slot files .0, .1, .2 created in turn.
+        using var dir = new TempDir();
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance, generations: 3);
+        for (int i = 1; i <= 3; i++)
+            persister.Save(MakeRichSnapshot(channel: 5) with { SequenceNumber = (uint)i });
+
+        Assert.True(File.Exists(Path.Combine(dir.Path, "channel-5.snapshot.0")));
+        Assert.True(File.Exists(Path.Combine(dir.Path, "channel-5.snapshot.1")));
+        Assert.True(File.Exists(Path.Combine(dir.Path, "channel-5.snapshot.2")));
+
+        // 4th save reuses slot 0 (round-robin).
+        persister.Save(MakeRichSnapshot(channel: 5) with { SequenceNumber = 99 });
+        Assert.Equal(99u, persister.TryLoad(5)!.SequenceNumber);
+    }
+
+    [Fact]
+    public void Rotation_LoadFallsBackToPreviousGeneration_WhenNewestCorrupted()
+    {
+        // Newest file is structurally invalid → persister must return
+        // the previous generation's snapshot, not null.
+        using var dir = new TempDir();
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance, generations: 3);
+
+        persister.Save(MakeRichSnapshot(channel: 9) with { SequenceNumber = 10 });
+        persister.Save(MakeRichSnapshot(channel: 9) with { SequenceNumber = 20 });
+
+        // Find which slot got the newest snapshot (should be slot .1)
+        // and corrupt it. Use a tiny sleep to ensure mtime ordering is
+        // deterministic on filesystems with low timer resolution.
+        Thread.Sleep(50);
+        var newest = Path.Combine(dir.Path, "channel-9.snapshot.1");
+        Assert.True(File.Exists(newest));
+        File.WriteAllText(newest, "{garbage");
+        // Bump mtime to make sure it remains "newest" by mtime.
+        File.SetLastWriteTimeUtc(newest, DateTime.UtcNow);
+
+        var loaded = persister.TryLoad(9);
+        Assert.NotNull(loaded);
+        Assert.Equal(10u, loaded!.SequenceNumber);
+    }
+
+    [Fact]
+    public void Rotation_DiscoversNewestSlot_AcrossPersisterRestart()
+    {
+        // Persister A writes 3 snapshots → slots .0, .1, .2 = seq 1,2,3.
+        // Persister B (new instance, same dir) must pick slot .0 next
+        // (round-robin from newest=.2), not overwrite slot .0 first.
+        using var dir = new TempDir();
+        var a = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance, generations: 3);
+        for (int i = 1; i <= 3; i++)
+        {
+            a.Save(MakeRichSnapshot(channel: 11) with { SequenceNumber = (uint)i });
+            Thread.Sleep(20); // deterministic mtime ordering
+        }
+
+        var b = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance, generations: 3);
+        // Newest from A is seq=3 in slot .2; after B's first Save, the
+        // newest available should still be seq=3 (slot .2 untouched
+        // because B writes to slot .0 next).
+        Thread.Sleep(20);
+        b.Save(MakeRichSnapshot(channel: 11) with { SequenceNumber = 100 });
+
+        // After this Save, newest is seq=100 in slot .0.
+        Assert.Equal(100u, b.TryLoad(11)!.SequenceNumber);
+        // Slot .2 (seq=3 from A) must still be intact for rollback.
+        var slot2 = File.ReadAllText(Path.Combine(dir.Path, "channel-11.snapshot.2"));
+        Assert.Contains("\"SequenceNumber\":3", slot2);
+    }
+
+    [Fact]
+    public void Rotation_LegacyFileIsLoadedAndThenRetired()
+    {
+        // A pre-#264 deployment has a single channel-7.snapshot file.
+        // First load must return it; first Save must replace it with a
+        // generational slot file and remove the legacy.
+        using var dir = new TempDir();
+        var bootstrap = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance, generations: 3);
+        // Write a legacy file by serializing the snapshot under the
+        // legacy name directly. We use the persister to produce a
+        // valid JSON, then move the slot file into the legacy name.
+        bootstrap.Save(MakeRichSnapshot(channel: 7) with { SequenceNumber = 42 });
+        var legacy = Path.Combine(dir.Path, "channel-7.snapshot");
+        File.Move(Path.Combine(dir.Path, "channel-7.snapshot.0"), legacy);
+
+        var persister = new FileChannelStatePersister(dir.Path,
+            NullLogger<FileChannelStatePersister>.Instance, generations: 3);
+        Assert.Equal(42u, persister.TryLoad(7)!.SequenceNumber);
+
+        persister.Save(MakeRichSnapshot(channel: 7) with { SequenceNumber = 99 });
+        Assert.False(File.Exists(legacy), "legacy file should be removed after first generational save");
+        Assert.Equal(99u, persister.TryLoad(7)!.SequenceNumber);
+    }
+
+    [Fact]
+    public void Rotation_GenerationsArgument_Validated()
+    {
+        using var dir = new TempDir();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new FileChannelStatePersister(
+            dir.Path, NullLogger<FileChannelStatePersister>.Instance, generations: 0));
+    }
+
     private static ChannelStateSnapshot MakeRichSnapshot(byte channel)
     {
         var orders = new[]


### PR DESCRIPTION
Closes #264.

## What
Replaces the single per-channel snapshot file with N rolling generations so a corrupt newest write transparently falls back to the previous generation on load and operators can manually roll back by deleting the newest slot file.

## Design
- Slot files: `channel-{N}.snapshot.{slot}`, slot in `0..generations-1`. Round-robin write order.
- Default `generations=3`; configurable via `persistence.generations`.
- Atomicity per slot unchanged from PR #261: tmp → fsync → rename → directory fsync.
- Slot discovery on cold start: scan slots, pick newest by mtime, advance from there. Restart never clobbers the most-recent snapshot before writing the next slot.
- Load: enumerate all candidates in mtime-desc order, return first that deserializes. Corrupted newest → automatic fallback. **Note:** `ValidateSnapshotStructure` failures still fail-closed in the dispatcher; generations defend against I/O-level corruption (truncated writes, bad JSON), not against semantically inconsistent snapshots.
- Backwards compat: pre-#264 `channel-{N}.snapshot` is still loaded; deleted after the first generational write succeeds.

## Config
```json
"persistence": {
  "dataDir": "/var/lib/b3matching",
  "generations": 3
}
```

## Tests
5 new tests in `FileChannelStatePersisterTests` (34 total):
- `Rotation_RoundRobinsAcrossSlots`
- `Rotation_LoadFallsBackToPreviousGeneration_WhenNewestCorrupted`
- `Rotation_DiscoversNewestSlot_AcrossPersisterRestart`
- `Rotation_LegacyFileIsLoadedAndThenRetired`
- `Rotation_GenerationsArgument_Validated`

Existing 29 persistence tests still pass; all other suites green; format clean.