### PR TITLE
fix(persistence): mid-stream WAL/snapshot corruption is fatal (#285 follow-up)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -180,6 +180,25 @@ public sealed partial class ChannelDispatcher
         if (_wal is null) return;
         IReadOnlyList<WalRecord> records;
         try { records = _wal.ReadAll(); }
+        catch (B3.Exchange.Core.WalCorruptionException ex)
+        {
+            // Issue #285 follow-up (gpt-5.5 review of PR #293): a
+            // mid-stream WAL corruption — distinct from a torn final
+            // write — would force replay to fabricate a book state
+            // that never existed if we silently skipped past the bad
+            // record. Halt the channel via the issue #286 mechanism
+            // instead. Operators see IsWalHealthy=false on /readyz and
+            // a CRITICAL log line; the engine remains at the snapshot
+            // baseline (no partial replay).
+            _metrics?.IncWalAppendFailure();
+            _metrics?.AddWalRecordCorruptions(_wal.LastReadCorruptCount);
+            _metrics?.AddWalRecordsLegacy(_wal.LastReadLegacyCount);
+            Volatile.Write(ref _walHalted, 1);
+            _logger.LogCritical(ex,
+                "channel {ChannelNumber}: WAL corruption detected at line {RecordNumber} during boot replay; channel marked WAL-halted, engine left at snapshot baseline (LastAppliedSeq={SnapshotSeq})",
+                ChannelNumber, ex.RecordNumber, snapshotLastAppliedSeq);
+            return;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex,

--- a/src/B3.Exchange.Core/WalCorruptionException.cs
+++ b/src/B3.Exchange.Core/WalCorruptionException.cs
@@ -1,0 +1,45 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Thrown by <see cref="IChannelWriteAheadLog.ReadAll"/> when a WAL
+/// record fails its integrity check (Crc32C mismatch, JSON parse
+/// failure with valid CRC framing, or a sequence-number gap) at a
+/// position that is not the physical tail of the file.
+///
+/// <para><b>Tail vs mid-stream (issue #285 follow-up):</b> the original
+/// #285 implementation skipped every corrupt record uniformly. That is
+/// only safe for a torn final write: if the host crashed mid-fsync the
+/// last record may be partial and dropping it preserves the surviving
+/// prefix. A mid-stream corruption is a different beast — silently
+/// applying records 1, 2, 4, 5 (with 3 dropped) yields a book state
+/// that never existed and violates the durability contract the WAL is
+/// supposed to provide. Raising this exception forces the dispatcher
+/// to halt the channel via the issue #286 mechanism instead of booting
+/// into a fabricated state.</para>
+///
+/// <para>Operators see this as a CRITICAL log line plus the channel
+/// flipping <c>IsWalHealthy=false</c>; recovery is to inspect the WAL
+/// (or fall back to an older snapshot generation) and restart.</para>
+/// </summary>
+public sealed class WalCorruptionException : Exception
+{
+    public byte ChannelNumber { get; }
+
+    /// <summary>Physical line / record number (1-based) where the
+    /// corruption was detected. Useful for operator triage.</summary>
+    public int RecordNumber { get; }
+
+    public WalCorruptionException(byte channelNumber, int recordNumber, string message)
+        : base(message)
+    {
+        ChannelNumber = channelNumber;
+        RecordNumber = recordNumber;
+    }
+
+    public WalCorruptionException(byte channelNumber, int recordNumber, string message, Exception innerException)
+        : base(message, innerException)
+    {
+        ChannelNumber = channelNumber;
+        RecordNumber = recordNumber;
+    }
+}

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -140,6 +140,38 @@ public static class BinaryChannelStateSnapshotCodec
 
     public static ChannelStateSnapshot Decode(ReadOnlySpan<byte> bytes)
     {
+        // Issue #285 follow-up (gpt-5.5 review of PR #293): verify
+        // the trailing Crc32C footer BEFORE structural decode when
+        // present. Decoding first means a corrupted varint count
+        // (e.g. owner count flipped to 0xFFFF_FFFF) would drive a
+        // multi-GB allocation before the post-decode CRC check
+        // catches it. Trying CRC first eliminates that class of
+        // recovery-time DoS for any file produced by a #285+ host.
+        // Files older than #285 lack the footer and fall through to
+        // the legacy decode path, which protects itself with the
+        // bounded-count helpers added below.
+        if (bytes.Length >= Magic.Length + 4)
+        {
+            int bodyEnd = bytes.Length - 4;
+            uint footer = BinaryPrimitives.ReadUInt32LittleEndian(bytes[bodyEnd..]);
+            uint computed = Crc32C.Compute(bytes[..bodyEnd]);
+            if (computed == footer)
+            {
+                // Modern file with intact footer — decode the body
+                // only and skip the trailing-bytes check.
+                return DecodeBody(bytes[..bodyEnd], hasVerifiedFooter: true);
+            }
+            // Either legacy (no footer) or modern-corrupt. Fall
+            // through to the legacy-compatible path; bounded counts
+            // protect us against allocation bombs in either case,
+            // and the trailing-bytes switch at the end will reject
+            // a 4-byte non-matching footer as corruption.
+        }
+        return DecodeBody(bytes, hasVerifiedFooter: false);
+    }
+
+    private static ChannelStateSnapshot DecodeBody(ReadOnlySpan<byte> bytes, bool hasVerifiedFooter)
+    {
         var r = new BinaryBufferReader(bytes);
         var magic = r.ReadRaw(Magic.Length);
         if (!magic.SequenceEqual(Magic))
@@ -156,7 +188,7 @@ public static class BinaryChannelStateSnapshotCodec
         uint nextTradeId = r.ReadUInt32();
         uint rptSeq = r.ReadUInt32();
 
-        ulong phaseCount = r.ReadUVarInt();
+        ulong phaseCount = ReadBoundedCount(ref r, bytes.Length, "phase");
         var phases = new EngineStateSnapshot.PhaseEntry[phaseCount];
         for (ulong i = 0; i < phaseCount; i++)
         {
@@ -165,18 +197,18 @@ public static class BinaryChannelStateSnapshotCodec
             phases[i] = new EngineStateSnapshot.PhaseEntry(securityId, (TradingPhase)phase);
         }
 
-        ulong bookCount = r.ReadUVarInt();
+        ulong bookCount = ReadBoundedCount(ref r, bytes.Length, "book");
         var books = new EngineStateSnapshot.BookSnapshot[bookCount];
         for (ulong i = 0; i < bookCount; i++)
         {
             long securityId = r.ReadInt64();
-            ulong orderCount = r.ReadUVarInt();
+            ulong orderCount = ReadBoundedCount(ref r, bytes.Length, "order");
             var orders = new RestingOrderRecord[orderCount];
             for (ulong j = 0; j < orderCount; j++) orders[j] = ReadRestingOrder(ref r);
             books[i] = new EngineStateSnapshot.BookSnapshot(securityId, orders);
         }
 
-        ulong stopCount = r.ReadUVarInt();
+        ulong stopCount = ReadBoundedCount(ref r, bytes.Length, "stop");
         IReadOnlyList<RestingStopRecord>? stops;
         if (stopCount == 0)
         {
@@ -193,35 +225,52 @@ public static class BinaryChannelStateSnapshotCodec
             stops = arr;
         }
 
-        ulong ownerCount = r.ReadUVarInt();
+        ulong ownerCount = ReadBoundedCount(ref r, bytes.Length, "owner");
         var owners = new OrderOwnerSnapshot[ownerCount];
         for (ulong i = 0; i < ownerCount; i++) owners[i] = ReadOwner(ref r);
 
-        // Issue #285: trailing bytes are either nothing (pre-#285
-        // file with no Crc32C footer) or exactly 4 bytes carrying the
-        // little-endian Crc32C of every byte before them. Anything
-        // else is corruption.
-        switch (r.Remaining)
+        if (hasVerifiedFooter)
         {
-            case 0:
-                // Legacy file (pre-#285). Accept silently — the
-                // tmp+fsync+rename + structural validator combo from
-                // the persister is the only integrity guard for these
-                // files and was the established contract before #285.
-                break;
-            case 4:
-                int bodyEnd = bytes.Length - 4;
-                uint computedCrc = Crc32C.Compute(bytes[..bodyEnd]);
-                uint footerCrc = BinaryPrimitives.ReadUInt32LittleEndian(bytes[bodyEnd..]);
-                if (computedCrc != footerCrc)
-                {
-                    throw new InvalidDataException(
-                        $"binary snapshot Crc32C mismatch: stored=0x{footerCrc:X8} computed=0x{computedCrc:X8}");
-                }
-                break;
-            default:
+            // CRC was already verified by Decode(); the body span
+            // passed in here ends at the last payload byte — there
+            // should be no remainder. A non-zero remainder means
+            // the file's encoded length disagrees with the count
+            // stream, which is a structural defect.
+            if (r.Remaining != 0)
+            {
                 throw new InvalidDataException(
-                    $"binary snapshot has {r.Remaining} trailing bytes past the encoded payload (expected 0 for legacy or 4 for #285 Crc32C footer)");
+                    $"binary snapshot has {r.Remaining} unread bytes after structural decode despite valid Crc32C footer (encoder/decoder length skew)");
+            }
+        }
+        else
+        {
+            // Issue #285: trailing bytes are either nothing (pre-#285
+            // file with no Crc32C footer) or exactly 4 bytes carrying
+            // the little-endian Crc32C of every byte before them.
+            // Anything else is corruption.
+            switch (r.Remaining)
+            {
+                case 0:
+                    // Legacy file (pre-#285). Accept silently — the
+                    // tmp+fsync+rename + structural validator combo
+                    // from the persister is the only integrity guard
+                    // for these files and was the established
+                    // contract before #285.
+                    break;
+                case 4:
+                    int bodyEnd = bytes.Length - 4;
+                    uint computedCrc = Crc32C.Compute(bytes[..bodyEnd]);
+                    uint footerCrc = BinaryPrimitives.ReadUInt32LittleEndian(bytes[bodyEnd..]);
+                    if (computedCrc != footerCrc)
+                    {
+                        throw new InvalidDataException(
+                            $"binary snapshot Crc32C mismatch: stored=0x{footerCrc:X8} computed=0x{computedCrc:X8}");
+                    }
+                    break;
+                default:
+                    throw new InvalidDataException(
+                        $"binary snapshot has {r.Remaining} trailing bytes past the encoded payload (expected 0 for legacy or 4 for #285 Crc32C footer)");
+            }
         }
 
         var engine = new EngineStateSnapshot(nextOrderId, nextTradeId, rptSeq, phases, books, stops);
@@ -312,6 +361,28 @@ public static class BinaryChannelStateSnapshotCodec
         byte side = r.ReadByte();
         long securityId = r.ReadInt64();
         return new OrderOwnerSnapshot(orderId, session, firm, clOrdId, (Side)side, securityId);
+    }
+
+    /// <summary>
+    /// Issue #285 follow-up: reads a uvarint collection count and
+    /// rejects anything that cannot physically fit in the input
+    /// buffer. Each element is at least one byte on the wire, so
+    /// a count strictly greater than <paramref name="totalInputLength"/>
+    /// must be either corruption or an attacker-supplied
+    /// allocation-bomb. Throwing here bounds recovery-time
+    /// allocations to <c>O(file size)</c> regardless of file
+    /// provenance (including legacy files that lack the Crc32C
+    /// footer).
+    /// </summary>
+    private static ulong ReadBoundedCount(ref BinaryBufferReader r, int totalInputLength, string label)
+    {
+        ulong count = r.ReadUVarInt();
+        if (count > (ulong)totalInputLength)
+        {
+            throw new InvalidDataException(
+                $"binary snapshot {label} count={count} exceeds the input length ({totalInputLength}); refusing to allocate (likely corruption or footer Crc32C mismatch — see issue #285 follow-up)");
+        }
+        return count;
     }
 }
 

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -19,10 +19,22 @@ namespace B3.Exchange.Persistence;
 /// (issue #285), terminated by a newline, and the implementation
 /// optionally <c>fsync</c>s the file before returning. The
 /// JSON-Lines + per-record CRC framing makes the file robust against
