### PR TITLE
feat(persistence): configurable WAL append-failure policy (#286)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -701,6 +701,8 @@ text format, `channel="{N}"` label on every series).
 | `exch_wal_truncations_total` | counter | WAL truncations (post-snapshot or admin-reset triggered). |
 | `exch_wal_record_corruption_total` | counter | WAL records dropped at replay because the per-record Crc32C did not match (bit-rot or external tampering). |
 | `exch_wal_records_legacy_total` | counter | WAL records replayed in pre-#285 (no Crc32C suffix) format. Steady-state should be `0` once every channel has rolled past the upgrade. |
+| `exch_wal_append_failures_total` | counter | WAL `Append` calls that threw (issue #286). Counted under both `continue` and `halt` policies; the canonical "WAL is failing" alert. |
+| `exch_wal_halt_rejects_total` | counter | Producer-side `Enqueue*` rejections after the channel was WAL-halted (issue #286). Always `0` unless the channel runs with `persistence.wal.onAppendFailure=halt`. |
 | `exch_owner_orphans_dropped_total` | counter | `OrderOwnerSnapshot` entries whose sessionId was not in the registry at restore time, dropped per `orphanSessionPolicy=drop`. |
 
 ### 7.4 On-disk layout & WAL design
@@ -763,6 +765,15 @@ intended behaviour for unclean shutdown.
    `exch_snapshot_save_failures_total`), replay stays sequential
    but takes proportionally longer. That is a saves-broken alert,
    not a replay-perf concern.
+
+**Append-failure policy** (issue #286): when
+`IChannelWriteAheadLog.Append` throws (disk full, EIO, permission
+flip), the channel honours `persistence.wal.onAppendFailure`:
+
+| Value | Behavior |
+| --- | --- |
+| `continue` (default) | Log + bump `exch_wal_append_failures_total`, then run the command. The live consumer view stays consistent, but the command is **not durable** — a host crash before the next snapshot will silently drop it on replay. |
+| `halt` | Log + bump `exch_wal_append_failures_total`, **refuse** the command (no engine mutation, no UMDF emission, no ExecutionReport), flip the channel's WAL-halt flag. The host's `wal-halt` readiness probe goes NOT_READY so load balancers drain new connections; subsequent `Enqueue*` calls are short-circuited and counted by `exch_wal_halt_rejects_total`. The halt is sticky — the operator must restart the host after fixing the underlying storage fault. |
 
 **Idempotency note:** if the newest snapshot is corrupt and the
 persister falls back to an older slot, replay starts from that

--- a/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
@@ -37,8 +37,26 @@ public sealed partial class ChannelDispatcher
         return act;
     }
 
+    /// <summary>
+    /// Issue #286: producer-side check used by every state-mutating
+    /// <c>Enqueue*</c> entry point. Returns <c>true</c> if the channel
+    /// is WAL-halted; the caller bumps
+    /// <c>exch_wal_halt_rejects_total</c>, returns <c>false</c> to the
+    /// upstream gateway (no work item is posted), and the operator
+    /// alert routes via the readiness probe + the rejection metric.
+    /// Cheap volatile read; called before any allocation.
+    /// </summary>
+    private bool RejectIfWalHalted(WorkKind kind)
+    {
+        if (Volatile.Read(ref _walHalted) == 0) return false;
+        _metrics?.IncWalHaltReject();
+        LogWalHalted(ChannelNumber, kind);
+        return true;
+    }
+
     public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue)
     {
+        if (RejectIfWalHalted(WorkKind.New)) return false;
         using var act = StartEnqueueSpan(WorkKind.New, session, enteringFirm, clOrdIdValue, cmd.SecurityId);
         var parent = act?.Context ?? System.Diagnostics.Activity.Current?.Context ?? default;
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.New, session, enteringFirm, true,
@@ -53,6 +71,7 @@ public sealed partial class ChannelDispatcher
     public bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
+        if (RejectIfWalHalted(WorkKind.Cancel)) return false;
         using var act = StartEnqueueSpan(WorkKind.Cancel, session, enteringFirm, clOrdIdValue, cmd.SecurityId);
         var parent = act?.Context ?? System.Diagnostics.Activity.Current?.Context ?? default;
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cancel, session, enteringFirm, true,
@@ -67,6 +86,7 @@ public sealed partial class ChannelDispatcher
     public bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm,
         ulong clOrdIdValue, ulong origClOrdIdValue)
     {
+        if (RejectIfWalHalted(WorkKind.Replace)) return false;
         using var act = StartEnqueueSpan(WorkKind.Replace, session, enteringFirm, clOrdIdValue, cmd.SecurityId);
         var parent = act?.Context ?? System.Diagnostics.Activity.Current?.Context ?? default;
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Replace, session, enteringFirm, true,

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -96,9 +96,17 @@ public sealed partial class ChannelDispatcher
         // resulting state is captured directly. _lastAppliedSeq is
         // advanced by WalAppendIfEnabled regardless, including in
         // replay mode, so the on-loop counter stays consistent.
+        // Issue #286: under WalAppendFailurePolicy.Halt the call
+        // returns false on the first append failure — the command
+        // must NOT reach the engine (state would diverge from the
+        // WAL on next replay). We bail out of ProcessOne entirely.
         if (item.Kind is WorkKind.New or WorkKind.Cancel or WorkKind.Replace)
         {
-            WalAppendIfEnabled(in item);
+            if (!WalAppendIfEnabled(in item))
+            {
+                _metrics?.IncWalHaltReject();
+                return;
+            }
         }
         bool succeeded = false;
         long engineStart = System.Diagnostics.Stopwatch.GetTimestamp();

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -23,14 +23,22 @@ public sealed partial class ChannelDispatcher
     /// engine observes the command. Called from <c>ProcessOne</c>
     /// before each <c>WorkKind.New</c> / <c>Cancel</c> /
     /// <c>Replace</c> branch.
+    ///
+    /// <para>Returns <c>true</c> when the caller may safely execute
+    /// the command. Returns <c>false</c> only when the configured
+    /// <see cref="WalAppendFailurePolicy"/> is
+    /// <see cref="WalAppendFailurePolicy.Halt"/> AND the append
+    /// threw — the command must be skipped (no engine mutation,
+    /// no UMDF emission, no ExecutionReport) and the channel is
+    /// permanently marked WAL-halted (issue #286).</para>
     /// </summary>
-    private void WalAppendIfEnabled(in WorkItem item)
+    private bool WalAppendIfEnabled(in WorkItem item)
     {
         // Always advance the applied counter so snapshot.LastAppliedSeq
         // is meaningful even when WAL is disabled (lets a future WAL
         // turn-on observe a sane "starting point").
         _lastAppliedSeq++;
-        if (_wal is null || _replayMode) return;
+        if (_wal is null || _replayMode) return true;
         WalRecord? rec = item.Kind switch
         {
             WorkKind.New when item.NewOrder is not null => new WalRecord(
@@ -50,7 +58,7 @@ public sealed partial class ChannelDispatcher
                 null, null, item.Replace),
             _ => null,
         };
-        if (rec is null) return;
+        if (rec is null) return true;
         try
         {
             // Best-effort byte accounting: Append re-serializes the
@@ -60,17 +68,38 @@ public sealed partial class ChannelDispatcher
             long approxBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(rec).Length + 1;
             _wal.Append(rec);
             _metrics?.IncWalAppend(approxBytes);
+            return true;
         }
         catch (Exception ex)
         {
-            // WAL append failure is a durability fault but not a
-            // correctness fault: log and continue. The dispatcher
-            // crash counter is bumped so operators alert on it; the
-            // command itself still runs so live consumers see no gap.
+            // Issue #286: track the WAL-specific append failure
+            // separately from the generic dispatcher crash counter so
+            // alert routing can target the persistence on-call story.
+            _metrics?.IncWalAppendFailure();
             _metrics?.IncDispatcherCrashes();
+            if (_walAppendFailurePolicy == WalAppendFailurePolicy.Halt)
+            {
+                // Sticky: the first failure flips the channel to
+                // halted; every subsequent producer-side enqueue and
+                // every readiness probe observe IsWalHealthy=false
+                // until the host is restarted. The command is not
+                // executed — the engine MUST NOT observe a mutation
+                // that did not reach the WAL, otherwise replay would
+                // diverge from the live consumer view.
+                Volatile.Write(ref _walHalted, 1);
+                _logger.LogCritical(ex,
+                    "channel {ChannelNumber}: WAL append failed (seq={Seq} kind={Kind}); WAL-halt policy → channel marked unhealthy and command refused; restart the host after resolving the storage fault",
+                    ChannelNumber, _lastAppliedSeq, item.Kind);
+                return false;
+            }
+            // Continue policy (default, pre-#286 behaviour): durability
+            // fault but not a correctness fault; let the command run so
+            // live consumers see no gap. Operators alert on the new
+            // exch_wal_append_failures_total counter.
             _logger.LogError(ex,
                 "channel {ChannelNumber}: WAL append failed (seq={Seq} kind={Kind}); command will run but is not durable",
                 ChannelNumber, _lastAppliedSeq, item.Kind);
+            return true;
         }
     }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -73,4 +73,8 @@ public sealed partial class ChannelDispatcher
     [LoggerMessage(EventId = 1004, Level = LogLevel.Error,
         Message = "channel {ChannelNumber} dispatcher work-item crash workKind={WorkKind} session={Session} firm={Firm} clOrdId={ClOrdId}")]
     private partial void LogDispatcherCrash(Exception ex, byte channelNumber, WorkKind workKind, string session, uint firm, ulong clOrdId);
+
+    [LoggerMessage(EventId = 1005, Level = LogLevel.Warning,
+        Message = "channel {ChannelNumber} rejecting {WorkKind} — channel WAL-halted (issue #286); restart host after resolving storage fault")]
+    private partial void LogWalHalted(byte channelNumber, WorkKind workKind);
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -146,6 +146,20 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// commands processed since the last snapshot are lost).
     /// </summary>
     private readonly IChannelWriteAheadLog? _wal;
+    /// <summary>
+    /// Issue #286: behaviour of <see cref="WalAppendIfEnabled"/> when
+    /// <see cref="IChannelWriteAheadLog.Append"/> throws. Captured from
+    /// the ctor; immutable for the dispatcher's lifetime.
+    /// </summary>
+    private readonly WalAppendFailurePolicy _walAppendFailurePolicy;
+    /// <summary>
+    /// Issue #286: sticky flag set on the first WAL append failure when
+    /// the policy is <see cref="WalAppendFailurePolicy.Halt"/>. Read from
+    /// any thread (Inbox short-circuit + readiness probe) — accessed via
+    /// <see cref="Volatile"/> for cross-thread visibility. Cleared only
+    /// by host restart.
+    /// </summary>
+    private int _walHalted;
     /// <summary>Monotonic per-channel command counter for the WAL
     /// (issue #269). Mutated only on the dispatch thread; persisted into
     /// <see cref="ChannelStateSnapshot.LastAppliedSeq"/> so the replay
@@ -228,6 +242,16 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     public SnapshotRotator? SnapshotRotator => _snapshotRotator;
 
+    /// <summary>
+    /// Issue #286: <c>false</c> once the channel has refused a WAL
+    /// append under <see cref="WalAppendFailurePolicy.Halt"/>. The
+    /// host's WAL readiness probe AND the producer-side
+    /// <c>Enqueue*</c> short-circuit consume this flag; both consumers
+    /// run off the dispatch thread, hence the
+    /// <see cref="Volatile.Read{T}"/>.
+    /// </summary>
+    public bool IsWalHealthy => Volatile.Read(ref _walHalted) == 0;
+
     public ChannelDispatcher(byte channelNumber, Func<IMatchingEventSink, MatchingEngine> engineFactory, IUmdfPacketSink packetSink,
         ICoreOutbound outbound,
         ILogger<ChannelDispatcher> logger,
@@ -239,6 +263,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         SnapshotThrottlePolicy? snapshotThrottle = null,
         bool useAsyncSnapshotWriter = false,
         IChannelWriteAheadLog? wal = null,
+        WalAppendFailurePolicy walAppendFailurePolicy = WalAppendFailurePolicy.Continue,
         Func<string, bool>? sessionExists = null,
         OrphanSessionPolicy orphanPolicy = OrphanSessionPolicy.Drop)
     {
@@ -257,6 +282,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _retxBuffer = retxBuffer;
         _persister = persister;
         _wal = wal;
+        _walAppendFailurePolicy = walAppendFailurePolicy;
         _sessionExists = sessionExists;
         _orphanPolicy = orphanPolicy;
         _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -181,6 +181,21 @@ public sealed class ChannelMetrics
     private long _walReplays;
     private long _walRecordCorruptions;
     private long _walRecordsLegacy;
+    /// <summary>
+    /// Issue #286: cumulative count of WAL <c>Append</c> calls that
+    /// threw. Bumped from <c>WalAppendIfEnabled</c> regardless of the
+    /// failure-policy in effect (so an alert can fire on the
+    /// <see cref="WalAppendFailurePolicy.Continue"/> path before a
+    /// crash exposes the silent durability gap).
+    /// </summary>
+    private long _walAppendFailures;
+    /// <summary>
+    /// Issue #286: cumulative count of producer-side
+    /// <c>Enqueue*</c> rejects after the channel has been WAL-halted.
+    /// Distinct from queue-full rejections so on-call can route the
+    /// alert correctly.
+    /// </summary>
+    private long _walHaltRejects;
     public long WalAppends => Interlocked.Read(ref _walAppends);
     public long WalBytesAppended => Interlocked.Read(ref _walBytesAppended);
     public long WalTruncations => Interlocked.Read(ref _walTruncations);
@@ -193,6 +208,15 @@ public sealed class ChannelMetrics
     /// (i.e. written by a pre-#285 host). Tracks the migration tail
     /// after upgrading.</summary>
     public long WalRecordsLegacy => Interlocked.Read(ref _walRecordsLegacy);
+    /// <summary>Issue #286: WAL <c>Append</c> calls that threw.
+    /// Counted under both <see cref="WalAppendFailurePolicy.Continue"/>
+    /// and <see cref="WalAppendFailurePolicy.Halt"/> so the metric is
+    /// the canonical "WAL is failing" alert signal.</summary>
+    public long WalAppendFailures => Interlocked.Read(ref _walAppendFailures);
+    /// <summary>Issue #286: <c>Enqueue*</c> rejections after the
+    /// dispatcher has been WAL-halted. Always 0 unless the channel is
+    /// configured with <see cref="WalAppendFailurePolicy.Halt"/>.</summary>
+    public long WalHaltRejects => Interlocked.Read(ref _walHaltRejects);
     public void IncWalAppend(long bytes)
     {
         Interlocked.Increment(ref _walAppends);
@@ -211,6 +235,8 @@ public sealed class ChannelMetrics
     {
         if (count > 0) Interlocked.Add(ref _walRecordsLegacy, count);
     }
+    public void IncWalAppendFailure() => Interlocked.Increment(ref _walAppendFailures);
+    public void IncWalHaltReject() => Interlocked.Increment(ref _walHaltRejects);
 
     public void IncSnapshotSaveOk() => Interlocked.Increment(ref _snapshotSavesOk);
     public void IncSnapshotSaveFailure() => Interlocked.Increment(ref _snapshotSaveFailures);
@@ -550,6 +576,12 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_wal_records_legacy_total",
             "Issue #285: WAL records read without a Crc32C suffix (i.e. written by a pre-#285 host). Tracks the migration tail after upgrading; should drift to zero once all pre-#285 records have been truncated by snapshot persists.",
             channels, c => c.WalRecordsLegacy);
+        EmitCounter(sb, "exch_wal_append_failures_total",
+            "Issue #286: WAL Append() calls that threw (disk full, EIO, permission flip, etc.). Counted under both the Continue and Halt failure policies — the canonical alert signal that the persistence layer is unhealthy on this channel.",
+            channels, c => c.WalAppendFailures);
+        EmitCounter(sb, "exch_wal_halt_rejects_total",
+            "Issue #286: producer-side Enqueue* rejections after the channel was WAL-halted. Always 0 unless the channel runs with persistence.wal.onAppendFailure=halt; non-zero means the operator must restart the host after fixing the underlying disk fault.",
+            channels, c => c.WalHaltRejects);
 
         // Issue #270: cross-channel consistency check. Counts owner
         // entries silently dropped at restore because their SessionId

--- a/src/B3.Exchange.Core/WalAppendFailurePolicy.cs
+++ b/src/B3.Exchange.Core/WalAppendFailurePolicy.cs
@@ -1,0 +1,34 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Policy for what the dispatcher does when the per-channel
+/// Write-Ahead Log refuses an <c>Append</c> call (disk full, EIO,
+/// permission flip — anything that throws out of
+/// <see cref="IChannelWriteAheadLog.Append"/>). Issue #286.
+///
+/// <para>The default <see cref="Continue"/> matches the pre-#286
+/// behaviour: log the failure, bump
+/// <c>exch_wal_append_failures_total</c>, and let the command
+/// execute against the engine. This favours availability — the
+/// live consumer view never sees a gap — at the cost of a window
+/// where the command is not durable: a host crash before the next
+/// successful snapshot will silently lose it on replay.</para>
+///
+/// <para><see cref="Halt"/> trades availability for durability: on
+/// the first failure the channel is marked WAL-halted, the
+/// dispatch loop refuses to execute the offending command (no
+/// engine mutation, no UMDF emission, no ExecutionReport), and the
+/// per-host readiness probe flips to NOT_READY so load balancers
+/// stop routing new connections. Subsequent
+/// <c>Enqueue*</c> calls are rejected at the producer side. The
+/// halt is sticky and clears only on host restart, after the
+/// operator has fixed the underlying disk fault.</para>
+/// </summary>
+public enum WalAppendFailurePolicy
+{
+    /// <summary>Log + metric, then run the command anyway (default).</summary>
+    Continue = 0,
+
+    /// <summary>Log + metric, refuse the command, mark the channel unhealthy.</summary>
+    Halt = 1,
+}

--- a/src/B3.Exchange.Core/WalHaltReadinessProbe.cs
+++ b/src/B3.Exchange.Core/WalHaltReadinessProbe.cs
@@ -1,0 +1,41 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #286: readiness probe that reports NOT_READY as soon as
+/// any of the channels passed at construction time has been
+/// WAL-halted (<see cref="ChannelDispatcher.IsWalHealthy"/>
+/// returned <c>false</c>). The host registers one of these per
+/// HTTP server when at least one channel runs with
+/// <see cref="WalAppendFailurePolicy.Halt"/>.
+///
+/// <para>The probe is read-only — the underlying flag is set
+/// inside the dispatch loop on the first failed
+/// <c>WAL.Append</c>. There is no path back to ready short of a
+/// host restart, so a load balancer that observes the probe
+/// flipping to NOT_READY drains the host while the operator
+/// resolves the storage fault.</para>
+/// </summary>
+public sealed class WalHaltReadinessProbe : IReadinessProbe
+{
+    private readonly IReadOnlyList<ChannelDispatcher> _dispatchers;
+
+    public WalHaltReadinessProbe(IReadOnlyList<ChannelDispatcher> dispatchers, string name = "wal-halt")
+    {
+        _dispatchers = dispatchers ?? throw new ArgumentNullException(nameof(dispatchers));
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    public bool IsReady
+    {
+        get
+        {
+            for (int i = 0; i < _dispatchers.Count; i++)
+            {
+                if (!_dispatchers[i].IsWalHealthy) return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -184,6 +184,7 @@ public sealed class ExchangeHost : IAsyncDisposable
                 snapshotThrottle: ch.Persistence?.Throttle?.ToPolicy(),
                 useAsyncSnapshotWriter: ch.Persistence?.AsyncWriter ?? false,
                 wal: wal,
+                walAppendFailurePolicy: ch.Persistence?.Wal?.ResolveOnAppendFailure() ?? B3.Exchange.Core.WalAppendFailurePolicy.Continue,
                 sessionExists: sessionExists,
                 orphanPolicy: orphanPolicy);
             disp.Start();
@@ -347,6 +348,16 @@ public sealed class ExchangeHost : IAsyncDisposable
                 action: () => _listener?.TerminateAllSessions("daily-reset"),
                 logger: _loggerFactory.CreateLogger<DailyResetScheduler>());
             _dailyReset.Start();
+        }
+
+        // Issue #286: register a WAL-halt probe iff at least one
+        // channel runs with WalAppendFailurePolicy.Halt. Keeping the
+        // probe optional means deployments that opt out of the halt
+        // semantics never see the probe in /health/ready output.
+        if (_config.Channels.Any(c => c.Persistence?.Wal is { } w
+            && w.ResolveOnAppendFailure() == B3.Exchange.Core.WalAppendFailurePolicy.Halt))
+        {
+            RegisterReadinessProbe(new B3.Exchange.Core.WalHaltReadinessProbe(_dispatchers));
         }
 
         _startupProbe.MarkReady();

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -349,6 +349,32 @@ public sealed class WalConfig
     /// throughput on workloads that tolerate losing the last few
     /// commands on a host crash.</summary>
     [JsonPropertyName("fsyncPerWrite")] public bool FsyncPerWrite { get; set; } = true;
+
+    /// <summary>Issue #286: behaviour when <c>Append</c> throws.
+    /// Default <c>continue</c> preserves the pre-#286 contract — the
+    /// failure is logged + counted via
+    /// <c>exch_wal_append_failures_total</c>, and the command runs
+    /// against the engine even though it is not durable. Set to
+    /// <c>halt</c> to refuse the command (no engine mutation, no
+    /// UMDF emission, no ExecutionReport) and flip the host's
+    /// readiness probe to NOT_READY on the first failure; the halt
+    /// is sticky and clears only on host restart.</summary>
+    [JsonPropertyName("onAppendFailure")] public string OnAppendFailure { get; set; } = "continue";
+
+    /// <summary>
+    /// Parses <see cref="OnAppendFailure"/> case-insensitively to
+    /// the typed enum. Throws on unknown values so misconfiguration
+    /// fails the boot rather than silently degrading to the wrong
+    /// policy.
+    /// </summary>
+    public B3.Exchange.Core.WalAppendFailurePolicy ResolveOnAppendFailure() =>
+        OnAppendFailure?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "continue" => B3.Exchange.Core.WalAppendFailurePolicy.Continue,
+            "halt" => B3.Exchange.Core.WalAppendFailurePolicy.Halt,
+            _ => throw new InvalidOperationException(
+                $"persistence.wal.onAppendFailure: unknown value '{OnAppendFailure}' (expected 'continue' or 'halt')"),
+        };
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
@@ -1,0 +1,187 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrderType = B3.Exchange.Matching.OrderType;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #286: <see cref="WalAppendFailurePolicy"/> end-to-end
+/// behaviour. <c>Continue</c> (the historical default) lets the
+/// command run despite a WAL append failure; <c>Halt</c> refuses
+/// the command, marks the channel unhealthy, and short-circuits
+/// every subsequent producer-side enqueue.
+/// </summary>
+public class WalAppendFailurePolicyTests
+{
+    private const long Sec = 900_000_000_002L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class CountingOutbound : ICoreOutbound
+    {
+        public int NewCount;
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue)
+        { NewCount++; return true; }
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+    }
+
+    private sealed class FailingWal : IChannelWriteAheadLog
+    {
+        public int AppendCalls;
+        public void Append(WalRecord record)
+        {
+            AppendCalls++;
+            throw new IOException("simulated disk failure");
+        }
+        public IReadOnlyList<WalRecord> ReadAll() => Array.Empty<WalRecord>();
+        public void Truncate() { }
+        public void Dispose() { }
+    }
+
+    private static ChannelDispatcher BuildDispatcher(
+        IChannelWriteAheadLog wal,
+        WalAppendFailurePolicy policy,
+        out CountingOutbound outbound,
+        ChannelMetrics? metrics = null)
+    {
+        var sink = new NoOpPacketSink();
+        var localOutbound = outbound = new CountingOutbound();
+        return new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s,
+                NullLogger<MatchingEngine>.Instance),
+            packetSink: sink,
+            outbound: localOutbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            metrics: metrics,
+            wal: wal,
+            walAppendFailurePolicy: policy);
+    }
+
+    private static bool EnqueueOrder(ChannelDispatcher disp, ulong clOrdIdValue)
+        => disp.EnqueueNewOrder(
+            new NewOrderCommand(clOrdIdValue.ToString(), Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 700u, EnteredAtNanos: 0),
+            new SessionId("S1"), enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+
+    [Fact]
+    public async Task Continue_OnWalFailure_RunsCommand_AndStaysHealthy()
+    {
+        var wal = new FailingWal();
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(wal, WalAppendFailurePolicy.Continue, out var outbound, metrics);
+        try
+        {
+            disp.Start();
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 1));
+            await WaitForAsync(() => wal.AppendCalls >= 1 && outbound.NewCount >= 1);
+
+            Assert.Equal(1, wal.AppendCalls);
+            Assert.Equal(1, outbound.NewCount);
+            Assert.Equal(1, metrics.WalAppendFailures);
+            Assert.Equal(0, metrics.WalHaltRejects);
+            Assert.True(disp.IsWalHealthy);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Halt_OnWalFailure_RefusesCommand_FlipsHealthAndShortCircuits()
+    {
+        var wal = new FailingWal();
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(wal, WalAppendFailurePolicy.Halt, out var outbound, metrics);
+        try
+        {
+            disp.Start();
+
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 1));
+            await WaitForAsync(() => !disp.IsWalHealthy);
+
+            Assert.Equal(1, wal.AppendCalls);
+            Assert.Equal(0, outbound.NewCount); // engine was NOT touched
+            Assert.False(disp.IsWalHealthy);
+            Assert.Equal(1, metrics.WalAppendFailures);
+            Assert.True(metrics.WalHaltRejects >= 1);
+
+            // Subsequent enqueues are rejected at the producer side
+            // (no work item posted, no Append call).
+            Assert.False(EnqueueOrder(disp, clOrdIdValue: 2));
+            Assert.False(EnqueueOrder(disp, clOrdIdValue: 3));
+            Assert.Equal(1, wal.AppendCalls); // still only the first one
+            Assert.True(metrics.WalHaltRejects >= 3);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task WalHaltReadinessProbe_Reports_NotReady_When_AnyChannelHalted()
+    {
+        var wal = new FailingWal();
+        var disp = BuildDispatcher(wal, WalAppendFailurePolicy.Halt, out _);
+        try
+        {
+            var probe = new WalHaltReadinessProbe(new[] { disp });
+            Assert.True(probe.IsReady);
+
+            disp.Start();
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 1));
+            // Wait for the dispatch loop to consume the item and trip
+            // the halt flag.
+            for (int i = 0; i < 50 && disp.IsWalHealthy; i++)
+            {
+                await Task.Delay(20);
+            }
+            Assert.False(disp.IsWalHealthy);
+            Assert.False(probe.IsReady);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
Closes #286.

## Why

Pre-#286, a WAL `Append` failure logged + bumped a generic crash counter and **let the command execute anyway**. The ExecutionReport reached the client and the UMDF packet hit the multicast bus, but the record was not durable — silent divergence between the live consumer view and the post-crash recovered state. Issue #286 adds a configurable policy so durability-first deployments can opt into hard-stop on the first failure.

## What

- **`WalAppendFailurePolicy` enum** (`Continue`, `Halt`) — `Continue` is the historical default and changes nothing for existing deployments.
- **`ChannelDispatcher`** takes the policy via ctor. On a halt-mode WAL failure: sticky `Volatile`-written `_walHalted` flag, command refused (no engine mutation, no UMDF emission, no ExecutionReport), and every subsequent `EnqueueNewOrder` / `EnqueueCancel` / `EnqueueReplace` short-circuits with a counted reject.
- **`IsWalHealthy`** property + **`WalHaltReadinessProbe`** registered in the host's `/health/ready` chain (only when at least one channel runs with `halt`). Probe goes NOT_READY on the first failure; halt is sticky and clears only on host restart.
- **Metrics**: `exch_wal_append_failures_total` (the canonical 'WAL is failing' alert — bumped under both policies, separate from the generic dispatcher-crash counter so on-call routes correctly) and `exch_wal_halt_rejects_total` (always 0 under `continue`).
- **Config**: `persistence.wal.onAppendFailure: continue | halt` with case-insensitive parsing; unknown values fail the boot.
- **RUNBOOK** §7.3 metrics rows + §7.4 policy table.

## Tests

- `Continue_OnWalFailure_RunsCommand_AndStaysHealthy` — Append throws, command still runs, channel stays healthy, only `exch_wal_append_failures_total` bumps.
- `Halt_OnWalFailure_RefusesCommand_FlipsHealthAndShortCircuits` — Append throws, command refused (`outbound.NewCount==0`), channel flips unhealthy, subsequent enqueues are rejected at the producer side without invoking the WAL.
- `WalHaltReadinessProbe_Reports_NotReady_When_AnyChannelHalted` — probe wiring.

Full suite green; `dotnet format --verify-no-changes` clean.