### PR TITLE
perf: tier-1 hot-path allocation cleanup

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -231,9 +231,8 @@ public sealed partial class ChannelDispatcher
         // evict the canonical entry. Pass the active session's ClOrdId (if
         // any) so the wire ER carries the requester's id while
         // OrigClOrdID points to the owner's original ClOrdID.
-        if (_orders.TryResolve(e.OrderId, out var owner))
+        if (_orders.TryEvict(e.OrderId, out var owner))
         {
-            _orders.Evict(e.OrderId);
             _outbound.WriteExecutionReportPassiveCancel(owner.Session, owner.ClOrdId, e.OrderId, e,
                 _currentClOrdId, _currentReceivedTimeNanos);
             _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
@@ -385,9 +384,8 @@ public sealed partial class ChannelDispatcher
     public void OnStopOrderCanceled(in StopOrderCanceledEvent e)
     {
         AssertOnLoopThread();
-        if (_orders.TryResolve(e.OrderId, out var owner))
+        if (_orders.TryEvict(e.OrderId, out var owner))
         {
-            _orders.Evict(e.OrderId);
             var canceled = new OrderCanceledEvent(
                 SecurityId: e.SecurityId,
                 OrderId: e.OrderId,

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -72,12 +72,11 @@ public sealed partial class ChannelDispatcher
         if (rec is null) return true;
         try
         {
-            // Best-effort byte accounting: Append re-serializes the
-            // record internally; we approximate the byte count from
-            // the JSON serializer here so the metric stays meaningful
-            // without requiring the Append signature to leak the size.
-            long approxBytes = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(rec).Length + 1;
-            _wal.Append(rec);
+            // Single serialization (issue: WAL hot-path double serialize).
+            // The dispatcher previously called SerializeToUtf8Bytes here
+            // *only* to get the byte count, then Append re-serialized — so
+            // we return the on-disk bytes from this single call.
+            long approxBytes = _wal.Append(rec);
             _metrics?.IncWalAppend(approxBytes);
             _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
             _metrics?.SetWalDropsOnFull(_wal.DropsOnFullCount);

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -63,9 +63,12 @@ public interface IChannelWriteAheadLog
     /// <summary>
     /// Appends a record to the WAL. Implementations choose whether to
     /// fsync per-write (zero RPO, lower throughput) or batch (higher
-    /// throughput, RPO bounded by batch interval).
+    /// throughput, RPO bounded by batch interval). Returns the number
+    /// of bytes the record consumed on the underlying medium so the
+    /// dispatcher can update <c>exch_wal_append_bytes_total</c> without
+    /// re-serializing the record itself.
     /// </summary>
-    void Append(WalRecord record);
+    int Append(WalRecord record);
 
     /// <summary>
     /// Returns every record currently in the log in append order.

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -97,8 +97,19 @@ public sealed class OrderRegistry
     /// reverse <c>(Firm, ClOrdId)</c> index entry (if any).
     /// </summary>
     public bool Evict(long orderId)
+        => TryEvict(orderId, out _);
+
+    /// <summary>
+    /// Single-pass evict: removes the entry for <paramref name="orderId"/>
+    /// (and its reverse index entry) and returns the evicted owner via
+    /// <paramref name="owner"/>. Use this in dispatcher sinks where the
+    /// outbound ER routing needs the owner's session/ClOrdId — saves the
+    /// dictionary lookup that <see cref="TryResolve"/> + <see cref="Evict"/>
+    /// would do twice.
+    /// </summary>
+    public bool TryEvict(long orderId, out OrderState owner)
     {
-        if (!_byOrderId.TryRemove(orderId, out var owner))
+        if (!_byOrderId.TryRemove(orderId, out owner))
             return false;
         if (owner.ClOrdId != 0)
             _byClOrdId.TryRemove(new KeyValuePair<(uint, ulong), long>((owner.Firm, owner.ClOrdId), orderId));

--- a/src/B3.Exchange.Core/UmdfPacketRetransmitBuffer.cs
+++ b/src/B3.Exchange.Core/UmdfPacketRetransmitBuffer.cs
@@ -40,18 +40,34 @@ public sealed class UmdfPacketRetransmitBuffer
     public int Capacity { get; }
 
     private readonly object _lock = new();
-    private readonly byte[]?[] _packets;
+    // Issue (perf tier-1): pre-allocate per-slot buffers and store the
+    // valid prefix length separately, so steady-state Append never
+    // allocates and never produces evictable garbage. Each slot holds a
+    // fixed-size 1.4 KiB buffer; the actual stored prefix is delimited
+    // by _lengths[i].
+    private readonly byte[][] _packets;
+    private readonly int[] _lengths;
     private readonly uint[] _seqs;
     private int _head;        // next write slot
     private int _count;
     private long _evictions;
 
+    /// <summary>Maximum payload bytes per slot — matches the UMDF packet
+    /// MTU enforced by the dispatcher, so any inbound packet always fits.
+    /// </summary>
+    public const int MaxPacketBytes = 1500;
+
     public UmdfPacketRetransmitBuffer(int capacity)
     {
         if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity), "capacity must be > 0");
         Capacity = capacity;
-        _packets = new byte[]?[capacity];
+        _packets = new byte[capacity][];
+        _lengths = new int[capacity];
         _seqs = new uint[capacity];
+        for (int i = 0; i < capacity; i++)
+        {
+            _packets[i] = new byte[MaxPacketBytes];
+        }
     }
 
     /// <summary>Number of packets currently retained.</summary>
@@ -93,12 +109,15 @@ public sealed class UmdfPacketRetransmitBuffer
         }
     }
 
-    /// <summary>Append a packet. Bytes are deep-copied. When the ring is
-    /// full the oldest entry is dropped and <see cref="Evictions"/> is
-    /// incremented.</summary>
+    /// <summary>Append a packet. Bytes are deep-copied into the
+    /// pre-allocated slot buffer (no per-call allocation). When the
+    /// ring is full the oldest entry is overwritten and
+    /// <see cref="Evictions"/> is incremented.</summary>
     public void Append(uint sequenceNumber, ReadOnlySpan<byte> packet)
     {
-        var copy = packet.ToArray();
+        if (packet.Length > MaxPacketBytes)
+            throw new ArgumentOutOfRangeException(nameof(packet),
+                $"packet too large: {packet.Length} > {MaxPacketBytes}");
         lock (_lock)
         {
             if (_count == Capacity)
@@ -109,7 +128,8 @@ public sealed class UmdfPacketRetransmitBuffer
             {
                 _count++;
             }
-            _packets[_head] = copy;
+            packet.CopyTo(_packets[_head].AsSpan(0, packet.Length));
+            _lengths[_head] = packet.Length;
             _seqs[_head] = sequenceNumber;
             _head = (_head + 1) % Capacity;
         }
@@ -122,7 +142,15 @@ public sealed class UmdfPacketRetransmitBuffer
     {
         lock (_lock)
         {
-            for (int i = 0; i < _packets.Length; i++) _packets[i] = null;
+            // We keep the per-slot buffers — they are reused across resets
+            // so a SequenceVersion roll doesn't trigger ~90 MiB of fresh
+            // allocations. Only the length/seq metadata needs clearing so
+            // a stale slot can never satisfy a TryGet from the new epoch.
+            for (int i = 0; i < _lengths.Length; i++)
+            {
+                _lengths[i] = 0;
+                _seqs[i] = 0;
+            }
             _head = 0;
             _count = 0;
             // _evictions intentionally retained — it is a lifetime
@@ -149,8 +177,8 @@ public sealed class UmdfPacketRetransmitBuffer
             // before the version bump.
             int offset = (int)(sequenceNumber - first);
             int slot = (oldest + offset) % Capacity;
-            var stored = _packets[slot];
-            if (stored is null || _seqs[slot] != sequenceNumber)
+            int len = _lengths[slot];
+            if (len == 0 || _seqs[slot] != sequenceNumber)
             {
                 // Defensive: shouldn't happen under append-only single-writer
                 // semantics, but if it does, fail safe rather than serve a
@@ -158,7 +186,7 @@ public sealed class UmdfPacketRetransmitBuffer
                 packet = Array.Empty<byte>();
                 return false;
             }
-            packet = (byte[])stored.Clone();
+            packet = _packets[slot].AsSpan(0, len).ToArray();
             return true;
         }
     }
@@ -185,13 +213,13 @@ public sealed class UmdfPacketRetransmitBuffer
             {
                 uint seq = fromSeq + (uint)i;
                 int slot = (oldest + (int)(seq - first)) % Capacity;
-                var stored = _packets[slot];
-                if (stored is null || _seqs[slot] != seq)
+                int len = _lengths[slot];
+                if (len == 0 || _seqs[slot] != seq)
                 {
                     packets = Array.Empty<byte[]>();
                     return false;
                 }
-                result[i] = (byte[])stored.Clone();
+                result[i] = _packets[slot].AsSpan(0, len).ToArray();
             }
             packets = result;
             return true;

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -162,12 +162,12 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         }
     }
 
-    public void Append(WalRecord record)
+    public int Append(WalRecord record)
     {
         ArgumentNullException.ThrowIfNull(record);
         lock (_writeLock)
         {
-            var json = JsonSerializer.SerializeToUtf8Bytes(record, JsonOptions);
+            var json = JsonSerializer.SerializeToUtf8Bytes(record, WalJsonContext.Default.WalRecord);
             // Layout: <json bytes> \t <8-hex Crc32C> \n
             int recordBytes = json.Length + 1 /* \t */ + 8 /* hex crc */ + 1 /* \n */;
             // Issue #291: enforce on-disk size cap before opening the
@@ -181,7 +181,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                     _logger.LogWarning(
                         "WAL channel-{Channel}: size cap reached (current={Current}B, incoming={Incoming}B, max={Max}B); dropping record (onFull=drop)",
                         _channelNumber, _currentSize, recordBytes, _maxBytes);
-                    return;
+                    return 0;
                 }
                 throw new WalSizeCapExceededException(_currentSize, _maxBytes, recordBytes);
             }
@@ -203,6 +203,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                 _appendStream.Flush();
             }
             Interlocked.Add(ref _currentSize, recordBytes);
