### PR TITLE
fix(persistence): halt on snapshot/WAL boundary seq gap

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -221,9 +221,35 @@ public sealed partial class ChannelDispatcher
         _outbound = NoOpOutbound;
         try
         {
+            bool boundaryChecked = false;
             foreach (var rec in records)
             {
                 if (rec.Seq <= snapshotLastAppliedSeq) { skipped++; continue; }
+                if (!boundaryChecked)
+                {
+                    boundaryChecked = true;
+                    // Issue #285 follow-up (gpt-5.5 round-2 review of PR
+                    // #298): FileChannelWriteAheadLog.ReadAll only
+                    // enforces contiguity among records physically
+                    // present in the WAL — it cannot detect a gap
+                    // straddling the snapshot/WAL boundary (e.g.
+                    // snapshot LastAppliedSeq=2 with WAL starting at
+                    // Seq=4). Replaying that record would fabricate
+                    // state that never existed, the same failure mode
+                    // PR #298 made fatal. Halt the channel here.
+                    long expected = snapshotLastAppliedSeq + 1;
+                    if (rec.Seq != expected)
+                    {
+                        _metrics?.IncWalAppendFailure();
+                        _metrics?.AddWalRecordCorruptions(_wal.LastReadCorruptCount);
+                        _metrics?.AddWalRecordsLegacy(_wal.LastReadLegacyCount);
+                        Volatile.Write(ref _walHalted, 1);
+                        _logger.LogCritical(
+                            "channel {ChannelNumber}: WAL replay aborted — snapshot/WAL boundary gap (snapshotLastAppliedSeq={SnapshotSeq}, firstReplayableSeq={FirstSeq}, expected={Expected}); channel marked WAL-halted, engine left at snapshot baseline",
+                            ChannelNumber, snapshotLastAppliedSeq, rec.Seq, expected);
+                        return;
+                    }
+                }
                 var item = TryBuildReplayWorkItem(rec);
                 if (item is null) continue;
                 try

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
@@ -295,4 +295,69 @@ public class ChannelDispatcherWalTests
         await disp.DisposeAsync();
         wal.Dispose();
     }
+
+    [Fact]
+    public async Task Replay_HaltsOnSnapshotWalBoundaryGap()
+    {
+        // Issue #285 follow-up (gpt-5.5 round-2 review of PR #298):
+        // FileChannelWriteAheadLog.ReadAll only enforces contiguity
+        // among records physically present in the WAL; it cannot
+        // detect a gap straddling the snapshot/WAL boundary
+        // (snapshot LastAppliedSeq=2 with WAL starting at Seq=4).
+        // Replay must halt the channel rather than apply Seq=4 on
+        // top of the snapshot baseline.
+        using var dir = new TempDir();
+        var persister = new InMemoryPersister();
+
+        // Round 1: two orders → snapshot persisted at LastAppliedSeq=2,
+        // WAL truncated.
+        var wal1 = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var dispA = BuildDispatcher(persister, wal1, out _, out _);
+        var probeA = dispA.CreateTestProbe();
+        var session = new SessionId("99999");
+        Assert.True(EnqueueOrder(dispA, session, "CL-A", 0xA, 100UL));
+        probeA.DrainInbound();
+        Assert.True(EnqueueOrder(dispA, session, "CL-B", 0xB, 101UL));
+        probeA.DrainInbound();
+        Assert.Equal(2L, persister.Last[84].LastAppliedSeq);
+        wal1.Dispose();
+
+        // Hand-craft a WAL containing a single record with Seq=4
+        // (Seq=3 missing) — within ReadAll a single record passes
+        // contiguity trivially, so only the dispatcher-level boundary
+        // check can catch this.
+        using (var raw = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false))
+        {
+            raw.Append(new WalRecord(
+                Seq: 4, Kind: WalRecordKind.NewOrder,
+                SessionValue: "99999", Firm: 700, ClOrdId: 0xC, OrigClOrdId: 0,
+                NewOrder: new NewOrderCommand("CL-C", Sec, Side.Buy, OrderType.Limit,
+                    TimeInForce.Day, Px(10.00m), 100, 100, 102UL),
+                Cancel: null, Replace: null));
+        }
+
+        var wal2 = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var metricsB = new ChannelMetrics(84);
+        var dispB = BuildDispatcher(persister, wal2, out var sinkB, out var outB,
+            metrics: metricsB);
+        dispB.Start();
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (dispB.IsWalHealthy && DateTime.UtcNow < deadline)
+            Thread.Sleep(20);
+
+        Assert.False(dispB.IsWalHealthy);
+        // Engine must remain at the snapshot baseline (2 resting orders);
+        // the post-gap record was not applied.
+        Assert.Equal(2, dispB.OrderRegistryCount);
+        // Replay must NOT publish on the wire or send ERs.
+        Assert.Equal(0, sinkB.Published);
+        Assert.Equal(0, outB.NewCount);
+
+        wal2.Dispose();
+        await dispB.DisposeAsync();
+    }
 }


### PR DESCRIPTION
## Context

gpt-5.5 round-2 review of PR #298 (issue #285) flagged a **BLOCKER**: `FileChannelWriteAheadLog.ReadAll` only enforces contiguity among records physically present in the WAL — it cannot detect a gap straddling the snapshot/WAL boundary.

### Failure mode

- Snapshot persisted with `LastAppliedSeq = 2`.
- WAL contains a single record at `Seq = 4` (record 3 missing).
- `ReadAll` succeeds: a single-record WAL passes the in-WAL contiguity check trivially (`prevSeq` starts null).
- `ReplayWalOnLoopThread` skipped `rec.Seq <= snapshotLastAppliedSeq`, then applied record 4 on top of the snapshot baseline → fabricated state that never existed at runtime.

This is the **exact** failure mode PR #298 was meant to make fatal.

## Fix

In `ChannelDispatcher.Wal.cs:ReplayWalOnLoopThread`, after the existing snapshot-skip filter, check the first replayable record's `Seq` against `snapshotLastAppliedSeq + 1`. On mismatch:

- `Volatile.Write(_walHalted, 1)` — same mechanism as the issue #286 halt.
- CRITICAL log line with `snapshotSeq`, `firstReplayableSeq`, `expected`.
- Increment `WalAppendFailure` + corruption/legacy counters.
- Return without applying anything → engine stays at snapshot baseline.

Operators observe `IsWalHealthy = false` on `/readyz` and the new line in stdout/stderr; recovery is to inspect the WAL file and re-bootstrap.

## Tests

New `Replay_HaltsOnSnapshotWalBoundaryGap` dispatcher-level test:

1. Round 1 enqueues two orders → snapshot persisted at `LastAppliedSeq = 2`, WAL truncated.
2. Hand-craft a fresh WAL with a single `Seq = 4` record.
3. Boot a new dispatcher with the same persister + new WAL → wait for `IsWalHealthy = false`.
4. Assert engine is at the snapshot baseline (`OrderRegistryCount = 2`), zero packets published, zero ERs.

## Verification

- `dotnet build SbeB3Exchange.slnx -c Release` — 0 warnings, 0 errors.
- `dotnet test SbeB3Exchange.slnx -c Release --no-build` — 1000 passed, 0 failed.
- `dotnet format SbeB3Exchange.slnx --verify-no-changes --severity warn` — clean.

## Related

Round-2 review of #298. Continuation of issues #285/#286/#293.