-/// two distinct failure modes: a torn final write fails the trailing
-/// CRC and is dropped, while a bit-rot landing mid-file fails just
-/// that record's CRC — replay logs the corruption and **continues
-/// past it** so the surviving prefix and suffix remain replayable.
+/// two distinct failure modes that demand different responses:
+/// <list type="bullet">
+///   <item><b>Torn final write:</b> the host crashed mid-fsync and
+///   the last physical line is incomplete. The trailing CRC fails (or
+///   the line has no CRC suffix and JSON parse fails), and the loader
+///   tolerates that by dropping the final record and stopping
+///   replay. The surviving prefix is fully replayable.</item>
+///   <item><b>Mid-stream corruption:</b> a CRC mismatch, parse
+///   failure, or sequence gap on any record that has at least one
+///   well-formed record after it. Continuing past the bad record
+///   would apply state transitions out of order and produce a book
+///   state that never existed, so the loader raises a
+///   <see cref="WalCorruptionException"/> (issue #285 follow-up after
+///   gpt-5.5 review of PR #293). The dispatcher catches this and
+///   marks the channel WAL-halted (issue #286 path).</item>
+/// </list>
 /// Per-write fsync gives zero-RPO recovery; the caller can opt for
 /// batched fsync (lower latency, RPO bounded by batch flush) via the
 /// <c>fsyncPerWrite=false</c> ctor argument.</para>
