### PR TITLE
feat(persistence): CRC32C per WAL record + binary snapshot footer (#285)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -699,6 +699,8 @@ text format, `channel="{N}"` label on every series).
 | `exch_wal_bytes_appended_total` | counter | Cumulative bytes appended (use as a rate gauge for IO planning). |
 | `exch_wal_replays_total` | counter | Records replayed at boot (one per WAL entry past `LastAppliedSeq`). |
 | `exch_wal_truncations_total` | counter | WAL truncations (post-snapshot or admin-reset triggered). |
+| `exch_wal_record_corruption_total` | counter | WAL records dropped at replay because the per-record Crc32C did not match (bit-rot or external tampering). |
+| `exch_wal_records_legacy_total` | counter | WAL records replayed in pre-#285 (no Crc32C suffix) format. Steady-state should be `0` once every channel has rolled past the upgrade. |
 | `exch_owner_orphans_dropped_total` | counter | `OrderOwnerSnapshot` entries whose sessionId was not in the registry at restore time, dropped per `orphanSessionPolicy=drop`. |
 
 ### 7.4 On-disk layout & WAL design
@@ -723,15 +725,19 @@ pointer advanced but the snapshot did not (or vice versa).
 sniffs the first bytes on load, so both formats coexist while a
 fleet rolls between `persistence.format=json` and `binary`.
 
-**WAL format:** JSON-Lines (one `WalRecord` per `\n`-terminated
-line). `Append` opens the file in append mode, writes the record,
-and (when `fsyncPerWrite=true`, the default) fsyncs. `ReadAll`
-parses line-by-line and **stops at the first malformed line** — this
-correctly tolerates a torn final write from an unclean shutdown, but
-is the conservative choice if bit-rot lands mid-file (records past
-the rot are silently dropped from replay; tracked under
-[#285](https://github.com/pedrosakuma/B3MatchingPlatform/issues/285)
-for per-record CRC).
+**WAL format:** JSON-Lines (one `WalRecord` per line). Each line
+since [#285](https://github.com/pedrosakuma/B3MatchingPlatform/issues/285)
+is `<json>\t<8-hex-Crc32C>\n` — `Append` opens the file in append
+mode, computes Crc32C (Castagnoli) over the JSON bytes, writes the
+suffix, and (when `fsyncPerWrite=true`, the default) fsyncs.
+`ReadAll` validates each record's CRC: a mismatch logs at warn,
+bumps `exch_wal_record_corruption_total`, and **skips that record
+while continuing replay** so a single bit-rot byte does not silently
+truncate the entire log. Records written by pre-#285 hosts have no
+suffix, are accepted unchecked (legacy path), and bump
+`exch_wal_records_legacy_total`. A torn final write on the legacy
+path (last line missing trailing `\n`) still stops replay — the
+intended behaviour for unclean shutdown.
 
 **WAL lifecycle:**
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -140,7 +140,14 @@ public sealed partial class ChannelDispatcher
                 ChannelNumber);
             return;
         }
-        if (records.Count == 0) return;
+        if (records.Count == 0)
+        {
+            // Even an empty record list can carry post-read counters
+            // (e.g. a WAL composed entirely of corrupt records).
+            _metrics?.AddWalRecordCorruptions(_wal.LastReadCorruptCount);
+            _metrics?.AddWalRecordsLegacy(_wal.LastReadLegacyCount);
+            return;
+        }
         int replayed = 0;
         int skipped = 0;
         _replayMode = true;
@@ -180,9 +187,14 @@ public sealed partial class ChannelDispatcher
             // ProcessOne via WalAppendIfEnabled (which still increments
             // the counter even in replay mode for a consistent view).
         }
+        // Issue #285: surface CRC-mismatch and legacy-record counts to
+        // observability so operators see storage-layer integrity loss
+        // and migration progress immediately after boot.
+        _metrics?.AddWalRecordCorruptions(_wal.LastReadCorruptCount);
+        _metrics?.AddWalRecordsLegacy(_wal.LastReadLegacyCount);
         _logger.LogInformation(
-            "channel {ChannelNumber}: WAL replay complete — replayed={Replayed} skipped={Skipped} (snapshotLastAppliedSeq={SnapshotSeq})",
-            ChannelNumber, replayed, skipped, snapshotLastAppliedSeq);
+            "channel {ChannelNumber}: WAL replay complete — replayed={Replayed} skipped={Skipped} corrupt={Corrupt} legacy={Legacy} (snapshotLastAppliedSeq={SnapshotSeq})",
+            ChannelNumber, replayed, skipped, _wal.LastReadCorruptCount, _wal.LastReadLegacyCount, snapshotLastAppliedSeq);
     }
 
     private static WorkItem? TryBuildReplayWorkItem(WalRecord rec)

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -90,4 +90,18 @@ public interface IChannelWriteAheadLog
     /// in-memory fakes used by tests don't need to implement it.
     /// </summary>
     void Reset() { }
