### PR TITLE
feat(host): admin snapshot endpoints (#271)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -32,6 +32,15 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.OperatorPersistSnapshot)
+        {
+            // Issue #271: admin "snapshot/force" — capture + persist the
+            // engine state on the loop thread and write through the
+            // configured persister. Bypasses the throttle.
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
         if (item.Kind == WorkKind.OperatorBumpVersion)
         {
             ProcessBumpVersion();

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -101,6 +101,20 @@ public sealed partial class ChannelDispatcher
             0, 0, null, null, null, null));
 
     /// <summary>
+    /// Issue #271: forces an on-disk snapshot persist on the next
+    /// dispatcher cycle (separate from <see cref="EnqueueOperatorSnapshotNow"/>
+    /// which only publishes a UMDF snapshot). Drives the
+    /// <c>POST /admin/channels/{ch}/snapshot/force</c> endpoint —
+    /// captures channel state on the loop thread and writes through
+    /// the configured <see cref="IChannelStatePersister"/>, bypassing
+    /// any throttle. Returns <c>false</c> if the inbound queue is
+    /// full. Safe to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorPersistSnapshot()
+        => _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorPersistSnapshot, default, 0, false,
+            0, 0, null, null, null, null));
+
+    /// <summary>
     /// Operator command (issue #6): atomically (a) bumps the incremental
     /// channel's <see cref="SequenceVersion"/> + the attached snapshot
     /// rotator's <c>SequenceVersion</c>, (b) clears every per-instrument

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -139,6 +139,29 @@ public sealed partial class ChannelDispatcher
     /// books, owners referencing orderIds not present in any book, etc.).
     /// Runs before any mutation so RestoreChannelState is all-or-nothing.
     /// </summary>
+    /// <summary>
+    /// Issue #271: public wrapper around the structural validator used
+    /// by the admin "snapshot/validate" HTTP endpoint. Returns
+    /// <c>true</c> when the snapshot's invariants hold; on failure
+    /// returns <c>false</c> and surfaces the first violation message
+    /// in <paramref name="error"/>.
+    /// </summary>
+    public static bool TryValidateSnapshot(ChannelStateSnapshot snapshot, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        try
+        {
+            ValidateSnapshotStructure(snapshot);
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
     private static void ValidateSnapshotStructure(ChannelStateSnapshot snapshot)
     {
         var seenOrderIds = new HashSet<long>();

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot }
 
     internal sealed record WorkItem(
         WorkKind Kind,

--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -77,4 +77,15 @@ public interface IChannelStatePersister
     /// + fsync + rename so a crash mid-write never leaves a partial file
     /// on disk.</summary>
     long Save(ChannelStateSnapshot snapshot);
+
+    /// <summary>
+    /// Issue #271: deletes every on-disk snapshot artifact for the
+    /// given channel (all rolling generations + any legacy files).
+    /// Used by the admin "snapshot/reset" endpoint so an operator can
+    /// force the next boot of this channel to start with no
+    /// pre-existing state. Returns the number of files removed (0 when
+    /// none existed). Default implementation is a no-op so in-memory
+    /// fakes used by tests don't need to implement it.
+    /// </summary>
+    int DeleteAll(byte channelNumber) => 0;
 }

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -82,4 +82,12 @@ public interface IChannelWriteAheadLog
     /// contains records that are not yet reflected in the snapshot.
     /// </summary>
     void Truncate();
+
+    /// <summary>
+    /// Issue #271: removes the underlying WAL artifact entirely (file,
+    /// table, etc.) so a subsequent boot has nothing to replay. Used
+    /// by the admin "snapshot/reset" endpoint. Default no-op so
+    /// in-memory fakes used by tests don't need to implement it.
+    /// </summary>
+    void Reset() { }
 }

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -30,6 +30,8 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly Func<ChannelConfig, SnapshotChannelConfig, IUmdfPacketSink>? _snapshotSinkFactory;
     private readonly Func<ChannelConfig, InstrumentDefinitionConfig, IUmdfPacketSink>? _instrumentDefSinkFactory;
     private readonly List<ChannelDispatcher> _dispatchers = new();
+    private readonly Dictionary<byte, IChannelStatePersister> _persistersByChannel = new();
+    private readonly Dictionary<byte, IChannelWriteAheadLog> _walsByChannel = new();
     private readonly List<InstrumentDefinitionPublisher> _instrumentDefPublishers = new();
     private readonly List<IDisposable> _ownedSinks = new();
     private readonly List<Timer> _snapshotTimers = new();
@@ -155,6 +157,10 @@ public sealed class ExchangeHost : IAsyncDisposable
             {
                 retxBuffer = new UmdfPacketRetransmitBuffer(retxCapacity);
             }
+            var persister = BuildPersister(ch);
+            var wal = BuildWal(ch);
+            if (persister != null) _persistersByChannel[ch.ChannelNumber] = persister;
+            if (wal != null) _walsByChannel[ch.ChannelNumber] = wal;
             var disp = new ChannelDispatcher(
                 channelNumber: ch.ChannelNumber,
                 engineFactory: s =>
@@ -169,10 +175,10 @@ public sealed class ExchangeHost : IAsyncDisposable
                 metrics: channelMetrics,
                 sessionFirmCounters: _metrics.SessionFirmMessages,
                 retxBuffer: retxBuffer,
-                persister: BuildPersister(ch),
+                persister: persister,
                 snapshotThrottle: ch.Persistence?.Throttle?.ToPolicy(),
                 useAsyncSnapshotWriter: ch.Persistence?.AsyncWriter ?? false,
-                wal: BuildWal(ch));
+                wal: wal);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -316,7 +322,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                 msg => _logger.LogInformation("{Message}", msg),
                 sessionsProvider: sessionProvider.Sample,
                 firms: firmInfos,