@@ -145,58 +157,20 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
             }
         }
         var result = new List<WalRecord>();
+        // Buffer all physical lines first so we can distinguish a
+        // torn final write (tolerable) from mid-stream corruption
+        // (must halt). The legacy "skip and keep going" path was
+        // unsafe — see WalCorruptionException for the rationale.
+        List<string> rawLines;
         try
         {
             using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var reader = new StreamReader(fs, Encoding.UTF8);
-            int lineNumber = 0;
+            rawLines = new List<string>();
             string? line;
             while ((line = reader.ReadLine()) is not null)
             {
-                lineNumber++;
-                if (line.Length == 0) continue;
-                int tab = line.LastIndexOf('\t');
-                if (tab >= 0 && line.Length - tab - 1 == 8)
-                {
-                    // Modern format: JSON \t crc8 .
-                    var json = line.AsSpan(0, tab);
-                    var crcHex = line.AsSpan(tab + 1, 8);
-                    if (!TryParseHex32(crcHex, out uint storedCrc))
-                    {
-                        // Suffix isn't a valid 8-hex CRC — treat as
-                        // legacy (no CRC) and fall through.
-                        ConsumeLegacyLine(line, lineNumber, result);
-                        continue;
-                    }
-                    var jsonBytes = Encoding.UTF8.GetBytes(line[..tab]);
-                    uint computedCrc = Crc32C.Compute(jsonBytes);
-                    if (computedCrc != storedCrc)
-                    {
-                        LastReadCorruptCount++;
-                        _logger.LogWarning(
-                            "channel {ChannelNumber}: WAL line {LineNumber} CRC mismatch (stored=0x{StoredCrc:X8} computed=0x{ComputedCrc:X8}); skipping record and continuing replay",
-                            _channelNumber, lineNumber, storedCrc, computedCrc);
-                        continue;
-                    }
-                    try
-                    {
-                        var rec = JsonSerializer.Deserialize<WalRecord>(jsonBytes, JsonOptions);
-                        if (rec is not null) result.Add(rec);
-                    }
-                    catch (Exception ex)
-                    {
-                        // CRC matched but JSON failed — bizarre, treat
-                        // as corrupt for metric purposes and continue.
-                        LastReadCorruptCount++;
-                        _logger.LogWarning(ex,
-                            "channel {ChannelNumber}: WAL line {LineNumber} JSON parse failed despite CRC match; skipping",
-                            _channelNumber, lineNumber);
-                    }
-                }
-                else
-                {
-                    if (!ConsumeLegacyLine(line, lineNumber, result)) break;
-                }
+                rawLines.Add(line);
             }
         }
         catch (Exception ex)
