### PR TITLE
feat(metrics): FIXP RetransmitBuffer dimensioning observability (#288)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -842,6 +842,33 @@ the primary recovery for these scenarios. The protocol offers a
 proper remediation (`RetransmitRequest`); the simulator's job is to
 make that remediation succeed.
 
+#### 7.5.1 Dimensioning observability — issue [#288](https://github.com/pedrosakuma/B3MatchingPlatform/issues/288)
+
+Four metrics make the `(outboundRetransmitCapacity,
+SuspendedTimeoutMs, fill rate)` tuple a measurable property of the
+running system instead of a guess:
+
+| Metric | Type | Cardinality | What to alert on |
+| --- | --- | --- | --- |
+| `exch_fixp_retransmit_buffer_evictions_total` | counter | process | **Any non-zero rate** ⇒ at least one session lost replayable history. Bump `outboundRetransmitCapacity` or shorten `SuspendedTimeoutMs`. |
+| `exch_fixp_passive_er_buffered_total` | counter | process | Informational — total `ExecutionReport`s buffered while the owning session was `Suspended`. Sustained growth without matching `exch_session_rebound_total` ⇒ disconnects becoming reaps. |
+| `exch_fixp_retransmit_buffer_utilization` | gauge (0..1) | **per-session** (opt-in) | `>0.8` for any session ⇒ undersized ring for that firm's burst pattern. |
+| `exch_session_reaped_total` (existing, [#70](https://github.com/pedrosakuma/B3MatchingPlatform/issues/70)) | counter | process | Non-zero ⇒ at least one `Suspended` session crossed `SuspendedTimeoutMs` and was dropped; downstream firm needs `OrderMassStatus` on reconnect. |
+
+The per-session utilization gauge is **off by default** to keep
+scrape cardinality bounded on deployments that cycle through many
+short-lived FIXP sessions. Opt in via:
+
+```jsonc
+{
+  "metrics": { "fixpSessionLabelsEnabled": true }
+}
+```
+
+The aggregate counters above are always emitted regardless of
+this flag, so the eviction-rate alert remains low-cost in every
+deployment.
+
 ### 7.6 Disaster recovery — backup / restore
 
 The persisted state for a channel is everything matching

--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -73,3 +73,36 @@ public sealed class TransportMetrics
 
     public void IncSendQueueFull() => Interlocked.Increment(ref _sendQueueFull);
 }
+
+/// <summary>
+/// Process-wide counters for the per-session FIXP RetransmitBuffer
+/// dimensioning (issue #288). The May 2026 disconnect/reattach review
+/// identified <c>(buffer capacity, SuspendedTimeoutMs, fill rate while
+/// disconnected)</c> as the dimensioning tuple for a successful reattach;
+/// without these counters, an undersized ring is only discovered when a
+/// peer fails to reattach — too late.
+///
+/// <list type="bullet">
+///   <item><see cref="BufferEvictions"/>: every tick is a sequence number
+///         that is no longer replayable. Each tick is a potential reattach
+///         failure if the peer requests it.</item>
+///   <item><see cref="PassiveErBuffered"/>: outbound frames the encoder
+///         appended to the ring while the session was Suspended (the
+///         issue #217 path). Quantifies "how much reattach traffic is
+///         post-disconnect catch-up?".</item>
+/// </list>
+///
+/// <para>Lives in <c>B3.Exchange.Contracts</c> so the Gateway can consume
+/// the type without taking a project reference on Core.</para>
+/// </summary>
+public sealed class RetransmitMetrics
+{
+    private long _bufferEvictions;
+    private long _passiveErBuffered;
+
+    public long BufferEvictions => Interlocked.Read(ref _bufferEvictions);
+    public long PassiveErBuffered => Interlocked.Read(ref _passiveErBuffered);
+
+    public void IncBufferEvictions() => Interlocked.Increment(ref _bufferEvictions);
+    public void IncPassiveErBuffered() => Interlocked.Increment(ref _passiveErBuffered);
+}

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -321,7 +321,16 @@ public readonly record struct SessionDiagnostics(
     int RetxBufferDepth,
     long SendQueueDepth,
     string? AttachedTransportId,
-    long LastActivityAtMs);
+    long LastActivityAtMs)
+{
+    /// <summary>
+    /// Capacity of the per-session FIXP retransmit ring. Combined with
+    /// <see cref="RetxBufferDepth"/> lets the Prometheus renderer expose
+    /// a 0..1 utilization gauge (issue #288). Zero means "unknown / not
+    /// reported by the provider"; treated as "skip the gauge sample".
+    /// </summary>
+    public int RetxBufferCapacity { get; init; }
+}
 
 /// <summary>
 /// Static identity for a participant (corretora). Mirror of the
@@ -344,11 +353,30 @@ public sealed class MetricsRegistry
     private readonly SessionLifecycleMetrics _sessionLifecycle = new();
     private readonly ThrottleMetrics _throttle = new();
     private readonly TransportMetrics _transport = new();
+    private readonly RetransmitMetrics _retransmit = new();
     private readonly BoundedSessionFirmCounters _sessionFirmMessages = new();
 
     public SessionLifecycleMetrics Sessions => _sessionLifecycle;
     public ThrottleMetrics Throttle => _throttle;
     public TransportMetrics Transport => _transport;
+
+    /// <summary>
+    /// Issue #288: process-wide RetransmitBuffer counters
+    /// (per-session-ring evictions and Suspended-state appends). The
+    /// per-session utilization gauge is rendered separately, gated by
+    /// <see cref="EmitFixpSessionLabels"/>.
+    /// </summary>
+    public RetransmitMetrics Retransmit => _retransmit;
+
+    /// <summary>
+    /// Issue #288: when <c>true</c>, the Prometheus renderer emits
+    /// <c>exch_fixp_retransmit_buffer_utilization</c> with a per-session
+    /// label. Default <c>false</c> so deployments with many short-lived
+    /// sessions do not blow up scrape cardinality. The aggregate counters
+    /// (<c>exch_fixp_retransmit_buffer_evictions_total</c>,
+    /// <c>exch_fixp_passive_er_buffered_total</c>) are always emitted.
+    /// </summary>
+    public bool EmitFixpSessionLabels { get; set; }
 
     /// <summary>
     /// Bounded-cardinality per-firm/per-session inbound message counters
@@ -504,6 +532,35 @@ public sealed class MetricsRegistry
         EmitProcessCounter(sb, "exch_transport_send_queue_full_total",
             "Total times the gateway's TcpTransport closed a session because its bounded outbound send queue overflowed (issue #155). A non-zero value means a stuck/slow consumer is causing teardowns — alert.",
             _transport.SendQueueFull);
+
+        // Issue #288: FIXP RetransmitBuffer dimensioning observability.
+        // Aggregate counters are always emitted; the per-session
+        // utilization gauge below is gated by EmitFixpSessionLabels to
+        // protect scrape cardinality on deployments with many short-lived
+        // sessions.
+        EmitProcessCounter(sb, "exch_fixp_retransmit_buffer_evictions_total",
+            "Total per-session FIXP RetransmitBuffer evictions (the ring was full when a new outbound business frame was appended). Each eviction drops a sequence number that can no longer be replayed; a non-zero rate means the configured RetransmitBufferCapacity is too small for the workload's disconnect-window fill rate (issue #288).",
+            _retransmit.BufferEvictions);
+        EmitProcessCounter(sb, "exch_fixp_passive_er_buffered_total",
+            "Total outbound FIXP business frames appended to a per-session RetransmitBuffer while the session was Suspended (the issue #217 path: passive ExecutionReports keep being encoded after the transport drops, awaiting a reattach + RetransmitRequest). Quantifies how much reattach traffic is post-disconnect catch-up (issue #288).",
+            _retransmit.PassiveErBuffered);
+        if (EmitFixpSessionLabels && sessionSnap.Length > 0)
+        {
+            sb.Append("# HELP exch_fixp_retransmit_buffer_utilization Per-session ratio of buffered frames to RetransmitBufferCapacity (0.0..1.0). Combined with exch_fixp_retransmit_buffer_evictions_total this is the dimensioning signal for issue #288. Per-session labels are opt-in; enable via metrics.fixpSessionLabelsEnabled.\n");
+            sb.Append("# TYPE exch_fixp_retransmit_buffer_utilization gauge\n");
+            foreach (var s in sessionSnap)
+            {
+                if (s.RetxBufferCapacity <= 0) continue;
+                double util = (double)s.RetxBufferDepth / s.RetxBufferCapacity;
+                sb.Append("exch_fixp_retransmit_buffer_utilization{session=\"")
+                  .Append(EscapeLabel(s.SessionId))
+                  .Append("\",firm=\"")
+                  .Append(EscapeLabel(s.FirmId))
+                  .Append("\"} ")
+                  .Append(util.ToString("0.######", CultureInfo.InvariantCulture))
+                  .Append('\n');
+            }
+        }
 
         // Issue #173: latency histograms. Per-channel buckets in seconds;
         // observed via Stopwatch.GetTimestamp() at the dispatcher

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -28,6 +28,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly NegotiationValidator? _negotiationValidator;
     private readonly SessionClaimRegistry? _sessionClaims;
     private readonly EstablishValidator? _establishValidator;
+    private readonly B3.Exchange.Contracts.RetransmitMetrics? _retransmitMetrics;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
@@ -62,7 +63,8 @@ public sealed class EntryPointListener : IAsyncDisposable
         Action<FixpSession, string>? onSessionClosed = null,
         NegotiationValidator? negotiationValidator = null,
         SessionClaimRegistry? sessionClaims = null,
-        EstablishValidator? establishValidator = null)
+        EstablishValidator? establishValidator = null,
+        B3.Exchange.Contracts.RetransmitMetrics? retransmitMetrics = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(registry);
@@ -78,6 +80,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         _negotiationValidator = negotiationValidator;
         _sessionClaims = sessionClaims;
         _establishValidator = establishValidator;
