### PR TITLE
perf(wal): GroupCommit fsync mode + durability watermark API (#312 PR-1/2)

### DIFF
--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -126,4 +126,43 @@ public interface IChannelWriteAheadLog
     /// <c>exch_wal_drops_on_full_total</c>. Defaults to 0.
     /// </summary>
     long DropsOnFullCount => 0;
+
+    /// <summary>
+    /// Issue #312 (Tier-2 perf): the <see cref="WalRecord.Seq"/>
+    /// of the most-recently <see cref="Append"/>ed record (i.e.
+    /// the highest seq the WAL has ACCEPTED — but not necessarily
+    /// fsynced). Equal to <see cref="DurableSeqOrZero"/> in
+    /// <see cref="WalFsyncMode.PerWrite"/> mode and in in-memory
+    /// fakes. <c>0</c> means nothing has been appended.
+    /// </summary>
+    long PendingDurableSeqOrZero => 0;
+
+    /// <summary>
+    /// Issue #312: the highest <see cref="WalRecord.Seq"/> that
+    /// has been fsynced to durable storage. In
+    /// <see cref="WalFsyncMode.PerWrite"/> mode this advances
+    /// inside every <see cref="Append"/>; in
+    /// <see cref="WalFsyncMode.GroupCommit"/> mode it advances on
+    /// each background fsync. <c>0</c> means nothing is durable
+    /// yet. Default implementation returns
+    /// <see cref="PendingDurableSeqOrZero"/> so in-memory fakes
+    /// trivially satisfy <see cref="WaitForDurable"/>.
+    /// </summary>
+    long DurableSeqOrZero => PendingDurableSeqOrZero;
+
+    /// <summary>
+    /// Issue #312: blocks until the WAL's
+    /// <see cref="DurableSeqOrZero"/> has reached
+    /// <paramref name="seq"/>, i.e. the record with that seq (and
+    /// every earlier record) is on durable storage. Returns
+    /// immediately when the predicate is already satisfied or
+    /// when <paramref name="seq"/> is &lt;= 0.
+    ///
+    /// <para>Implementations MUST honour
+    /// <paramref name="cancellationToken"/> so the caller can
+    /// abort on shutdown without leaking the dispatch thread.
+    /// The default implementation is a no-op (the in-memory fake
+    /// reports its writes as immediately durable).</para>
+    /// </summary>
+    void WaitForDurable(long seq, CancellationToken cancellationToken = default) { }
 }

--- a/src/B3.Exchange.Core/WalFsyncMode.cs
+++ b/src/B3.Exchange.Core/WalFsyncMode.cs
@@ -1,0 +1,42 @@
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #312 (Tier-2 perf review): controls when
+/// <see cref="IChannelWriteAheadLog.Append"/> calls <c>fsync</c>
+/// on the underlying file.
+///
+/// <para><see cref="PerWrite"/> (default) fsyncs inside every
+/// <see cref="IChannelWriteAheadLog.Append"/> call, giving zero
+/// RPO at the cost of one disk-flush per command. This was the
+/// pre-#312 behaviour and remains the default so existing
+/// deployments see no behavioural change.</para>
+///
+/// <para><see cref="GroupCommit"/> defers <c>fsync</c> to a
+/// background thread that batches multiple appended records into
+/// a single flush. <see cref="IChannelWriteAheadLog.Append"/>
+/// returns as soon as the bytes have hit the OS buffer; callers
+/// that need durability before publishing externally observable
+/// effects (e.g. an ExecutionReport on the wire) MUST call
+/// <see cref="IChannelWriteAheadLog.WaitForDurable(long, System.Threading.CancellationToken)"/>
+/// with the record's <c>Seq</c> before doing so. This trades a
+/// small bounded RPO (the inter-flush interval) for a large
+/// throughput win under load: while one batch is being fsynced,
+/// the dispatch thread can keep appending the next batch.</para>
+///
+/// <para>The <c>fsync</c>-batching logic itself is implementation
+/// defined; <see cref="Persistence.FileChannelWriteAheadLog"/>
+/// uses a signalled background thread with a fixed maximum
+/// inter-flush interval. The <see cref="GroupCommit"/> mode is
+/// safe under abrupt termination: records that were appended but
+/// not yet fsynced are simply absent from the post-restart WAL,
+/// and the dispatcher's replay sees the same state it would have
+/// seen had those commands never reached the host.</para>
+/// </summary>
+public enum WalFsyncMode
+{
+    /// <summary>Synchronous fsync inside every <c>Append</c> call (default; pre-#312 behaviour).</summary>
+    PerWrite = 0,
+
+    /// <summary>Batched fsync on a background thread; callers that need durability gating must call <c>WaitForDurable</c>.</summary>
+    GroupCommit = 1,
+}

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -79,6 +79,19 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     private long _currentSize;
     private long _dropsOnFull;
 