@@ -206,34 +180,151 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                 _channelNumber, _path);
             return Array.Empty<WalRecord>();
         }
+
+        // Find the index of the LAST non-empty line — only that line
+        // is allowed to fail integrity (torn-tail tolerance). Lines
+        // beyond it must be empty (a partial trailing newline is fine).
+        int lastNonEmptyIdx = -1;
+        for (int i = rawLines.Count - 1; i >= 0; i--)
+        {
+            if (rawLines[i].Length > 0) { lastNonEmptyIdx = i; break; }
+        }
+
+        long? prevSeq = null;
+        for (int i = 0; i <= lastNonEmptyIdx; i++)
+        {
+            var line = rawLines[i];
+            int lineNumber = i + 1;
+            bool isLastNonEmpty = i == lastNonEmptyIdx;
+            if (line.Length == 0) continue;
+
+            int tab = line.LastIndexOf('\t');
+            if (tab >= 0 && line.Length - tab - 1 == 8)
+            {
+                // Modern format: JSON \t crc8 .
+                var crcHex = line.AsSpan(tab + 1, 8);
+                if (!TryParseHex32(crcHex, out uint storedCrc))
+                {
+                    // Suffix isn't a valid 8-hex CRC — treat as legacy
+                    // (no CRC) and fall through.
+                    if (!ConsumeLegacyLine(line, lineNumber, isLastNonEmpty, result, ref prevSeq))
+                        break;
+                    continue;
+                }
+                var jsonBytes = Encoding.UTF8.GetBytes(line[..tab]);
+                uint computedCrc = Crc32C.Compute(jsonBytes);
+                if (computedCrc != storedCrc)
+                {
+                    LastReadCorruptCount++;
+                    if (isLastNonEmpty)
+                    {
+                        // Torn final write — tolerate and stop.
+                        _logger.LogWarning(
+                            "channel {ChannelNumber}: WAL line {LineNumber} CRC mismatch on the FINAL record (stored=0x{StoredCrc:X8} computed=0x{ComputedCrc:X8}); treating as torn-tail and truncating replay here",
+                            _channelNumber, lineNumber, storedCrc, computedCrc);
+                        break;
+                    }
+                    // Mid-stream corruption — refuse to fabricate a
+                    // book state by skipping past the gap.
+                    var msg = $"channel {_channelNumber}: WAL line {lineNumber} CRC mismatch (stored=0x{storedCrc:X8} computed=0x{computedCrc:X8}) and a well-formed record exists after it; refusing to replay around mid-stream corruption";
+                    _logger.LogCritical("{Message}", msg);
+                    throw new WalCorruptionException(_channelNumber, lineNumber, msg);
+                }
+                WalRecord? rec;
+                try
+                {
+                    rec = JsonSerializer.Deserialize<WalRecord>(jsonBytes, JsonOptions);
+                }
+                catch (Exception ex)
+                {
+                    // CRC matched but JSON failed — the on-disk bytes
+                    // are coherent w.r.t. their checksum but the
+                    // schema is wrong (e.g. an enum value the loader
+                    // does not recognize). That is a persistent
+                    // corruption-equivalent condition, never a torn
+                    // write; halt regardless of position.
+                    LastReadCorruptCount++;
+                    var msg = $"channel {_channelNumber}: WAL line {lineNumber} JSON parse failed despite CRC match: {ex.Message}";
+                    _logger.LogCritical(ex, "{Message}", msg);
+                    throw new WalCorruptionException(_channelNumber, lineNumber, msg, ex);
+                }
+                if (rec is null)
+                {
+                    var msg = $"channel {_channelNumber}: WAL line {lineNumber} deserialized to null";
+                    _logger.LogCritical("{Message}", msg);
+                    throw new WalCorruptionException(_channelNumber, lineNumber, msg);
+                }
+                CheckSeqContiguity(rec.Seq, lineNumber, ref prevSeq);
+                result.Add(rec);
+            }
+            else
+            {
+                if (!ConsumeLegacyLine(line, lineNumber, isLastNonEmpty, result, ref prevSeq))
+                    break;
+            }
+        }
         return result;