-                dailyResetTrigger: () => TriggerDailyReset("http-trigger"));
+                dailyResetTrigger: () => TriggerDailyReset("http-trigger"),
+                persisters: _persistersByChannel,
+                wals: _walsByChannel);
             await _http.StartAsync().ConfigureAwait(false);
         }
 

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -34,6 +34,8 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly Func<IEnumerable<SessionDiagnostics>>? _sessionsProvider;
     private readonly IReadOnlyList<FirmInfo> _firms;
     private readonly Func<int>? _dailyResetTrigger;
+    private readonly IReadOnlyDictionary<byte, IChannelStatePersister> _persisters;
+    private readonly IReadOnlyDictionary<byte, IChannelWriteAheadLog> _wals;
     private readonly Action<string>? _log;
     private WebApplication? _app;
 
@@ -43,7 +45,9 @@ public sealed class HttpServer : IAsyncDisposable
         Action<string>? log = null,
         Func<IEnumerable<SessionDiagnostics>>? sessionsProvider = null,
         IReadOnlyList<FirmInfo>? firms = null,
-        Func<int>? dailyResetTrigger = null)
+        Func<int>? dailyResetTrigger = null,
+        IReadOnlyDictionary<byte, IChannelStatePersister>? persisters = null,
+        IReadOnlyDictionary<byte, IChannelWriteAheadLog>? wals = null)
     {
         _config = config;
         _metrics = metrics;
@@ -52,6 +56,8 @@ public sealed class HttpServer : IAsyncDisposable
         _sessionsProvider = sessionsProvider;
         _firms = firms ?? Array.Empty<FirmInfo>();
         _dailyResetTrigger = dailyResetTrigger;
+        _persisters = persisters ?? new Dictionary<byte, IChannelStatePersister>();
+        _wals = wals ?? new Dictionary<byte, IChannelWriteAheadLog>();
         _log = log;
     }
 
@@ -174,6 +180,48 @@ public sealed class HttpServer : IAsyncDisposable
             ctx.Response.StatusCode = StatusCodes.Status202Accepted;
             return Results.Text($"accepted daily-reset terminated={closed}\n", "text/plain");
         });
