### PR TITLE
fix(host): WAL halt enforcement gaps (#286 follow-up)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
@@ -100,6 +100,7 @@ public sealed partial class ChannelDispatcher
 
     public bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm)
     {
+        if (RejectIfWalHalted(WorkKind.Cross)) return false;
         using var act = StartEnqueueSpan(WorkKind.Cross, session, enteringFirm, cmd.BuyClOrdIdValue, cmd.Buy.SecurityId);
         var parent = act?.Context ?? System.Diagnostics.Activity.Current?.Context ?? default;
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.Cross, session, enteringFirm, true,
@@ -137,6 +138,7 @@ public sealed partial class ChannelDispatcher
         ulong enteredAtNanos)
     {
         if (orderIds == null || orderIds.Count == 0) return true;
+        if (RejectIfWalHalted(WorkKind.MassCancel)) return false;
         var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
         using var act = StartEnqueueSpan(WorkKind.MassCancel, session, enteringFirm, 0, securityId: 0);
         var parent = act?.Context ?? System.Diagnostics.Activity.Current?.Context ?? default;

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -41,6 +41,20 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        // Issue #286 follow-up: producer-side gates (RejectIfWalHalted)
+        // catch most halts, but a work item already in the channel when
+        // the WAL flips to halted would still reach here and mutate the
+        // engine. Drop any state-mutating work item observed on the loop
+        // after halt; snapshot/persist items above are intentionally
+        // allowed through. This is the last line of defence — readiness
+        // probes already report the channel as unhealthy.
+        if (Volatile.Read(ref _walHalted) != 0)
+        {
+            _metrics?.IncWalHaltReject();
+            LogWalHalted(ChannelNumber, item.Kind);
+            return;
+        }
+
         if (item.Kind == WorkKind.OperatorBumpVersion)
         {
             ProcessBumpVersion();

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -318,6 +318,17 @@ public sealed class ExchangeHost : IAsyncDisposable
         var sessionProvider = new ListenerSessionProvider(_listener, firmRegistry);
         _metrics.SetSessionProvider(sessionProvider);
 
+        // Issue #286: register the WAL-halt readiness probe BEFORE the
+        // HttpServer snapshots _probes. Registering after StartAsync
+        // throws (the snapshot is taken on construction); registering
+        // before construction also makes /health/ready report the
+        // halted channels from the very first scrape after boot.
+        if (_config.Channels.Any(c => c.Persistence?.Wal is { } w
+            && w.ResolveOnAppendFailure() == B3.Exchange.Core.WalAppendFailurePolicy.Halt))
+        {
+            RegisterReadinessProbe(new B3.Exchange.Core.WalHaltReadinessProbe(_dispatchers));
+        }
+
         if (_config.Http != null)
         {
             IReadOnlyList<IReadinessProbe> probeSnapshot;
@@ -354,16 +365,6 @@ public sealed class ExchangeHost : IAsyncDisposable
                 action: () => _listener?.TerminateAllSessions("daily-reset"),
                 logger: _loggerFactory.CreateLogger<DailyResetScheduler>());
             _dailyReset.Start();
-        }
-
-        // Issue #286: register a WAL-halt probe iff at least one
-        // channel runs with WalAppendFailurePolicy.Halt. Keeping the
-        // probe optional means deployments that opt out of the halt
-        // semantics never see the probe in /health/ready output.
-        if (_config.Channels.Any(c => c.Persistence?.Wal is { } w
-            && w.ResolveOnAppendFailure() == B3.Exchange.Core.WalAppendFailurePolicy.Halt))
-        {
-            RegisterReadinessProbe(new B3.Exchange.Core.WalHaltReadinessProbe(_dispatchers));
         }
 
         _startupProbe.MarkReady();

--- a/tests/B3.Exchange.Host.Tests/WalHaltProbeRegistrationTests.cs
+++ b/tests/B3.Exchange.Host.Tests/WalHaltProbeRegistrationTests.cs
@@ -1,0 +1,88 @@
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #294 follow-up: the WAL-halt readiness probe must register
+/// BEFORE <c>HttpServer</c> snapshots <c>_probes</c>, otherwise
+/// <c>RegisterReadinessProbe</c> throws because <c>_http</c> is set.
+/// Regression test: a host with both HTTP enabled and at least one
+/// channel running <see cref="WalAppendFailurePolicy.Halt"/> must boot
+/// cleanly.
+/// </summary>
+public class WalHaltProbeRegistrationTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort cleanup */ }
+    }
+
+    [Fact]
+    public async Task StartAsync_WithWalHaltAndHttpEnabled_BootsCleanly()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var dataDir = Path.Combine(Path.GetTempPath(),
+            "b3-walhalt-boot-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+        try
+        {
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 60000 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 92,
+                        IncrementalGroup = "239.255.42.92",
+                        IncrementalPort = 30192,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                        Persistence = new PersistenceConfig
+                        {
+                            DataDir = dataDir,
+                            Wal = new WalConfig
+                            {
+                                Enabled = true,
+                                FsyncPerWrite = false,
+                                OnAppendFailure = "halt",
+                            },
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            // Pre-fix: this would throw InvalidOperationException because
+            // RegisterReadinessProbe runs after _http is constructed.
+            await host.StartAsync();
+
+            // Probe must observe an initially-healthy channel.
+            Assert.NotNull(host.HttpEndpoint);
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+            using var resp = await client.GetAsync("/health/ready");
+            Assert.True(resp.IsSuccessStatusCode);
+        }
+        finally { TryDeleteDir(dataDir); }
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
@@ -184,4 +184,114 @@ public class WalAppendFailurePolicyTests
             await disp.DisposeAsync();
         }
     }