+    }
+
+    /// <summary>
+    /// Enforces strict monotonic-by-1 ordering on WAL record
+    /// sequences. A gap means we lost a write between the surviving
+    /// records — replaying the records on either side of the gap
+    /// applies state transitions out of order, so we treat any
+    /// non-contiguous seq as mid-stream corruption.
+    /// </summary>
+    private void CheckSeqContiguity(long currentSeq, int lineNumber, ref long? prevSeq)
+    {
+        if (prevSeq.HasValue && currentSeq != prevSeq.Value + 1)
+        {
+            var msg = $"channel {_channelNumber}: WAL line {lineNumber} seq={currentSeq} is not contiguous after seq={prevSeq.Value}; refusing to replay around the gap";
+            _logger.LogCritical("{Message}", msg);
+            throw new WalCorruptionException(_channelNumber, lineNumber, msg);
+        }
+        prevSeq = currentSeq;
     }
 
     /// <summary>
     /// Handles a line written by a pre-#285 host (no <c>\t</c>+CRC
     /// suffix). Returns <c>false</c> to signal the caller to stop
     /// further line processing — preserving the original "torn-final
-    /// stops replay" behavior for legacy files.
+    /// stops replay" behavior for legacy files when the failure is on
+    /// the final line. A parse failure on a NON-final legacy line is
+    /// promoted to a <see cref="WalCorruptionException"/> for the
+    /// same reason mid-stream modern corruption is fatal: skipping
+    /// past it would replay state transitions out of order.
     /// </summary>