+        _retransmitMetrics = retransmitMetrics;
         if ((_negotiationValidator is null) ^ (_sessionClaims is null))
         {
             throw new ArgumentException(
@@ -427,7 +430,8 @@ public sealed class EntryPointListener : IAsyncDisposable
             options: _sessionOptions, onClosed: onClosed,
             negotiationValidator: _negotiationValidator,
             sessionClaims: _sessionClaims,
-            establishValidator: _establishValidator);
+            establishValidator: _establishValidator,
+            retransmitMetrics: _retransmitMetrics);
         _registry.Register(session);
         lock (_lock) _sessions.Add(session);
         session.Start();

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -228,6 +228,12 @@ public sealed partial class FixpSession : IAsyncDisposable
     /// in response to a <c>RetransmitRequest</c>. Diagnostic only.</summary>
     public int RetxBufferDepth => _retxBuffer.Count;
 
+    /// <summary>Capacity of the per-session FIXP retransmit ring. Combined
+    /// with <see cref="RetxBufferDepth"/> drives the
+    /// <c>exch_fixp_retransmit_buffer_utilization</c> gauge (issue #288).
+    /// Diagnostic only.</summary>
+    public int RetxBufferCapacity => _retxBuffer.Capacity;
+
     /// <summary>Last allocated outbound MsgSeqNum (the value the next
     /// emitted business frame's <c>NextMsgSeqNum()</c> call will return
     /// is <c>OutboundSeq + 1</c>). Diagnostic only.</summary>
