### PR TITLE
feat(persistence): cross-channel orphan-session check on restore (#270)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -122,14 +122,34 @@ public sealed partial class ChannelDispatcher
         // appends keep increasing monotonically across the restart.
         _lastAppliedSeq = snapshot.LastAppliedSeq;
 
+        long droppedOrphans = 0;
+
         foreach (var o in snapshot.Owners)
         {
+            // Issue #270: cross-channel consistency check. Skip owners
+            // whose SessionId no longer resolves in the host registry
+            // under the Drop policy (with a warning + metric); under
+            // Reject the orphan-set is collected and thrown below.
+            if (_sessionExists is not null && !_sessionExists(o.SessionValue))
+            {
+                if (_orphanPolicy == OrphanSessionPolicy.Reject)
+                {
+                    throw new InvalidOperationException(
+                        $"channel {ChannelNumber}: snapshot owner orderId {o.OrderId} references unknown SessionId '{o.SessionValue}' (orphan); orphanPolicy=Reject");
+                }
+                droppedOrphans++;
+                _logger.LogWarning(
+                    "channel {ChannelNumber}: dropping orphan owner orderId={OrderId} sessionId={SessionId} (not in registry)",
+                    ChannelNumber, o.OrderId, o.SessionValue);
+                continue;
+            }
             _orders.Register(o.OrderId, new SessionId(o.SessionValue), o.ClOrdId, o.Firm, o.Side, o.SecurityId);
         }
+        if (droppedOrphans > 0) _metrics?.AddOwnerOrphansDropped(droppedOrphans);
 
         _logger.LogInformation(
-            "channel {ChannelNumber}: restored snapshot — seq={SequenceNumber}/{SequenceVersion} owners={OwnerCount}",
-            ChannelNumber, snapshot.SequenceNumber, snapshot.SequenceVersion, snapshot.Owners.Count);
+            "channel {ChannelNumber}: restored snapshot — seq={SequenceNumber}/{SequenceVersion} owners={OwnerCount} orphansDropped={OrphansDropped}",
+            ChannelNumber, snapshot.SequenceNumber, snapshot.SequenceVersion, snapshot.Owners.Count, droppedOrphans);
     }
 
     /// <summary>

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -170,6 +170,15 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly IChannelStatePersister? _persister;
     private readonly SnapshotThrottlePolicy _snapshotThrottle;
     private readonly BackgroundSnapshotWriter? _asyncSnapshotWriter;
+    /// <summary>
+    /// Issue #270: predicate the restore path uses to detect orphan
+    /// <see cref="OrderOwnerSnapshot.SessionValue"/> entries — owners
+    /// whose original session is no longer present in the host's
+    /// session/firm registry. <c>null</c> ⇒ no check (legacy
+    /// behaviour, all owners restored).
+    /// </summary>
+    private readonly Func<string, bool>? _sessionExists;
+    private readonly OrphanSessionPolicy _orphanPolicy;
     // Throttle bookkeeping (issue #267). Mutated only on the dispatch
     // loop thread → no Interlocked needed.
     private long _commandsSincePersist;
@@ -229,7 +238,9 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         IChannelStatePersister? persister = null,
         SnapshotThrottlePolicy? snapshotThrottle = null,
         bool useAsyncSnapshotWriter = false,
-        IChannelWriteAheadLog? wal = null)
+        IChannelWriteAheadLog? wal = null,
+        Func<string, bool>? sessionExists = null,
+        OrphanSessionPolicy orphanPolicy = OrphanSessionPolicy.Drop)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -246,6 +257,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _retxBuffer = retxBuffer;
         _persister = persister;
         _wal = wal;
+        _sessionExists = sessionExists;
+        _orphanPolicy = orphanPolicy;
         _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
         // Issue #268: opt-in async snapshot writer. Off by default so
         // pre-existing deployments keep the synchronous in-loop persist

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -201,11 +201,46 @@ public sealed class ChannelMetrics
     public void SetSnapshotLastSizeBytes(long bytes) => Interlocked.Exchange(ref _snapshotLastSizeBytes, bytes);
     public void SetSnapshotLastSuccessUnixMs(long unixMs) => Interlocked.Exchange(ref _snapshotLastSuccessUnixMs, unixMs);
 