+    // Issue #312 (Tier-2 perf): GroupCommit mode infrastructure.
+    // _pendingSeq advances in Append (under _writeLock); _durableSeq
+    // advances after the background fsync completes. Waiters block on
+    // _durabilityLock and are pulsed when _durableSeq advances.
+    private readonly bool _groupCommit;
+    private readonly TimeSpan _groupCommitInterval;
+    private readonly object _durabilityLock = new();
+    private readonly ManualResetEventSlim _fsyncSignal;
+    private readonly CancellationTokenSource? _stopFsyncThread;
+    private readonly Thread? _fsyncThread;
+    private long _pendingSeq;
+    private long _durableSeq;
+
     /// <summary>
     /// Number of records the most recent <see cref="ReadAll"/> call
     /// rejected because their stored Crc32C did not match the JSON
@@ -102,6 +115,14 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     /// <summary>Issue #291: cumulative count of appends silently
     /// skipped under <see cref="WalSizeCapPolicy.Drop"/>.</summary>
     public long DropsOnFullCount => Interlocked.Read(ref _dropsOnFull);
+
+    /// <summary>Issue #312: see
+    /// <see cref="IChannelWriteAheadLog.PendingDurableSeqOrZero"/>.</summary>
+    public long PendingDurableSeqOrZero => Interlocked.Read(ref _pendingSeq);
+
+    /// <summary>Issue #312: see
+    /// <see cref="IChannelWriteAheadLog.DurableSeqOrZero"/>.</summary>
+    public long DurableSeqOrZero => Interlocked.Read(ref _durableSeq);
 
     public string Path => _path;
 
@@ -140,9 +161,49 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         bool fsyncPerWrite,
         long maxBytes,
         WalSizeCapPolicy onFull)
+        : this(dataDirectory, channelNumber, logger, fsyncPerWrite, maxBytes, onFull,
+            fsyncMode: WalFsyncMode.PerWrite, groupCommitInterval: default)
+    {
+    }
+
+    /// <summary>
+    /// Issue #312 (Tier-2 perf): full constructor accepting the
+    /// <see cref="WalFsyncMode"/> selector and the
+    /// <paramref name="groupCommitInterval"/> used in
+    /// <see cref="WalFsyncMode.GroupCommit"/> mode as the maximum
+    /// time between background fsync passes (i.e. the worst-case
+    /// RPO when no caller blocks on
+    /// <see cref="WaitForDurable"/>). When the interval is
+    /// <c>default</c> a 1ms default is applied — small enough to
+    /// bound RPO and large enough to amortise fsync syscall cost
+    /// across multiple appends under load.
+    ///
+    /// <para><see cref="WalFsyncMode.GroupCommit"/> requires
+    /// <paramref name="fsyncPerWrite"/> = <c>false</c>; passing
+    /// the conflicting combination throws
+    /// <see cref="ArgumentException"/>. Both legacy fsync flags
+    /// (<paramref name="fsyncPerWrite"/>) and the new mode are
+    /// kept on the surface so existing call sites need not
+    /// change.</para>
+    /// </summary>
+    public FileChannelWriteAheadLog(
+        string dataDirectory,
+        byte channelNumber,
+        ILogger<FileChannelWriteAheadLog> logger,
+        bool fsyncPerWrite,
+        long maxBytes,
+        WalSizeCapPolicy onFull,
+        WalFsyncMode fsyncMode,
+        TimeSpan groupCommitInterval)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(dataDirectory);
         ArgumentNullException.ThrowIfNull(logger);