+
+    /// <summary>
+    /// Issue #285: number of records the most recent
+    /// <see cref="ReadAll"/> dropped because their stored Crc32C did
+    /// not match the record bytes. Default 0 for in-memory fakes.
+    /// </summary>
+    int LastReadCorruptCount => 0;
+
+    /// <summary>
+    /// Issue #285: number of records the most recent
+    /// <see cref="ReadAll"/> accepted that had no Crc32C suffix
+    /// (pre-#285 files). Default 0 for in-memory fakes.
+    /// </summary>
+    int LastReadLegacyCount => 0;
 }

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -179,10 +179,20 @@ public sealed class ChannelMetrics
     private long _walBytesAppended;
     private long _walTruncations;
     private long _walReplays;
+    private long _walRecordCorruptions;
+    private long _walRecordsLegacy;
     public long WalAppends => Interlocked.Read(ref _walAppends);
     public long WalBytesAppended => Interlocked.Read(ref _walBytesAppended);
     public long WalTruncations => Interlocked.Read(ref _walTruncations);
     public long WalReplays => Interlocked.Read(ref _walReplays);
+    /// <summary>Issue #285: WAL records dropped on read because the
+    /// stored Crc32C did not match the record bytes (bit-rot).
+    /// Cumulative across all replays for the channel.</summary>
+    public long WalRecordCorruptions => Interlocked.Read(ref _walRecordCorruptions);
+    /// <summary>Issue #285: WAL records read without a CRC suffix
+    /// (i.e. written by a pre-#285 host). Tracks the migration tail
+    /// after upgrading.</summary>
+    public long WalRecordsLegacy => Interlocked.Read(ref _walRecordsLegacy);
     public void IncWalAppend(long bytes)
     {
         Interlocked.Increment(ref _walAppends);
@@ -192,6 +202,14 @@ public sealed class ChannelMetrics
     public void AddWalReplays(long count)
     {
         if (count > 0) Interlocked.Add(ref _walReplays, count);
+    }
+    public void AddWalRecordCorruptions(long count)
+    {
+        if (count > 0) Interlocked.Add(ref _walRecordCorruptions, count);
+    }
+    public void AddWalRecordsLegacy(long count)
+    {
+        if (count > 0) Interlocked.Add(ref _walRecordsLegacy, count);
     }
 
     public void IncSnapshotSaveOk() => Interlocked.Increment(ref _snapshotSavesOk);
@@ -526,6 +544,12 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_wal_replays_total",
             "Total WAL records replayed at boot to bring this channel up to the most-recently-acknowledged command. Non-zero only on the boot following an unclean shutdown.",
             channels, c => c.WalReplays);
+        EmitCounter(sb, "exch_wal_record_corruption_total",
+            "Issue #285: WAL records dropped on read because the stored Crc32C did not match the record bytes (bit-rot). Replay continues past the corrupt record; non-zero indicates storage-layer integrity loss and warrants investigation.",
+            channels, c => c.WalRecordCorruptions);
+        EmitCounter(sb, "exch_wal_records_legacy_total",
+            "Issue #285: WAL records read without a Crc32C suffix (i.e. written by a pre-#285 host). Tracks the migration tail after upgrading; should drift to zero once all pre-#285 records have been truncated by snapshot persists.",
+            channels, c => c.WalRecordsLegacy);
 
         // Issue #270: cross-channel consistency check. Counts owner
         // entries silently dropped at restore because their SessionId

--- a/src/B3.Exchange.Persistence/B3.Exchange.Persistence.csproj
+++ b/src/B3.Exchange.Persistence/B3.Exchange.Persistence.csproj
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Exchange.Persistence.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -124,7 +124,18 @@ public static class BinaryChannelStateSnapshotCodec
         w.WriteUVarInt((ulong)snapshot.Owners.Count);
         foreach (var o in snapshot.Owners) WriteOwner(w, o);
 
-        return w.ToArray();
+        // Issue #285: append a 4-byte little-endian Crc32C footer
+        // covering every preceding byte. Loaders compare the
+        // computed CRC against this footer before invoking the
+        // structural decode; a mismatch surfaces a bit-flip that
+        // would otherwise pass the structural validator (e.g. a
+        // mantissa flipping to a different valid mantissa).
+        var bodyBytes = w.ToArray();
+        uint crc = Crc32C.Compute(bodyBytes);
+        var withFooter = new byte[bodyBytes.Length + 4];
+        Buffer.BlockCopy(bodyBytes, 0, withFooter, 0, bodyBytes.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(withFooter.AsSpan(bodyBytes.Length, 4), crc);
+        return withFooter;
     }
 
     public static ChannelStateSnapshot Decode(ReadOnlySpan<byte> bytes)
