### PR TITLE
feat(persistence): schema evolution policy for snapshots (#272)

### DIFF
--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -209,6 +209,30 @@ Exposes:
     the floor as before. Omit the `persistence` block to keep the legacy
     stateless boot.
 
+### Snapshot schema evolution (issue #272)
+
+`ChannelStateSnapshot` carries an integer `Version` field
+(`ChannelStateSnapshot.CurrentVersion`, currently `1`). The persister
+parses every snapshot to a `JsonNode` first and runs it through
+`SnapshotMigrationSet` before final deserialization. Three rules apply:
+
+* **Forward compatibility** — System.Text.Json ignores unknown JSON
+  properties on read by default, so a payload written by a *newer* host
+  loads cleanly under an *older* host as long as the fields the old
+  host already knows about retain their meaning. Only ever add new
+  optional fields with sensible defaults; never repurpose or rename a
+  field without a version bump.
+* **Backward compatibility** — payloads written by older hosts require
+  a registered migration for every step from their `Version` up to
+  `CurrentVersion`. Bumping the schema is a two-commit dance: first
+  register the `N → N+1` migration in `SnapshotMigrationSet.BuildDefault`,
+  then bump `CurrentVersion`. Missing any step on the chain throws and
+  the dispatcher fails closed (per issue #270's restore contract).
+* **Forward-version rejection** — if the on-disk `Version` is *higher*
+  than `CurrentVersion` the load fails with a clear message. Operators
+  must run a host version that supports the snapshot or invoke
+  `POST /admin/channels/{ch}/snapshot/reset?force=true` to start fresh.
+
 ## Operability endpoints
 
 Only enabled when the `http` config block is present. All endpoints are

--- a/src/B3.Exchange.Core/SnapshotMigrations.cs
+++ b/src/B3.Exchange.Core/SnapshotMigrations.cs
@@ -1,0 +1,141 @@
+using System.Text.Json.Nodes;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #272: per-version migration shim used by persister implementations
+/// to upgrade an older on-disk <see cref="ChannelStateSnapshot"/> JSON
+/// payload to <see cref="ChannelStateSnapshot.CurrentVersion"/> *before*
+/// final deserialization into the strongly-typed record.
+///
+/// <para><b>Why JSON-level migration:</b> System.Text.Json deserializes
+/// init-only records positionally — once a property is added or removed,
+/// older payloads either fail to materialise the record or silently drop
+/// fields that no longer match by name. Migrating the
+/// <see cref="JsonNode"/> tree first lets us reshape the document to match
+/// the current schema (rename, add defaults, recompute, drop) using a
+/// single chain of small, composable, version-bound functions.</para>
+///
+/// <para><b>Forward compatibility:</b> System.Text.Json ignores unknown
+/// JSON properties on read by default — a payload written by a NEWER
+/// host therefore loads cleanly under an OLDER host as long as the
+/// fields it ALREADY knows about retain their meaning. Best practice:
+/// only add new optional fields with sensible defaults; never repurpose
+/// or rename a field without a version bump + migration.</para>
+///
+/// <para><b>Backward compatibility:</b> a payload written by an OLDER
+/// host requires a registered migration for every step from its
+/// <c>Version</c> to <see cref="ChannelStateSnapshot.CurrentVersion"/>.
+/// <see cref="MigrateToCurrent"/> applies the chain in order; missing
+/// any step throws so the dispatcher fails closed (per issue #270's
+/// fail-closed restore contract).</para>
+///
+/// <para><b>Forward-version rejection:</b> a payload whose
+/// <c>Version</c> is higher than <see cref="ChannelStateSnapshot.CurrentVersion"/>
+/// is rejected — the older host has no way to know whether the future
+/// schema's invariants are compatible. Operators must run a host
+/// version that supports the snapshot, or invoke
+/// <c>POST /admin/channels/{ch}/snapshot/reset?force=true</c> to start
+/// fresh.</para>
+///
+/// <para>Instances are mutable but registration is intended to be done
+/// during host startup (or in test setup) before any
+/// <see cref="MigrateToCurrent"/> call. Concurrent registration is
+/// guarded internally so misuse from background threads still yields a
+/// consistent table.</para>
+/// </summary>
+public sealed class SnapshotMigrationSet
+{
+    /// <summary>Migration delegate: takes the JSON tree of a snapshot at
+    /// version <c>fromVersion</c>, returns the JSON tree shaped as
+    /// <c>fromVersion + 1</c>. Implementations must mutate-and-return or
+    /// build a new node — the returned node replaces the input in the
+    /// chain.</summary>
+    public delegate JsonNode Migration(JsonNode previous);
+
+    private readonly object _lock = new();
+    private readonly SortedDictionary<int, Migration> _migrations = new();
+
+    /// <summary>
+    /// Builds the default migration set used by the file persister.
+    /// Currently empty — <see cref="ChannelStateSnapshot.CurrentVersion"/>
+    /// is 1 and no on-disk format predates that. Future schema bumps
+    /// register migrations here.
+    /// </summary>
+    public static SnapshotMigrationSet BuildDefault() => new();
+
+    /// <summary>
+    /// Registers a migration that upgrades a snapshot tree from
+    /// <paramref name="fromVersion"/> to <c>fromVersion + 1</c>. The
+    /// delegate must produce a tree whose <c>Version</c> field equals
+    /// <c>fromVersion + 1</c>; <see cref="MigrateToCurrent"/> verifies
+    /// this after each step and throws on mismatch.
+    /// </summary>
+    public void Register(int fromVersion, Migration migration)
+    {
+        ArgumentNullException.ThrowIfNull(migration);
+        if (fromVersion < 0)
+            throw new ArgumentOutOfRangeException(nameof(fromVersion),
+                "fromVersion must be >= 0");
+        lock (_lock)
+        {
+            _migrations[fromVersion] = migration;
+        }
+    }
+
+    /// <summary>
+    /// Walks the registered chain from the source <paramref name="root"/>'s
+    /// <c>Version</c> field up to <paramref name="targetVersion"/>. Returns
+    /// the migrated root. Throws when the source version is greater than
+    /// the target (forward-version rejection) or when a step on the path
+    /// is missing.
+    /// </summary>
+    public JsonNode MigrateToCurrent(JsonNode root, int targetVersion)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        int current = ReadVersion(root);
+        if (current == targetVersion) return root;
+        if (current > targetVersion)
+            throw new InvalidOperationException(
+                $"snapshot version {current} is newer than supported version {targetVersion}; " +
+                "upgrade the host or reset the snapshot via POST /admin/channels/{ch}/snapshot/reset?force=true");
+
+        var node = root;
+        while (current < targetVersion)
+        {
+            Migration? step;
+            lock (_lock)
+            {
+                _migrations.TryGetValue(current, out step);
+            }
+            if (step is null)
+                throw new InvalidOperationException(
+                    $"no registered migration from snapshot version {current} to {current + 1} " +
+                    $"(target {targetVersion}); the on-disk snapshot cannot be upgraded by this host");
+            node = step(node);
+            int next = ReadVersion(node);
+            int expected = current + 1;
+            if (next != expected)
+                throw new InvalidOperationException(
+                    $"migration {current}->{expected} produced a tree with version {next}; " +
+                    "migration delegates must stamp the new version on their output");
+            current = next;
+        }
+        return node;
+    }
+
+    /// <summary>
+    /// Reads the <c>Version</c> field from a snapshot JSON tree. Treats
+    /// a missing or null field as version <c>0</c> so legacy payloads
+    /// that predate explicit versioning can be migrated by registering
+    /// a <c>0 → 1</c> shim.
+    /// </summary>
+    private static int ReadVersion(JsonNode root)
+    {
+        if (root is not JsonObject obj) return 0;
+        if (!obj.TryGetPropertyValue("Version", out var v) || v is null)
+            return 0;
+        try { return v.GetValue<int>(); }
+        catch { return 0; }
+    }
+}

--- a/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
+++ b/src/B3.Exchange.Persistence/FileChannelStatePersister.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using B3.Exchange.Core;
 using Microsoft.Extensions.Logging;
@@ -52,6 +53,7 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
     private readonly string _dataDir;
     private readonly int _generations;
     private readonly ILogger<FileChannelStatePersister> _logger;
+    private readonly SnapshotMigrationSet _migrations;
 
     // Per-channel last-used slot, -1 = unknown (derive from filesystem).
     // Mutated only inside Save under the per-channel lock.
@@ -60,11 +62,13 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
 
     public string DataDirectory => _dataDir;
     public int Generations => _generations;
+    public SnapshotMigrationSet Migrations => _migrations;
 
     public FileChannelStatePersister(
         string dataDirectory,
         ILogger<FileChannelStatePersister> logger,
-        int generations = DefaultGenerations)
+        int generations = DefaultGenerations,
+        SnapshotMigrationSet? migrations = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
         ArgumentNullException.ThrowIfNull(logger);
@@ -74,6 +78,7 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
         _dataDir = Path.GetFullPath(dataDirectory);
         _logger = logger;
         _generations = generations;
+        _migrations = migrations ?? SnapshotMigrationSet.BuildDefault();
         Directory.CreateDirectory(_dataDir);
     }
 