+        if (fsyncMode == WalFsyncMode.GroupCommit && fsyncPerWrite)
+        {
+            throw new ArgumentException(
+                "WalFsyncMode.GroupCommit is incompatible with fsyncPerWrite=true; choose one durability strategy.",
+                nameof(fsyncMode));
+        }
         _dataDir = System.IO.Path.GetFullPath(dataDirectory);
         Directory.CreateDirectory(_dataDir);
         _channelNumber = channelNumber;
@@ -159,6 +220,22 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
         {
             try { _currentSize = new FileInfo(_path).Length; }
             catch { _currentSize = 0; }
+        }
+
+        _groupCommit = fsyncMode == WalFsyncMode.GroupCommit;
+        _groupCommitInterval = _groupCommit
+            ? (groupCommitInterval > TimeSpan.Zero ? groupCommitInterval : TimeSpan.FromMilliseconds(1))
+            : TimeSpan.Zero;
+        _fsyncSignal = new ManualResetEventSlim(initialState: false);
+        if (_groupCommit)
+        {
+            _stopFsyncThread = new CancellationTokenSource();
+            _fsyncThread = new Thread(GroupCommitFsyncLoop)
+            {
+                IsBackground = true,
+                Name = $"wal-fsync-ch{channelNumber}",
+            };
+            _fsyncThread.Start();
         }
     }
 
@@ -194,16 +271,106 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
             _appendStream.WriteByte(CrcSeparator);
             _appendStream.Write(crcBytes);
             _appendStream.WriteByte((byte)'\n');
-            if (_fsyncPerWrite)
+            if (_groupCommit)
+            {
+                // Push bytes to the OS so the background fsync thread
+                // (which doesn't take _writeLock) sees a consistent
+                // snapshot of the file contents. The disk-level sync
+                // is deferred to GroupCommitFsyncLoop.
+                _appendStream.Flush();
+                Interlocked.Exchange(ref _pendingSeq, record.Seq);
+                _fsyncSignal.Set();
+            }
+            else if (_fsyncPerWrite)
             {
                 _appendStream.Flush(flushToDisk: true);
+                Interlocked.Exchange(ref _pendingSeq, record.Seq);
+                Interlocked.Exchange(ref _durableSeq, record.Seq);
             }
             else
             {
                 _appendStream.Flush();
+                Interlocked.Exchange(ref _pendingSeq, record.Seq);
             }
             Interlocked.Add(ref _currentSize, recordBytes);
             return recordBytes;
+        }
+    }
+
+    public void WaitForDurable(long seq, CancellationToken cancellationToken = default)
+    {
+        if (seq <= 0) return;
+        if (Interlocked.Read(ref _durableSeq) >= seq) return;
+        if (!_groupCommit)
+        {
+            // PerWrite / fire-and-forget Flush modes advance _durableSeq
+            // (or skip durability entirely) inside Append itself; if we
+            // haven't reached `seq` yet it never will via this WAL.
+            return;
+        }
+        // Nudge the bg thread in case the signal was missed (e.g. a
+        // caller blocked between Append and WaitForDurable while the
+        // bg thread was already sleeping).
+        _fsyncSignal.Set();
+        lock (_durabilityLock)
+        {
+            while (Interlocked.Read(ref _durableSeq) < seq)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Monitor.Wait(_durabilityLock, _groupCommitInterval);
+            }
+        }
+    }
+
+    private void GroupCommitFsyncLoop()
+    {
+        var stopToken = _stopFsyncThread!.Token;
+        while (!stopToken.IsCancellationRequested)
+        {
+            try { _fsyncSignal.Wait(_groupCommitInterval, stopToken); }
+            catch (OperationCanceledException) { break; }
+            _fsyncSignal.Reset();
+            FsyncOnce();
+        }
+        // Final pass on shutdown so anything appended between the last
+        // signal and the cancellation request still hits the disk.
+        FsyncOnce();
+    }
+
+    private void FsyncOnce()
+    {
+        long pending;
+        lock (_writeLock)
+        {
+            if (_appendStream is null) return;
+            pending = Interlocked.Read(ref _pendingSeq);
+            if (pending <= Interlocked.Read(ref _durableSeq)) return;
+            try
+            {
+                _appendStream.Flush(flushToDisk: true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: WAL background fsync failed; durable seq stays at {Durable}",
+                    _channelNumber, Interlocked.Read(ref _durableSeq));
+                return;
+            }
+        }
+        // Publish the new durability watermark and pulse waiters
+        // outside the write lock so an Append on the dispatch thread
+        // never contends with a wakeup.
+        lock (_durabilityLock)
+        {
+            // Use Math.Max because pending may have advanced again
+            // between our snapshot above and the lock acquisition; we
+            // only ever want to MOVE FORWARD here.
+            long current = Interlocked.Read(ref _durableSeq);
+            if (pending > current)
+            {
+                Interlocked.Exchange(ref _durableSeq, pending);
+            }
+            Monitor.PulseAll(_durabilityLock);
         }
     }
 