@@ -186,9 +197,32 @@ public static class BinaryChannelStateSnapshotCodec
         var owners = new OrderOwnerSnapshot[ownerCount];
         for (ulong i = 0; i < ownerCount; i++) owners[i] = ReadOwner(ref r);
 
-        if (!r.AtEnd)
-            throw new InvalidDataException(
-                $"binary snapshot has {r.Remaining} trailing bytes past the encoded payload");
+        // Issue #285: trailing bytes are either nothing (pre-#285
+        // file with no Crc32C footer) or exactly 4 bytes carrying the
+        // little-endian Crc32C of every byte before them. Anything
+        // else is corruption.
+        switch (r.Remaining)
+        {
+            case 0:
+                // Legacy file (pre-#285). Accept silently — the
+                // tmp+fsync+rename + structural validator combo from
+                // the persister is the only integrity guard for these
+                // files and was the established contract before #285.
+                break;
+            case 4:
+                int bodyEnd = bytes.Length - 4;
+                uint computedCrc = Crc32C.Compute(bytes[..bodyEnd]);
+                uint footerCrc = BinaryPrimitives.ReadUInt32LittleEndian(bytes[bodyEnd..]);
+                if (computedCrc != footerCrc)
+                {
+                    throw new InvalidDataException(
+                        $"binary snapshot Crc32C mismatch: stored=0x{footerCrc:X8} computed=0x{computedCrc:X8}");
+                }
+                break;
+            default:
+                throw new InvalidDataException(
+                    $"binary snapshot has {r.Remaining} trailing bytes past the encoded payload (expected 0 for legacy or 4 for #285 Crc32C footer)");
+        }
 
         var engine = new EngineStateSnapshot(nextOrderId, nextTradeId, rptSeq, phases, books, stops);
         return new ChannelStateSnapshot(version, channelNumber, sequenceNumber, sequenceVersion, engine, owners)

--- a/src/B3.Exchange.Persistence/Crc32C.cs
+++ b/src/B3.Exchange.Persistence/Crc32C.cs
@@ -1,0 +1,57 @@
+namespace B3.Exchange.Persistence;
+
+/// <summary>
+/// Software Crc32C (Castagnoli, polynomial <c>0x1EDC6F41</c> in
+/// reflected form <c>0x82F63B78</c>) used by the persistence stack
+/// to detect bit-rot in WAL records and binary snapshot files
+/// (issue #285).
+///
+/// <para>Software-only implementation deliberately avoids adding a
+/// new NuGet dependency (<c>System.IO.Hashing</c> exposes vanilla
+/// <c>Crc32</c> but not Crc32C). Throughput is bounded by the
+/// 256-entry table lookup; on a modern x64 core this clears
+/// gigabytes per second per thread, well above the WAL append rate
+/// the simulator targets. Hardware-accelerated CRC32C intrinsics
+/// (<c>System.Runtime.Intrinsics.X86.Sse42</c>,
+/// <c>System.Runtime.Intrinsics.Arm.Crc32</c>) could be wired in
+/// later if profiling shows hashing on the hot path; the
+/// public surface is identical so a swap is transparent.</para>
+///
+/// <para>Castagnoli polynomial chosen over the IEEE/zlib variant
+/// for its better collision properties on short payloads (it is the
+/// CRC used by SCTP, iSCSI, and modern filesystems for the same
+/// "detect storage bit-rot" job we have here).</para>
+/// </summary>
+internal static class Crc32C
+{
+    private const uint ReflectedPolynomial = 0x82F63B78u;
+    private static readonly uint[] Table = BuildTable();
+
+    private static uint[] BuildTable()
+    {
+        var t = new uint[256];
+        for (uint i = 0; i < 256; i++)
+        {
+            uint c = i;
+            for (int k = 0; k < 8; k++)
+            {
+                c = (c & 1u) != 0 ? (c >> 1) ^ ReflectedPolynomial : c >> 1;
+            }
+            t[i] = c;
+        }
+        return t;
+    }
+
+    /// <summary>
+    /// Computes the Crc32C of <paramref name="bytes"/>.
+    /// </summary>
+    public static uint Compute(ReadOnlySpan<byte> bytes)
+    {
+        uint crc = 0xFFFFFFFFu;
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            crc = (crc >> 8) ^ Table[(crc ^ bytes[i]) & 0xFF];
+        }
+        return crc ^ 0xFFFFFFFFu;
+    }
+}

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -14,15 +14,25 @@ namespace B3.Exchange.Persistence;
 /// <c>channel-{N}.wal</c>, written as JSON-Lines (one
 /// <see cref="WalRecord"/> per line, terminated by <c>\n</c>).
 ///