@@ -266,7 +272,8 @@ public sealed partial class FixpSession : IAsyncDisposable
         NegotiationValidator? negotiationValidator = null,
         SessionClaimRegistry? sessionClaims = null,
         EstablishValidator? establishValidator = null,
-        Func<long>? nowMs = null)
+        Func<long>? nowMs = null,
+        B3.Exchange.Contracts.RetransmitMetrics? retransmitMetrics = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ConnectionId = connectionId;
@@ -281,7 +288,13 @@ public sealed partial class FixpSession : IAsyncDisposable
         _nowMs = nowMs ?? (() => Environment.TickCount64);
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
-        _retxBuffer = new RetransmitBuffer(_options.RetransmitBufferCapacity);
+        // Issue #288: feed the per-session ring with the process-wide
+        // RetransmitMetrics + a "currently Suspended?" predicate so the
+        // outbound encoder can attribute frames buffered while the
+        // transport is down (the #217 path).
+        _retxBuffer = new RetransmitBuffer(_options.RetransmitBufferCapacity,
+            metrics: retransmitMetrics,
+            isSuspended: () => State == FixpState.Suspended);
         _outboundEncoder = new FixpOutboundEncoder(
             sessionId: () => SessionId,
             nextMsgSeqNum: NextMsgSeqNum,

--- a/src/B3.Exchange.Gateway/RetransmitBuffer.cs
+++ b/src/B3.Exchange.Gateway/RetransmitBuffer.cs
@@ -46,6 +46,8 @@ internal sealed class RetransmitBuffer
     private readonly object _lock = new();
     private readonly byte[]?[] _frames;
     private readonly uint[] _seqs;
+    private readonly B3.Exchange.Contracts.RetransmitMetrics? _metrics;
+    private readonly Func<bool>? _isSuspended;
     private int _head;        // next write index
     private int _count;
     private uint _lastSeq;
@@ -53,30 +55,57 @@ internal sealed class RetransmitBuffer
     public int Capacity { get; }
 
     public RetransmitBuffer(int capacity)
+        : this(capacity, metrics: null, isSuspended: null)
+    {
+    }
+
+    /// <summary>
+    /// Issue #288 overload: the optional <paramref name="metrics"/> sink
+    /// receives a tick on every full-ring eviction
+    /// (<see cref="B3.Exchange.Contracts.RetransmitMetrics.IncBufferEvictions"/>)
+    /// and on every Append observed while
+    /// <paramref name="isSuspended"/> returns <c>true</c>
+    /// (<see cref="B3.Exchange.Contracts.RetransmitMetrics.IncPassiveErBuffered"/>).
+    /// Both callbacks may be <c>null</c> in tests / standalone use.
+    /// </summary>
+    public RetransmitBuffer(int capacity,
+        B3.Exchange.Contracts.RetransmitMetrics? metrics,
+        Func<bool>? isSuspended)
     {
         if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
         Capacity = capacity;
         _frames = new byte[]?[capacity];
         _seqs = new uint[capacity];
+        _metrics = metrics;
+        _isSuspended = isSuspended;
     }
 
     /// <summary>
     /// Appends a wire frame (SOFH+SBE+body) to the buffer at the given
     /// sequence number. The buffer takes a reference; do not mutate
     /// <paramref name="frame"/> after calling. Evicts the oldest entry
-    /// if the buffer is full.
+    /// if the buffer is full (and bumps
+    /// <see cref="B3.Exchange.Contracts.RetransmitMetrics.BufferEvictions"/>
+    /// for issue #288 alerting).
     /// </summary>
     public void Append(uint seq, byte[] frame)
     {
         ArgumentNullException.ThrowIfNull(frame);
+        bool evicted;
         lock (_lock)
         {
+            evicted = _count == Capacity;
             _frames[_head] = frame;
             _seqs[_head] = seq;
             _head = (_head + 1) % Capacity;
             if (_count < Capacity) _count++;
             _lastSeq = seq;
         }
+        // Issue #288: surface eviction + suspended-write counters outside
+        // the lock so a slow metrics consumer cannot back-pressure the
+        // outbound encoder. Both checks are best-effort.
+        if (evicted) _metrics?.IncBufferEvictions();
+        if (_isSuspended is { } cb && cb()) _metrics?.IncPassiveErBuffered();
     }
 
     /// <summary>Snapshot of the lowest seq currently retained, or 0 if

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -305,9 +305,15 @@ public sealed class ExchangeHost : IAsyncDisposable
             onSessionClosed: (s, reason) => _logger.LogInformation("session {ConnectionId} closed: {Reason}", s.ConnectionId, reason),
             negotiationValidator: requireHandshake ? negotiationValidator : null,
             sessionClaims: requireHandshake ? sessionClaims : null,
-            establishValidator: requireHandshake ? establishValidator : null);
+            establishValidator: requireHandshake ? establishValidator : null,
+            retransmitMetrics: _metrics.Retransmit);
         _listener.Start();
         _logger.LogInformation("entrypoint listening on {Endpoint}", _listener.LocalEndpoint);