+    private long _ownerOrphansDropped;
+    public long OwnerOrphansDropped => Interlocked.Read(ref _ownerOrphansDropped);
+    public void AddOwnerOrphansDropped(long count)
+    {
+        if (count > 0) Interlocked.Add(ref _ownerOrphansDropped, count);
+    }
+
     /// <summary>
     /// Heartbeat. Called from the dispatch thread on every loop wakeup so
     /// liveness probes can detect a stuck/dead dispatcher.
     /// </summary>
     public void RecordTick(long unixMs) => Interlocked.Exchange(ref _lastTickUnixMs, unixMs);
+}
+
+/// <summary>
+/// Issue #270: policy applied when a restored
+/// <see cref="OrderOwnerSnapshot.SessionValue"/> does not resolve in
+/// the host's session/firm registry — i.e. an "orphan" owner whose
+/// original session was removed from configuration between the
+/// snapshot being persisted and the channel being restored.
+/// </summary>
+public enum OrphanSessionPolicy
+{
+    /// <summary>
+    /// Skip the owner registration with a warning + metric increment.
+    /// The engine state still loads — the orphaned resting order keeps
+    /// matching, but PASSIVE-side execution reports it generates have
+    /// no destination session and are dropped at the outbound layer.
+    /// Default policy.
+    /// </summary>
+    Drop = 0,
+
+    /// <summary>
+    /// Treat any orphan owner as a fatal restore error and fail-closed.
+    /// <see cref="ChannelDispatcher.RestoreChannelState"/> throws and
+    /// the dispatcher loop terminates so an operator can either repair
+    /// the snapshot, restore the missing session credentials, or
+    /// invoke the admin reset endpoint.
+    /// </summary>
+    Reject = 1,
 }
 
 /// <summary>
@@ -491,6 +526,14 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_wal_replays_total",
             "Total WAL records replayed at boot to bring this channel up to the most-recently-acknowledged command. Non-zero only on the boot following an unclean shutdown.",
             channels, c => c.WalReplays);
+
+        // Issue #270: cross-channel consistency check. Counts owner
+        // entries silently dropped at restore because their SessionId
+        // does not resolve in the host's firm/session registry. Always
+        // 0 under the Reject policy (which throws instead of dropping).
+        EmitCounter(sb, "exch_owner_orphans_dropped_total",
+            "Total OrderOwnerSnapshot entries dropped on snapshot restore because their SessionId did not resolve in the host registry (issue #270, Drop policy).",
+            channels, c => c.OwnerOrphansDropped);
 
         // Issue #174: throughput counters. Bounded labels (msg_type ≤ 6,
         // exec_type ≤ 7, feed = 3) — safe to ship per-channel.

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -161,6 +161,11 @@ public sealed class ExchangeHost : IAsyncDisposable
             var wal = BuildWal(ch);
             if (persister != null) _persistersByChannel[ch.ChannelNumber] = persister;
             if (wal != null) _walsByChannel[ch.ChannelNumber] = wal;
+            // Issue #270: cross-channel consistency check on restore.
+            // Resolve the policy here so the dispatcher can stay
+            // host-agnostic (it just gets a predicate + enum).
+            var orphanPolicy = ParseOrphanPolicy(ch.Persistence?.OrphanSessionPolicy);
+            Func<string, bool> sessionExists = sid => firmRegistry.FindSession(sid) is not null;
             var disp = new ChannelDispatcher(
                 channelNumber: ch.ChannelNumber,
                 engineFactory: s =>
@@ -178,7 +183,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                 persister: persister,
                 snapshotThrottle: ch.Persistence?.Throttle?.ToPolicy(),
                 useAsyncSnapshotWriter: ch.Persistence?.AsyncWriter ?? false,
-                wal: wal);
+                wal: wal,
+                sessionExists: sessionExists,
+                orphanPolicy: orphanPolicy);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -471,6 +478,24 @@ public sealed class ExchangeHost : IAsyncDisposable
             ch.ChannelNumber,
             _loggerFactory.CreateLogger<FileChannelWriteAheadLog>(),
             walCfg.FsyncPerWrite);