@@ -447,6 +614,16 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                 File.Move(tmp, _path, overwrite: true);
                 FsyncDirectory(_dataDir);
                 Interlocked.Exchange(ref _currentSize, 0);
+                // Issue #312: every previously-appended record is now
+                // either durable (it was fsynced into the old file
+                // before snapshot persist asked us to truncate) or
+                // intentionally discarded — either way it can't be
+                // replayed any more, so it counts as "durable" for
+                // any caller still waiting on its seq. Advancing
+                // _durableSeq here unblocks them instead of letting
+                // them spin until the fsync thread notices the empty
+                // file.
+                AdvanceDurableSeqOnTruncate();
             }
             catch (Exception ex)
             {
@@ -479,6 +656,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                 _logger.LogInformation(
                     "channel {ChannelNumber}: admin Reset removed WAL at {Path}",
                     _channelNumber, _path);
+                AdvanceDurableSeqOnTruncate();
             }
             catch (Exception ex)
             {
@@ -492,10 +670,41 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
 
     public void Dispose()
     {
+        // Issue #312: stop the bg fsync thread before tearing down the
+        // append stream so its final flush sees a live FileStream.
+        // Order matters: cancel + signal + join, then dispose stream.
+        if (_groupCommit && _stopFsyncThread is not null && _fsyncThread is not null)
+        {
+            try { _stopFsyncThread.Cancel(); } catch { /* ignore */ }
+            _fsyncSignal.Set();
+            try { _fsyncThread.Join(TimeSpan.FromSeconds(5)); } catch { /* ignore */ }
+            _stopFsyncThread.Dispose();
+        }
+        _fsyncSignal.Dispose();
         lock (_writeLock)
         {
             _appendStream?.Dispose();
             _appendStream = null;
+        }
+        // Anyone still parked in WaitForDurable on a disposed log
+        // should bail; pulse the monitor so the loop wakes and re-checks
+        // (cancellation token is the contractual exit, but disposing
+        // the WAL while someone waits is undefined and we'd rather
+        // unblock than deadlock).
+        lock (_durabilityLock)
+        {
+            Monitor.PulseAll(_durabilityLock);
+        }
+    }
+
+    private void AdvanceDurableSeqOnTruncate()
+    {
+        long pending = Interlocked.Read(ref _pendingSeq);
+        long durable = Interlocked.Read(ref _durableSeq);
+        if (pending > durable)
+        {
+            Interlocked.Exchange(ref _durableSeq, pending);
+            lock (_durabilityLock) Monitor.PulseAll(_durabilityLock);
         }
     }
 

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelWalGroupCommitTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelWalGroupCommitTests.cs
@@ -1,0 +1,235 @@
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #312 (Tier-2 perf): <see cref="WalFsyncMode.GroupCommit"/>
+/// behaviour for <see cref="FileChannelWriteAheadLog"/>. Verifies
+/// the durability watermark contract: <see cref="IChannelWriteAheadLog.PendingDurableSeqOrZero"/>
+/// advances per <c>Append</c>, <see cref="IChannelWriteAheadLog.DurableSeqOrZero"/>
+/// advances on each background fsync, and
+/// <see cref="IChannelWriteAheadLog.WaitForDurable"/> blocks
+/// callers until that promise is met.
+/// </summary>
+public class FileChannelWalGroupCommitTests
+{
+    private static WalRecord NewRec(long seq) => new(
+        seq, WalRecordKind.NewOrder,
+        SessionValue: "01",
+        Firm: 1,
+        ClOrdId: (ulong)seq,
+        OrigClOrdId: 0,
+        NewOrder: new B3.Exchange.Matching.NewOrderCommand(
+            ClOrdId: seq.ToString(),
+            SecurityId: 900_000_000_001L,
+            Side: B3.Exchange.Matching.Side.Buy,
+            Type: B3.Exchange.Matching.OrderType.Limit,
+            Tif: B3.Exchange.Matching.TimeInForce.Day,
+            PriceMantissa: 100_000,
+            Quantity: 100,
+            EnteringFirm: 1,
+            EnteredAtNanos: 0),
+        Cancel: null,
+        Replace: null);
+
+    private static string TempDir() => Directory.CreateTempSubdirectory("wal-gc-").FullName;
+
+    [Fact]
+    public void Append_DoesNotAdvanceDurableSeq_UntilBackgroundFsyncRuns()
+    {
+        var dir = TempDir();
+        try
+        {
+            // 100ms interval is long enough that we can observe the
+            // pending != durable window before the bg thread fires.
+            using var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 7, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromMilliseconds(100));
+
+            wal.Append(NewRec(1));
+            wal.Append(NewRec(2));
+            wal.Append(NewRec(3));
+
+            Assert.Equal(3, wal.PendingDurableSeqOrZero);
+            // Bg thread is signalled but won't have fired yet under
+            // contention; if it has, durable will be 3 — still valid.
+            Assert.True(wal.DurableSeqOrZero <= 3);
+
+            wal.WaitForDurable(3, CancellationToken.None);
+            Assert.Equal(3, wal.DurableSeqOrZero);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void WaitForDurable_BatchesMultipleAppends_IntoOneFsync()
+    {
+        var dir = TempDir();
+        try
+        {
+            using var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 8, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromMilliseconds(50));
+
+            for (int i = 1; i <= 10; i++) wal.Append(NewRec(i));
+
+            wal.WaitForDurable(10, CancellationToken.None);
+            Assert.True(wal.DurableSeqOrZero >= 10);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void WaitForDurable_ReturnsImmediately_WhenSeqAlreadyDurable()
+    {
+        var dir = TempDir();
+        try
+        {
+            using var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 9, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromMilliseconds(5));
+
+            wal.Append(NewRec(1));
+            wal.WaitForDurable(1, CancellationToken.None);
+
+            // Now durable >= 1; calling again with seq 1 must be a
+            // no-op even with a cancelled token (we never enter the
+            // wait loop).
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            wal.WaitForDurable(1, cts.Token);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void WaitForDurable_HonoursCancellation_WhenSeqUnreachable()
+    {
+        var dir = TempDir();
+        try
+        {
+            // Long interval so the bg thread won't fsync for a while.
+            using var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 10, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromSeconds(60));
+
+            // No append: pending stays at 0 forever; waiting for seq=5
+            // would hang indefinitely without cancellation.
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+            Assert.Throws<OperationCanceledException>(() =>
+                wal.WaitForDurable(5, cts.Token));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Dispose_DrainsPendingFsync_BeforeReturning()
+    {
+        var dir = TempDir();
+        var path = Path.Combine(dir, "channel-11.wal");
+        try
+        {
+            // Long interval so the bg thread definitely hasn't fsynced
+            // by the time we Dispose; the final-pass drain must do it.
+            var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 11, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromSeconds(60));
+            wal.Append(NewRec(1));
+            wal.Append(NewRec(2));
+
+            // File exists but bytes may still be in-kernel; Dispose
+            // performs the final fsync and closes the stream so we can
+            // re-open it for reading.
+            wal.Dispose();
+
+            using var reopened = new FileChannelWriteAheadLog(
+                dir, channelNumber: 11, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: true);
+            var records = reopened.ReadAll();
+            Assert.Equal(2, records.Count);
+            Assert.Equal(1, records[0].Seq);
+            Assert.Equal(2, records[1].Seq);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void PerWriteMode_AdvancesDurableSeq_InsideAppend()
+    {
+        var dir = TempDir();
+        try
+        {
+            using var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 12, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: true);
+
+            Assert.Equal(0, wal.PendingDurableSeqOrZero);
+            Assert.Equal(0, wal.DurableSeqOrZero);
+
+            wal.Append(NewRec(1));
+            Assert.Equal(1, wal.PendingDurableSeqOrZero);
+            Assert.Equal(1, wal.DurableSeqOrZero);
+
+            wal.Append(NewRec(2));
+            Assert.Equal(2, wal.PendingDurableSeqOrZero);
+            Assert.Equal(2, wal.DurableSeqOrZero);
+
+            // WaitForDurable on PerWrite is a no-op fast-path.
+            wal.WaitForDurable(2, CancellationToken.None);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Truncate_AdvancesDurableSeq_ToCurrentPending()
+    {
+        var dir = TempDir();
+        try
+        {
+            using var wal = new FileChannelWriteAheadLog(
+                dir, channelNumber: 13, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: false, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromSeconds(60));
+
+            wal.Append(NewRec(1));
+            wal.Append(NewRec(2));
+            Assert.Equal(2, wal.PendingDurableSeqOrZero);
+
+            // Without Truncate's durability advance, durable stays at
+            // 0 (bg thread is sleeping for 60s) and any waiter would
+            // spin. After Truncate it must be unblocked because the
+            // records are gone — there is no further work to fsync.
+            wal.Truncate();
+            Assert.Equal(2, wal.DurableSeqOrZero);
+            wal.WaitForDurable(2, CancellationToken.None);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void GroupCommit_RejectedWhen_FsyncPerWrite_True()
+    {
+        var dir = TempDir();
+        try
+        {
+            Assert.Throws<ArgumentException>(() => new FileChannelWriteAheadLog(
+                dir, channelNumber: 14, NullLogger<FileChannelWriteAheadLog>.Instance,
+                fsyncPerWrite: true, maxBytes: 0, onFull: WalSizeCapPolicy.Halt,
+                fsyncMode: WalFsyncMode.GroupCommit,
+                groupCommitInterval: TimeSpan.FromMilliseconds(1)));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}


### PR DESCRIPTION
Tier-2 perf review #3, **PR-1 of 2**. Pure WAL infrastructure — no dispatcher/outbound changes; default behaviour unchanged.

## What this PR ships

- New `WalFsyncMode` enum (`PerWrite` default, `GroupCommit` opt-in).
- `IChannelWriteAheadLog` gains `PendingDurableSeqOrZero`, `DurableSeqOrZero`, `WaitForDurable(seq, ct)` (default impls keep in-memory fakes happy).
- `FileChannelWriteAheadLog` gains a background fsync thread under `GroupCommit`. `Append` returns once bytes hit the OS buffer; the bg thread fsyncs on signal + interval (default 1ms). Truncate/Reset/Dispose drain pending fsync and unblock waiters.
- 8 new tests: pending vs durable advance, batching across N appends, cancellation while waiting, dispose-time drain, PerWrite parity, and the `GroupCommit + fsyncPerWrite=true` validation.

## What this PR does NOT ship

- HostConfig knob — to land in PR-2 once the gating is wired.
- Dispatcher / outbound durability gating — PR-2 will route ER emission through a delivery thread that awaits `WaitForDurable` per packet, which is the change that actually unlocks the throughput win.

## Correctness notes

- `GroupCommit` is rejected at construction time when paired with `fsyncPerWrite=true` (conflicting durability strategies).
- Background fsync errors are logged and durable seq stays put (waiters keep blocking until the next successful pass — exactly the right semantics for a transient IO fault).
- Truncate/Reset advance `_durableSeq` to current `_pendingSeq` because every previously-appended record is now either already on disk (it was fsynced into the old file before the snapshot persist asked us to truncate) or intentionally discarded — either way it can't be replayed and shouldn't keep waiters parked.

## Tests

Persistence suite green (122/122) including the 8 new tests; full `SbeB3Exchange.slnx` test run green on rerun (one flaky `MultiSessionReplayTests.TwoSessions_CrossingScript_LandsErTradesOnBothSides` recovered on the second pass — known flake unrelated to this change). `dotnet format` clean.