### PR TITLE
Add dataDir lock-file to prevent multi-writer corruption (#290)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -876,6 +876,21 @@ The persisted state for a channel is everything matching
 `{dataDir}/channel-{N}.wal`. See §7.4 for the layout — files are
 self-describing, there is no out-of-band index to back up.
 
+> **Single-writer fence (issue [#290](https://github.com/pedrosakuma/B3MatchingPlatform/issues/290)).**
+> On startup the host acquires an exclusive lock on
+> `{dataDir}/.lock` for every distinct configured `dataDir`. A
+> second host process pointed at the same directory refuses to
+> start with `DataDirLockedException` (the message carries the
+> holder's `pid=… startedUtc=… host=…` line written to the lock
+> file). The lock is released on graceful shutdown and on process
+> exit (the OS drops the file handle), so an ungraceful crash does
+> not strand the lock. **Operational implication:** if a stuck pod
+> holds the lock after a forced reschedule, the new pod will fail
+> fast — `kubectl logs` will surface the holder PID; resolve by
+> killing the orphaned process or removing the stale `.lock` file
+> only after confirming no live writer remains. Never run two
+> hosts against the same `dataDir`.
+
 **Backup recipe (rsync-friendly hot copy):**
 
 ```bash

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -44,6 +44,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private HostRouter? _router;
     private HttpServer? _http;
     private DailyResetScheduler? _dailyReset;
+    private readonly List<B3.Exchange.Persistence.DataDirLock> _dataDirLocks = new();
 
     public ExchangeHost(HostConfig config, ILoggerFactory? loggerFactory = null,
         Func<ChannelConfig, IUmdfPacketSink>? packetSinkFactory = null,
@@ -105,6 +106,14 @@ public sealed class ExchangeHost : IAsyncDisposable
     public async Task StartAsync()
     {
         _logger.LogInformation("exchange host starting with {ChannelCount} channels", _config.Channels.Count);
+        // Issue #290: acquire an exclusive lock on every distinct
+        // persistence dataDir before constructing any persister or
+        // WAL. Two host processes pointed at the same dataDir would
+        // silently corrupt each other's snapshot + WAL files; the
+        // lock turns that misconfiguration into a loud refuse-to-
+        // start error with the holder PID surfaced in the exception
+        // message. Acquired locks are released by DisposeAsync.
+        AcquireDataDirLocks();
         var sessionRegistry = new SessionRegistry();
         var gatewayRouter = new GatewayRouter(sessionRegistry, _loggerFactory.CreateLogger<GatewayRouter>());
 
@@ -458,6 +467,35 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// Builds the per-channel persister (issue #260). Returns
     /// <c>null</c> when the channel has no <c>persistence</c> block,
     /// preserving the legacy stateless boot for configs that haven't
+    /// <summary>
+    /// Issue #290: walks the channels list, dedupes by absolute
+    /// dataDir path, and acquires an exclusive
+    /// <see cref="B3.Exchange.Persistence.DataDirLock"/> per
+    /// distinct directory. Throws on the first directory that is
+    /// already held by another process so the host fails fast
+    /// rather than silently corrupting concurrent writers.
+    /// </summary>
+    private void AcquireDataDirLocks()
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var ch in _config.Channels)
+        {
+            if (ch.Persistence is null) continue;
+            var dir = ch.Persistence.DataDir;
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            var canonical = Path.GetFullPath(dir);
+            if (!seen.Add(canonical)) continue;
+            var lockHandle = B3.Exchange.Persistence.DataDirLock.Acquire(
+                canonical,
+                _loggerFactory.CreateLogger<B3.Exchange.Persistence.DataDirLock>());
+            _dataDirLocks.Add(lockHandle);
+        }
+    }
+
+    /// <summary>
+    /// Builds the per-channel persister (issue #260). Returns
+    /// <c>null</c> when the channel has no <c>persistence</c> block,
+    /// preserving the legacy stateless boot for configs that haven't
     /// opted in.
     /// </summary>
     private IChannelStatePersister? BuildPersister(ChannelConfig ch)
@@ -626,6 +664,13 @@ public sealed class ExchangeHost : IAsyncDisposable
         foreach (var p in _instrumentDefPublishers) await p.DisposeAsync().ConfigureAwait(false);
         foreach (var d in _dispatchers) await d.DisposeAsync().ConfigureAwait(false);
         foreach (var s in _ownedSinks) s.Dispose();
+        // Issue #290: release dataDir locks last so any persister/WAL
+        // shutdown that needs the directory still has it.
+        foreach (var l in _dataDirLocks)
+        {
+            try { l.Dispose(); } catch { }
+        }
+        _dataDirLocks.Clear();
     }
 
     private int _stopCalled;

--- a/src/B3.Exchange.Persistence/DataDirLock.cs
+++ b/src/B3.Exchange.Persistence/DataDirLock.cs
@@ -1,0 +1,155 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Persistence;
+
+/// <summary>
+/// Issue #290: exclusive single-writer fence for a persistence
+/// <c>dataDir</c>. Two host processes pointing at the same directory
+/// would silently corrupt each other's WAL + snapshot files
+/// (interleaved appends, racing tmp+rename, lost truncations).
+///
+/// <para>The lock is implemented as a held-open file
+/// (<c>{dataDir}/.lock</c>) opened with <see cref="FileShare.None"/>.
+/// The OS releases the file handle automatically on process exit, so
+/// even an ungraceful shutdown (kill -9, segfault, OOM) does not
+/// strand the lock. On graceful shutdown <see cref="Dispose"/>
+/// closes the handle and removes the file.</para>
+///
+/// <para>The first line of the file is the holder's PID + ISO-8601
+/// UTC start timestamp + machine name, written for diagnostic
+/// purposes — when a second instance fails to acquire, it tries to
+/// read the line and surfaces it in the thrown
+/// <see cref="DataDirLockedException"/> so the operator can identify
+/// the offending process.</para>
+/// </summary>
+public sealed class DataDirLock : IDisposable
+{
+    /// <summary>Lock file name within the data directory.</summary>
+    public const string LockFileName = ".lock";
+
+    private readonly FileStream _stream;
+    private readonly string _path;
+    private readonly ILogger<DataDirLock> _logger;
+    private int _disposed;
+
+    /// <summary>Absolute path to the held lock file.</summary>
+    public string Path => _path;
+
+    private DataDirLock(FileStream stream, string path, ILogger<DataDirLock> logger)
+    {
+        _stream = stream;
+        _path = path;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Acquires the exclusive lock on <paramref name="dataDir"/>.
+    /// Creates the directory if it does not exist. Throws
+    /// <see cref="DataDirLockedException"/> if another process
+    /// already holds the lock.
+    /// </summary>
+    public static DataDirLock Acquire(string dataDir, ILogger<DataDirLock> logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataDir);
+        ArgumentNullException.ThrowIfNull(logger);
+        Directory.CreateDirectory(dataDir);
+        var path = System.IO.Path.Combine(System.IO.Path.GetFullPath(dataDir), LockFileName);
+
+        FileStream stream;
+        try
+        {
+            // FileShare.None on both POSIX and Windows: a second
+            // process opening the same path with FileShare.None will
+            // fail with IOException (Windows) or, on Linux, .NET
+            // emulates exclusive open via flock — either way, the
+            // second open throws.
+            stream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite,
+                FileShare.None, bufferSize: 4096, FileOptions.None);
+        }
+        catch (IOException ex)
+        {
+            // Best-effort read of the existing holder identity.
+            string? holder = TryReadHolder(path);
+            logger.LogError(ex,
+                "datadir {DataDir} lock acquisition failed; holder={Holder}",
+                dataDir, holder ?? "<unknown>");
+            throw new DataDirLockedException(dataDir, holder, ex);
+        }
+
+        try
+        {
+            stream.SetLength(0);
+            int pid = Environment.ProcessId;
+            string line = string.Create(CultureInfo.InvariantCulture,
+                $"pid={pid} startedUtc={DateTime.UtcNow:O} host={Environment.MachineName}\n");
+            byte[] bytes = Encoding.UTF8.GetBytes(line);
+            stream.Write(bytes, 0, bytes.Length);
+            stream.Flush(flushToDisk: true);
+        }
+        catch
+        {
+            try { stream.Dispose(); } catch { }
+            throw;
+        }
+
+        logger.LogInformation("datadir {DataDir} lock acquired (pid={Pid})",
+            dataDir, Environment.ProcessId);
+        return new DataDirLock(stream, path, logger);
+    }
+
+    private static string? TryReadHolder(string path)
+    {
+        try
+        {
+            // Re-open with FileShare.ReadWrite so we can read while
+            // the holder still has it open exclusively. On most
+            // platforms FileShare.None on the holder will block this,
+            // in which case we just return null.
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            using var sr = new StreamReader(fs, Encoding.UTF8);
+            return sr.ReadLine();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+        try { _stream.Dispose(); } catch { }
+        // Best-effort delete; if it fails the next process will just
+        // overwrite the contents on acquire.
+        try { File.Delete(_path); } catch { }
+        _logger.LogInformation("datadir lock released ({Path})", _path);
+    }
+}
+
+/// <summary>
+/// Thrown by <see cref="DataDirLock.Acquire"/> when the directory
+/// is already locked by another process. The
+/// <see cref="HolderInfo"/> property carries the
+/// <c>pid=… startedUtc=… host=…</c> line written by the holder, or
+/// <c>null</c> if it could not be read.
+/// </summary>
+public sealed class DataDirLockedException : InvalidOperationException
+{
+    public string DataDir { get; }
+    public string? HolderInfo { get; }
+
+    public DataDirLockedException(string dataDir, string? holderInfo, Exception innerException)
+        : base(BuildMessage(dataDir, holderInfo), innerException)
+    {
+        DataDir = dataDir;
+        HolderInfo = holderInfo;
+    }
+
+    private static string BuildMessage(string dataDir, string? holderInfo)
+        => holderInfo is null
+            ? $"data directory '{dataDir}' is already locked by another process (could not read holder)"
+            : $"data directory '{dataDir}' is already locked by another process ({holderInfo})";
+}

--- a/tests/B3.Exchange.Persistence.Tests/DataDirLockTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/DataDirLockTests.cs
@@ -1,0 +1,76 @@
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+public sealed class DataDirLockTests : IDisposable
+{
+    private readonly string _root;
+
+    public DataDirLockTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "datadir-lock-tests-" + Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void Acquire_CreatesLockFile()
+    {
+        using var lk = DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance);
+        var path = Path.Combine(_root, DataDirLock.LockFileName);
+        Assert.True(File.Exists(path));
+        Assert.Equal(path, lk.Path);
+    }
+
+    [Fact]
+    public void Dispose_RemovesLockFile()
+    {
+        var lk = DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance);
+        var path = Path.Combine(_root, DataDirLock.LockFileName);
+        Assert.True(File.Exists(path));
+        lk.Dispose();
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void Acquire_SecondInstance_Throws()
+    {
+        using var first = DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance);
+        var ex = Assert.Throws<DataDirLockedException>(() =>
+            DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance));
+        Assert.Equal(Path.GetFullPath(_root), ex.DataDir);
+        Assert.Contains("locked by another process", ex.Message);
+    }
+
+    [Fact]
+    public void Acquire_AfterDispose_Succeeds()
+    {
+        var first = DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance);
+        first.Dispose();
+        // Second acquisition must succeed and not throw.
+        using var second = DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance);
+        Assert.True(File.Exists(Path.Combine(_root, DataDirLock.LockFileName)));
+    }
+
+    [Fact]
+    public void Acquire_CreatesMissingDirectory()
+    {
+        var nested = Path.Combine(_root, "nested", "sub");
+        using var lk = DataDirLock.Acquire(nested, NullLogger<DataDirLock>.Instance);
+        Assert.True(Directory.Exists(nested));
+        Assert.True(File.Exists(Path.Combine(nested, DataDirLock.LockFileName)));
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var lk = DataDirLock.Acquire(_root, NullLogger<DataDirLock>.Instance);
+        lk.Dispose();
+        lk.Dispose(); // no-throw
+    }
+}


### PR DESCRIPTION
Closes #290.

## Summary

Two host processes pointed at the same persistence `dataDir` would
silently interleave snapshot generations and WAL appends. This PR
adds an exclusive single-writer fence acquired at host startup
before any persister/WAL is constructed, so the misconfiguration
becomes a loud refuse-to-start error with the holder PID surfaced
in the exception message.

## Implementation

- New `DataDirLock` class in `B3.Exchange.Persistence`. Holds an
  open `FileStream` on `{dataDir}/.lock` (`FileMode.OpenOrCreate`
  + `FileShare.None`). Writes `pid=… startedUtc=… host=…` to the
  file. Disposable; deletes the file on graceful shutdown. The OS
  releases the file handle on process exit (SIGKILL, SIGSEGV,
  OOM) so an ungraceful crash never strands the lock.
- New `DataDirLockedException` carries the holder identity for
  diagnostics.
- `ExchangeHost.AcquireDataDirLocks` dedupes channel persistence
  `dataDir`s by absolute path and acquires one lock per distinct
  directory at the top of `StartAsync`. Releases in
  `DisposeAsync` after persisters/WAL have shut down.

## Tests

6 new unit tests in `DataDirLockTests`: creation, dispose removes
file, second-instance refusal, post-dispose reacquire,
missing-directory create, dispose idempotency. Full suite green.

## Docs

`RUNBOOK §7.6` gains a single-writer-fence callout with operator
guidance for stuck-pod scenarios.

## Acceptance criteria from the issue

- [x] Lock acquired on startup, released on graceful shutdown.
- [x] Failure to acquire ⇒ structured log + exception.
- [x] Test for "second instance refuses to start".
- [x] RUNBOOK §7.6 gains a note about the lock.