-/// <para>Append semantics: each record is JSON-serialized, written
-/// with a trailing newline, and the implementation optionally
-/// <c>fsync</c>s the file before returning. The JSON-Lines format makes
-/// partial / torn writes self-detecting on read — a record without a
-/// terminating newline (or that fails to deserialize) is dropped,
-/// halting replay at the last whole record. Combined with per-write
-/// fsync this gives zero-RPO recovery; the caller can opt for batched
-/// fsync (lower latency, RPO bounded by batch flush) via the
+/// <para>Append semantics: each record is JSON-serialized, suffixed
+/// with a <c>\t</c>-separated 8-hex-digit Crc32C of the JSON bytes
+/// (issue #285), terminated by a newline, and the implementation
+/// optionally <c>fsync</c>s the file before returning. The
+/// JSON-Lines + per-record CRC framing makes the file robust against
+/// two distinct failure modes: a torn final write fails the trailing
+/// CRC and is dropped, while a bit-rot landing mid-file fails just
+/// that record's CRC — replay logs the corruption and **continues
+/// past it** so the surviving prefix and suffix remain replayable.
+/// Per-write fsync gives zero-RPO recovery; the caller can opt for
+/// batched fsync (lower latency, RPO bounded by batch flush) via the
 /// <c>fsyncPerWrite=false</c> ctor argument.</para>
+///
+/// <para>Backwards compatibility: lines without the <c>\t</c>+CRC
+/// suffix (i.e. files written by pre-#285 hosts) are accepted as
+/// "legacy" records and counted via <see cref="LastReadLegacyCount"/>
+/// so operators can monitor migration. A legacy line that fails to
+/// JSON-parse is treated as torn-final and stops replay (preserving
+/// the original behavior).</para>
 ///
 /// <para>Truncation rewrites the file to an empty version atomically
 /// (tmp + rename + dir fsync) so a crash during truncate either keeps
