### PR TITLE
Add WAL size cap with halt/drop on-full policy (#291)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -703,6 +703,8 @@ text format, `channel="{N}"` label on every series).
 | `exch_wal_records_legacy_total` | counter | WAL records replayed in pre-#285 (no Crc32C suffix) format. Steady-state should be `0` once every channel has rolled past the upgrade. |
 | `exch_wal_append_failures_total` | counter | WAL `Append` calls that threw (issue #286). Counted under both `continue` and `halt` policies; the canonical "WAL is failing" alert. |
 | `exch_wal_halt_rejects_total` | counter | Producer-side `Enqueue*` rejections after the channel was WAL-halted (issue #286). Always `0` unless the channel runs with `persistence.wal.onAppendFailure=halt`. |
+| `exch_wal_size_bytes` | gauge | Current on-disk size of the channel's WAL file (issue #291). Compare against `persistence.wal.maxBytes` to alert before the cap is reached. A flat-line at the cap under `onFull=halt` indicates a halted channel; a flat-line under `onFull=drop` indicates silent data loss. |
+| `exch_wal_drops_on_full_total` | counter | WAL appends silently skipped because `persistence.wal.maxBytes` was reached and `onFull=drop` (issue #291). Distinct from `exch_wal_append_failures_total` so on-call can route a capacity-exhaustion alert separately from a generic IO-fault alert. |
 | `exch_owner_orphans_dropped_total` | counter | `OrderOwnerSnapshot` entries whose sessionId was not in the registry at restore time, dropped per `orphanSessionPolicy=drop`. |
 
 ### 7.4 On-disk layout & WAL design
@@ -774,6 +776,25 @@ flip), the channel honours `persistence.wal.onAppendFailure`:
 | --- | --- |
 | `continue` (default) | Log + bump `exch_wal_append_failures_total`, then run the command. The live consumer view stays consistent, but the command is **not durable** — a host crash before the next snapshot will silently drop it on replay. |
 | `halt` | Log + bump `exch_wal_append_failures_total`, **refuse** the command (no engine mutation, no UMDF emission, no ExecutionReport), flip the channel's WAL-halt flag. The host's `wal-halt` readiness probe goes NOT_READY so load balancers drain new connections; subsequent `Enqueue*` calls are short-circuited and counted by `exch_wal_halt_rejects_total`. The halt is sticky — the operator must restart the host after fixing the underlying storage fault. |
+
+**Size cap & on-full policy** (issue
+[#291](https://github.com/pedrosakuma/B3MatchingPlatform/issues/291)):
+without a cap the WAL grows unbounded between snapshots. If
+snapshots stop succeeding (disk-full elsewhere, persister bug,
+permission flip) the WAL alone will eventually fill the
+filesystem and bring down unrelated subsystems. Set
+`persistence.wal.maxBytes` to the operational ceiling for a
+single channel's WAL and pick `persistence.wal.onFull`:
+
+| Value | Behavior |
+| --- | --- |
+| `halt` (default) | The next `Append` that would push past `maxBytes` throws `WalSizeCapExceededException`. The dispatcher catches this exception **specifically** and marks the channel WAL-halted **regardless** of `onAppendFailure` — silent degradation is disallowed once the operator has explicitly opted into a hard cap. The halt is sticky and clears only on host restart (after raising the cap or resolving the snapshot fault). Same readiness-probe + producer-side reject behaviour as `onAppendFailure=halt`. |
+| `drop` | Silently skip the WAL write, log at warning, bump `exch_wal_drops_on_full_total`, let the command run. Same trade-off as `onAppendFailure=continue` — the live consumer view stays consistent but the command is **not durable**. Distinct counter so on-call can route a "WAL is full" page differently from a "WAL is throwing" page. |
+
+The cap is checked **before** the append stream is opened, so a
+breach never adds even one byte to the file. A successful
+snapshot persist truncates the WAL and resets `exch_wal_size_bytes`
+to `0`, restoring the full budget.
 
 **Idempotency note:** if the newest snapshot is corrupt and the
 persister falls back to an older slot, replay starts from that

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -79,7 +79,25 @@ public sealed partial class ChannelDispatcher
             long approxBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(rec).Length + 1;
             _wal.Append(rec);
             _metrics?.IncWalAppend(approxBytes);
+            _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
+            _metrics?.SetWalDropsOnFull(_wal.DropsOnFullCount);
             return true;
+        }
+        catch (WalSizeCapExceededException ex)
+        {
+            // Issue #291: cap breach is a configuration/capacity bug,
+            // not a transient IO fault — always halt regardless of
+            // _walAppendFailurePolicy. We never want to silently
+            // degrade durability when the operator has explicitly
+            // opted into a hard cap.
+            _metrics?.IncWalAppendFailure();
+            _metrics?.IncDispatcherCrashes();
+            _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
+            Volatile.Write(ref _walHalted, 1);
+            _logger.LogCritical(ex,
+                "channel {ChannelNumber}: WAL size cap exceeded (seq={Seq} kind={Kind} current={CurrentBytes}B max={MaxBytes}B); channel marked unhealthy and command refused; restart the host after raising the cap or resolving the snapshot fault",
+                ChannelNumber, _lastAppliedSeq, item.Kind, ex.CurrentSizeBytes, ex.MaxBytes);
+            return false;
         }
         catch (Exception ex)
         {
@@ -126,6 +144,7 @@ public sealed partial class ChannelDispatcher
         {
             _wal.Truncate();
             _metrics?.IncWalTruncation();
+            _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
         }
         catch (Exception ex)
         {
@@ -148,6 +167,7 @@ public sealed partial class ChannelDispatcher
         {
             _wal.Truncate();
             _metrics?.IncWalTruncation();
+            _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
         }
         catch (Exception ex)
         {

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -104,4 +104,23 @@ public interface IChannelWriteAheadLog
     /// (pre-#285 files). Default 0 for in-memory fakes.
     /// </summary>
     int LastReadLegacyCount => 0;
+
+    /// <summary>
+    /// Issue #291: current on-disk size in bytes (or in-memory
+    /// equivalent for non-file implementations). Surfaced via the
+    /// <c>exch_wal_size_bytes</c> gauge so operators can alert
+    /// before the configured cap is hit. Defaults to 0 for
+    /// in-memory fakes.
+    /// </summary>
+    long CurrentSizeBytes => 0;
+
+    /// <summary>
+    /// Issue #291: cumulative count of <see cref="Append"/> calls
+    /// that the WAL silently dropped because the configured
+    /// <c>maxBytes</c> cap was already reached and the resolved
+    /// <see cref="WalSizeCapPolicy"/> is
+    /// <see cref="WalSizeCapPolicy.Drop"/>. Surfaced via
+    /// <c>exch_wal_drops_on_full_total</c>. Defaults to 0.
+    /// </summary>
+    long DropsOnFullCount => 0;
 }

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -238,6 +238,27 @@ public sealed class ChannelMetrics
     public void IncWalAppendFailure() => Interlocked.Increment(ref _walAppendFailures);
     public void IncWalHaltReject() => Interlocked.Increment(ref _walHaltRejects);
 
+    /// <summary>Issue #291: current on-disk WAL size in bytes
+    /// (gauge). Updated by the dispatcher after every successful
+    /// Append/Truncate so the alert can fire well before
+    /// <c>maxBytes</c> is reached.</summary>
+    private long _walSizeBytes;
+    public long WalSizeBytes => Interlocked.Read(ref _walSizeBytes);
+    public void SetWalSizeBytes(long bytes) => Interlocked.Exchange(ref _walSizeBytes, bytes);
+
+    /// <summary>Issue #291: cumulative count of WAL appends silently
+    /// skipped because <c>maxBytes</c> was reached and the resolved
+    /// <see cref="WalSizeCapPolicy"/> is
+    /// <see cref="WalSizeCapPolicy.Drop"/>. Distinct from
+    /// <see cref="WalAppendFailures"/> so on-call can route a "WAL
+    /// is full" page differently from a "WAL is throwing" page.
+    /// Always 0 under <see cref="WalSizeCapPolicy.Halt"/> (the
+    /// halt path bumps <see cref="WalAppendFailures"/> instead and
+    /// flips the channel to unhealthy).</summary>
+    private long _walDropsOnFull;
+    public long WalDropsOnFull => Interlocked.Read(ref _walDropsOnFull);
+    public void SetWalDropsOnFull(long count) => Interlocked.Exchange(ref _walDropsOnFull, count);
+
     public void IncSnapshotSaveOk() => Interlocked.Increment(ref _snapshotSavesOk);
     public void IncSnapshotSaveFailure() => Interlocked.Increment(ref _snapshotSaveFailures);
     public void IncSnapshotValidationFailure() => Interlocked.Increment(ref _snapshotValidationFailures);
@@ -645,6 +666,12 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_wal_halt_rejects_total",
             "Issue #286: producer-side Enqueue* rejections after the channel was WAL-halted. Always 0 unless the channel runs with persistence.wal.onAppendFailure=halt; non-zero means the operator must restart the host after fixing the underlying disk fault.",
             channels, c => c.WalHaltRejects);
+        EmitGauge(sb, "exch_wal_size_bytes",
+            "Issue #291: current on-disk size of the channel's WAL file in bytes. Compare against persistence.wal.maxBytes to alert before the cap is reached. A flat-line at the cap under onFull=halt indicates a halted channel; a flat-line under onFull=drop indicates silent data loss.",
+            channels, c => c.WalSizeBytes);
+        EmitCounter(sb, "exch_wal_drops_on_full_total",
+            "Issue #291: WAL Append() calls silently skipped because persistence.wal.maxBytes was reached and persistence.wal.onFull=drop. Distinct from exch_wal_append_failures_total so on-call can route a capacity-exhaustion alert separately from a generic IO-fault alert. Non-zero means the durability contract has been silently relaxed on this channel.",
+            channels, c => c.WalDropsOnFull);
 
         // Issue #270: cross-channel consistency check. Counts owner
         // entries silently dropped at restore because their SessionId

--- a/src/B3.Exchange.Core/WalSizeCapExceededException.cs
+++ b/src/B3.Exchange.Core/WalSizeCapExceededException.cs
@@ -1,0 +1,33 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #291: thrown by
+/// <see cref="IChannelWriteAheadLog.Append"/> when the configured
+/// <c>maxBytes</c> cap would be exceeded by the incoming record
+/// AND the resolved <see cref="WalSizeCapPolicy"/> is
+/// <see cref="WalSizeCapPolicy.Halt"/>. The dispatcher catches
+/// this exception specifically (before its
+/// <see cref="WalAppendFailurePolicy"/> dispatch) and always
+/// marks the channel WAL-halted — a cap breach is a
+/// configuration / capacity bug, not a transient IO fault, so we
+/// never silently degrade to the Continue path.
+/// </summary>
+public sealed class WalSizeCapExceededException : System.IO.IOException
+{
+    /// <summary>Current on-disk size in bytes.</summary>
+    public long CurrentSizeBytes { get; }
+
+    /// <summary>Configured cap in bytes.</summary>
+    public long MaxBytes { get; }
+
+    /// <summary>Size of the record that would have pushed past the cap.</summary>
+    public int IncomingRecordBytes { get; }
+
+    public WalSizeCapExceededException(long currentSizeBytes, long maxBytes, int incomingRecordBytes)
+        : base($"WAL size cap exceeded: current={currentSizeBytes}B + incoming={incomingRecordBytes}B > maxBytes={maxBytes}B")
+    {
+        CurrentSizeBytes = currentSizeBytes;
+        MaxBytes = maxBytes;
+        IncomingRecordBytes = incomingRecordBytes;
+    }
+}

--- a/src/B3.Exchange.Core/WalSizeCapPolicy.cs
+++ b/src/B3.Exchange.Core/WalSizeCapPolicy.cs
@@ -1,0 +1,39 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #291: policy applied by
+/// <see cref="IChannelWriteAheadLog.Append"/> when accepting the
+/// next record would push the on-disk WAL size past its
+/// configured <c>maxBytes</c> cap.
+///
+/// <para>The cap exists to bound disk consumption when snapshots
+/// stop succeeding (disk-full elsewhere, persister bug,
+/// permission flip): without it the WAL grows until the
+/// filesystem is full, at which point unrelated subsystems also
+/// start failing. The cap turns "WAL eats the disk" into a loud,
+/// channel-scoped failure that the operator can react to.</para>
+///
+/// <para><see cref="Halt"/> (default) refuses the append by
+/// throwing — the dispatcher catches the cap-specific exception
+/// and marks the channel WAL-halted regardless of
+/// <see cref="WalAppendFailurePolicy"/>, because a cap breach is
+/// a configuration / capacity bug rather than a transient IO
+/// fault and we never want to silently degrade durability when
+/// the operator has explicitly opted into a hard cap.</para>
+///
+/// <para><see cref="Drop"/> silently skips the append, logs at
+/// <c>Warning</c>, and bumps <c>exch_wal_drops_on_full_total</c>.
+/// Same trade-off as <see cref="WalAppendFailurePolicy.Continue"/>
+/// on append failure but explicit: the engine still mutates so
+/// the live consumer view stays consistent, but the command is
+/// not durable — a host crash before the next successful
+/// snapshot will silently lose it on replay.</para>
+/// </summary>
+public enum WalSizeCapPolicy
+{
+    /// <summary>Throw, refuse the command, mark the channel unhealthy (default).</summary>
+    Halt = 0,
+
+    /// <summary>Log + metric, skip the WAL write, let the command run anyway.</summary>
+    Drop = 1,
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -557,7 +557,9 @@ public sealed class ExchangeHost : IAsyncDisposable
             ch.Persistence.DataDir,
             ch.ChannelNumber,
             _loggerFactory.CreateLogger<FileChannelWriteAheadLog>(),
-            walCfg.FsyncPerWrite);
+            walCfg.FsyncPerWrite,
+            walCfg.MaxBytes,
+            walCfg.ResolveOnFull());
     }
 
     /// <summary>

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -400,6 +400,43 @@ public sealed class WalConfig
             _ => throw new InvalidOperationException(
                 $"persistence.wal.onAppendFailure: unknown value '{OnAppendFailure}' (expected 'continue' or 'halt')"),
         };
+
+    /// <summary>
+    /// Issue #291: optional cap (in bytes) on the on-disk WAL
+    /// size. <c>0</c> (default) disables the cap, restoring the
+    /// pre-#291 unbounded behaviour. When set, the dispatcher
+    /// applies <see cref="OnFull"/> when the next append would
+    /// exceed the cap; until a successful snapshot persist
+    /// truncates the WAL the cap stays in force.
+    /// </summary>
+    [JsonPropertyName("maxBytes")] public long MaxBytes { get; set; }
+
+    /// <summary>
+    /// Issue #291: behaviour when <see cref="MaxBytes"/> would be
+    /// exceeded. Accepted values: <c>"halt"</c> (default — refuse
+    /// the command, mark the channel WAL-halted regardless of
+    /// <see cref="OnAppendFailure"/>) or <c>"drop"</c> (silently
+    /// skip the WAL write, log + bump
+    /// <c>exch_wal_drops_on_full_total</c>, let the command run).
+    /// Case-insensitive. Ignored when
+    /// <see cref="MaxBytes"/> &lt;= 0.
+    /// </summary>
+    [JsonPropertyName("onFull")] public string OnFull { get; set; } = "halt";
+
+    /// <summary>
+    /// Parses <see cref="OnFull"/> case-insensitively to the typed
+    /// enum. Throws on unknown values so misconfiguration fails
+    /// the boot rather than silently degrading to the wrong
+    /// policy.
+    /// </summary>
+    public B3.Exchange.Core.WalSizeCapPolicy ResolveOnFull() =>
+        OnFull?.Trim().ToLowerInvariant() switch
+        {
+            null or "" or "halt" => B3.Exchange.Core.WalSizeCapPolicy.Halt,
+            "drop" => B3.Exchange.Core.WalSizeCapPolicy.Drop,
+            _ => throw new InvalidOperationException(
+                $"persistence.wal.onFull: unknown value '{OnFull}' (expected 'halt' or 'drop')"),
+        };
 }
 
 /// <summary>

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -70,10 +70,14 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     private readonly string _path;
     private readonly string _dataDir;
     private readonly bool _fsyncPerWrite;
+    private readonly long _maxBytes;
+    private readonly WalSizeCapPolicy _onFull;
     private readonly ILogger<FileChannelWriteAheadLog> _logger;
     private readonly byte _channelNumber;
     private readonly object _writeLock = new();
     private FileStream? _appendStream;
+    private long _currentSize;
+    private long _dropsOnFull;
 
     /// <summary>
     /// Number of records the most recent <see cref="ReadAll"/> call
@@ -91,6 +95,14 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     /// </summary>
     public int LastReadLegacyCount { get; private set; }
 
+    /// <summary>Issue #291: current on-disk size in bytes; surfaces
+    /// <c>exch_wal_size_bytes</c> via <see cref="CurrentSizeBytes"/>.</summary>
+    public long CurrentSizeBytes => Interlocked.Read(ref _currentSize);
+
+    /// <summary>Issue #291: cumulative count of appends silently
+    /// skipped under <see cref="WalSizeCapPolicy.Drop"/>.</summary>
+    public long DropsOnFullCount => Interlocked.Read(ref _dropsOnFull);
+
     public string Path => _path;
 
     public FileChannelWriteAheadLog(
@@ -98,6 +110,36 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         byte channelNumber,
         ILogger<FileChannelWriteAheadLog> logger,
         bool fsyncPerWrite = true)
+        : this(dataDirectory, channelNumber, logger, fsyncPerWrite,
+            maxBytes: 0, onFull: WalSizeCapPolicy.Halt)
+    {
+    }
+
+    /// <summary>
+    /// Issue #291 overload accepting an on-disk size cap and the
+    /// policy applied when the next append would exceed it.
+    /// <paramref name="maxBytes"/> &lt;= 0 disables the cap (legacy
+    /// unbounded behaviour). When the cap is positive,
+    /// <paramref name="onFull"/>:
+    /// <list type="bullet">
+    ///   <item><see cref="WalSizeCapPolicy.Halt"/> (default) throws
+    ///   <see cref="WalSizeCapExceededException"/> from
+    ///   <see cref="Append"/>. The dispatcher recognises this
+    ///   exception specifically and marks the channel WAL-halted
+    ///   regardless of <see cref="WalAppendFailurePolicy"/>.</item>
+    ///   <item><see cref="WalSizeCapPolicy.Drop"/> silently skips the
+    ///   write, logs at Warning, and increments
+    ///   <see cref="DropsOnFullCount"/> (surfaced as
+    ///   <c>exch_wal_drops_on_full_total</c>).</item>
+    /// </list>
+    /// </summary>
+    public FileChannelWriteAheadLog(
+        string dataDirectory,
+        byte channelNumber,
+        ILogger<FileChannelWriteAheadLog> logger,
+        bool fsyncPerWrite,
+        long maxBytes,
+        WalSizeCapPolicy onFull)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
         ArgumentNullException.ThrowIfNull(logger);
@@ -105,9 +147,19 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         Directory.CreateDirectory(_dataDir);
         _channelNumber = channelNumber;
         _fsyncPerWrite = fsyncPerWrite;
+        _maxBytes = maxBytes > 0 ? maxBytes : 0;
+        _onFull = onFull;
         _logger = logger;
         _path = System.IO.Path.Combine(_dataDir,
             string.Format(CultureInfo.InvariantCulture, WalFileNameFormat, channelNumber));
+        // Initialise the size counter from any existing on-disk file
+        // so a host restart inherits the pre-restart usage instead of
+        // claiming the WAL is empty until the next truncation.
+        if (File.Exists(_path))
+        {
+            try { _currentSize = new FileInfo(_path).Length; }
+            catch { _currentSize = 0; }
+        }
     }
 
     public void Append(WalRecord record)