-    private bool ConsumeLegacyLine(string line, int lineNumber, List<WalRecord> result)
+    private bool ConsumeLegacyLine(string line, int lineNumber, bool isLastNonEmpty, List<WalRecord> result, ref long? prevSeq)
     {
+        WalRecord? rec;
         try
         {
-            var rec = JsonSerializer.Deserialize<WalRecord>(line, JsonOptions);
-            if (rec is not null)
-            {
-                result.Add(rec);
-                LastReadLegacyCount++;
-            }
-            return true;
+            rec = JsonSerializer.Deserialize<WalRecord>(line, JsonOptions);
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex,
-                "channel {ChannelNumber}: legacy WAL line {LineNumber} failed to parse; truncating replay set here",
-                _channelNumber, lineNumber);
-            return false;
+            if (isLastNonEmpty)
+            {
+                _logger.LogWarning(ex,
+                    "channel {ChannelNumber}: legacy WAL line {LineNumber} failed to parse on the FINAL record; treating as torn-tail and truncating replay here",
+                    _channelNumber, lineNumber);
+                return false;
+            }
+            var msg = $"channel {_channelNumber}: legacy WAL line {lineNumber} failed to parse and a well-formed record exists after it; refusing to replay around mid-stream corruption";
+            _logger.LogCritical(ex, "{Message}", msg);
+            throw new WalCorruptionException(_channelNumber, lineNumber, msg, ex);
         }
+        if (rec is null)
+        {
+            if (isLastNonEmpty) return false;
+            var msg = $"channel {_channelNumber}: legacy WAL line {lineNumber} deserialized to null mid-stream";
+            _logger.LogCritical("{Message}", msg);
+            throw new WalCorruptionException(_channelNumber, lineNumber, msg);
+        }
+        CheckSeqContiguity(rec.Seq, lineNumber, ref prevSeq);
+        result.Add(rec);
+        LastReadLegacyCount++;
+        return true;
     }
 
     private static void WriteHexUtf8(uint value, Span<byte> dst)

--- a/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecCrcTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecCrcTests.cs
@@ -99,4 +99,50 @@ public class BinaryChannelStateSnapshotCodecCrcTests
         Assert.Throws<InvalidDataException>(
             () => BinaryChannelStateSnapshotCodec.Decode(bad));
     }
+
+    [Fact]
+    public void Decode_BoundsAttackerCounts_BeforeAllocating()
+    {
+        // Issue #285 follow-up (gpt-5.5 review of PR #293): a
+        // crafted varint count larger than the input buffer must
+        // be rejected before the decoder allocates an N-element
+        // array. Without the bounded-count guard a corrupted owner
+        // count of 0xFFFF_FFFF would request a 32 GB allocation
+        // during recovery.
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+
+        // The phase count is the first uvarint after a fixed-size
+        // header (magic 4 + version 2 + channel 1 + seqNum 4 +
+        // seqVer 2 + lastApplied 8 + nextOrder 8 + nextTrade 4 +
+        // rptSeq 4 = 37). In the minimal snapshot phase count == 0
+        // (single byte 0x00). Replace it with a 5-byte uvarint
+        // encoding ulong.MaxValue and strip the footer so the
+        // decoder takes the legacy path.
+        const int phaseCountOffset = 4 + 2 + 1 + 4 + 2 + 8 + 8 + 4 + 4;
+        Assert.Equal((byte)0, bytes[phaseCountOffset]);
+        // 5-byte uvarint encoding of a value with all top bits set
+        // (decodes to a count >> bytes.Length).
+        var attack = new List<byte>(bytes.Length + 8);
+        attack.AddRange(bytes.Take(phaseCountOffset));
+        attack.AddRange(new byte[] { 0xFF, 0xFF, 0xFF, 0xFF, 0x7F });
+        attack.AddRange(bytes.Skip(phaseCountOffset + 1).Take(bytes.Length - phaseCountOffset - 1 - 4));
+        var ex = Assert.Throws<InvalidDataException>(
+            () => BinaryChannelStateSnapshotCodec.Decode(attack.ToArray()));
+        Assert.Contains("phase", ex.Message);
+        Assert.Contains("refusing to allocate", ex.Message);
+    }
+
+    [Fact]
+    public void Decode_VerifiesCrcBeforeStructuralDecode_OnIntactFiles()
+    {
+        // Sanity round-trip: a valid snapshot still decodes through
+        // the new CRC-first fast path. Asserts the refactor didn't
+        // break the happy path.
+        var snap = MakeMinimalSnapshot();
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
+        Assert.Equal(snap.SequenceNumber, decoded.SequenceNumber);
+        Assert.Equal(snap.LastAppliedSeq, decoded.LastAppliedSeq);
+    }
 }

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogCrcTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogCrcTests.cs
@@ -49,8 +49,13 @@ public class FileChannelWriteAheadLogCrcTests
     }
 
     [Fact]