+
+        // Issue #288: opt-in per-session label cardinality for the
+        // RetransmitBuffer utilization gauge.
+        if (_config.Metrics?.FixpSessionLabelsEnabled == true)
+            _metrics.EmitFixpSessionLabels = true;
 
         var sessionProvider = new ListenerSessionProvider(_listener, firmRegistry);
         _metrics.SetSessionProvider(sessionProvider);
@@ -395,7 +401,10 @@ public sealed class ExchangeHost : IAsyncDisposable
                     RetxBufferDepth: s.RetxBufferDepth,
                     SendQueueDepth: s.SendQueueDepth,
                     AttachedTransportId: s.AttachedTransportId,
-                    LastActivityAtMs: s.LastActivityAtMs);
+                    LastActivityAtMs: s.LastActivityAtMs)
+                {
+                    RetxBufferCapacity = s.RetxBufferCapacity,
+                };
             }
         }
     }

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -18,6 +18,31 @@ public sealed class HostConfig
     [JsonPropertyName("dailyReset")] public DailyResetConfig? DailyReset { get; set; }
     [JsonPropertyName("shutdown")] public ShutdownConfig Shutdown { get; set; } = new();
     [JsonPropertyName("channels")] public List<ChannelConfig> Channels { get; set; } = new();
+
+    /// <summary>
+    /// Issue #288: optional metrics-rendering tunables (per-session label
+    /// gates, etc). Omit to keep all defaults. Today only controls
+    /// <see cref="MetricsConfig.FixpSessionLabelsEnabled"/>.
+    /// </summary>
+    [JsonPropertyName("metrics")] public MetricsConfig? Metrics { get; set; }
+}
+
+/// <summary>
+/// Issue #288: gates for metrics that carry per-session labels. Per-session
+/// cardinality can blow up scrape size on deployments where firms cycle
+/// through many short-lived FIXP sessions; opt in only when the operator
+/// explicitly accepts that cost.
+/// </summary>
+public sealed class MetricsConfig
+{
+    /// <summary>
+    /// When <c>true</c>, the Prometheus renderer emits the
+    /// <c>exch_fixp_retransmit_buffer_utilization</c> gauge with a
+    /// per-session label. Default <c>false</c>; the aggregate counters
+    /// (<c>exch_fixp_retransmit_buffer_evictions_total</c>,
+    /// <c>exch_fixp_passive_er_buffered_total</c>) are always emitted.
+    /// </summary>
+    [JsonPropertyName("fixpSessionLabelsEnabled")] public bool FixpSessionLabelsEnabled { get; set; }
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -376,6 +376,75 @@ public class MetricsRegistryTests
         Assert.Equal(2, inner.PublishCount);
     }
 