+            return recordBytes;
         }
     }
 

--- a/src/B3.Exchange.Persistence/WalJsonContext.cs
+++ b/src/B3.Exchange.Persistence/WalJsonContext.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Persistence;
+
+/// <summary>
+/// System.Text.Json source-generated <see cref="JsonSerializerContext"/>
+/// for <see cref="WalRecord"/>. The WAL append path used to call
+/// <c>JsonSerializer.SerializeToUtf8Bytes(record, options)</c>, which
+/// walks the record graph reflectively and allocates pooled internal
+/// buffers per call — measurable Gen0 pressure on the dispatch thread
+/// at 50k+ records/sec. Source generation produces a precompiled
+/// converter that emits straight to a pooled <c>Utf8JsonWriter</c>
+/// without runtime reflection.
+///
+/// <para><b>Wire compatibility:</b>
+/// <see cref="JsonSourceGenerationOptionsAttribute.UseStringEnumConverter"/>
+/// + <see cref="JsonSourceGenerationOptionsAttribute.DefaultIgnoreCondition"/>
+/// match the previous runtime <c>JsonSerializerOptions</c> exactly, so the
+/// JSON bytes produced by this context are byte-identical to what
+/// pre-change writers emitted. A WAL written by this build replays
+/// cleanly under the previous decoder, and vice-versa.</para>
+/// </summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = false,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    UseStringEnumConverter = true)]
+[JsonSerializable(typeof(WalRecord))]
+internal sealed partial class WalJsonContext : JsonSerializerContext
+{
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
@@ -56,7 +56,7 @@ public class WalAppendFailurePolicyTests
     private sealed class FailingWal : IChannelWriteAheadLog
     {
         public int AppendCalls;
-        public void Append(WalRecord record)
+        public int Append(WalRecord record)
         {
             AppendCalls++;
             throw new IOException("simulated disk failure");

--- a/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
@@ -67,7 +67,7 @@ public class WalSizeCapDispatcherTests
         public long DropsOnFullCount => 0;
 
         public CapExceededAfterNWal(int allowedAppends) { _allowedAppends = allowedAppends; }
-        public void Append(WalRecord record)
+        public int Append(WalRecord record)
         {
             AppendCalls++;
             if (AppendCalls > _allowedAppends)
@@ -75,6 +75,7 @@ public class WalSizeCapDispatcherTests
                     currentSizeBytes: CurrentSizeBytes,
                     maxBytes: CurrentSizeBytes,
                     incomingRecordBytes: 64);
+            return 64;
         }
         public IReadOnlyList<WalRecord> ReadAll() => Array.Empty<WalRecord>();
         public void Truncate() { }


### PR DESCRIPTION
Tier-1 batch from a fresh perf audit. Four small, low-risk allocation/throughput fixes on the dispatcher hot path. None touch the matching engine itself, so the existing matching microbench numbers don't move — these are wins on the persistence/retransmit/registry paths which are currently outside microbench coverage.

## What changed

| # | Fix | File | Effect |
|---|-----|------|--------|
| 1 | WAL append no longer double-serializes | `ChannelDispatcher.Wal.cs`, `ChannelWriteAheadLog.cs`, `FileChannelWriteAheadLog.cs` | `Append(WalRecord)` returns `int` (bytes written); dispatcher uses that for the metric instead of running `SerializeToUtf8Bytes` a second time. ~50k throwaway byte arrays/sec saved at 50k cmd/s. |
| 2 | UMDF retransmit ring pre-allocates slot buffers | `UmdfPacketRetransmitBuffer.cs` | Per-slot 1500-byte buffer is allocated once at construction and rewritten in place; `Append` is alloc-free. Memory ceiling unchanged. |
| 3 | WAL JSON moves to STJ source generation | new `WalJsonContext.cs`, `FileChannelWriteAheadLog.cs` | Wire-compatible (`UseStringEnumConverter=true` + `WhenWritingNull` match prior options exactly). Faster encode, removes reflective allocs. |
| 4 | OrderRegistry: collapse TryResolve+Evict pairs | `OrderRegistry.cs`, `ChannelDispatcher.Sinks.cs` | New `TryEvict(long, out OrderState)` returns the evicted owner. Halves the ConcurrentDictionary work on passive cancel and stop-cancel. |

## Verification

- `dotnet build -c Release` — clean, 0 warnings.
- `dotnet test  -c Release` — 1011/1011 pass.
- `dotnet format --verify-no-changes` — clean.
- BenchmarkDotNet matching suite — unchanged (expected; bench uses NoOpSink and no WAL).

## Risk

Low across the board. The only public-API change is `IChannelWriteAheadLog.Append`'s return type (`void` → `int`); two test fakes adapted. Wire format for both the WAL JSON stream and the UMDF retransmit packets is byte-identical to main.

## What's NOT in this PR (deferred)

From the same audit:
- **WAL fsync on dispatch thread** — biggest throughput ceiling, but architectural; deserves its own PR with a group-commit / SPSC handoff design.
- **`OppositeLevels` per-aggressor `List<>` allocation** in `LimitOrderBook` — engine-internal; needs care around the FOK pre-check / actual walk separation.
- **`ClOrdId: ulong → string` materialization** in the inbound decoder — touches snapshot wire format, dedicated PR.
