### PR TITLE
docs: persistence roadmap deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ participants that surround a real exchange:
 - **`B3.Exchange.Core`** — per-channel `ChannelDispatcher`: bounded
   inbound queue, single dispatch thread, packs MBO/Trade frames into 1400-byte
   UMDF packets, publishes via `IUmdfPacketSink`.
+- **`B3.Exchange.Persistence`** — opt-in per-channel snapshot + Write-Ahead
+  Log so a host restart resumes with the live working book, RptSeq, order
+  ownership, and untriggered stops intact. Atomic generational writes
+  (tmp + fsync + rename), schema-migration framework, JSON or compact
+  binary encoding. See `docs/EXCHANGE-SIMULATOR.md` § *Persistence* and
+  `docs/RUNBOOK.md` § *State persistence ops*.
 - **`B3.Exchange.Host`** — JSON-configured single-binary host wiring
   EntryPoint listener + dispatchers + multicast UDP sinks.
 - **`B3.Exchange.SyntheticTrader`** — separate console client that connects

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -192,22 +192,75 @@ Exposes:
   30, ~1.3 KB per chunk → fits a standard 1500-byte MTU). Omit the
   `snapshot` block to publish only the incremental feed (no bootstrap for
   mid-session consumers).
-* `persistence` *(optional, per channel — issue #260)* — enables order
-  book + counter persistence so a restart resumes with the live working
-  book, RptSeq, and order/trade-id allocators intact. When present, the
-  dispatcher writes an atomic JSON snapshot to
-  `{dataDir}/channel-{N}.snapshot` after every command flush and reloads
-  it on the dispatch loop's first turn.
-  * `dataDir` — directory holding the per-channel snapshot file. The host
-    creates it if missing. Mount a durable volume here in container
-    deployments (e.g. `/var/lib/b3matching` — see Dockerfile).
-  * Limitations *(out of scope for this PR; tracked separately)*: stop
-    orders, auction-top throttling state, the UMDF retransmit ring,
-    snapshot-rotator cursor, and FIXP session counters are not persisted.
-    Resting `OrderRegistry` ownership is restored as-is — passive fills
-    that arrive while the original session is still away are dropped on
-    the floor as before. Omit the `persistence` block to keep the legacy
-    stateless boot.
+* `persistence` *(optional, per channel — issue #260 + roadmap #262–#272)*
+  — enables order book + counter persistence so a restart resumes with
+  the live working book, RptSeq, order/trade-id allocators, untriggered
+  stops, and resting-order ownership intact. The dispatcher captures a
+  snapshot on the loop thread after every command flush (subject to
+  `throttle`), serializes it (synchronously by default, or off-loop
+  when `asyncWriter=true`) and writes it atomically into one of N
+  rolling generation slots. Optional Write-Ahead Log records every
+  state-mutating command between snapshots, replayed on cold start.
+  * `dataDir` — directory holding the per-channel snapshot file(s) and
+    optional WAL. The host creates it if missing. Mount a durable
+    volume here in container deployments (e.g. `/var/lib/b3matching`
+    — see Dockerfile).
+  * `format` *(#266)* — `"json"` (default; pretty + `jq`-friendly) or
+    `"binary"` (compact `B3SS`-prefixed framing, ~3× smaller). Both
+    formats are auto-detected on load via magic-byte sniff, so a
+    deployment can flip the value (or roll back) without a one-shot
+    conversion.
+  * `generations` *(#264)* — number of rolling snapshot slots kept on
+    disk per channel. The persister round-robins across slots
+    `0..generations-1` and falls back to the previous slot if the
+    newest is corrupted. Default `3`.
+  * `throttle` *(#267)* — `{ everyN, minIntervalMs }`. Both fields
+    optional; whichever fires first triggers the persist. Operator
+    commands always force-persist regardless of throttle. Absent /
+    both zero ⇒ persist after every command flush (PR #261 default).
+  * `asyncWriter` *(#268)* — when `true`, the dispatcher captures the
+    snapshot POCO on the loop thread (cheap) and hands serialization
+    + write to a dedicated writer thread. Backpressure is
+    last-write-wins (newest capture supersedes older queued one) —
+    monitor `exch_snapshot_dropped_by_backpressure_total`. Default
+    `false` so existing deployments keep zero-RPO behaviour.
+  * `wal` *(#269)* — `{ enabled, fsyncPerWrite }`. When
+    `enabled=true` the dispatcher appends one record per
+    state-mutating command to `{dataDir}/channel-{N}.wal` BEFORE the
+    engine observes it, and replays the surviving records on cold
+    start — closing the gap between the most-recent snapshot and an
+    unclean shutdown. `fsyncPerWrite` (default `true`) trades
+    latency for durability per-record. Off by default so existing
+    deployments pay no per-command file IO.
+  * `orphanSessionPolicy` *(#270)* — policy applied to
+    `OrderOwnerSnapshot` entries whose `SessionValue` is no longer
+    present in the host's session registry at restore time. Either
+    `"drop"` (default — log + bump
+    `exch_owner_orphans_dropped_total`, skip the owner; engine
+    state still loads) or `"reject"` (treat as fatal; channel fails
+    closed). Case-insensitive.
+* Snapshot evolution and on-disk schema versioning are described in the
+  *Snapshot file format* and *Snapshot schema evolution* sections below.
+* Limitations: auction-top throttling state, the UMDF retransmit ring,
+  snapshot-rotator cursor, and FIXP session counters are not persisted.
+  Operators that depend on auction throttling should drain in-flight
+  indicative state before restart. Omit the `persistence` block to keep
+  the legacy stateless boot.
+
+**Consolidated example with every sub-block:**
+
+```jsonc
+"persistence": {
+  "dataDir": "/var/lib/b3matching/channel-84",
+  "format": "binary",
+  "generations": 5,
+  "throttle": { "everyN": 100, "minIntervalMs": 250 },
+  "asyncWriter": true,
+  "wal": { "enabled": true, "fsyncPerWrite": true },
+  "orphanSessionPolicy": "drop"
+}
+```
+
 
 ### Snapshot file format (issue #266)
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -634,7 +634,149 @@ sampler) are honored by the SDK directly.
 
 ---
 
-## 7. Where to look in the code
+## 7. State persistence ops
+
+State persistence is **opt-in per channel** via the `persistence` block
+in `config/exchange-simulator.json` (see *Persistence* in
+[`EXCHANGE-SIMULATOR.md`](./EXCHANGE-SIMULATOR.md) for every
+sub-field). When configured, each channel writes a snapshot of its
+matching engine + `OrderRegistry` to disk after every command flush
+(subject to throttle), and optionally appends each command to a
+Write-Ahead Log between snapshots so recovery is nearly RPO-zero.
+
+### 7.1 Boot-time recovery flow
+
+1. Dispatcher cold-starts → `FileChannelStatePersister.TryLoad`
+   sniffs each candidate file (`B3SS` magic ⇒ binary, else JSON),
+   migrates the JSON tree through `SnapshotMigrationSet` if needed,
+   and returns the newest valid snapshot. Corrupt newest slot ⇒
+   transparently falls back to an older generation.
+2. The dispatcher applies the snapshot, then if a WAL exists it
+   replays every record whose sequence number is **greater than**
+   `ChannelStateSnapshot.LastAppliedSeq` — so commands that landed
+   between the last snapshot and an unclean shutdown are reapplied.
+3. Orphaned `OrderOwnerSnapshot` entries (sessionId not in the
+   firm/session registry) are handled per
+   `persistence.orphanSessionPolicy` — `drop` (default) increments
+   `exch_owner_orphans_dropped_total`; `reject` fails the channel
+   closed.
+4. The first outbound packet is stamped with `SequenceNumber+1`
+   under the previous `SequenceVersion`. Consumers that miss the
+   gap recover via the snapshot multicast feed.
+
+### 7.2 Admin endpoints
+
+All endpoints below dispatch onto the channel's inbound queue and
+return `202 Accepted` immediately (`404` unknown channel, `503`
+queue full). They live under `/admin` to keep them out of the
+client-facing operator surface from §2.4.
+
+| Endpoint | Method | What |
+| --- | --- | --- |
+| `/admin/channels/{ch}/snapshot` | GET | JSON summary of the most recently persisted snapshot for the channel (sequence numbers, owner count, file size, mtime). `404` if none exists. |
+| `/admin/channels/{ch}/snapshot/force` | POST | Operator alias for `/channel/{ch}/snapshot-now` under the `/admin` namespace — enqueues a `WorkKind.OperatorPersistSnapshot` so the next dispatcher cycle captures and persists. |
+| `/admin/channels/{ch}/snapshot/validate` | POST | Loads the most recent snapshot through the same structural validator the boot path uses (duplicate orderId, owners-reference-known-orders, stop-record sanity) WITHOUT restoring it. `200 ok` on success, `422` + reason on validation failure, `404` no snapshot, `503` no persister. |
+| `/admin/channels/{ch}/snapshot/reset?force=true` | POST | **Destructive.** Deletes every on-disk snapshot artifact (all rolling generations + legacy file) AND truncates the WAL. The live in-memory engine state is NOT touched — restart the host to actually start the channel empty. The `?force=true` query string is required to acknowledge irreversibility. Use only when an operator has decided to abandon persisted state (e.g., after a forward-version rejection). |
+
+### 7.3 Persistence metrics
+
+Exposed under the existing `/metrics` endpoint (Prometheus 0.0.4
+text format, `channel="{N}"` label on every series).
+
+| Metric | Type | What |
+| --- | --- | --- |
+| `exch_snapshot_saves_total` | counter | Successful snapshot writes (each = one tmp+fsync+rename cycle). |
+| `exch_snapshot_save_failures_total` | counter | Persist attempts that threw (disk full, permission, etc). The dispatcher swallows the exception and keeps running. |
+| `exch_snapshot_skipped_by_throttle_total` | counter | Snapshots the throttle (`everyN` / `minIntervalMs`) suppressed. Operator force-saves bypass the throttle and never increment this. |
+| `exch_snapshot_dropped_by_backpressure_total` | counter | `asyncWriter=true` only. Captures dropped because a newer one superseded them while the writer thread was still serializing the previous one. Last-write-wins is intentional. |
+| `exch_snapshot_last_size_bytes` | gauge | Bytes written by the most recent successful save. Useful for sizing volumes and tracking format-flip impact (json↔binary). |
+| `exch_snapshot_last_success_unixms` | gauge | Unix-ms timestamp of the most recent successful save. Alert if `(now - this)` exceeds your RPO budget. |
+| `exch_snapshot_load_seconds` | gauge | Wall-clock time the boot-time `TryLoad` took (single observation per channel; 0 when no snapshot was loaded). |
+| `exch_snapshot_write_seconds` | gauge | Wall-clock time of the most recent successful save (serialize + fsync + rename + dir-fsync). |
+| `exch_snapshot_restore_failures_total` | counter | Snapshots that loaded but failed structural validation (bumps `RestoreOutcome=FailedValidation`). |
+| `exch_snapshot_validation_failures_total` | counter | `/admin/.../snapshot/validate` calls that returned `422`. |
+| `exch_wal_appends_total` | counter | Records appended to the WAL (one per state-mutating command). |
+| `exch_wal_bytes_appended_total` | counter | Cumulative bytes appended (use as a rate gauge for IO planning). |
+| `exch_wal_replays_total` | counter | Records replayed at boot (one per WAL entry past `LastAppliedSeq`). |
+| `exch_wal_truncations_total` | counter | WAL truncations (post-snapshot or admin-reset triggered). |
+| `exch_owner_orphans_dropped_total` | counter | `OrderOwnerSnapshot` entries whose sessionId was not in the registry at restore time, dropped per `orphanSessionPolicy=drop`. |
+
+### 7.4 Disaster recovery — backup / restore
+
+The persisted state for a channel is everything matching
+`{dataDir}/channel-{N}.snapshot.*` plus (if WAL is enabled)
+`{dataDir}/channel-{N}.wal`. There is no out-of-band index — the
+files are self-describing.
+
+**Backup recipe (rsync-friendly hot copy):**
+
+```bash
+# Hot copy of all persisted state. Files are written via
+# tmp+fsync+rename so a concurrent rsync sees a consistent point-in-time
+# generation; worst case the destination's newest slot is one revision
+# behind the source.
+rsync -a --delete /var/lib/b3matching/ /backup/b3matching/$(date +%F)/
+```
+
+**Restore recipe:**
+
+1. Stop the host.
+2. Replace `dataDir` with the backup contents (preserve filename
+   layout — the persister discovers slots by the `channel-{N}.snapshot.{slot}`
+   pattern).
+3. Start the host. Boot-time recovery (§7.1) takes care of the rest.
+4. Confirm with `curl -sS http://127.0.0.1:8080/admin/channels/84/snapshot`
+   — the returned `sequenceNumber` should match what the backup captured.
+
+### 7.5 Switching format (json ↔ binary)
+
+The persister auto-detects the format on **load**, so flipping
+direction is a config change + restart:
+
+```bash
+# 1. Edit config/exchange-simulator.json:
+#      "persistence": { ..., "format": "binary" }
+# 2. Restart the host. Existing JSON slots remain loadable.
+# 3. The next save writes binary; old JSON slots age out as the
+#    rolling generations rotate (3 saves by default).
+```
+
+Roll-back works identically — set `format: "json"` and restart.
+**Caveat:** if you bumped `ChannelStateSnapshot.CurrentVersion`
+between the host versions, the older host will reject the snapshot
+with a forward-version error. Switch the format *before* the schema
+bump, or use `/admin/channels/{ch}/snapshot/reset?force=true` to
+abandon the on-disk state.
+
+### 7.6 Common persistence headaches
+
+* **"Channel boots empty after restart."** Check
+  `exch_snapshot_load_seconds` — `0` means `TryLoad` returned null.
+  Most likely the `dataDir` is wrong (typo, missing volume mount,
+  permissions). Tail the host log for `failed to load snapshot at
+  ...` warnings.
+* **"`exch_snapshot_restore_failures_total` keeps incrementing."**
+  A persisted snapshot loaded but failed the structural validator.
+  Run `/admin/channels/{ch}/snapshot/validate` for the reason.
+  Usually a hand-edited file or a developer-only test artifact.
+  Recover with `/admin/channels/{ch}/snapshot/reset?force=true`
+  + restart.
+* **"Disk usage on `dataDir` grows unboundedly."** Check
+  `generations` (rolling slots cap snapshot growth). The WAL is
+  truncated on every successful snapshot — if it grows, snapshots
+  are failing (see `exch_snapshot_save_failures_total`) or
+  throttled too aggressively (`everyN` too high relative to command
+  rate).
+* **"`asyncWriter` shows backpressure drops under load."** That is
+  by design — the latest capture supersedes older queued ones so
+  on a crash you lose at most the captures between the latest
+  durable write and the crash. Lower `everyN` / `minIntervalMs` if
+  the drop rate is unacceptable, or switch `asyncWriter=false` to
+  enforce zero-RPO at the cost of a slower dispatch loop.
+
+---
+
+## 8. Where to look in the code
 
 | Subsystem | Path |
 | --- | --- |
@@ -643,6 +785,7 @@ sampler) are honored by the SDK directly.
 | FIXP session lifecycle | `src/B3.Exchange.Gateway/FixpSession.cs`, `FixpStateMachine.cs` |
 | Mass-cancel / CoD plumbing | `src/B3.Exchange.Gateway/OrderOwnershipMap.cs`, `FixpSession.cs` (CoD) |
 | Per-channel matching | `src/B3.Exchange.Core/ChannelDispatcher.cs`, `src/B3.Exchange.Matching/MatchingEngine.cs` |
+| State persistence | `src/B3.Exchange.Persistence/FileChannelStatePersister.cs`, `BinaryChannelStateSnapshotCodec.cs`, `FileChannelWriteAheadLog.cs`; migration framework in `src/B3.Exchange.Core/SnapshotMigrations.cs` |
 | UMDF wire encoders | `src/B3.Umdf.WireEncoder/` |
 | Synthetic trader strategies | `src/B3.Exchange.SyntheticTrader/MarketMakerStrategy.cs`, `NoiseTakerStrategy.cs` |
 


### PR DESCRIPTION
Catches the user-facing docs up to the persistence work merged in this roadmap (10 issues #260, #262–#272, #266; 10 PRs #274–#283). **Docs only — no code changes.**

### README.md
- Adds `B3.Exchange.Persistence` to the *What's inside* list with a one-liner on the snapshot+WAL feature, atomic generational writes, and the link to the operator docs.

### docs/EXCHANGE-SIMULATOR.md
- Expands the `persistence` config bullet to cover every sub-block landed since #260: `format` (#266), `generations` (#264), `throttle` (#267), `asyncWriter` (#268), `wal` (#269), `orphanSessionPolicy` (#270).
- Drops the obsolete *stops not persisted* caveat (#262 fixed that).
- Adds a consolidated JSON example showing every sub-block together so operators have one paste-able reference.

### docs/RUNBOOK.md
- New §7 *State persistence ops*:
  - **§7.1** boot-time recovery flow (snapshot sniff → JSON-tree migrations → WAL replay above `LastAppliedSeq` → orphan-owner policy → first packet at `SequenceNumber+1`).
  - **§7.2** admin endpoints table for the four `/admin/channels/{ch}/snapshot[/force|/reset|/validate]` routes from #271.
  - **§7.3** every persistence metric currently exposed on `/metrics` (saves, failures, throttle skips, backpressure drops, sizes, timings, restore failures, validation failures, WAL appends/bytes/replays/truncations, orphan owners) with what each is for.
  - **§7.4** disaster recovery — rsync-friendly backup recipe + step-by-step restore.
  - **§7.5** json↔binary format flip recipe (auto-detect on load means it's a config change + restart, no one-shot conversion).
  - **§7.6** common-headaches troubleshooting list (boots empty, restore failures climbing, disk growing unbounded, asyncWriter backpressure).
- *Where to look in the code* table renumbered §8 and gained a *State persistence* row pointing at `FileChannelStatePersister`, `BinaryChannelStateSnapshotCodec`, `FileChannelWriteAheadLog`, and `SnapshotMigrations`.

### Verification
- `dotnet format SbeB3Exchange.slnx --verify-no-changes`: clean.
- All metric names cross-checked against the source (`grep -r 'exch_snapshot_'`).