-    public void CorruptMiddleRecord_IsSkipped_AndReplayContinues()
+    public void CorruptMiddleRecord_FailsReplay_WithWalCorruptionException()
     {
+        // Issue #285 follow-up (gpt-5.5 review of PR #293): silently
+        // skipping a mid-stream corrupted record would let replay
+        // apply state transitions out of order and fabricate a book
+        // state that never existed. The loader must refuse to do
+        // that — only a torn FINAL record is tolerable.
         using var dir = new TempDir();
         var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
         using (var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
@@ -58,11 +63,7 @@ public class FileChannelWriteAheadLogCrcTests
         {
             for (int i = 1; i <= 3; i++) wal.Append(MakeNew(i, (ulong)i));
         }
-        // Flip a single byte inside the JSON payload of the middle
-        // line to force a CRC mismatch on that record only.
         var bytes = File.ReadAllBytes(walPath);
-        // Find the second '\n' and corrupt a byte midway in the
-        // second line's JSON (i.e. between the first \n and second \n).
         int firstNl = Array.IndexOf(bytes, (byte)'\n');
         int secondNl = Array.IndexOf(bytes, (byte)'\n', firstNl + 1);
         Assert.True(firstNl >= 0 && secondNl > firstNl);
@@ -72,14 +73,71 @@ public class FileChannelWriteAheadLogCrcTests
 
         using var reread = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
             NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var ex = Assert.Throws<B3.Exchange.Core.WalCorruptionException>(() => reread.ReadAll());
+        Assert.Equal((byte)7, ex.ChannelNumber);
+        Assert.Equal(2, ex.RecordNumber);
+        Assert.Equal(1, reread.LastReadCorruptCount);
+    }
+
+    [Fact]
+    public void CorruptFinalRecord_IsToleratedAsTornTail()
+    {
+        using var dir = new TempDir();
+        var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
+        using (var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false))
+        {
+            for (int i = 1; i <= 3; i++) wal.Append(MakeNew(i, (ulong)i));
+        }
+        // Flip a byte inside the JSON of the LAST line — torn-tail
+        // semantics: the final record is dropped, prefix survives.
+        var bytes = File.ReadAllBytes(walPath);
+        int secondNl = -1, thirdNl = -1;
+        for (int i = 0, n = 0; i < bytes.Length; i++)
+        {
+            if (bytes[i] == (byte)'\n')
+            {
+                n++;
+                if (n == 2) secondNl = i;
+                else if (n == 3) { thirdNl = i; break; }
+            }
+        }
+        Assert.True(secondNl > 0 && thirdNl > secondNl);
+        bytes[secondNl + 5] ^= 0xFF;
+        File.WriteAllBytes(walPath, bytes);
+
+        using var reread = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
         var records = reread.ReadAll();
         Assert.Equal(2, records.Count);
         Assert.Equal(1, reread.LastReadCorruptCount);
-        Assert.Equal(0, reread.LastReadLegacyCount);
-        // Records 1 and 3 survived; the corrupt one in the middle was skipped.
         Assert.Contains(records, r => r.Seq == 1);
-        Assert.Contains(records, r => r.Seq == 3);
-        Assert.DoesNotContain(records, r => r.Seq == 2);
+        Assert.Contains(records, r => r.Seq == 2);
+        Assert.DoesNotContain(records, r => r.Seq == 3);
+    }
+
+    [Fact]
+    public void NonContiguousSeq_FailsReplay_WithWalCorruptionException()
+    {
+        // Hand-craft a WAL where seq jumps 1 → 3 (record with seq=2
+        // is missing). This is the exact failure mode the seq
+        // contiguity check is built to catch — without it, the
+        // engine would replay r1 + r3 and end up in a state that
+        // never existed at runtime.
+        using var dir = new TempDir();
+        var walPath = System.IO.Path.Combine(dir.Path, "channel-7.wal");
+        using (var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false))
+        {
+            wal.Append(MakeNew(1, 1));
+            wal.Append(MakeNew(3, 3));   // intentional gap at seq=2
+        }
+
+        using var reread = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var ex = Assert.Throws<B3.Exchange.Core.WalCorruptionException>(() => reread.ReadAll());
+        Assert.Equal((byte)7, ex.ChannelNumber);
+        Assert.Equal(2, ex.RecordNumber);
     }
 
     [Fact]