+    }
+
+    /// <summary>
+    /// Issue #270: parses the <c>persistence.orphanSessionPolicy</c>
+    /// JSON string into the <see cref="OrphanSessionPolicy"/> enum
+    /// expected by <see cref="ChannelDispatcher"/>. Defaults to
+    /// <see cref="OrphanSessionPolicy.Drop"/> when absent.
+    /// </summary>
+    private static OrphanSessionPolicy ParseOrphanPolicy(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return OrphanSessionPolicy.Drop;
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "drop" => OrphanSessionPolicy.Drop,
+            "reject" => OrphanSessionPolicy.Reject,
+            _ => throw new InvalidOperationException(
+                $"persistence.orphanSessionPolicy must be 'drop' or 'reject' (got '{raw}')"),
+        };
     }
 
     private FirmRegistry BuildFirmRegistry()

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -303,6 +303,17 @@ public sealed class PersistenceConfig
     /// the snapshot-only behaviour (and pay no per-command file IO).
     /// </summary>
     [JsonPropertyName("wal")] public WalConfig? Wal { get; set; }
+
+    /// <summary>
+    /// Issue #270: policy applied to <see cref="OrderOwnerSnapshot"/>
+    /// entries whose <c>SessionValue</c> is not present in the host's
+    /// firm/session registry at restore time. Accepted values:
+    /// <c>"drop"</c> (default — log + metric, skip the owner; engine
+    /// state still loads) or <c>"reject"</c> (treat as fatal restore
+    /// error → channel fails closed). Case-insensitive. Absent ⇒
+    /// <c>"drop"</c>.
+    /// </summary>
+    [JsonPropertyName("orphanSessionPolicy")] public string? OrphanSessionPolicy { get; set; }
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherOrphanSessionTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherOrphanSessionTests.cs
@@ -1,0 +1,174 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+using OrderType = B3.Exchange.Matching.OrderType;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #270: cross-channel consistency check on restore. Verifies
+/// that <see cref="ChannelDispatcher.RestoreChannelState"/> partitions
+/// owners by the host's session-existence predicate and applies the
+/// configured <see cref="OrphanSessionPolicy"/>: <see cref="OrphanSessionPolicy.Drop"/>
+/// logs + skips orphan owners (engine state still loads), while
+/// <see cref="OrphanSessionPolicy.Reject"/> throws so the channel
+/// fails closed.
+/// </summary>
+public class ChannelDispatcherOrphanSessionTests
+{
+    private const long Sec = 900_000_000_001L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class NoOpOutbound : ICoreOutbound
+    {
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+    }
+
+    private static ChannelDispatcher BuildDispatcher(
+        ChannelMetrics? metrics,
+        Func<string, bool>? sessionExists,
+        OrphanSessionPolicy policy)
+    {
+        return new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s,
+                NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: new NoOpOutbound(),
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            metrics: metrics,
+            sessionExists: sessionExists,
+            orphanPolicy: policy);
+    }
+
+    private static ChannelStateSnapshot BuildSnapshotWithOwners(params string[] sessionIds)
+    {
+        var orders = new List<RestingOrderRecord>();
+        var owners = new List<OrderOwnerSnapshot>();
+        long nextId = 1;
+        foreach (var sid in sessionIds)
+        {
+            long oid = nextId++;
+            orders.Add(new RestingOrderRecord(
+                OrderId: oid,
+                ClOrdId: "CL-" + oid,
+                Side: Side.Buy,
+                PriceMantissa: 100000,
+                RemainingQuantity: 100,
+                EnteringFirm: 100,
+                InsertTimestampNanos: 1000UL,
+                Tif: TimeInForce.Day,
+                MaxFloor: 100,
+                HiddenQuantity: 0));
+            owners.Add(new OrderOwnerSnapshot(
+                OrderId: oid,
+                SessionValue: sid,
+                Firm: 100,
+                ClOrdId: (ulong)oid,
+                Side: Side.Buy,
+                SecurityId: Sec));
+        }
+        var book = new EngineStateSnapshot.BookSnapshot(Sec, orders);
+        var engine = new EngineStateSnapshot(
+            NextOrderId: nextId,
+            NextTradeId: 1,
+            RptSeq: 0,
+            Phases: Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+            Books: new[] { book });
+        return new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 84,
+            SequenceNumber: 0,
+            SequenceVersion: 1,
+            Engine: engine,
+            Owners: owners);
+    }
+
+    [Fact]
+    public void DropPolicy_OrphanOwnerIsSkipped_KnownOwnerIsRegistered()
+    {
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(metrics,
+            sessionExists: sid => sid == "10101",
+            policy: OrphanSessionPolicy.Drop);
+        var snap = BuildSnapshotWithOwners("10101", "99999");
+
+        disp.RestoreChannelState(snap);
+
+        // Both orders sit in the engine book; only the recognised
+        // session's owner is in the routing map.
+        Assert.Equal(2, snap.Engine.Books.Single().Orders.Count);
+        Assert.Equal(1L, metrics.OwnerOrphansDropped);
+    }
+
+    [Fact]
+    public void RejectPolicy_OrphanOwnerThrows()
+    {
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(metrics,
+            sessionExists: sid => sid == "10101",
+            policy: OrphanSessionPolicy.Reject);
+        var snap = BuildSnapshotWithOwners("10101", "99999");
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => disp.RestoreChannelState(snap));
+        Assert.Contains("99999", ex.Message);
+        Assert.Contains("orphan", ex.Message);
+    }
+
+    [Fact]
+    public void NullPredicate_RestoresEverything_NoOrphanCounting()
+    {
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(metrics,
+            sessionExists: null,
+            policy: OrphanSessionPolicy.Reject);
+        var snap = BuildSnapshotWithOwners("10101", "99999");
+
+        // No predicate ⇒ legacy behaviour: every owner registers and
+        // the orphan counter stays at zero regardless of policy.
+        disp.RestoreChannelState(snap);
+
+        Assert.Equal(0L, metrics.OwnerOrphansDropped);
+    }
+
+    [Fact]
+    public void DropPolicy_AllOwnersOrphan_MetricCountsAll()
+    {
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(metrics,
+            sessionExists: _ => false,
+            policy: OrphanSessionPolicy.Drop);
+        var snap = BuildSnapshotWithOwners("10101", "20202", "30303");
+
+        disp.RestoreChannelState(snap);
+
+        Assert.Equal(3L, metrics.OwnerOrphansDropped);
+    }
+}