+    [Fact]
+    public void Issue288_RetransmitCounters_AreRenderedEvenAtZero()
+    {
+        // Aggregate counters must be present at t=0 so alert rules can
+        // be written before the first eviction or first Suspended-state
+        // append happens.
+        var reg = new MetricsRegistry();
+        var text = reg.RenderProm();
+        Assert.Contains("# TYPE exch_fixp_retransmit_buffer_evictions_total counter\n", text);
+        Assert.Contains("exch_fixp_retransmit_buffer_evictions_total 0\n", text);
+        Assert.Contains("# TYPE exch_fixp_passive_er_buffered_total counter\n", text);
+        Assert.Contains("exch_fixp_passive_er_buffered_total 0\n", text);
+    }
+
+    [Fact]
+    public void Issue288_RetransmitCounters_RenderObservedTotals()
+    {
+        var reg = new MetricsRegistry();
+        reg.Retransmit.IncBufferEvictions();
+        reg.Retransmit.IncBufferEvictions();
+        reg.Retransmit.IncBufferEvictions();
+        reg.Retransmit.IncPassiveErBuffered();
+        var text = reg.RenderProm();
+        Assert.Contains("exch_fixp_retransmit_buffer_evictions_total 3\n", text);
+        Assert.Contains("exch_fixp_passive_er_buffered_total 1\n", text);
+    }
+
+    [Fact]
+    public void Issue288_FixpUtilizationGauge_OmittedByDefault_EvenWithSessions()
+    {
+        // Per-session label cardinality is opt-in via
+        // EmitFixpSessionLabels. Default deployments should not see the
+        // utilization gauge regardless of how many sessions are live.
+        var reg = new MetricsRegistry();
+        reg.SetSessionProvider(new StubSessionProvider(new[]
+        {
+            new SessionDiagnostics(
+                SessionId: "conn-1", FirmId: "F1", State: 2, SessionVerId: 1,
+                OutboundSeq: 50, InboundExpectedSeq: 1, RetxBufferDepth: 50,
+                SendQueueDepth: 0, AttachedTransportId: null, LastActivityAtMs: 0)
+            { RetxBufferCapacity = 100 },
+        }));
+        var text = reg.RenderProm();
+        Assert.DoesNotContain("exch_fixp_retransmit_buffer_utilization", text);
+    }
+
+    [Fact]
+    public void Issue288_FixpUtilizationGauge_EmittedWhenLabelsEnabled()
+    {
+        var reg = new MetricsRegistry { EmitFixpSessionLabels = true };
+        reg.SetSessionProvider(new StubSessionProvider(new[]
+        {
+            new SessionDiagnostics(
+                SessionId: "conn-1", FirmId: "F1", State: 2, SessionVerId: 1,
+                OutboundSeq: 75, InboundExpectedSeq: 1, RetxBufferDepth: 75,
+                SendQueueDepth: 0, AttachedTransportId: null, LastActivityAtMs: 0)
+            { RetxBufferCapacity = 100 },
+            // Capacity 0 => gauge skipped entirely (avoids div-by-zero).
+            new SessionDiagnostics(
+                SessionId: "conn-2", FirmId: "F2", State: 2, SessionVerId: 1,
+                OutboundSeq: 0, InboundExpectedSeq: 1, RetxBufferDepth: 0,
+                SendQueueDepth: 0, AttachedTransportId: null, LastActivityAtMs: 0),
+        }));
+        var text = reg.RenderProm();
+        Assert.Contains("# TYPE exch_fixp_retransmit_buffer_utilization gauge\n", text);
+        Assert.Contains("exch_fixp_retransmit_buffer_utilization{session=\"conn-1\",firm=\"F1\"} 0.75\n", text);
+        Assert.DoesNotContain("session=\"conn-2\"", text.Substring(text.IndexOf("exch_fixp_retransmit_buffer_utilization", StringComparison.Ordinal)));
+    }
+
     private sealed class CapturingSink : IUmdfPacketSink
     {
         public int PublishCount;

--- a/tests/B3.Exchange.Gateway.Tests/RetransmitBufferTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/RetransmitBufferTests.cs
@@ -127,4 +127,66 @@ public class RetransmitBufferTests
         var snap = buf.TryGet(uint.MaxValue, 5);
         Assert.Equal(B3.Entrypoint.Fixp.Sbe.V6.RetransmitRejectCode.INVALID_FROMSEQNO, snap.RejectCode);
     }