@@ -33,6 +43,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
 {
     private const string WalFileNameFormat = "channel-{0}.wal";
     private const string WalTempFileNameFormat = "channel-{0}.wal.tmp";
+    private const byte CrcSeparator = (byte)'\t';
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -51,6 +62,22 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     private readonly byte _channelNumber;
     private readonly object _writeLock = new();
     private FileStream? _appendStream;
+
+    /// <summary>
+    /// Number of records the most recent <see cref="ReadAll"/> call
+    /// rejected because their stored Crc32C did not match the JSON
+    /// payload (bit-rot). The dispatcher reads this after replay and
+    /// bumps <c>exch_wal_record_corruption_total</c>.
+    /// </summary>
+    public int LastReadCorruptCount { get; private set; }
+
+    /// <summary>
+    /// Number of records the most recent <see cref="ReadAll"/> call
+    /// accepted that had no Crc32C suffix (i.e. were written by a
+    /// pre-#285 host). Useful for tracking the migration window
+    /// after upgrading.
+    /// </summary>
+    public int LastReadLegacyCount { get; private set; }
 
     public string Path => _path;
 
@@ -79,7 +106,16 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
             _appendStream ??= new FileStream(_path,
                 FileMode.Append, FileAccess.Write, FileShare.Read);
             var json = JsonSerializer.SerializeToUtf8Bytes(record, JsonOptions);
+            uint crc = Crc32C.Compute(json);
+            // Layout: <json bytes> \t <8-hex Crc32C> \n. Tab is safe
+            // because JsonSerializer escapes literal tabs to \t inside
+            // strings, so the last \t in the line is always our
+            // separator.
+            Span<byte> crcBytes = stackalloc byte[8];
+            WriteHexUtf8(crc, crcBytes);
             _appendStream.Write(json, 0, json.Length);
+            _appendStream.WriteByte(CrcSeparator);
+            _appendStream.Write(crcBytes);
             _appendStream.WriteByte((byte)'\n');
             if (_fsyncPerWrite)
             {
@@ -94,6 +130,8 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
 
     public IReadOnlyList<WalRecord> ReadAll()
     {
+        LastReadCorruptCount = 0;
+        LastReadLegacyCount = 0;
         if (!File.Exists(_path)) return Array.Empty<WalRecord>();
         // Close any open append handle so reads see all flushed bytes
         // and the read can re-open the file with shared access.
@@ -117,21 +155,47 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
             {
                 lineNumber++;
                 if (line.Length == 0) continue;
-                try
+                int tab = line.LastIndexOf('\t');
+                if (tab >= 0 && line.Length - tab - 1 == 8)
                 {
-                    var rec = JsonSerializer.Deserialize<WalRecord>(line, JsonOptions);
-                    if (rec is not null) result.Add(rec);
+                    // Modern format: JSON \t crc8 .
+                    var json = line.AsSpan(0, tab);
+                    var crcHex = line.AsSpan(tab + 1, 8);
+                    if (!TryParseHex32(crcHex, out uint storedCrc))
+                    {
+                        // Suffix isn't a valid 8-hex CRC — treat as
+                        // legacy (no CRC) and fall through.
+                        ConsumeLegacyLine(line, lineNumber, result);
+                        continue;
+                    }
+                    var jsonBytes = Encoding.UTF8.GetBytes(line[..tab]);
+                    uint computedCrc = Crc32C.Compute(jsonBytes);
+                    if (computedCrc != storedCrc)
+                    {
+                        LastReadCorruptCount++;
+                        _logger.LogWarning(
+                            "channel {ChannelNumber}: WAL line {LineNumber} CRC mismatch (stored=0x{StoredCrc:X8} computed=0x{ComputedCrc:X8}); skipping record and continuing replay",
+                            _channelNumber, lineNumber, storedCrc, computedCrc);
+                        continue;
+                    }
+                    try
+                    {
+                        var rec = JsonSerializer.Deserialize<WalRecord>(jsonBytes, JsonOptions);
+                        if (rec is not null) result.Add(rec);
+                    }
+                    catch (Exception ex)
+                    {
+                        // CRC matched but JSON failed — bizarre, treat
+                        // as corrupt for metric purposes and continue.
+                        LastReadCorruptCount++;
+                        _logger.LogWarning(ex,
+                            "channel {ChannelNumber}: WAL line {LineNumber} JSON parse failed despite CRC match; skipping",
+                            _channelNumber, lineNumber);
+                    }
                 }
-                catch (Exception ex)
+                else
                 {
-                    // Torn final line or otherwise corrupt entry.
-                    // JSON-Lines lets us stop here cleanly: every prior
-                    // line is fully framed by its own newline so the
-                    // surviving prefix is a valid replay set.
-                    _logger.LogWarning(ex,
-                        "channel {ChannelNumber}: WAL line {LineNumber} failed to parse; truncating replay set here",
-                        _channelNumber, lineNumber);
-                    break;
+                    if (!ConsumeLegacyLine(line, lineNumber, result)) break;
                 }
             }
         }
@@ -143,6 +207,65 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
             return Array.Empty<WalRecord>();
         }
         return result;
+    }
+
+    /// <summary>
+    /// Handles a line written by a pre-#285 host (no <c>\t</c>+CRC
+    /// suffix). Returns <c>false</c> to signal the caller to stop
+    /// further line processing — preserving the original "torn-final
+    /// stops replay" behavior for legacy files.
+    /// </summary>
+    private bool ConsumeLegacyLine(string line, int lineNumber, List<WalRecord> result)
+    {
+        try
+        {
+            var rec = JsonSerializer.Deserialize<WalRecord>(line, JsonOptions);
+            if (rec is not null)
+            {
+                result.Add(rec);
+                LastReadLegacyCount++;
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "channel {ChannelNumber}: legacy WAL line {LineNumber} failed to parse; truncating replay set here",
+                _channelNumber, lineNumber);
+            return false;
+        }
+    }
+
+    private static void WriteHexUtf8(uint value, Span<byte> dst)
+    {
+        // dst is exactly 8 bytes; write big-endian-nibble hex digits.
+        const string Hex = "0123456789ABCDEF";
+        for (int i = 7; i >= 0; i--)
+        {
+            dst[i] = (byte)Hex[(int)(value & 0xF)];
+            value >>= 4;
+        }
+    }
+
+    private static bool TryParseHex32(ReadOnlySpan<char> chars, out uint value)
+    {
+        value = 0;
+        if (chars.Length != 8) return false;
+        for (int i = 0; i < 8; i++)
+        {
+            int d = HexDigit(chars[i]);
+            if (d < 0) return false;
+            value = (value << 4) | (uint)d;
+        }
+        return true;
+
+        static int HexDigit(char c) => c switch
+        {
+            >= '0' and <= '9' => c - '0',
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ => -1,
+        };
     }
 
     public void Truncate()