+
+    [Fact]
+    public async Task Halt_RejectsCross_AtProducerSide()
+    {
+        // Issue #294 follow-up: Cross is state-mutating just like
+        // New/Cancel/Replace and must be gated by the halt check.
+        var wal = new FailingWal();
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(wal, WalAppendFailurePolicy.Halt, out var outbound, metrics);
+        try
+        {
+            disp.Start();
+
+            // Trip the halt by submitting a normal order first.
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 1));
+            await WaitForAsync(() => !disp.IsWalHealthy);
+            Assert.False(disp.IsWalHealthy);
+
+            var buy = new NewOrderCommand("c-buy", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 700u, EnteredAtNanos: 0);
+            var sell = new NewOrderCommand("c-sell", Sec, Side.Sell, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 700u, EnteredAtNanos: 0);
+            var cross = new CrossOrderCommand(buy, sell, BuyClOrdIdValue: 100, SellClOrdIdValue: 101, CrossId: 999);
+            int before = wal.AppendCalls;
+            long rejectsBefore = metrics.WalHaltRejects;
+
+            Assert.False(disp.EnqueueCross(cross, new SessionId("S1"), enteringFirm: 700));
+
+            // No new WAL append (work item never reached the loop) and
+            // halt-reject metric advanced.
+            Assert.Equal(before, wal.AppendCalls);
+            Assert.True(metrics.WalHaltRejects > rejectsBefore);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Halt_RejectsResolvedMassCancel_AtProducerSide()
+    {
+        var wal = new FailingWal();
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(wal, WalAppendFailurePolicy.Halt, out var outbound, metrics);
+        try
+        {
+            disp.Start();
+
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 1));
+            await WaitForAsync(() => !disp.IsWalHealthy);
+            Assert.False(disp.IsWalHealthy);
+
+            int before = wal.AppendCalls;
+            long rejectsBefore = metrics.WalHaltRejects;
+
+            // A non-empty list is required to exercise the gate; the
+            // empty-list short-circuit returns true without checking
+            // halt (idempotent no-op) which is intentional.
+            Assert.False(disp.EnqueueResolvedMassCancel(
+                new long[] { 12345L },
+                new SessionId("S1"),
+                enteringFirm: 700,
+                enteredAtNanos: 0));
+
+            Assert.Equal(before, wal.AppendCalls);
+            Assert.True(metrics.WalHaltRejects > rejectsBefore);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task Halt_DropsAlreadyQueuedWork_OnDispatchLoop()
+    {
+        // Defence-in-depth: a work item posted before the WAL fails can
+        // still be queued when the halt flips. The loop-side gate must
+        // refuse to deliver it to the engine.
+        var wal = new FailingWal();
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(wal, WalAppendFailurePolicy.Halt, out var outbound, metrics);
+        try
+        {
+            // Enqueue many items BEFORE Start so they all sit in the
+            // bounded channel. Once Start runs, the first triggers halt
+            // (WAL throws); all subsequent items must be dropped on the
+            // loop without reaching the engine.
+            for (ulong i = 1; i <= 5; i++)
+                Assert.True(EnqueueOrder(disp, clOrdIdValue: i));
+
+            disp.Start();
+            await WaitForAsync(() => !disp.IsWalHealthy);
+            Assert.False(disp.IsWalHealthy);
+
+            // Give the loop a chance to drain queued items.
+            await Task.Delay(100);
+
+            // Only the very first command attempted a WAL append (and
+            // failed). The engine never observed any New event because
+            // ProcessOne short-circuits on halt.
+            Assert.Equal(1, wal.AppendCalls);
+            Assert.Equal(0, outbound.NewCount);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
 }


### PR DESCRIPTION
gpt-5.5 review of merged PR #294 surfaced one BLOCKER and one HIGH.

## BLOCKER — \`WalHaltReadinessProbe\` registered after \`HttpServer\`

\`ExchangeHost.StartAsync\` called \`RegisterReadinessProbe\` AFTER
constructing \`HttpServer\` (line 366 vs HTTP at line 335).
\`HttpServer\` snapshots the probe list once at construction, and
\`RegisterReadinessProbe\` throws \`InvalidOperationException\` whenever
\`_http != null\`. Any deployment with both HTTP enabled AND at least
one channel running \`WAL OnAppendFailure=halt\` would fail to boot.

**Fix:** move the probe-registration block ABOVE \`HttpServer\`
construction. Probe is now in the very first \`/health/ready\` snapshot.

## HIGH — Halt enforced only for New/Cancel/Replace

The original PR gated \`EnqueueNewOrder\` / \`EnqueueCancel\` /
\`EnqueueReplace\`, but \`EnqueueCross\`, \`EnqueueResolvedMassCancel\`,
operator BumpVersion/TradeBust/SetTradingPhase, and any work item
already queued when halt flipped were still processed by the engine.

**Fix (defence in depth):**
- Producer-side: \`RejectIfWalHalted\` added to \`EnqueueCross\` and
  \`EnqueueResolvedMassCancel\` (after the empty-list short-circuit so
  the idempotent no-op path stays unaffected).
- Loop-side: \`ProcessOne\` now checks \`Volatile.Read(_walHalted)\` after
  the dispatch_wait observation and the snapshot/persist-snapshot
  branches. \`SnapshotRotation\` / \`OperatorSnapshotNow\` /
  \`OperatorPersistSnapshot\` are intentionally still allowed through.

## Tests
- \`Halt_RejectsCross_AtProducerSide\`
- \`Halt_RejectsResolvedMassCancel_AtProducerSide\`
- \`Halt_DropsAlreadyQueuedWork_OnDispatchLoop\` (pre-fills 5 items
  before Start, asserts only 1 WAL append + 0 \`outbound.NewCount\`)
- \`WalHaltProbeRegistrationTests.StartAsync_WithWalHaltAndHttpEnabled_BootsCleanly\`
  (regression for the BLOCKER; also smoke-tests \`/health/ready\`)

994 → 998 tests, all green. Format clean.

Refs #286.