+
+    // Issue #288: dimensioning observability tests.
+
+    [Fact]
+    public void Append_below_capacity_does_not_increment_evictions()
+    {
+        var metrics = new B3.Exchange.Contracts.RetransmitMetrics();
+        var buf = new RetransmitBuffer(4, metrics, isSuspended: null);
+        for (uint i = 1; i <= 4; i++) buf.Append(i, FrameWithSeq(i));
+        Assert.Equal(0L, metrics.BufferEvictions);
+    }
+
+    [Fact]
+    public void Append_past_capacity_increments_eviction_counter_per_overflow()
+    {
+        var metrics = new B3.Exchange.Contracts.RetransmitMetrics();
+        var buf = new RetransmitBuffer(3, metrics, isSuspended: null);
+        // First 3 fill the ring without eviction; next 4 each evict one.
+        for (uint i = 1; i <= 7; i++) buf.Append(i, FrameWithSeq(i));
+        Assert.Equal(4L, metrics.BufferEvictions);
+        // Window should have advanced; ring still satisfies the contract.
+        Assert.Equal(5u, buf.FirstAvailableSeqOrZero);
+        Assert.Equal(7u, buf.LastSeqOrZero);
+    }
+
+    [Fact]
+    public void Append_when_isSuspended_true_increments_passive_er_buffered()
+    {
+        var metrics = new B3.Exchange.Contracts.RetransmitMetrics();
+        bool suspended = true;
+        var buf = new RetransmitBuffer(8, metrics, isSuspended: () => suspended);
+        buf.Append(1, FrameWithSeq(1));
+        buf.Append(2, FrameWithSeq(2));
+        Assert.Equal(2L, metrics.PassiveErBuffered);
+    }
+
+    [Fact]
+    public void Append_when_isSuspended_false_does_not_increment_passive_er_buffered()
+    {
+        var metrics = new B3.Exchange.Contracts.RetransmitMetrics();
+        var buf = new RetransmitBuffer(8, metrics, isSuspended: () => false);
+        buf.Append(1, FrameWithSeq(1));
+        buf.Append(2, FrameWithSeq(2));
+        Assert.Equal(0L, metrics.PassiveErBuffered);
+    }
+
+    [Fact]
+    public void Append_isSuspended_predicate_evaluated_per_call()
+    {
+        // Mid-stream Suspended flip: only the appends observed while
+        // suspended should bump the counter.
+        var metrics = new B3.Exchange.Contracts.RetransmitMetrics();
+        bool suspended = false;
+        var buf = new RetransmitBuffer(8, metrics, isSuspended: () => suspended);
+        buf.Append(1, FrameWithSeq(1));        // not counted
+        suspended = true;
+        buf.Append(2, FrameWithSeq(2));        // counted
+        buf.Append(3, FrameWithSeq(3));        // counted
+        suspended = false;
+        buf.Append(4, FrameWithSeq(4));        // not counted
+        Assert.Equal(2L, metrics.PassiveErBuffered);
+    }
 }