+
+        // Issue #271: admin endpoints for snapshot management.
+        //
+        // GET /admin/channels/{ch}/snapshot
+        //   Reads the most recently persisted on-disk snapshot via the
+        //   channel's IChannelStatePersister and returns it as JSON.
+        //   This is the *durable* state, NOT the live in-memory state.
+        //   To inspect live state first call POST .../snapshot/force
+        //   then GET — that round-trip routes through the dispatch
+        //   thread and persists atomically. 404 if the channel has no
+        //   persister wired (persistence.dataDir empty); 204 if the
+        //   persister has no snapshot yet.
+        app.MapGet("/admin/channels/{ch:int}/snapshot", (int ch, HttpContext ctx) =>
+            HandleAdminGetSnapshot(ctx, ch));
+
+        // POST /admin/channels/{ch}/snapshot/force
+        //   Alias of /channel/{ch}/snapshot-now under the /admin
+        //   namespace for ops tooling discoverability. Enqueues an
+        //   operator snapshot work item; the dispatch thread captures
+        //   and persists. Returns 202 Accepted on enqueue success.
+        app.MapPost("/admin/channels/{ch:int}/snapshot/force", (int ch, HttpContext ctx) =>
+            HandleOperatorEnqueue(ctx, ch, d => d.EnqueueOperatorPersistSnapshot(), "snapshot-force"));
+
+        // POST /admin/channels/{ch}/snapshot/reset?force=true
+        //   Deletes every on-disk snapshot artifact (all rolling
+        //   generations + legacy file) AND truncates/removes the WAL
+        //   for the channel. The live in-memory engine state is NOT
+        //   touched — restart the host to actually start the channel
+        //   empty. Requires explicit ?force=true to acknowledge the
+        //   irreversible nature of the operation.
+        app.MapPost("/admin/channels/{ch:int}/snapshot/reset", (int ch, HttpContext ctx) =>
+            HandleAdminReset(ctx, ch));
+
+        // POST /admin/channels/{ch}/snapshot/validate
+        //   Loads the most recently persisted snapshot and runs the
+        //   structural validator the boot path uses (duplicate orderId
+        //   check, owners-reference-known-orders, stop-record sanity,
+        //   etc.) WITHOUT restoring it. 200 + "ok" on success;
+        //   422 + reason on validation failure; 404 when no snapshot
+        //   exists; 503 when no persister is wired.
+        app.MapPost("/admin/channels/{ch:int}/snapshot/validate", (int ch, HttpContext ctx) =>
+            HandleAdminValidate(ctx, ch));
 
         await app.StartAsync(ct).ConfigureAwait(false);
         _app = app;
@@ -369,6 +417,130 @@ public sealed class HttpServer : IAsyncDisposable
         if (string.IsNullOrEmpty(s)) return allowMissing;
         return long.TryParse(s, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value);
     }