@@ -91,7 +96,22 @@ public sealed class FileChannelStatePersister : IChannelStatePersister
             try
             {
                 using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
-                var snapshot = JsonSerializer.Deserialize<ChannelStateSnapshot>(fs, JsonOptions);
+                // Issue #272: parse to a JsonNode first so older
+                // payloads can be migrated up to the current schema
+                // before the strongly-typed deserializer runs. Forward
+                // compat is delegated to STJ (unknown fields ignored
+                // by default); backward compat goes through the
+                // migration chain.
+                var root = JsonNode.Parse(fs);
+                if (root is null)
+                {
+                    _logger.LogWarning(
+                        "channel {ChannelNumber}: snapshot at {Path} parsed to null; trying older generation",
+                        channelNumber, path);
+                    continue;
+                }
+                var migrated = _migrations.MigrateToCurrent(root, ChannelStateSnapshot.CurrentVersion);
+                var snapshot = JsonSerializer.Deserialize<ChannelStateSnapshot>(migrated.ToJsonString(), JsonOptions);
                 if (snapshot is null)
                 {
                     _logger.LogWarning(

--- a/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json.Nodes;
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #272: schema evolution policy tests. Cover the happy paths
+/// (forward compat via unknown-field ignore, backward compat via
+/// registered migration) and rejection paths (no migration, future
+/// version) of <see cref="SnapshotMigrationSet"/> as wired into
+/// <see cref="FileChannelStatePersister"/>.
+/// </summary>
+public class SnapshotMigrationTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "b3-migration-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string WriteRawSnapshot(string dir, byte channelNumber, string json)
+    {
+        var path = Path.Combine(dir, $"channel-{channelNumber}.snapshot.0");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    private const string MinimalV1Body =
+        "\"ChannelNumber\":7," +
+        "\"SequenceNumber\":42," +
+        "\"SequenceVersion\":3," +
+        "\"Engine\":{\"NextOrderId\":1,\"NextTradeId\":1,\"RptSeq\":0,\"Phases\":[],\"Books\":[]}," +
+        "\"Owners\":[]," +
+        "\"LastAppliedSeq\":0";
+
+    [Fact]
+    public void ForwardCompat_UnknownFieldIsIgnored()
+    {
+        // Snapshot at the current version with an extra unknown field
+        // simulating a payload written by a NEWER host. Default STJ
+        // behaviour ignores unknown properties on read.
+        var dir = NewTempDir();
+        try
+        {
+            var json = "{\"Version\":1," + MinimalV1Body + ",\"FuturisticField\":\"xyz\"}";
+            WriteRawSnapshot(dir, 7, json);
+            var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
+            var loaded = p.TryLoad(7);
+            Assert.NotNull(loaded);
+            Assert.Equal(1, loaded!.Version);
+            Assert.Equal((uint)42, loaded.SequenceNumber);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
+    public void BackwardCompat_MigratesV0ToV1ViaRegisteredShim()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            // Pretend a legacy v0 snapshot was on disk: NO Version
+            // field at all (ReadVersion treats this as 0).
+            var json = "{" + MinimalV1Body + "}";
+            WriteRawSnapshot(dir, 7, json);
+
+            var migrations = SnapshotMigrationSet.BuildDefault();
+            migrations.Register(0, prev =>
+            {
+                // The "migration" stamps the new version onto the
+                // existing tree — no other shape change is needed
+                // because v1 just added Version.
+                var obj = (JsonObject)prev;
+                obj["Version"] = 1;
+                return obj;
+            });
+
+            var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance,
+                migrations: migrations);
+            var loaded = p.TryLoad(7);
+            Assert.NotNull(loaded);
+            Assert.Equal(1, loaded!.Version);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
+    public void MissingMigration_FailsLoadWithClearMessage()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            // v0 payload but the persister's migration set is empty.
+            var json = "{\"Version\":0," + MinimalV1Body + "}";
+            WriteRawSnapshot(dir, 7, json);
+
+            var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
+            // TryLoad swallows per-file errors and walks generations;
+            // with only one (failing) candidate it returns null.
+            var loaded = p.TryLoad(7);
+            Assert.Null(loaded);
+        }
+        finally { try { Directory.Delete(dir, true); } catch { } }
+    }
+
+    [Fact]
+    public void FutureVersion_IsRejected()
+    {
+        // Direct unit test against the migration set: a payload from a
+        // host newer than us must be rejected even when no migration
+        // exists for the gap.
+        var migrations = SnapshotMigrationSet.BuildDefault();
+        var futureRoot = JsonNode.Parse("{\"Version\":99}")!;
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => migrations.MigrateToCurrent(futureRoot, ChannelStateSnapshot.CurrentVersion));
+        Assert.Contains("newer than supported", ex.Message);
+    }
+
+    [Fact]
+    public void Migration_ChainedAcrossMultipleVersions()
+    {
+        // Validates that the chain walks step-by-step (0 → 1 → 2).
+        var migrations = SnapshotMigrationSet.BuildDefault();
+        migrations.Register(0, prev =>
+        {
+            var obj = (JsonObject)prev;
+            obj["Version"] = 1;
+            obj["AddedAtV1"] = "first";
+            return obj;
+        });
+        migrations.Register(1, prev =>
+        {
+            var obj = (JsonObject)prev;
+            obj["Version"] = 2;
+            obj["AddedAtV2"] = "second";
+            return obj;
+        });
+
+        var root = JsonNode.Parse("{}")!;
+        var migrated = migrations.MigrateToCurrent(root, targetVersion: 2);
+        var obj = Assert.IsType<JsonObject>(migrated);
+        Assert.Equal(2, obj["Version"]!.GetValue<int>());
+        Assert.Equal("first", obj["AddedAtV1"]!.GetValue<string>());
+        Assert.Equal("second", obj["AddedAtV2"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Migration_ThatForgetsToBumpVersion_IsRejected()
+    {
+        var migrations = SnapshotMigrationSet.BuildDefault();
+        migrations.Register(0, prev => prev); // buggy: no version stamp
+
+        var root = JsonNode.Parse("{\"Version\":0}")!;
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => migrations.MigrateToCurrent(root, targetVersion: 1));
+        Assert.Contains("must stamp the new version", ex.Message);
+    }
+}


### PR DESCRIPTION
Closes #272.

Adds `SnapshotMigrationSet` (B3.Exchange.Core), a JSON-tree migration registry that runs between `FileChannelStatePersister.TryLoad`'s `JsonNode` parse and the final `ChannelStateSnapshot` deserialization. The persister reads on-disk JSON to a tree, walks the migration chain up to `ChannelStateSnapshot.CurrentVersion`, then deserializes.

### Policy
- **Forward compat:** STJ ignores unknown fields by default — newer payloads load on older hosts as long as known fields keep their meaning. Add new fields as optional with defaults; never repurpose/rename without a version bump.
- **Backward compat:** older payloads need a registered migration for every step up to `CurrentVersion`. Missing any step throws — the dispatcher fails closed (per #270 restore contract). Bump dance: register `N→N+1` migration in `BuildDefault`, then bump `CurrentVersion`.
- **Forward-version rejection:** `Version` higher than `CurrentVersion` is rejected with a message pointing at `POST /admin/channels/{ch}/snapshot/reset?force=true`.

### Changes
- `src/B3.Exchange.Core/SnapshotMigrations.cs` — new `SnapshotMigrationSet` class with `BuildDefault`, `Register(fromVersion, Migration)`, `MigrateToCurrent(root, targetVersion)`. Each step's output Version verified to equal `from + 1`. Thread-safe.
- `src/B3.Exchange.Persistence/FileChannelStatePersister.cs` — new optional `SnapshotMigrationSet?` ctor param (defaults to `BuildDefault()`); `TryLoad` uses `JsonNode.Parse` → `MigrateToCurrent` → `Deserialize`.
- `tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs` — 6 tests covering forward compat, backward compat via shim, missing migration, future version, chained migrations, version-not-bumped guard.
- `docs/EXCHANGE-SIMULATOR.md` — new section *Snapshot schema evolution (issue #272)* with the three rules above.

### Verification
- `dotnet build SbeB3Exchange.slnx -c Release`: clean.
- `dotnet test SbeB3Exchange.slnx -c Release`: all green.
- `dotnet format … --verify-no-changes`: clean.