### PR DESCRIPTION
Closes #270.

Adds a cross-channel consistency check to `ChannelDispatcher.RestoreChannelState` so a snapshot persisted before a session was removed from config no longer silently loads owners that point at a session the host no longer knows about.

### Behaviour
On restore, owners are partitioned by an injected `Func<string, bool> sessionExists` predicate (host wires it to `firmRegistry.FindSession(sid) is not null`) and the configured policy is applied:

| Policy | Effect on orphan owner | Effect on engine state |
|--------|------------------------|------------------------|
| `Drop` (default) | Log warning + increment `exch_owner_orphans_dropped_total`; skip registration | Engine still loads (orphan order keeps matching; PASSIVE ER drops at outbound) |
| `Reject` | Throw `InvalidOperationException` | Dispatcher fails closed → `/health/live` trips |

### Config
```json
"channels": [{
  "persistence": {
    "dataDir": "...",
    "orphanSessionPolicy": "drop"   // or "reject"
  }
}]
```

### Backwards compatibility
When no predicate is supplied (e.g. unit tests that construct a dispatcher without a host), the legacy "register every owner unconditionally" path is preserved and the orphan counter stays at zero regardless of policy.

### Tests
4 new tests in `ChannelDispatcherOrphanSessionTests.cs`:
- `DropPolicy_OrphanOwnerIsSkipped_KnownOwnerIsRegistered`
- `RejectPolicy_OrphanOwnerThrows`
- `NullPredicate_RestoresEverything_NoOrphanCounting`
- `DropPolicy_AllOwnersOrphan_MetricCountsAll`

Build clean (0 warnings), `dotnet format` clean, full suite green (one pre-existing flaky WAL timing test that passes on retry — unrelated).