+
+    private IResult HandleAdminGetSnapshot(HttpContext ctx, int channelNumber)
+    {
+        if (channelNumber < 0 || channelNumber > 255)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown channel {channelNumber}\n", "text/plain");
+        }
+        if (!_persisters.TryGetValue((byte)channelNumber, out var persister))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"channel {channelNumber} has no persister wired\n", "text/plain");
+        }
+        ChannelStateSnapshot? snap;
+        try { snap = persister.TryLoad((byte)channelNumber); }
+        catch (Exception ex)
+        {
+            _log?.Invoke($"admin: snapshot-get channel={channelNumber} failed: {ex.Message}");
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"failed to load snapshot: {ex.Message}\n", "text/plain");
+        }
+        if (snap is null)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status204NoContent;
+            return Results.Empty;
+        }
+        _log?.Invoke($"admin: snapshot-get channel={channelNumber} returned snapshot version={snap.Version}");
+        var json = System.Text.Json.JsonSerializer.Serialize(snap, AdminJsonOptions);
+        return Results.Text(json, "application/json");
+    }
+
+    private IResult HandleAdminReset(HttpContext ctx, int channelNumber)
+    {
+        if (channelNumber < 0 || channelNumber > 255)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown channel {channelNumber}\n", "text/plain");
+        }
+        var force = ctx.Request.Query["force"].ToString();
+        if (!string.Equals(force, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("snapshot/reset is irreversible; pass ?force=true to confirm\n", "text/plain");
+        }
+        bool any = false;
+        int filesRemoved = 0;
+        if (_persisters.TryGetValue((byte)channelNumber, out var persister))
+        {
+            any = true;
+            try { filesRemoved += persister.DeleteAll((byte)channelNumber); }
+            catch (Exception ex)
+            {
+                _log?.Invoke($"admin: snapshot-reset channel={channelNumber} persister failed: {ex.Message}");
+                ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                return Results.Text($"persister DeleteAll failed: {ex.Message}\n", "text/plain");
+            }
+        }
+        if (_wals.TryGetValue((byte)channelNumber, out var wal))
+        {
+            any = true;
+            try { wal.Reset(); }
+            catch (Exception ex)
+            {
+                _log?.Invoke($"admin: snapshot-reset channel={channelNumber} wal reset failed: {ex.Message}");
+                ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                return Results.Text($"wal Reset failed: {ex.Message}\n", "text/plain");
+            }
+        }
+        if (!any)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"channel {channelNumber} has no persister or WAL wired\n", "text/plain");
+        }
+        _log?.Invoke($"admin: snapshot-reset channel={channelNumber} files-removed={filesRemoved}");
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        return Results.Text(
+            $"reset channel={channelNumber} files-removed={filesRemoved} (in-memory state untouched; restart host for empty boot)\n",
+            "text/plain");
+    }
+
+    private IResult HandleAdminValidate(HttpContext ctx, int channelNumber)
+    {
+        if (channelNumber < 0 || channelNumber > 255)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown channel {channelNumber}\n", "text/plain");
+        }
+        if (!_persisters.TryGetValue((byte)channelNumber, out var persister))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {channelNumber} has no persister wired\n", "text/plain");
+        }
+        ChannelStateSnapshot? snap;
+        try { snap = persister.TryLoad((byte)channelNumber); }
+        catch (Exception ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"failed to load snapshot: {ex.Message}\n", "text/plain");
+        }
+        if (snap is null)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"channel {channelNumber} has no persisted snapshot\n", "text/plain");
+        }
+        if (!ChannelDispatcher.TryValidateSnapshot(snap, out var err))
+        {
+            _log?.Invoke($"admin: snapshot-validate channel={channelNumber} INVALID: {err}");
+            ctx.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+            return Results.Text($"invalid: {err}\n", "text/plain");
+        }
+        _log?.Invoke($"admin: snapshot-validate channel={channelNumber} ok version={snap.Version}");
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        return Results.Text($"ok version={snap.Version} sequenceNumber={snap.SequenceNumber} lastAppliedSeq={snap.LastAppliedSeq}\n", "text/plain");
+    }
+
+    private static readonly System.Text.Json.JsonSerializerOptions AdminJsonOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        Converters =
+        {
+            new System.Text.Json.Serialization.JsonStringEnumConverter(),
+        },
+    };
 
     private static IPEndPoint ParseEndpoint(string s)
     {

--- a/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
+++ b/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
@@ -160,6 +160,51 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
     }
 
     /// <summary>
+    /// Issue #271: removes every on-disk snapshot artifact for the
+    /// channel — all rolling generations, the legacy single-file
+    /// snapshot if present, plus any leftover tmp files. Returns the
+    /// count of deleted files. The internal slot-rotation cursor is
+    /// reset so the next <see cref="Save"/> starts from slot 0.
+    /// </summary>
+    public int DeleteAll(byte channelNumber)
+    {
+        int removed = 0;
+        for (int i = 0; i < _generations; i++)
+        {
+            removed += TryDelete(SlotPath(channelNumber, i));
+            removed += TryDelete(TempPath(channelNumber, i));
+        }
+        removed += TryDelete(LegacyPath(channelNumber));
+        lock (_slotLock)
+        {
+            _lastUsedSlot.Remove(channelNumber);
+        }
+        if (removed > 0)
+        {
+            try { FsyncDirectory(_dataDir); }
+            catch { /* best effort */ }
+            _logger.LogInformation(
+                "channel {ChannelNumber}: admin DeleteAll removed {Removed} snapshot file(s)",
+                channelNumber, removed);
+        }
+        return removed;
+    }
+
+    private static int TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+                return 1;
+            }
+        }
+        catch { /* best effort — admin path */ }
+        return 0;
+    }
+
+    /// <summary>
     /// Picks the next round-robin slot for the channel, lazily deriving
     /// the starting point from the on-disk newest file the first time
     /// a channel is observed (so a host restart does not reuse the slot

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -177,6 +177,36 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         }
     }
 