@@ -115,14 +167,27 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         ArgumentNullException.ThrowIfNull(record);
         lock (_writeLock)
         {
+            var json = JsonSerializer.SerializeToUtf8Bytes(record, JsonOptions);
+            // Layout: <json bytes> \t <8-hex Crc32C> \n
+            int recordBytes = json.Length + 1 /* \t */ + 8 /* hex crc */ + 1 /* \n */;
+            // Issue #291: enforce on-disk size cap before opening the
+            // append stream so a Drop policy never even creates the
+            // file when the cap is already exceeded by replay state.
+            if (_maxBytes > 0 && _currentSize + recordBytes > _maxBytes)
+            {
+                if (_onFull == WalSizeCapPolicy.Drop)
+                {
+                    Interlocked.Increment(ref _dropsOnFull);
+                    _logger.LogWarning(
+                        "WAL channel-{Channel}: size cap reached (current={Current}B, incoming={Incoming}B, max={Max}B); dropping record (onFull=drop)",
+                        _channelNumber, _currentSize, recordBytes, _maxBytes);
+                    return;
+                }
+                throw new WalSizeCapExceededException(_currentSize, _maxBytes, recordBytes);
+            }
             _appendStream ??= new FileStream(_path,
                 FileMode.Append, FileAccess.Write, FileShare.Read);
-            var json = JsonSerializer.SerializeToUtf8Bytes(record, JsonOptions);
             uint crc = Crc32C.Compute(json);
-            // Layout: <json bytes> \t <8-hex Crc32C> \n. Tab is safe
-            // because JsonSerializer escapes literal tabs to \t inside
-            // strings, so the last \t in the line is always our
-            // separator.
             Span<byte> crcBytes = stackalloc byte[8];
             WriteHexUtf8(crc, crcBytes);
             _appendStream.Write(json, 0, json.Length);
@@ -137,6 +202,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
             {
                 _appendStream.Flush();
             }
+            Interlocked.Add(ref _currentSize, recordBytes);
         }
     }
 