--- a/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecCrcTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecCrcTests.cs
@@ -1,0 +1,102 @@
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #285: <see cref="BinaryChannelStateSnapshotCodec"/> appends
+/// a 4-byte little-endian Crc32C footer covering every preceding
+/// byte. <see cref="BinaryChannelStateSnapshotCodec.Decode"/> must
+/// validate the footer when present and reject mismatches; files
+/// written by pre-#285 hosts (no footer) must still load (legacy
+/// path).
+/// </summary>
+public class BinaryChannelStateSnapshotCodecCrcTests
+{
+    private static ChannelStateSnapshot MakeMinimalSnapshot()
+    {
+        var engine = new EngineStateSnapshot(
+            NextOrderId: 100,
+            NextTradeId: 7,
+            RptSeq: 3,
+            Phases: Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+            Books: Array.Empty<EngineStateSnapshot.BookSnapshot>(),
+            Stops: null);
+        return new ChannelStateSnapshot(
+            Version: ChannelStateSnapshot.CurrentVersion,
+            ChannelNumber: 84,
+            SequenceNumber: 42,
+            SequenceVersion: 1,
+            Engine: engine,
+            Owners: Array.Empty<OrderOwnerSnapshot>())
+        {
+            LastAppliedSeq = 99,
+        };
+    }
+
+    [Fact]
+    public void Encode_AppendsFourByteFooter()
+    {
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        // Decode parses everything up to the last 4 bytes; the
+        // footer is exactly 4 bytes long.
+        var roundTripped = BinaryChannelStateSnapshotCodec.Decode(bytes);
+        Assert.Equal(snap.SequenceNumber, roundTripped.SequenceNumber);
+        Assert.Equal(snap.LastAppliedSeq, roundTripped.LastAppliedSeq);
+    }
+
+    [Fact]
+    public void Decode_DetectsFlippedByte_InPayload()
+    {
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        // Flip a byte well inside the structural payload (skip the
+        // magic and version header so the decoder still reaches the
+        // CRC validation step rather than failing earlier).
+        bytes[20] ^= 0xFF;
+        var ex = Assert.Throws<InvalidDataException>(
+            () => BinaryChannelStateSnapshotCodec.Decode(bytes));
+        Assert.Contains("Crc32C mismatch", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Decode_DetectsFlippedByte_InFooter()
+    {
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        bytes[^1] ^= 0xFF;
+        Assert.Throws<InvalidDataException>(
+            () => BinaryChannelStateSnapshotCodec.Decode(bytes));
+    }
+
+    [Fact]
+    public void Decode_AcceptsLegacyFile_WithoutFooter()
+    {
+        // Simulate a pre-#285 binary file: encode normally then
+        // strip the trailing 4 bytes. The decoder must accept this
+        // (the migration window for pre-#285 binary slots).
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        var legacy = bytes.AsSpan(0, bytes.Length - 4).ToArray();
+        var decoded = BinaryChannelStateSnapshotCodec.Decode(legacy);
+        Assert.Equal(snap.SequenceNumber, decoded.SequenceNumber);
+        Assert.Equal(snap.LastAppliedSeq, decoded.LastAppliedSeq);
+    }
+
+    [Fact]
+    public void Decode_RejectsTrailingGarbage_NotFourBytes()
+    {
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        // Append 3 bogus bytes after the legitimate footer — total
+        // trailing is 7 bytes which matches neither legacy (0) nor
+        // modern (4). The decoder must reject.
+        var bad = new byte[bytes.Length + 3];
+        Buffer.BlockCopy(bytes, 0, bad, 0, bytes.Length);
+        bad[^1] = 0xAA;
+        Assert.Throws<InvalidDataException>(
+            () => BinaryChannelStateSnapshotCodec.Decode(bad));
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
@@ -133,8 +133,8 @@ public class BinaryChannelStateSnapshotCodecTests
         var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
         // 4 magic + 2 ver + 1 ch + 4 seq + 2 seqVer + 8 last + 8 + 4 + 4
         // engine prims + 1 phase-count + 1 book-count + 1 stop-count + 1
-        // owner-count = 41 bytes.
-        Assert.Equal(41, bytes.Length);
+        // owner-count + 4 Crc32C footer (issue #285) = 45 bytes.
+        Assert.Equal(45, bytes.Length);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/Crc32CTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/Crc32CTests.cs
@@ -1,0 +1,57 @@
+using B3.Exchange.Persistence;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #285: smoke tests for the software Crc32C implementation
+/// (Castagnoli polynomial). Test vectors taken from RFC 3720
+/// (iSCSI) Appendix B.4.
+/// </summary>
+public class Crc32CTests
+{
+    [Fact]
+    public void EmptyInput_HasZeroCrc()
+    {
+        // Initial 0xFFFFFFFF cancels with the final XOR for an empty
+        // buffer, yielding 0x00000000.
+        Assert.Equal(0x00000000u, Crc32C.Compute(ReadOnlySpan<byte>.Empty));
+    }
+
+    [Fact]
+    public void RFC3720_AllZeros32_Yields_8A9136AA()
+    {
+        var input = new byte[32];
+        Assert.Equal(0x8A9136AAu, Crc32C.Compute(input));
+    }
+
+    [Fact]
+    public void RFC3720_AllOnes32_Yields_62A8AB43()
+    {
+        var input = new byte[32];
+        Array.Fill(input, (byte)0xFF);
+        Assert.Equal(0x62A8AB43u, Crc32C.Compute(input));
+    }
+
+    [Fact]
+    public void RFC3720_IncrementingBytes32_Yields_46DD794E()
+    {
+        var input = new byte[32];
+        for (int i = 0; i < 32; i++) input[i] = (byte)i;
+        Assert.Equal(0x46DD794Eu, Crc32C.Compute(input));
+    }
+
+    [Fact]
+    public void OneBitDifference_ChangesCrc()
+    {
+        var a = new byte[] { 0x00 };
+        var b = new byte[] { 0x01 };
+        Assert.NotEqual(Crc32C.Compute(a), Crc32C.Compute(b));
+    }
+
+    [Fact]
+    public void Determinism_SameInputAlwaysSameOutput()
+    {
+        var input = System.Text.Encoding.UTF8.GetBytes("hello world");
+        Assert.Equal(Crc32C.Compute(input), Crc32C.Compute(input));
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogCrcTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogCrcTests.cs
@@ -1,0 +1,160 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using Side = B3.Exchange.Matching.Side;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #285: WAL records carry a Crc32C suffix; on read a record
+/// whose CRC does not match its bytes is dropped (counted via
+/// <see cref="FileChannelWriteAheadLog.LastReadCorruptCount"/>) and
+/// replay continues past it. Pre-#285 records (no CRC suffix) load
+/// as legacy and are counted via
+/// <see cref="FileChannelWriteAheadLog.LastReadLegacyCount"/>.
+/// </summary>
+public class FileChannelWriteAheadLogCrcTests
+{
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "wal-crc-" + Guid.NewGuid().ToString("N"));
+
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { } }
+    }
+
+    private static WalRecord MakeNew(long seq, ulong clOrdId)
+        => new(seq, WalRecordKind.NewOrder, "S", 1u, clOrdId, 0,
+            new NewOrderCommand(ClOrdId: clOrdId.ToString(), SecurityId: 1, Side: Side.Buy,
+                Type: OrderType.Limit, Tif: TimeInForce.Day, PriceMantissa: 100_0000,
+                Quantity: 10, EnteringFirm: 1u, EnteredAtNanos: 0),
+            null, null);
+
+    [Fact]
+    public void Append_Then_Read_RoundTrip_With_Crc()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        for (int i = 1; i <= 5; i++) wal.Append(MakeNew(i, (ulong)i));
+        var read = wal.ReadAll();
+        Assert.Equal(5, read.Count);
+        Assert.Equal(0, wal.LastReadCorruptCount);
+        Assert.Equal(0, wal.LastReadLegacyCount);
+    }
+
+    [Fact]
+    public void CorruptMiddleRecord_IsSkipped_AndReplayContinues()
+    {
+        using var dir = new TempDir();
+        var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
+        using (var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false))
+        {
+            for (int i = 1; i <= 3; i++) wal.Append(MakeNew(i, (ulong)i));
+        }
+        // Flip a single byte inside the JSON payload of the middle
+        // line to force a CRC mismatch on that record only.
+        var bytes = File.ReadAllBytes(walPath);
+        // Find the second '\n' and corrupt a byte midway in the
+        // second line's JSON (i.e. between the first \n and second \n).
+        int firstNl = Array.IndexOf(bytes, (byte)'\n');
+        int secondNl = Array.IndexOf(bytes, (byte)'\n', firstNl + 1);
+        Assert.True(firstNl >= 0 && secondNl > firstNl);
+        int target = firstNl + 5;
+        bytes[target] ^= 0xFF;
+        File.WriteAllBytes(walPath, bytes);
+
+        using var reread = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var records = reread.ReadAll();
+        Assert.Equal(2, records.Count);
+        Assert.Equal(1, reread.LastReadCorruptCount);
+        Assert.Equal(0, reread.LastReadLegacyCount);
+        // Records 1 and 3 survived; the corrupt one in the middle was skipped.
+        Assert.Contains(records, r => r.Seq == 1);
+        Assert.Contains(records, r => r.Seq == 3);
+        Assert.DoesNotContain(records, r => r.Seq == 2);
+    }
+
+    [Fact]
+    public void LegacyLine_NoCrcSuffix_IsAcceptedAndCounted()
+    {
+        using var dir = new TempDir();
+        var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
+        // Hand-craft a single legacy record (pre-#285 format: bare
+        // JSON + \n, no \t<crc>) so we exercise the migration path.
+        var rec = MakeNew(seq: 99, clOrdId: 99);
+        var json = System.Text.Json.JsonSerializer.Serialize(rec, new System.Text.Json.JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+        });
+        File.WriteAllText(walPath, json + "\n");
+
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var records = wal.ReadAll();
+        Assert.Single(records);
+        Assert.Equal(99L, records[0].Seq);
+        Assert.Equal(0, wal.LastReadCorruptCount);
+        Assert.Equal(1, wal.LastReadLegacyCount);
+    }
+
+    [Fact]
+    public void TornFinalLine_StopsReplay_PreservingPriorRecords()
+    {
+        using var dir = new TempDir();
+        var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
+        using (var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false))
+        {
+            wal.Append(MakeNew(1, 1));
+            wal.Append(MakeNew(2, 2));
+        }
+        // Append a half-written line (no terminator → readline still
+        // returns it as the final line; missing CRC suffix → falls to
+        // legacy parse → fails JSON → stops replay).
+        File.AppendAllText(walPath, "{\"Seq\":3,\"Kind\":");
+
+        using var reread = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var records = reread.ReadAll();
+        Assert.Equal(2, records.Count);
+        Assert.Equal(0, reread.LastReadCorruptCount);
+    }
+
+    [Fact]
+    public void LegacyAndModern_Mixed_SurvivesReplay()
+    {
+        using var dir = new TempDir();
+        var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
+        // Write a legacy record by hand, then append a modern one
+        // through the WAL writer.
+        var rec1 = MakeNew(1, 1);
+        var json1 = System.Text.Json.JsonSerializer.Serialize(rec1, new System.Text.Json.JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() },
+        });
+        File.WriteAllText(walPath, json1 + "\n");
+
+        using (var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false))
+        {
+            wal.Append(MakeNew(2, 2));
+        }
+
+        using var reread = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var records = reread.ReadAll();
+        Assert.Equal(2, records.Count);
+        Assert.Equal(1, reread.LastReadLegacyCount);
+        Assert.Equal(0, reread.LastReadCorruptCount);
+    }
+}