+    public void Reset()
+    {
+        lock (_writeLock)
+        {
+            if (_appendStream is not null)
+            {
+                _appendStream.Dispose();
+                _appendStream = null;
+            }
+            try
+            {
+                if (File.Exists(_path)) File.Delete(_path);
+                var tmp = System.IO.Path.Combine(_dataDir,
+                    string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
+                if (File.Exists(tmp)) File.Delete(tmp);
+                FsyncDirectory(_dataDir);
+                _logger.LogInformation(
+                    "channel {ChannelNumber}: admin Reset removed WAL at {Path}",
+                    _channelNumber, _path);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: failed to reset WAL at {Path}",
+                    _channelNumber, _path);
+                throw;
+            }
+        }
+    }
+
     public void Dispose()
     {
         lock (_writeLock)

--- a/tests/B3.Exchange.Host.Tests/AdminSnapshotEndpointsTests.cs
+++ b/tests/B3.Exchange.Host.Tests/AdminSnapshotEndpointsTests.cs
@@ -1,0 +1,206 @@
+using System.Net;
+using System.Net.Http;
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #271: tests for the /admin/channels/{ch}/snapshot/* HTTP
+/// endpoints. Covers GET (load from disk + JSON), POST force (alias of
+/// snapshot-now), POST reset (delete files + WAL, requires force flag),
+/// and POST validate (TryValidateSnapshot on the persisted snapshot).
+/// </summary>
+public class AdminSnapshotEndpointsTests
+{
+    private static (HostConfig cfg, string dataDir) BuildConfig(string testName)
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var dataDir = Path.Combine(Path.GetTempPath(), "b3-admin-tests-" + testName + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+        var cfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 60000 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 91,
+                    IncrementalGroup = "239.255.42.91",
+                    IncrementalPort = 30191,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    Persistence = new PersistenceConfig
+                    {
+                        DataDir = dataDir,
+                        Wal = new WalConfig { Enabled = true, FsyncPerWrite = false },
+                    },
+                },
+            },
+        };
+        return (cfg, dataDir);
+    }
+
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    [Fact]
+    public async Task GetSnapshot_WhenNoneExists_Returns204()
+    {
+        var (cfg, dataDir) = BuildConfig(nameof(GetSnapshot_WhenNoneExists_Returns204));
+        try
+        {
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+
+            using var resp = await client.GetAsync("/admin/channels/91/snapshot");
+            Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+
+    [Fact]
+    public async Task ForceSnapshot_ThenGet_ReturnsJsonAndValidatesOk()
+    {
+        var (cfg, dataDir) = BuildConfig(nameof(ForceSnapshot_ThenGet_ReturnsJsonAndValidatesOk));
+        try
+        {
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+
+            using var force = await client.PostAsync("/admin/channels/91/snapshot/force", content: null);
+            Assert.Equal(HttpStatusCode.Accepted, force.StatusCode);
+
+            // Snapshot capture is async on the dispatch thread; poll
+            // briefly until the file appears.
+            string? snapshotJson = null;
+            for (int i = 0; i < 50 && snapshotJson is null; i++)
+            {
+                using var get = await client.GetAsync("/admin/channels/91/snapshot");
+                if (get.StatusCode == HttpStatusCode.OK)
+                {
+                    snapshotJson = await get.Content.ReadAsStringAsync();
+                    break;
+                }
+                await Task.Delay(50);
+            }
+            Assert.NotNull(snapshotJson);
+            Assert.Contains("\"ChannelNumber\":91", snapshotJson);
+
+            using var validate = await client.PostAsync("/admin/channels/91/snapshot/validate", content: null);
+            Assert.Equal(HttpStatusCode.OK, validate.StatusCode);
+            var body = await validate.Content.ReadAsStringAsync();
+            Assert.StartsWith("ok ", body);
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+
+    [Fact]
+    public async Task Reset_WithoutForceFlag_Returns400()
+    {
+        var (cfg, dataDir) = BuildConfig(nameof(Reset_WithoutForceFlag_Returns400));
+        try
+        {
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+
+            using var resp = await client.PostAsync("/admin/channels/91/snapshot/reset", content: null);
+            Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+
+    [Fact]
+    public async Task Reset_WithForceFlag_DeletesSnapshotFiles()
+    {
+        var (cfg, dataDir) = BuildConfig(nameof(Reset_WithForceFlag_DeletesSnapshotFiles));
+        try
+        {
+            await using (var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink()))
+            {
+                await host.StartAsync();
+                using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+
+                using var force = await client.PostAsync("/admin/channels/91/snapshot/force", content: null);
+                Assert.Equal(HttpStatusCode.Accepted, force.StatusCode);
+
+                // Wait for snapshot file to appear.
+                for (int i = 0; i < 50; i++)
+                {
+                    if (Directory.GetFiles(dataDir, "channel-91.snapshot*").Length > 0) break;
+                    await Task.Delay(50);
+                }
+                Assert.NotEmpty(Directory.GetFiles(dataDir, "channel-91.snapshot*"));
+
+                using var reset = await client.PostAsync("/admin/channels/91/snapshot/reset?force=true", content: null);
+                Assert.Equal(HttpStatusCode.OK, reset.StatusCode);
+                var body = await reset.Content.ReadAsStringAsync();
+                Assert.Contains("files-removed=", body);
+
+                Assert.Empty(Directory.GetFiles(dataDir, "channel-91.snapshot*"));
+            }
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+
+    [Fact]
+    public async Task Validate_WhenNoSnapshot_Returns404()
+    {
+        var (cfg, dataDir) = BuildConfig(nameof(Validate_WhenNoSnapshot_Returns404));
+        try
+        {
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+
+            using var resp = await client.PostAsync("/admin/channels/91/snapshot/validate", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+
+    [Fact]
+    public async Task UnknownChannel_AllEndpoints_Return404()
+    {
+        var (cfg, dataDir) = BuildConfig(nameof(UnknownChannel_AllEndpoints_Return404));
+        try
+        {
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+
+            using var get = await client.GetAsync("/admin/channels/200/snapshot");
+            Assert.Equal(HttpStatusCode.NotFound, get.StatusCode);
+
+            using var force = await client.PostAsync("/admin/channels/200/snapshot/force", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, force.StatusCode);
+
+            using var reset = await client.PostAsync("/admin/channels/200/snapshot/reset?force=true", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, reset.StatusCode);
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
+    }
+}


### PR DESCRIPTION
Closes #271.

Adds four operator HTTP endpoints under `/admin/channels/{id}/snapshot`:

| Method | Path | Purpose |
|--------|------|---------|
| GET    | `/admin/channels/{ch}/snapshot` | Returns most-recent persisted snapshot as JSON (204 if none) |
| POST   | `/admin/channels/{ch}/snapshot/force` | Forces capture + on-disk persist via new `WorkKind.OperatorPersistSnapshot` |
| POST   | `/admin/channels/{ch}/snapshot/reset?force=true` | Deletes every snapshot artifact + WAL file (in-memory state untouched) |
| POST   | `/admin/channels/{ch}/snapshot/validate` | Runs `ChannelDispatcher.TryValidateSnapshot` on the persisted snapshot |

### API surface added
- `IChannelStatePersister.DeleteAll(byte)` — default no-op so existing in-memory test fakes don't break.
- `IChannelWriteAheadLog.Reset()` — default no-op; `FileChannelWriteAheadLog` deletes the WAL file.
- `ChannelDispatcher.TryValidateSnapshot(snapshot, out err)` — public wrapper around the existing private structural validator.
- `ChannelDispatcher.EnqueueOperatorPersistSnapshot()` — distinct from pre-existing `EnqueueOperatorSnapshotNow` (which only publishes a UMDF snapshot frame, **not** an on-disk persist).

### Notes
- `force` enqueues a work item that runs on the loop thread and calls `OnAfterCommandFlushed(force: true)` so the throttle is bypassed.
- `reset` only touches on-disk files; the running channel keeps its in-memory state. Operators must restart the host to actually start the channel empty. The endpoint requires `?force=true` to confirm intent.
- `GET` returns the durable on-disk snapshot, not live state. To inspect live state: POST force, then GET.
- Same auth posture as existing `/channel/*` operator endpoints (network-level protection — no auth in v1).

### Tests
- 6 new tests in `AdminSnapshotEndpointsTests.cs` covering: 204 when no snapshot, force→GET round-trip + validate, reset without/with `?force=true`, validate-without-snapshot, unknown-channel 404s.
- Full suite: 927/927 (one pre-existing flaky `MultiSessionReplayTests.TwoSessions_CrossingScript_LandsErTradesOnBothSides` — unrelated, will retry CI).
- `dotnet format --verify-no-changes`: clean.