### PR DESCRIPTION
Closes #288.

Adds the four metrics needed to size the `(outboundRetransmitCapacity, SuspendedTimeoutMs, fill rate)` tuple before a real disconnect surfaces the limit.

## New metrics

| Metric | Type | Cardinality | When it bumps |
| --- | --- | --- | --- |
| `exch_fixp_retransmit_buffer_evictions_total` | counter | process | `RetransmitBuffer.Append` overwrites the oldest entry on a full ring |
| `exch_fixp_passive_er_buffered_total` | counter | process | An outbound business frame is appended while the owning session is in `FixpState.Suspended` (issue #217 path) |
| `exch_fixp_retransmit_buffer_utilization` | gauge (0..1) | per-session, **opt-in** | depth / capacity per scrape |
| `exch_session_reaped_total` (existing, #70) | counter | process | Documented as the fourth signal — already wired |

## Cardinality control

Per-session labels are off by default. Operators opt in via:

```jsonc
{ "metrics": { "fixpSessionLabelsEnabled": true } }
```

Aggregate counters always render so eviction-rate alerts work in every deployment.

## Implementation notes

- `RetransmitMetrics` lives in `B3.Exchange.Contracts` (matches `TransportMetrics`/`ThrottleMetrics` pattern).
- `RetransmitBuffer` gets an optional `(metrics, isSuspended)` overload; the legacy 1-arg ctor still works (test fixtures unchanged).
- Counter increments happen **outside** the buffer's lock so a slow metrics consumer cannot back-pressure the outbound encoder.
- `FixpSession` passes `() => State == FixpState.Suspended` as the predicate.
- `SessionDiagnostics` gets `RetxBufferCapacity { get; init; }` (additive — existing named-arg call sites still compile).
- Per-session utilization gauge skips sessions with `Capacity == 0` (avoids div-by-zero).

## Tests

- `RetransmitBufferTests`: 5 new (no eviction below capacity, eviction count per overflow, passive-er when suspended, not when not, predicate re-evaluated per call).
- `MetricsRegistryTests`: 4 new (zero rendering, observed totals, gauge omitted by default, gauge emitted when flag on with capacity==0 skip).

## Docs

`docs/RUNBOOK.md` §7.5.1 lists the four metrics with alert thresholds and the opt-in config block.

## Verification

```
dotnet build SbeB3Exchange.slnx -c Release --no-restore   # 0 warnings
dotnet format SbeB3Exchange.slnx --verify-no-changes      # clean
dotnet test SbeB3Exchange.slnx --no-build -c Release      # all green
```