### PR DESCRIPTION
gpt-5.5 review of merged PR #293 surfaced two integrity bugs introduced
by the CRC framing rollout. This PR addresses both.

## BLOCKER — WAL mid-stream corruption silently skipped

\`FileChannelWriteAheadLog.ReadAll()\` treated every CRC mismatch
identically: log warning, increment \`LastReadCorruptCount\`, skip the
record, keep going. The behaviour was even codified in the
\`CorruptMiddleRecord_IsSkipped_AndReplayContinues\` test.

That contract is only safe for a torn FINAL write. Skipping a mid-stream
record makes the engine replay a sequence of state transitions that
never existed at runtime: drop seq 2, still apply 1/3/4, and the
recovered book is fictional.

**Fix:**
- New \`WalCorruptionException\` (in \`B3.Exchange.Core\`, since
  Persistence references Core not vice versa).
- \`ReadAll()\` rewritten to buffer all lines, find the last non-empty
  line, then classify failures: tail = torn-tail (drop, stop);
  mid-stream = throw. Applies to both modern (CRC) and legacy lines.
- New \`CheckSeqContiguity\` helper enforces strict monotonic-by-1 seq
  ordering during read.
- \`ChannelDispatcher.ReplayWalOnLoopThread\` catches
  \`WalCorruptionException\` separately, sets \`_walHalted=1\` (#286
  mechanism), increments \`IncWalAppendFailure\`, logs CRITICAL, and
  leaves the engine at the snapshot baseline. Operators see
  \`IsWalHealthy=false\` on \`/readyz\`.

## HIGH — Snapshot CRC verified after structural decode

\`BinaryChannelStateSnapshotCodec.Decode\` parsed the entire snapshot —
allocating per-element arrays from unverified uvarint counts — BEFORE
checking the trailing 4-byte CRC. A crafted owner count of
\`0xFFFF_FFFF\` would request a 32 GB allocation during recovery before
the CRC mismatch surfaced.

**Fix (defence in depth):**
- \`Decode\` now does a CRC-first fast path: if the trailing 4 bytes
  Crc32C-match the prefix, decode the body only.
- \`DecodeBody\` uses a new \`ReadBoundedCount\` helper rejecting any
  count > \`totalInputLength\` (each element is ≥1 byte on the wire).
  Protects legacy files (no footer) and the corner case where a modern
  body is corrupted but the CRC-first path didn't match.

## Tests
- \`CorruptMiddleRecord_FailsReplay_WithWalCorruptionException\`
  (renamed; assertion inverted).
- \`CorruptFinalRecord_IsToleratedAsTornTail\` (preserves the only safe
  torn-tail case).
- \`NonContiguousSeq_FailsReplay_WithWalCorruptionException\`.
- \`Decode_BoundsAttackerCounts_BeforeAllocating\` (5-byte uvarint of
  \`0x7FFF_FFFF_FFFF_FFFF\`).
- \`Decode_VerifiesCrcBeforeStructuralDecode_OnIntactFiles\` (happy-path
  round-trip).

991 → 994 tests, all green. Format clean.

Refs #285, #286.