### PR TITLE
fix(metrics): emit exch_fixp_sessions_reaped_total alias (#288)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -853,7 +853,7 @@ running system instead of a guess:
 | `exch_fixp_retransmit_buffer_evictions_total` | counter | process | **Any non-zero rate** ⇒ at least one session lost replayable history. Bump `outboundRetransmitCapacity` or shorten `SuspendedTimeoutMs`. |
 | `exch_fixp_passive_er_buffered_total` | counter | process | Informational — total `ExecutionReport`s buffered while the owning session was `Suspended`. Sustained growth without matching `exch_session_rebound_total` ⇒ disconnects becoming reaps. |
 | `exch_fixp_retransmit_buffer_utilization` | gauge (0..1) | **per-session** (opt-in) | `>0.8` for any session ⇒ undersized ring for that firm's burst pattern. |
-| `exch_session_reaped_total` (existing, [#70](https://github.com/pedrosakuma/B3MatchingPlatform/issues/70)) | counter | process | Non-zero ⇒ at least one `Suspended` session crossed `SuspendedTimeoutMs` and was dropped; downstream firm needs `OrderMassStatus` on reconnect. |
+| `exch_session_reaped_total` (existing, [#70](https://github.com/pedrosakuma/B3MatchingPlatform/issues/70); also exported as the alias `exch_fixp_sessions_reaped_total` for issue #288) | counter | process | Non-zero ⇒ at least one `Suspended` session crossed `SuspendedTimeoutMs` and was dropped; downstream firm needs `OrderMassStatus` on reconnect. |
 
 The per-session utilization gauge is **off by default** to keep
 scrape cardinality bounded on deployments that cycle through many

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -520,6 +520,12 @@ public sealed class MetricsRegistry
         EmitProcessCounter(sb, "exch_session_reaped_total",
             "Total Suspended FIXP sessions closed by the listener's CoD/suspended reaper after exceeding SuspendedTimeoutMs.",
             _sessionLifecycle.Reaped);
+        // Issue #288 acceptance: emit the FIXP-prefixed alias backed by
+        // the same counter so dashboards/alerts that follow the issue's
+        // metric naming work without picking the legacy series name.
+        EmitProcessCounter(sb, "exch_fixp_sessions_reaped_total",
+            "Alias of exch_session_reaped_total exposed for issue #288 (FIXP RetransmitBuffer dimensioning) so operator alerts can use the FIXP-prefixed name listed in the runbook §7.5 mitigation table. Same underlying counter (_sessionLifecycle.Reaped); pick exactly one in your alert rules.",
+            _sessionLifecycle.Reaped);
         EmitProcessCounter(sb, "exch_session_cancel_on_disconnect_fired_total",
             "Total times the cancel-on-disconnect timer fired for a Suspended FIXP session (issue #54 / GAP-18) and the gateway issued a session-scoped mass cancel.",
             _sessionLifecycle.CancelOnDisconnectFired);

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -92,6 +92,8 @@ public class MetricsRegistryTests
         Assert.Contains("exch_session_suspended_total 1\n", text);
         Assert.Contains("exch_session_rebound_total 1\n", text);
         Assert.Contains("exch_session_reaped_total 3\n", text);
+        // Issue #288 alias backed by the same counter.
+        Assert.Contains("exch_fixp_sessions_reaped_total 3\n", text);
     }
 
     [Fact]
@@ -105,6 +107,7 @@ public class MetricsRegistryTests
         Assert.Contains("exch_session_suspended_total 0\n", text);
         Assert.Contains("exch_session_rebound_total 0\n", text);
         Assert.Contains("exch_session_reaped_total 0\n", text);
+        Assert.Contains("exch_fixp_sessions_reaped_total 0\n", text);
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #296 (gpt-5.5 review finding, MEDIUM).

## Problem

Issue #288 acceptance and the existing RUNBOOK §7.5 mitigation table both reference `exch_fixp_sessions_reaped_total`, but the renderer only exported the legacy `exch_session_reaped_total` (from #70). Dashboards/alerts that follow the issue body or that line of the runbook would query a non-existent series and silently fail.

## Fix

Additive: emit a second `EmitProcessCounter` line backed by the same `_sessionLifecycle.Reaped` counter. Help string flags it as an alias and warns operators to pick exactly one in alert rules to avoid double-counting.

RUNBOOK §7.5.1 metric table updated to mention the alias alongside the legacy name.

## Tests

Existing zero-render and observed-totals tests extended — both `exch_session_reaped_total` and `exch_fixp_sessions_reaped_total` must render with the same value.

Closes the last gpt-5.5 finding on #296. No behavior change other than the new metric line.