### PR DESCRIPTION
Closes #285.

## Why

Per the resilience runbook in PR #292, the WAL had no per-record integrity check: a single flipped byte mid-file would either parse-fail and silently truncate the rest of replay, or pass through corrupt data unnoticed. Same exposure on the binary snapshot file. This PR plugs both holes.

## What

- **Crc32C helper** — software Castagnoli Crc32C (polynomial `0x82F63B78`, reflected; 256-entry table). No new NuGet dep. RFC 3720 §B.4 vectors covered in tests.
- **WAL line format** — `<json>\t<8hex-crc>\n`. `Append` writes the suffix; `ReadAll` validates each record. CRC mismatch ⇒ log warning + bump `exch_wal_record_corruption_total` + **continue** (one bad byte no longer truncates the tail). Pre-#285 records (no suffix) flow through a legacy path and bump `exch_wal_records_legacy_total`. Torn final legacy line still stops replay (preserves the unclean-shutdown contract).
- **Binary snapshot codec** — `Encode` appends a 4-byte LE Crc32C footer over the full payload; `Decode` validates it. Files with no trailing 4 bytes (pre-#285 binary slots, dev-only at this stage) still load.
- **Metrics** — `exch_wal_record_corruption_total` and `exch_wal_records_legacy_total` exposed in `MetricsRegistry`, documented in RUNBOOK §7.3 / §7.4.

## Tests

- `Crc32CTests` — RFC 3720 vectors + determinism + bit-flip sensitivity.
- `FileChannelWriteAheadLogCrcTests` — round-trip, mid-file corruption is skipped, legacy line accepted, torn final still stops replay, mixed legacy+modern.
- `BinaryChannelStateSnapshotCodecCrcTests` — round-trip, payload corruption rejected, footer corruption rejected, legacy file (no footer) accepted, trailing garbage rejected.
- Pre-existing snapshot-size assertion bumped 41 → 45 bytes.

Full suite green; `dotnet format --verify-no-changes` clean.