@@ -379,6 +445,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                 }
                 File.Move(tmp, _path, overwrite: true);
                 FsyncDirectory(_dataDir);
+                Interlocked.Exchange(ref _currentSize, 0);
             }
             catch (Exception ex)
             {
@@ -407,6 +474,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                     string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
                 if (File.Exists(tmp)) File.Delete(tmp);
                 FsyncDirectory(_dataDir);
+                Interlocked.Exchange(ref _currentSize, 0);
                 _logger.LogInformation(
                     "channel {ChannelNumber}: admin Reset removed WAL at {Path}",
                     _channelNumber, _path);

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogSizeCapTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogSizeCapTests.cs
@@ -1,0 +1,140 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using Side = B3.Exchange.Matching.Side;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #291: <see cref="FileChannelWriteAheadLog"/> enforces an
+/// optional <c>maxBytes</c> cap with two policies — Halt (default,
+/// throws <see cref="WalSizeCapExceededException"/>) and Drop
+/// (silently skips the write + bumps
+/// <see cref="FileChannelWriteAheadLog.DropsOnFullCount"/>). Both
+/// policies leave <see cref="FileChannelWriteAheadLog.CurrentSizeBytes"/>
+/// at the pre-overflow value (drops do not advance it; halts never
+/// reach the disk).
+/// </summary>
+public class FileChannelWriteAheadLogSizeCapTests
+{
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "wal-cap-" + Guid.NewGuid().ToString("N"));
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { } }
+    }
+
+    private static WalRecord MakeNew(long seq, ulong clOrdId)
+        => new(seq, WalRecordKind.NewOrder, "S", 1u, clOrdId, 0,
+            new NewOrderCommand(ClOrdId: clOrdId.ToString(), SecurityId: 1, Side: Side.Buy,
+                Type: OrderType.Limit, Tif: TimeInForce.Day, PriceMantissa: 100_0000,
+                Quantity: 10, EnteringFirm: 1u, EnteredAtNanos: 0),
+            null, null);
+
+    [Fact]
+    public void NoCap_AcceptsArbitraryAppends()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(
+            dir.Path, channelNumber: 1,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt);
+        for (long s = 1; s <= 50; s++) wal.Append(MakeNew(s, (ulong)s));
+        Assert.Equal(50, wal.ReadAll().Count);
+        Assert.True(wal.CurrentSizeBytes > 0);
+        Assert.Equal(0, wal.DropsOnFullCount);
+    }
+
+    [Fact]
+    public void Halt_Throws_WhenAppendWouldExceedCap()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(
+            dir.Path, channelNumber: 1,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: false, maxBytes: 512, onFull: WalSizeCapPolicy.Halt);
+
+        long seq = 1;
+        // Fill until the next append would exceed.
+        Assert.Throws<WalSizeCapExceededException>(() =>
+        {
+            for (; seq <= 1_000; seq++) wal.Append(MakeNew(seq, (ulong)seq));
+        });
+
+        long sizeAfterThrow = wal.CurrentSizeBytes;
+        Assert.True(sizeAfterThrow <= 512);
+        Assert.Equal(0, wal.DropsOnFullCount);
+
+        // Subsequent attempts should also throw (no silent advance).
+        Assert.Throws<WalSizeCapExceededException>(() => wal.Append(MakeNew(seq, (ulong)seq)));
+        Assert.Equal(sizeAfterThrow, wal.CurrentSizeBytes);
+    }
+
+    [Fact]
+    public void Drop_SilentlySkips_AndBumpsCounter()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(
+            dir.Path, channelNumber: 1,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: false, maxBytes: 512, onFull: WalSizeCapPolicy.Drop);
+
+        for (long s = 1; s <= 1_000; s++) wal.Append(MakeNew(s, (ulong)s));
+
+        Assert.True(wal.CurrentSizeBytes <= 512);
+        Assert.True(wal.DropsOnFullCount > 0);
+        // Records that fit are durable.
+        var records = wal.ReadAll();
+        Assert.True(records.Count > 0);
+        Assert.True(records.Count + wal.DropsOnFullCount == 1_000);
+    }
+
+    [Fact]
+    public void Truncate_ResetsCurrentSize_AndAllowsAppendsAgain()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(
+            dir.Path, channelNumber: 1,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: false, maxBytes: 512, onFull: WalSizeCapPolicy.Halt);
+
+        try { for (long s = 1; s <= 1_000; s++) wal.Append(MakeNew(s, (ulong)s)); }
+        catch (WalSizeCapExceededException) { /* expected */ }
+
+        Assert.True(wal.CurrentSizeBytes > 0);
+        wal.Truncate();
+        Assert.Equal(0, wal.CurrentSizeBytes);
+
+        // Cap is still enforced post-truncate but with a fresh budget.
+        wal.Append(MakeNew(1, 1));
+        Assert.True(wal.CurrentSizeBytes > 0);
+        Assert.True(wal.CurrentSizeBytes <= 512);
+    }
+
+    [Fact]
+    public void CurrentSize_RehydratedFromDisk_OnReopen()
+    {
+        using var dir = new TempDir();
+        long sizeAfterFirstSession;
+        using (var wal = new FileChannelWriteAheadLog(
+            dir.Path, channelNumber: 1,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: true, maxBytes: 0, onFull: WalSizeCapPolicy.Halt))
+        {
+            for (long s = 1; s <= 5; s++) wal.Append(MakeNew(s, (ulong)s));
+            sizeAfterFirstSession = wal.CurrentSizeBytes;
+            Assert.True(sizeAfterFirstSession > 0);
+        }
+
+        using var reopened = new FileChannelWriteAheadLog(
+            dir.Path, channelNumber: 1,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: true, maxBytes: 0, onFull: WalSizeCapPolicy.Halt);
+        Assert.Equal(sizeAfterFirstSession, reopened.CurrentSizeBytes);
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
@@ -1,0 +1,157 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrderType = B3.Exchange.Matching.OrderType;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #291: dispatcher behaviour when the WAL throws
+/// <see cref="WalSizeCapExceededException"/>. The cap-breach
+/// halt is sticky and ALWAYS overrides
+/// <see cref="WalAppendFailurePolicy"/> — even
+/// <see cref="WalAppendFailurePolicy.Continue"/> must not be
+/// allowed to silently degrade to a non-durable execution
+/// once the operator has explicitly opted into a hard cap.
+/// </summary>
+public class WalSizeCapDispatcherTests
+{
+    private const long Sec = 900_000_000_002L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class NoOpOutbound : ICoreOutbound
+    {
+        public int NewCount;
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue)
+        { NewCount++; return true; }
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+    }
+
+    /// <summary>
+    /// First call succeeds, every subsequent call throws
+    /// <see cref="WalSizeCapExceededException"/>.
+    /// </summary>
+    private sealed class CapExceededAfterNWal : IChannelWriteAheadLog
+    {
+        private readonly int _allowedAppends;
+        public int AppendCalls;
+        public long CurrentSizeBytes => _allowedAppends * 64L;
+        public long DropsOnFullCount => 0;
+
+        public CapExceededAfterNWal(int allowedAppends) { _allowedAppends = allowedAppends; }
+        public void Append(WalRecord record)
+        {
+            AppendCalls++;
+            if (AppendCalls > _allowedAppends)
+                throw new WalSizeCapExceededException(
+                    currentSizeBytes: CurrentSizeBytes,
+                    maxBytes: CurrentSizeBytes,
+                    incomingRecordBytes: 64);
+        }
+        public IReadOnlyList<WalRecord> ReadAll() => Array.Empty<WalRecord>();
+        public void Truncate() { }
+        public void Dispose() { }
+    }
+
+    private static ChannelDispatcher BuildDispatcher(
+        IChannelWriteAheadLog wal,
+        WalAppendFailurePolicy appendPolicy,
+        out NoOpOutbound outbound,
+        ChannelMetrics? metrics = null)
+    {
+        var sink = new NoOpPacketSink();
+        var localOutbound = outbound = new NoOpOutbound();
+        return new ChannelDispatcher(
+            channelNumber: 91,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s,
+                NullLogger<MatchingEngine>.Instance),
+            packetSink: sink,
+            outbound: localOutbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            metrics: metrics,
+            wal: wal,
+            walAppendFailurePolicy: appendPolicy);
+    }
+
+    private static bool EnqueueOrder(ChannelDispatcher disp, ulong clOrdIdValue)
+        => disp.EnqueueNewOrder(
+            new NewOrderCommand(clOrdIdValue.ToString(), Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 700u, EnteredAtNanos: 0),
+            new SessionId("S1"), enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    private static async Task WaitForAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return;
+            await Task.Delay(20);
+        }
+    }
+
+    [Theory]
+    [InlineData(WalAppendFailurePolicy.Continue)]
+    [InlineData(WalAppendFailurePolicy.Halt)]
+    public async Task SizeCap_AlwaysHalts_RegardlessOfAppendFailurePolicy(WalAppendFailurePolicy appendPolicy)
+    {
+        var wal = new CapExceededAfterNWal(allowedAppends: 1);
+        var metrics = new ChannelMetrics(91);
+        var disp = BuildDispatcher(wal, appendPolicy, out var outbound, metrics);
+        try
+        {
+            disp.Start();
+
+            // First order: succeeds (under the cap).
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 1));
+            await WaitForAsync(() => outbound.NewCount >= 1);
+            Assert.True(disp.IsWalHealthy);
+
+            // Second order: WAL throws WalSizeCapExceededException.
+            // Regardless of appendPolicy (Continue or Halt) the
+            // dispatcher MUST halt the channel — silent degradation
+            // is disallowed when the operator has opted into a cap.
+            Assert.True(EnqueueOrder(disp, clOrdIdValue: 2));
+            await WaitForAsync(() => !disp.IsWalHealthy);
+
+            Assert.False(disp.IsWalHealthy);
+            Assert.Equal(1, outbound.NewCount); // second order NOT executed
+            Assert.Equal(1, metrics.WalAppendFailures);
+
+            // Subsequent enqueues are rejected producer-side.
+            Assert.False(EnqueueOrder(disp, clOrdIdValue: 3));
+            Assert.True(metrics.WalHaltRejects >= 1);
+        }
+        finally
+        {
+            await disp.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
Closes #291.

## What
Bound the on-disk WAL size with a configurable `persistence.wal.maxBytes` cap and a per-policy reaction (`onFull: halt|drop`). Without the cap, a stuck-snapshot scenario lets the WAL silently consume the filesystem and bring down unrelated subsystems.

## Behaviour

| `onFull` | Reaction when next `Append` would breach the cap |
| --- | --- |
| `halt` (default) | `FileChannelWriteAheadLog.Append` throws `WalSizeCapExceededException`. `ChannelDispatcher` catches it **specifically** (before the existing `onAppendFailure` switch) and marks the channel WAL-halted **regardless** of the configured `WalAppendFailurePolicy` — silent degradation is disallowed once the operator has opted into a hard cap. Sticky; clears on host restart. |
| `drop` | Silently skip the write, log Warning, bump `exch_wal_drops_on_full_total`. Same trade-off as `onAppendFailure=continue` but explicit and metered via a dedicated counter so on-call can route capacity-exhaustion alerts separately from generic IO-fault alerts. |

## Metrics
- `exch_wal_size_bytes` (gauge) — current on-disk size, refreshed after every successful Append/Truncate. Rehydrated from disk in the WAL ctor so restarts inherit pre-restart usage.
- `exch_wal_drops_on_full_total` (counter) — silent drops under `onFull=drop`. Always 0 under `onFull=halt`.

## Config
`HostConfig.WalConfig` gains `MaxBytes` + `OnFull` (string, case-insensitive, throws on unknown values). `MaxBytes <= 0` disables the cap → preserves pre-#291 behaviour.

## Tests
- `FileChannelWriteAheadLogSizeCapTests` (5) — no-cap accepts arbitrary, halt throws and refuses subsequent appends, drop silently skips + counter advances + records that fit are durable, truncate resets size, reopen rehydrates from disk.
- `WalSizeCapDispatcherTests` (1 `[Theory]` × 2 inputs) — cap-breach halt overrides BOTH `WalAppendFailurePolicy.Continue` AND `.Halt`. Channel flips unhealthy + producer-side enqueues rejected in either case.

## Docs
- RUNBOOK §7.3 documents the two new metrics in the persistence-metrics table.
- RUNBOOK §7.4 gains a size-cap subsection adjacent to the append-failure policy table.