### PR TITLE
perf(wal): gate outbound ER bytes on WAL durability (#312 PR-2)

### DIFF
--- a/src/B3.Exchange.Contracts/Durability.cs
+++ b/src/B3.Exchange.Contracts/Durability.cs
@@ -1,0 +1,65 @@
+namespace B3.Exchange.Contracts;
+
+/// <summary>
+/// Issue #312 (Tier-2 perf): minimal durability surface that the
+/// Gateway-side outbound stack consults before writing externally
+/// observable bytes (e.g. an ExecutionReport on the wire) to the
+/// peer. Implemented by the per-channel Write-Ahead Log; passed
+/// down to the encoder + transport via <see cref="DurabilityHandle"/>
+/// on every <see cref="ICoreOutbound"/> call so that the WAL's
+/// background fsync (under
+/// <c>WalFsyncMode.GroupCommit</c>) can batch multiple appends
+/// without ever exposing not-yet-durable state to the client.
+///
+/// <para>The default in-memory / no-WAL paths supply
+/// <see cref="DurabilityHandle.None"/> — the transport then writes
+/// the frame immediately, preserving the pre-#312 behaviour.</para>
+/// </summary>
+public interface IDurabilityBarrier
+{
+    /// <summary>
+    /// Blocks the caller until every record up to and including
+    /// <paramref name="seq"/> is on durable storage (returns
+    /// immediately when the predicate already holds or
+    /// <paramref name="seq"/> is &lt;= 0).
+    ///
+    /// <para>Implementations MUST honour
+    /// <paramref name="cancellationToken"/> so the caller (typically
+    /// the TCP send loop) can abort on shutdown without leaking the
+    /// <para>The default implementation is a no-op (the in-memory
+    /// fake reports its writes as immediately durable, matching the
+    /// pre-#312 behaviour of the WAL interface).</para>
+    /// </summary>
+    void WaitForDurable(long seq, CancellationToken cancellationToken = default) { }
+}
+
+/// <summary>
+/// Pair of <see cref="IDurabilityBarrier"/> reference and the
+/// <see cref="WalRecord.Seq"/> the calling outbound write depends
+/// on. <see cref="None"/> (the default value) means "no durability
+/// gating" — the transport writes the frame immediately. This is
+/// the path taken by every call site that does not have a WAL
+/// behind it (in-memory tests, channels with WAL disabled, and
+/// frames produced outside the dispatch loop such as session
+/// keep-alives).
+///
+/// <para>Carried as a single value type rather than two
+/// parameters so future surface widening (e.g. propagating a
+/// snapshot durability watermark too) needs only one signature
+/// change. The struct is small enough (one reference + one long)
+/// to be passed by value without overhead.</para>
+/// </summary>
+public readonly record struct DurabilityHandle(IDurabilityBarrier? Barrier, long Seq)
+{
+    /// <summary>The "no-op" handle: <c>WriteXxx</c> implementations
+    /// MUST treat this as "send the frame immediately, no
+    /// durability wait".</summary>
+    public static DurabilityHandle None => default;
+
+    /// <summary><c>true</c> when the handle carries a real barrier
+    /// reference and a positive seq — i.e. the transport SHOULD
+    /// call <see cref="IDurabilityBarrier.WaitForDurable"/> before
+    /// writing the frame. <c>false</c> for <see cref="None"/> (in
+    /// which case the wait is skipped).</summary>
+    public bool IsActive => Barrier is not null && Seq > 0;
+}

--- a/src/B3.Exchange.Contracts/Ports.cs
+++ b/src/B3.Exchange.Contracts/Ports.cs
@@ -33,10 +33,12 @@ namespace B3.Exchange.Contracts;
 public interface ICoreOutbound
 {
     bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e,
-        ulong receivedTimeNanos = ulong.MaxValue);
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default);
 
     bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor,
-        long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty);
+        long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
+        DurabilityHandle durability = default);
 
     /// <summary>
     /// Routes an <c>ExecutionReport_Trade</c> for the resting (passive) side
@@ -49,7 +51,8 @@ public interface ICoreOutbound
     /// behaviour as the active path).
     /// </summary>
     bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId,
-        in TradeEvent e, long leavesQty, long cumQty);
+        in TradeEvent e, long leavesQty, long cumQty,
+        DurabilityHandle durability = default);
 
     /// <summary>
     /// Routes an <c>ExecutionReport_Cancel</c> for the owner of
@@ -63,14 +66,17 @@ public interface ICoreOutbound
     /// a request from a live session (e.g. engine-internal cancel).
     /// </summary>
     bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId,
-        in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue);
+        in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default);
 
     bool WriteExecutionReportModify(SessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
         MatchingSide side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
-        ulong receivedTimeNanos = ulong.MaxValue);
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default);
 
-    bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue);
+    bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue,
+        DurabilityHandle durability = default);
 }
 
 /// <summary>

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -268,7 +268,7 @@ public sealed partial class ChannelDispatcher
                     {
                         _outbound.WriteExecutionReportReject(_currentSession,
                             new RejectEvent(_currentClOrdId.ToString(), 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
-                            _currentClOrdId);
+                            _currentClOrdId, CurrentDurability);
                         _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
                     }
                     break;
@@ -332,7 +332,7 @@ public sealed partial class ChannelDispatcher
         {
             _outbound.WriteExecutionReportReject(_currentSession,
                 new RejectEvent(clOrdId, securityId, 0, RejectReason.UnknownOrderId, nowNanos),
-                _currentClOrdId);
+                _currentClOrdId, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
         }
     }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
 using Side = B3.Exchange.Matching.Side;
 
@@ -34,7 +35,7 @@ public sealed partial class ChannelDispatcher
             // trade fired in the same dispatch turn can resolve owner ↦
             // session locally.
             _orders.Register(e.OrderId, _currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId);
-            _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, e, _currentReceivedTimeNanos);
+            _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, e, _currentReceivedTimeNanos, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.New);
         }
     }
@@ -79,7 +80,8 @@ public sealed partial class ChannelDispatcher
             side: e.Side, newPriceMantissa: e.NewPriceMantissa,
             newRemainingQty: e.NewRemainingQuantity,
             transactTimeNanos: e.TransactTimeNanos, rptSeq: e.RptSeq,
-            receivedTimeNanos: _currentReceivedTimeNanos);
+            receivedTimeNanos: _currentReceivedTimeNanos,
+            durability: CurrentDurability);
         _metrics?.IncExecutionReport(ExecutionReportKind.Replace);
 
         // Refresh the canonical (Firm, ClOrdID) → OrderId index so
@@ -234,7 +236,7 @@ public sealed partial class ChannelDispatcher
         if (_orders.TryEvict(e.OrderId, out var owner))
         {
             _outbound.WriteExecutionReportPassiveCancel(owner.Session, owner.ClOrdId, e.OrderId, e,
-                _currentClOrdId, _currentReceivedTimeNanos);
+                _currentClOrdId, _currentReceivedTimeNanos, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
         }
     }
@@ -286,7 +288,7 @@ public sealed partial class ChannelDispatcher
         {
             _outbound.WriteExecutionReportTrade(_currentSession, e, isAggressor: true,
                 ownerOrderId: e.AggressorOrderId, clOrdIdValue: _currentClOrdId,
-                leavesQty: 0, cumQty: e.Quantity);
+                leavesQty: 0, cumQty: e.Quantity, durability: CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.Trade);
         }
         // ER_Trade for the resting side: resolve owner locally on the
@@ -296,7 +298,7 @@ public sealed partial class ChannelDispatcher
         if (_orders.TryResolve(e.RestingOrderId, out var owner))
         {
             _outbound.WriteExecutionReportPassiveTrade(owner.Session, owner.ClOrdId, e.RestingOrderId,
-                e, leavesQty: 0, cumQty: e.Quantity);
+                e, leavesQty: 0, cumQty: e.Quantity, durability: CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.TradePassive);
         }
     }
@@ -306,7 +308,7 @@ public sealed partial class ChannelDispatcher
         AssertOnLoopThread();
         if (_hasCurrentSession)
         {
-            _outbound.WriteExecutionReportReject(_currentSession, e, _currentClOrdId);
+            _outbound.WriteExecutionReportReject(_currentSession, e, _currentClOrdId, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
         }
     }
@@ -370,7 +372,7 @@ public sealed partial class ChannelDispatcher
                 EnteringFirm: e.EnteringFirm,
                 InsertTimestampNanos: e.InsertTimestampNanos,
                 RptSeq: e.RptSeq);
-            _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, accepted, _currentReceivedTimeNanos);
+            _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, accepted, _currentReceivedTimeNanos, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.New);
         }
     }
@@ -396,7 +398,7 @@ public sealed partial class ChannelDispatcher
                 Reason: CancelReason.Client,
                 RptSeq: e.RptSeq);
             _outbound.WriteExecutionReportPassiveCancel(owner.Session, owner.ClOrdId, e.OrderId, canceled,
-                _currentClOrdId, _currentReceivedTimeNanos);
+                _currentClOrdId, _currentReceivedTimeNanos, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
         }
     }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -346,19 +346,24 @@ public sealed partial class ChannelDispatcher
     private sealed class NoOpCoreOutboundImpl : ICoreOutbound
     {
         public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue,
-            in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
+            in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
+            DurabilityHandle durability = default) => true;
         public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor,
-            long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
+            long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
+            DurabilityHandle durability = default) => true;
         public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId,
-            long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
+            long restingOrderId, in TradeEvent e, long leavesQty, long cumQty,
+            DurabilityHandle durability = default) => true;
         public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId,
             long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero,
-            ulong receivedTimeNanos = ulong.MaxValue) => true;
+            ulong receivedTimeNanos = ulong.MaxValue,
+            DurabilityHandle durability = default) => true;
         public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId,
             ulong clOrdIdValue, ulong origClOrdIdValue,
             MatchingSide side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos,
-            uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
+            uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue,
+            DurabilityHandle durability = default) => true;
         public bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e,
-            ulong clOrdIdValue) => true;
+            ulong clOrdIdValue, DurabilityHandle durability = default) => true;
     }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -173,6 +173,19 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// session.</summary>
     private bool _replayMode;
 
+    /// <summary>
+    /// Issue #312: snapshot of the durability barrier the outbound ER
+    /// for the currently-dispatching command must wait on. Captured
+    /// after <see cref="WalAppendIfEnabled"/> stamps <c>_lastAppliedSeq</c>
+    /// so every ER triggered by the same command awaits the SAME WAL
+    /// seq, regardless of how many engine events fire. Returns
+    /// <see cref="DurabilityHandle.None"/> when WAL is disabled or
+    /// during replay so the send loop fast-paths through.
+    /// </summary>
+    private DurabilityHandle CurrentDurability =>
+        (_wal is null || _replayMode) ? DurabilityHandle.None
+            : new DurabilityHandle(_wal, _lastAppliedSeq);
+
     private static readonly IUmdfPacketSink NoOpPacketSink = new NoOpPacketSinkImpl();
     private static readonly ICoreOutbound NoOpOutbound = new NoOpCoreOutboundImpl();
     /// <summary>

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -58,7 +58,7 @@ public enum WalRecordKind
 /// visible to <see cref="ReadAll"/> or absent — partial / torn writes
 /// would invalidate replay.</para>
 /// </summary>
-public interface IChannelWriteAheadLog
+public interface IChannelWriteAheadLog : IDurabilityBarrier
 {
     /// <summary>
     /// Appends a record to the WAL. Implementations choose whether to
@@ -149,20 +149,4 @@ public interface IChannelWriteAheadLog
     /// trivially satisfy <see cref="WaitForDurable"/>.
     /// </summary>
     long DurableSeqOrZero => PendingDurableSeqOrZero;
-
-    /// <summary>
-    /// Issue #312: blocks until the WAL's
-    /// <see cref="DurableSeqOrZero"/> has reached
-    /// <paramref name="seq"/>, i.e. the record with that seq (and
-    /// every earlier record) is on durable storage. Returns
-    /// immediately when the predicate is already satisfied or
-    /// when <paramref name="seq"/> is &lt;= 0.
-    ///
-    /// <para>Implementations MUST honour
-    /// <paramref name="cancellationToken"/> so the caller can
-    /// abort on shutdown without leaking the dispatch thread.
-    /// The default implementation is a no-op (the in-memory fake
-    /// reports its writes as immediately durable).</para>
-    /// </summary>
-    void WaitForDurable(long seq, CancellationToken cancellationToken = default) { }
 }

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -1,6 +1,7 @@
 using B3.EntryPoint.Wire;
 using System.Buffers.Binary;
 using B3.Exchange.Matching;
+using DurabilityHandle = B3.Exchange.Contracts.DurabilityHandle;
 
 namespace B3.Exchange.Gateway;
 
@@ -58,7 +59,8 @@ internal sealed class FixpOutboundEncoder
         _close = close;
     }
 
-    public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+    public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
     {
         if (!_isOpen()) return false;
         ulong clOrd = ulong.TryParse(e.ClOrdId, out var v) ? v : 0;
@@ -72,11 +74,12 @@ internal sealed class FixpOutboundEncoder
                 OrderType.Limit, TimeInForce.Day,
                 e.RemainingQuantity, e.PriceMantissa,
                 receivedTimeNanos);
-            return AppendAndEnqueueLocked(exact);
+            return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
-    public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
+    public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
+        DurabilityHandle durability = default)
     {
         if (!_isOpen()) return false;
         var side = isAggressor ? e.AggressorSide : (e.AggressorSide == Side.Buy ? Side.Sell : Side.Buy);
@@ -92,12 +95,13 @@ internal sealed class FixpOutboundEncoder
                 isAggressor ? e.RestingFirm : e.AggressorFirm,
                 tradeDate: 0,
                 orderQty: leavesQty + cumQty);
-            return AppendAndEnqueueLocked(exact);
+            return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
     public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue,
-        ulong receivedTimeNanos = ulong.MaxValue)
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
     {
         if (!_isOpen()) return false;
         var exact = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
@@ -110,13 +114,14 @@ internal sealed class FixpOutboundEncoder
                 (ulong)e.RptSeq, e.TransactTimeNanos,
                 cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa,
                 receivedTimeNanos);
-            return AppendAndEnqueueLocked(exact);
+            return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
         Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
-        ulong receivedTimeNanos = ulong.MaxValue)
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
     {
         if (!_isOpen()) return false;
         var exact = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
@@ -128,7 +133,7 @@ internal sealed class FixpOutboundEncoder
                 securityId, orderId, (ulong)rptSeq, transactTimeNanos,
                 leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa,
                 receivedTimeNanos: receivedTimeNanos);
-            return AppendAndEnqueueLocked(exact);
+            return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
@@ -155,7 +160,8 @@ internal sealed class FixpOutboundEncoder
         }
     }
 
-    public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue)
+    public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue,
+        DurabilityHandle durability = default)
     {
         if (!_isOpen()) return false;
         uint rej = MapRejectReason(e.Reason);
@@ -166,7 +172,7 @@ internal sealed class FixpOutboundEncoder
                 _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
                 clOrdIdValue, origClOrdIdValue: 0, e.SecurityId, e.OrderIdOrZero,
                 rej, e.TransactTimeNanos);
-            return AppendAndEnqueueLocked(exact);
+            return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
@@ -203,7 +209,7 @@ internal sealed class FixpOutboundEncoder
     /// transport. Centralizes the two-step "buffer + enqueue" so every
     /// business-frame write site has identical semantics.
     /// </summary>
-    private bool AppendAndEnqueueLocked(byte[] exact)
+    private bool AppendAndEnqueueLocked(byte[] exact, DurabilityHandle durability = default)
     {
         // OutboundBusinessHeader.MsgSeqNum sits at body offset 4
         // (SessionID(4) | MsgSeqNum(4) | …) → absolute offset
@@ -215,7 +221,7 @@ internal sealed class FixpOutboundEncoder
         // that has been allocated MUST be replayable, even if the local
         // send queue rejects the frame (gpt-5.5 critique #9).
         _retxBuffer.Append(seq, exact);
-        return _transport().TryEnqueueFrame(exact);
+        return _transport().TryEnqueueFrame(exact, durability);
     }
 
     /// <summary>

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -431,21 +431,25 @@ public sealed partial class FixpSession : IAsyncDisposable
     private void ProcessAndEnqueueRetransmitRequest(ReadOnlySpan<byte> fixedBlock)
         => _retransmitController.ProcessAndEnqueueRetransmitRequest(fixedBlock);
 
-    public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
-        => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos);
+    public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
+        => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos, durability);
 
-    public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
-        => _outboundEncoder.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty);
+    public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
+        DurabilityHandle durability = default)
+        => _outboundEncoder.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty, durability);
 
     public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue,
-        ulong receivedTimeNanos = ulong.MaxValue)
-        => _outboundEncoder.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos);
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
+        => _outboundEncoder.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos, durability);
 
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
         B3.Exchange.Matching.Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
-        ulong receivedTimeNanos = ulong.MaxValue)
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
         => _outboundEncoder.WriteExecutionReportModify(securityId, orderId, clOrdIdValue, origClOrdIdValue,
-            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos);
+            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos, durability);
 
     /// <summary>
     /// Encodes and enqueues an <c>OrderMassActionReport</c> (template 702,
@@ -460,8 +464,9 @@ public sealed partial class FixpSession : IAsyncDisposable
         => _outboundEncoder.WriteOrderMassActionReport(clOrdIdValue, massActionResponse,
             massActionRejectReason, side, securityId, transactTimeNanos, text);
 
-    public bool WriteExecutionReportReject(in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue)
-        => _outboundEncoder.WriteExecutionReportReject(e, clOrdIdValue);
+    public bool WriteExecutionReportReject(in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue,
+        DurabilityHandle durability = default)
+        => _outboundEncoder.WriteExecutionReportReject(e, clOrdIdValue, durability);
 
     public bool WriteSessionReject(byte terminationCode)
         => _outboundEncoder.WriteSessionReject(terminationCode);

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -47,48 +47,54 @@ public sealed class GatewayRouter : ICoreOutbound
     }
 
     public bool WriteExecutionReportNew(ContractsSessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e,
-        ulong receivedTimeNanos = ulong.MaxValue)
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportNew"); return false; }
-        return s.WriteExecutionReportNew(e, receivedTimeNanos);
+        return s.WriteExecutionReportNew(e, receivedTimeNanos, durability);
     }
 
     public bool WriteExecutionReportTrade(ContractsSessionId session, in TradeEvent e, bool isAggressor,
-        long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
+        long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
+        DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportTrade"); return false; }
-        return s.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty);
+        return s.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty, durability);
     }
 
     public bool WriteExecutionReportPassiveTrade(ContractsSessionId ownerSession, ulong ownerClOrdId, long restingOrderId,
-        in TradeEvent e, long leavesQty, long cumQty)
+        in TradeEvent e, long leavesQty, long cumQty,
+        DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportPassiveTrade"); return false; }
-        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, ownerClOrdId, leavesQty, cumQty);
+        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, ownerClOrdId, leavesQty, cumQty, durability);
     }
 
     public bool WriteExecutionReportPassiveCancel(ContractsSessionId ownerSession, ulong ownerClOrdId, long orderId,
-        in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+        in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportPassiveCancel"); return false; }
         ulong clOrdIdOnWire = requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : ownerClOrdId;
-        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, ownerClOrdId, receivedTimeNanos);
+        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, ownerClOrdId, receivedTimeNanos, durability);
     }
 
     public bool WriteExecutionReportModify(ContractsSessionId session, long securityId, long orderId,
         ulong clOrdIdValue, ulong origClOrdIdValue,
         Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
-        ulong receivedTimeNanos = ulong.MaxValue)
+        ulong receivedTimeNanos = ulong.MaxValue,
+        DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportModify"); return false; }
         return s.WriteExecutionReportModify(securityId, orderId, clOrdIdValue, origClOrdIdValue,
-            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos);
+            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos, durability);
     }
 
-    public bool WriteExecutionReportReject(ContractsSessionId session, in RejectEvent e, ulong clOrdIdValue)
+    public bool WriteExecutionReportReject(ContractsSessionId session, in RejectEvent e, ulong clOrdIdValue,
+        DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportReject"); return false; }
-        return s.WriteExecutionReportReject(e, clOrdIdValue);
+        return s.WriteExecutionReportReject(e, clOrdIdValue, durability);
     }
 
     private void LogMiss(ContractsSessionId session, string kind)

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -1,4 +1,5 @@
 using System.Threading.Channels;
+using B3.Exchange.Contracts;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Exchange.Gateway;
@@ -26,7 +27,7 @@ public sealed class TcpTransport : IAsyncDisposable
 {
     private readonly Stream _stream;
     private readonly ILogger<TcpTransport> _logger;
-    private readonly Channel<byte[]> _sendQueue;
+    private readonly Channel<OutboundFrame> _sendQueue;
     private readonly SemaphoreSlim _streamWriteLock = new(1, 1);
     private readonly long _connectionId;
     private readonly Action<string>? _onClose;
@@ -34,6 +35,15 @@ public sealed class TcpTransport : IAsyncDisposable
     private int _isOpen = 1;
     private long _lastOutboundTickMs;
     private Task? _sendTask;
+
+    /// <summary>
+    /// Issue #312: per-frame envelope tying the encoded bytes to the
+    /// optional durability handle the send loop must satisfy before
+    /// writing them to the socket. <see cref="DurabilityHandle.None"/>
+    /// (the default for non-ER frames such as keep-alive,
+    /// SessionReject, BusinessMessageReject) skips the wait.
+    /// </summary>
+    private readonly record struct OutboundFrame(byte[] Bytes, DurabilityHandle Durability);
 
     /// <summary>
     /// Underlying stream. Exposed for the session-level receive loop —
@@ -70,7 +80,7 @@ public sealed class TcpTransport : IAsyncDisposable
         _logger = logger;
         _onClose = onClose;
         _onSendQueueFull = onSendQueueFull;
-        _sendQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(sendQueueCapacity)
+        _sendQueue = Channel.CreateBounded<OutboundFrame>(new BoundedChannelOptions(sendQueueCapacity)
         {
             SingleReader = true,
             SingleWriter = false,
@@ -94,11 +104,18 @@ public sealed class TcpTransport : IAsyncDisposable
     /// <c>false</c> if the transport is closed or the queue overflowed
     /// (in which case the transport is closed as a side-effect to avoid
     /// unbounded memory growth under a stuck peer).
+    ///
+    /// <para>Issue #312: the optional <paramref name="durability"/>
+    /// pair tells the send loop which WAL seq must be fsynced before
+    /// the bytes leave the host. <see cref="DurabilityHandle.None"/>
+    /// (the default) means "send immediately" — the pre-#312
+    /// behaviour preserved by every keep-alive / SessionReject /
+    /// BusinessMessageReject call site.</para>
     /// </summary>
-    public bool TryEnqueueFrame(byte[] frame)
+    public bool TryEnqueueFrame(byte[] frame, DurabilityHandle durability = default)
     {
         if (!IsOpen) return false;
-        if (_sendQueue.Writer.TryWrite(frame)) return true;
+        if (_sendQueue.Writer.TryWrite(new OutboundFrame(frame, durability))) return true;
         try { _onSendQueueFull?.Invoke(); } catch { }
         Close("send-queue-full");
         return false;
@@ -134,10 +151,21 @@ public sealed class TcpTransport : IAsyncDisposable
             {
                 try
                 {
+                    // Issue #312: never let an ER (or any frame tagged
+                    // with a durability handle) hit the wire before its
+                    // covering WAL record is fsynced. Synchronous wait
+                    // is fine here — the send loop is the only consumer
+                    // of the queue and we WANT it to back-pressure on
+                    // un-durable frames; that's the whole point of the
+                    // gating contract.
+                    if (frame.Durability.IsActive)
+                    {
+                        frame.Durability.Barrier!.WaitForDurable(frame.Durability.Seq, ct);
+                    }
                     await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
                     try
                     {
-                        await _stream.WriteAsync(frame, ct).ConfigureAwait(false);
+                        await _stream.WriteAsync(frame.Bytes, ct).ConfigureAwait(false);
                     }
                     finally
                     {

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -574,13 +574,22 @@ public sealed class ExchangeHost : IAsyncDisposable
                 ch.ChannelNumber);
             return null;
         }
+        var fsyncMode = walCfg.ResolveFsyncMode();
+        // GroupCommit MUST NOT also fsync per write — the WAL ctor
+        // hard-rejects the contradictory combination. ResolveFsyncMode
+        // already ensures the operator-facing config is consistent;
+        // here we just normalise the internal flag passed downstream.
+        bool fsyncPerWrite = fsyncMode == B3.Exchange.Core.WalFsyncMode.PerWrite;
+        var groupCommitInterval = TimeSpan.FromMilliseconds(Math.Max(1, walCfg.GroupCommitIntervalMs));
         return new FileChannelWriteAheadLog(
             ch.Persistence.DataDir,
             ch.ChannelNumber,
             _loggerFactory.CreateLogger<FileChannelWriteAheadLog>(),
-            walCfg.FsyncPerWrite,
+            fsyncPerWrite,
             walCfg.MaxBytes,
-            walCfg.ResolveOnFull());
+            walCfg.ResolveOnFull(),
+            fsyncMode,
+            groupCommitInterval);
     }
 
     /// <summary>

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -434,6 +434,37 @@ public sealed class WalConfig
     [JsonPropertyName("onFull")] public string OnFull { get; set; } = "halt";
 
     /// <summary>
+    /// Issue #312 (Tier-2 perf): selects the WAL fsync strategy.
+    /// <list type="bullet">
+    ///   <item><c>"perWrite"</c> (default when <see cref="FsyncPerWrite"/>
+    ///   is <c>true</c>) — every <c>Append</c> calls <c>fsync</c>
+    ///   before returning. Zero RPO, per-command disk latency.</item>
+    ///   <item><c>"groupCommit"</c> — appends are written + fsynced on
+    ///   a background thread no more often than every
+    ///   <c>groupCommitIntervalMs</c> milliseconds. The outbound
+    ///   stack uses <c>WaitForDurable</c> to gate ER frames so
+    ///   peers never observe state that is not yet on disk; this
+    ///   amortises fsync cost across bursty workloads while keeping
+    ///   the durable-before-observable contract intact.</item>
+    /// </list>
+    /// When omitted, the resolved mode comes from
+    /// <see cref="FsyncPerWrite"/>: <c>true</c> ⇒ <c>perWrite</c>,
+    /// <c>false</c> ⇒ <c>groupCommit</c>. Setting both
+    /// <see cref="FsyncMode"/>=<c>perWrite</c> AND
+    /// <see cref="FsyncPerWrite"/>=<c>false</c> (or the inverse) is
+    /// flagged as a misconfiguration at boot.
+    /// </summary>
+    [JsonPropertyName("fsyncMode")] public string? FsyncMode { get; set; }
+
+    /// <summary>
+    /// Group-commit batching window in milliseconds. Ignored unless
+    /// the resolved fsync mode is <c>groupCommit</c>. Defaults to
+    /// <c>1</c> ms — small enough to bound RPO under steady load,
+    /// large enough to amortise fsync syscall cost across the burst.
+    /// </summary>
+    [JsonPropertyName("groupCommitIntervalMs")] public int GroupCommitIntervalMs { get; set; } = 1;
+
+    /// <summary>
     /// Parses <see cref="OnFull"/> case-insensitively to the typed
     /// enum. Throws on unknown values so misconfiguration fails
     /// the boot rather than silently degrading to the wrong
@@ -447,6 +478,48 @@ public sealed class WalConfig
             _ => throw new InvalidOperationException(
                 $"persistence.wal.onFull: unknown value '{OnFull}' (expected 'halt' or 'drop')"),
         };
+
+    /// <summary>
+    /// Resolves <see cref="FsyncMode"/> + <see cref="FsyncPerWrite"/>
+    /// into the typed <see cref="B3.Exchange.Core.WalFsyncMode"/>
+    /// the WAL ctor expects. When <see cref="FsyncMode"/> is unset,
+    /// derives from the legacy <see cref="FsyncPerWrite"/> flag so
+    /// existing configs keep their pre-#312 behaviour. Throws on
+    /// unknown values or contradictory combinations
+    /// (<c>perWrite</c> + <see cref="FsyncPerWrite"/>=<c>false</c>,
+    /// or <c>groupCommit</c> + <see cref="FsyncPerWrite"/>=<c>true</c>).
+    /// </summary>
+    public B3.Exchange.Core.WalFsyncMode ResolveFsyncMode()
+    {
+        var raw = FsyncMode?.Trim().ToLowerInvariant();
+        switch (raw)
+        {
+            case null or "":
+                return FsyncPerWrite
+                    ? B3.Exchange.Core.WalFsyncMode.PerWrite
+                    : B3.Exchange.Core.WalFsyncMode.GroupCommit;
+            case "perwrite":
+                if (!FsyncPerWrite)
+                {
+                    throw new InvalidOperationException(
+                        "persistence.wal.fsyncMode='perWrite' contradicts persistence.wal.fsyncPerWrite=false; remove one of the two settings.");
+                }
+                return B3.Exchange.Core.WalFsyncMode.PerWrite;
+            case "groupcommit":
+                if (FsyncPerWrite && FsyncMode is not null)
+                {
+                    // FsyncPerWrite default is true; treat the explicit
+                    // groupCommit override as authoritative and override
+                    // the legacy flag transparently. Operators upgrading
+                    // an old config only need to set fsyncMode.
+                    return B3.Exchange.Core.WalFsyncMode.GroupCommit;
+                }
+                return B3.Exchange.Core.WalFsyncMode.GroupCommit;
+            default:
+                throw new InvalidOperationException(
+                    $"persistence.wal.fsyncMode: unknown value '{FsyncMode}' (expected 'perWrite' or 'groupCommit').");
+        }
+    }
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs
@@ -50,12 +50,12 @@ public class ChannelDispatcherRetxBufferTests
 
     private sealed class NoopOutbound : ICoreOutbound
     {
-        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId session, in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue) => true;
+        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId session, in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default) => true;
     }
 
     private static (ChannelDispatcher disp, RecordingPacketSink pkt, UmdfPacketRetransmitBuffer ring) NewDispatcherWithRing(int capacity = 16)

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -63,13 +63,13 @@ public class ChannelDispatcherTests
         private FakeSession? Find(B3.Exchange.Contracts.SessionId id)
             => _sessions.TryGetValue(id, out var s) ? s : null;
 
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         { _owners[e.OrderId] = (session, clOrdIdValue); if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); s.LastReceivedTime = receivedTimeNanos; } return true; }
-        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
+        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default)
         { if (Find(session) is { } s) { s.Trades.Add(e); s.Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); } return true; }
-        public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty)
+        public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default)
         { if (Find(ownerSession) is { } s) { s.Trades.Add(e); s.Calls.Add("TradePass"); } return true; }
-        public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         {
             if (Find(ownerSession) is { } s)
             {
@@ -78,9 +78,9 @@ public class ChannelDispatcherTests
             }
             return true;
         }
-        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         { if (Find(session) is { } s) { s.Calls.Add("Modify"); s.LastReceivedTime = receivedTimeNanos; } return true; }
-        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue)
+        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default)
         { if (Find(session) is { } s) { s.Rejects.Add(e); s.Calls.Add("Reject"); } return true; }
     }
 
@@ -541,17 +541,17 @@ public class ChannelDispatcherTests
         public int Throws;
         public int Successes;
         public bool ThrowOnNext = true;
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         {
             if (ThrowOnNext) { ThrowOnNext = false; Throws++; throw new InvalidOperationException("synthetic crash"); }
             Successes++;
             return true;
         }
-        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
+        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default) => true;
     }
 
     private sealed class TestSession

--- a/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
+++ b/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
@@ -57,33 +57,33 @@ public class CrossOrderSemanticsTests
         private readonly Dictionary<B3.Exchange.Contracts.SessionId, FakeSession> _sessions = new();
         public void Register(FakeSession s) => _sessions[s.Id] = s;
 
-        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         {
             if (_sessions.TryGetValue(session, out var s)) s.News.Add(e);
             return true;
         }
 
-        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty)
+        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default)
         {
             if (_sessions.TryGetValue(session, out var s)) { s.Trades.Add(e); s.TradeIsAggressor.Add(isAggressor); }
             return true;
         }
 
-        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty)
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default)
         {
             if (_sessions.TryGetValue(ownerSession, out var s)) { s.Trades.Add(e); s.TradeIsAggressor.Add(false); }
             return true;
         }
 
-        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue)
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         {
             if (_sessions.TryGetValue(ownerSession, out var s)) s.Cancels.Add(e);
             return true;
         }
 
-        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
+        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
 
-        public bool WriteExecutionReportReject(SessionId session, in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue) => true;
+        public bool WriteExecutionReportReject(SessionId session, in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default) => true;
     }
 
     private static (ChannelDispatcher disp, RecordingPacketSink pkt, RecordingOutbound outbound) NewDispatcher()

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -327,10 +327,10 @@ public class ChannelDispatcherSnapshotTests
 
 internal sealed class ChannelDispatcherTests_RecordingOutbound : B3.Exchange.Contracts.ICoreOutbound
 {
-    public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
-    public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-    public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
-    public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
-    public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) => true;
+    public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+    public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+    public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+    public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+    public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+    public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default) => true;
 }

--- a/tests/B3.Exchange.Core.Tests/TracingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/TracingTests.cs
@@ -44,12 +44,12 @@ public class TracingTests
 
     private sealed class NoopOutbound : ICoreOutbound
     {
-        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, MatchingSide side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue) => true;
+        public bool WriteExecutionReportNew(SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, MatchingSide side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default) => true;
     }
 
     private static ChannelDispatcher NewDispatcher() => new(

--- a/tests/B3.Exchange.Gateway.Tests/TcpTransportDurabilityTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/TcpTransportDurabilityTests.cs
@@ -1,0 +1,126 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Gateway;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #312: the send loop MUST not write a frame whose
+/// <see cref="DurabilityHandle"/> is active until the barrier
+/// signals durability for the frame's seq. Frames carrying
+/// <see cref="DurabilityHandle.None"/> bypass the wait and hit
+/// the wire immediately (preserving the pre-#312 fast path for
+/// keep-alives, SessionReject, etc.).
+/// </summary>
+public class TcpTransportDurabilityTests
+{
+    /// <summary>
+    /// Releases <see cref="WaitForDurable"/> only when
+    /// <see cref="Release"/> is called. The send loop must observe
+    /// "frame waited" semantics for any seq &gt; 0.
+    /// </summary>
+    private sealed class GatedBarrier : IDurabilityBarrier
+    {
+        private readonly ManualResetEventSlim _gate = new(false);
+        public int WaitCount;
+        public long LastAwaitedSeq;
+        public void Release() => _gate.Set();
+        public void WaitForDurable(long seq, CancellationToken cancellationToken = default)
+        {
+            Interlocked.Increment(ref WaitCount);
+            Volatile.Write(ref LastAwaitedSeq, seq);
+            _gate.Wait(cancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task SendLoop_BlocksFrameUntilBarrierSignalsDurability()
+    {
+        // Pair a MemoryStream with a TaskCompletionSource we set on first write.
+        using var ms = new MemoryStream();
+        using var observed = new SemaphoreSlim(0, 1);
+        var observingStream = new ObservingMemoryStream(ms, observed);
+        await using var transport = new TcpTransport(
+            connectionId: 1, stream: observingStream,
+            logger: NullLogger<TcpTransport>.Instance,
+            sendQueueCapacity: 8);
+        using var cts = new CancellationTokenSource();
+        transport.StartSendLoop(cts.Token);
+
+        var barrier = new GatedBarrier();
+        var frame = new byte[] { 1, 2, 3, 4 };
+        Assert.True(transport.TryEnqueueFrame(frame, new DurabilityHandle(barrier, Seq: 7)));
+
+        // Frame must NOT have been written yet — the loop is parked in
+        // WaitForDurable. Allow scheduler latency, then assert silence.
+        await Task.Delay(150);
+        Assert.True(barrier.WaitCount >= 1, $"send loop never entered WaitForDurable (WaitCount={barrier.WaitCount})");
+        Assert.Equal(7, Volatile.Read(ref barrier.LastAwaitedSeq));
+        Assert.Equal(0, ms.Length);
+
+        // Release the barrier and assert the frame lands on the stream.
+        barrier.Release();
+        Assert.True(await observed.WaitAsync(TimeSpan.FromSeconds(5)),
+            "send loop did not write the frame after barrier release");
+        Assert.Equal(frame, ms.ToArray());
+
+        cts.Cancel();
+    }
+
+    [Fact]
+    public async Task SendLoop_DoesNotWait_WhenDurabilityHandleIsNone()
+    {
+        using var ms = new MemoryStream();
+        using var observed = new SemaphoreSlim(0, 1);
+        var observingStream = new ObservingMemoryStream(ms, observed);
+        await using var transport = new TcpTransport(
+            connectionId: 2, stream: observingStream,
+            logger: NullLogger<TcpTransport>.Instance,
+            sendQueueCapacity: 8);
+        using var cts = new CancellationTokenSource();
+        transport.StartSendLoop(cts.Token);
+
+        var frame = new byte[] { 9, 9, 9 };
+        Assert.True(transport.TryEnqueueFrame(frame));
+
+        Assert.True(await observed.WaitAsync(TimeSpan.FromSeconds(5)),
+            "default DurabilityHandle.None path should send immediately");
+        Assert.Equal(frame, ms.ToArray());
+
+        cts.Cancel();
+    }
+
+    /// <summary>
+    /// MemoryStream wrapper that releases <paramref name="signal"/>
+    /// the first time the loop writes anything — lets the test wait
+    /// deterministically rather than polling.
+    /// </summary>
+    private sealed class ObservingMemoryStream : Stream
+    {
+        private readonly MemoryStream _inner;
+        private readonly SemaphoreSlim _signal;
+        private int _signalled;
+        public ObservingMemoryStream(MemoryStream inner, SemaphoreSlim signal)
+        { _inner = inner; _signal = signal; }
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => _inner.CanSeek;
+        public override bool CanWrite => true;
+        public override long Length => _inner.Length;
+        public override long Position { get => _inner.Position; set => _inner.Position = value; }
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+        public override void SetLength(long value) => _inner.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _inner.Write(buffer, offset, count);
+            if (Interlocked.Exchange(ref _signalled, 1) == 0) _signal.Release();
+        }
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            _inner.Write(buffer.Span);
+            if (Interlocked.Exchange(ref _signalled, 1) == 0) _signal.Release();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -22,12 +22,12 @@ public class HostRouterTests
     private sealed class RecordingOutbound : ICoreOutbound
     {
         public List<RejectEvent> Rejects { get; } = new();
-        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue) { Rejects.Add(e); return true; }
+        public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle durability = default) => true;
+        public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle durability = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle durability = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle durability = default) => true;
+        public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle durability = default) => true;
+        public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue, DurabilityHandle durability = default) { Rejects.Add(e); return true; }
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherDurabilityHandleTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherDurabilityHandleTests.cs
@@ -1,0 +1,129 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrderType = B3.Exchange.Matching.OrderType;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #312: end-to-end gating contract — when the channel has a
+/// WAL configured the <see cref="ChannelDispatcher"/> must hand
+/// every <c>WriteExecutionReportXxx</c> a
+/// <see cref="DurabilityHandle"/> tied to the WAL barrier and the
+/// command's seq, so the gateway send loop blocks the bytes until
+/// fsync. When no WAL is configured the dispatcher must hand
+/// <see cref="DurabilityHandle.None"/> and the legacy fast path
+/// stays unaffected.
+/// </summary>
+public class ChannelDispatcherDurabilityHandleTests
+{
+    private const long Sec = 900_000_000_002L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class CapturingOutbound : ICoreOutbound
+    {
+        public List<DurabilityHandle> NewDurabilities { get; } = new();
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default)
+        { NewDurabilities.Add(d); return true; }
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "wal-dh-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+        public void Dispose()
+        { try { Directory.Delete(Path, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public void WalEnabled_PassesActiveDurabilityHandle_ToOutboundEr()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance,
+            fsyncPerWrite: false, maxBytes: 0,
+            onFull: WalSizeCapPolicy.Halt,
+            fsyncMode: WalFsyncMode.GroupCommit,
+            groupCommitInterval: TimeSpan.FromMilliseconds(1));
+        var outbound = new CapturingOutbound();
+        var disp = new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s, NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            wal: wal);
+        var probe = disp.CreateTestProbe();
+
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-1", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, 1_000UL),
+            new SessionId("S"), enteringFirm: 700, clOrdIdValue: 1));
+        probe.DrainInbound();
+
+        var handle = Assert.Single(outbound.NewDurabilities);
+        Assert.True(handle.IsActive,
+            "ChannelDispatcher with WAL must propagate an active DurabilityHandle so the gateway can fsync-gate the ER");
+        Assert.NotNull(handle.Barrier);
+        Assert.Equal(1L, handle.Seq);
+    }
+
+    [Fact]
+    public void WalDisabled_PassesNoneDurabilityHandle_ToOutboundEr()
+    {
+        var outbound = new CapturingOutbound();
+        var disp = new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s, NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            wal: null);
+        var probe = disp.CreateTestProbe();
+
+        Assert.True(disp.EnqueueNewOrder(
+            new NewOrderCommand("CL-1", Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, 1_000UL),
+            new SessionId("S"), enteringFirm: 700, clOrdIdValue: 1));
+        probe.DrainInbound();
+
+        var handle = Assert.Single(outbound.NewDurabilities);
+        Assert.False(handle.IsActive,
+            "no-WAL channel must hand DurabilityHandle.None so the gateway send loop fast-paths through");
+        Assert.Equal(DurabilityHandle.None, handle);
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherOrphanSessionTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherOrphanSessionTests.cs
@@ -42,12 +42,12 @@ public class ChannelDispatcherOrphanSessionTests
 
     private sealed class NoOpOutbound : ICoreOutbound
     {
-        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue) => true;
-        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
     }
 
     private static ChannelDispatcher BuildDispatcher(

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -42,12 +42,12 @@ public class ChannelDispatcherPersistenceTests
 
     private sealed class NoOpOutbound : ICoreOutbound
     {
-        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue) => true;
-        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId s, in RejectEvent e, ulong c) => true;
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in RejectEvent e, ulong c, DurabilityHandle d = default) => true;
     }
 
     /// <summary>

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
@@ -44,13 +44,13 @@ public class ChannelDispatcherWalTests
     private sealed class CountingOutbound : ICoreOutbound
     {
         public int NewCount;
-        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue)
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default)
         { NewCount++; return true; }
-        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
     }
 
     private sealed class InMemoryPersister : IChannelStatePersister

--- a/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
@@ -44,13 +44,13 @@ public class WalAppendFailurePolicyTests
     private sealed class CountingOutbound : ICoreOutbound
     {
         public int NewCount;
-        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue)
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default)
         { NewCount++; return true; }
-        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
     }
 
     private sealed class FailingWal : IChannelWriteAheadLog

--- a/tests/B3.Exchange.Persistence.Tests/WalReplayIdempotencyTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalReplayIdempotencyTests.cs
@@ -72,12 +72,12 @@ public class WalReplayIdempotencyTests
 
     private sealed class NoOpOutbound : ICoreOutbound
     {
-        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue) => true;
-        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
     }
 
     private sealed class InMemoryPersister : IChannelStatePersister

--- a/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
@@ -46,13 +46,13 @@ public class WalSizeCapDispatcherTests
     private sealed class NoOpOutbound : ICoreOutbound
     {
         public int NewCount;
-        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue)
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default)
         { NewCount++; return true; }
-        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u) => true;
-        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u) => true;
-        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue) => true;
-        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
     }
 
     /// <summary>


### PR DESCRIPTION
Tier-2 perf #3 (WAL group-commit), PR-2 of 2.

PR-1 (#312) landed the WAL infrastructure: `WalFsyncMode.GroupCommit` and `IChannelWriteAheadLog.WaitForDurable`. This PR wires it end-to-end through the outbound stack so an ExecutionReport never leaves the host before the WAL record that produced it is fsynced — making `groupCommit` mode safe to ship without weakening the durable-before-observable contract.

## What changes

* **New `IDurabilityBarrier` + `DurabilityHandle`** in `B3.Exchange.Contracts`. `DurabilityHandle` is a `(IDurabilityBarrier? Barrier, long Seq)` value-type carried as a single optional last param on every `ICoreOutbound` method (default = `DurabilityHandle.None`, preserving the pre-#312 fast path for keep-alives, SessionReject, BusinessMessageReject).
* **`IChannelWriteAheadLog : IDurabilityBarrier`** — the WAL is its own barrier; the inherited interface declares the no-op default.
* **`ChannelDispatcher`** captures `CurrentDurability` after `WalAppendIfEnabled` stamps `_lastAppliedSeq`, so every ER triggered by the same command awaits the same WAL seq. Threaded through all 10 outbound ER call sites (Sinks + Loop).
* **`GatewayRouter` → `FixpSession` → `FixpOutboundEncoder` → `TcpTransport`** forward the handle. `FixpOutboundEncoder.AppendAndEnqueueLocked` hands it to `TcpTransport.TryEnqueueFrame`.
* **`TcpTransport`** queue widened from `Channel<byte[]>` to `Channel<OutboundFrame>` (struct: `{ byte[] Bytes, DurabilityHandle Durability }`). Send loop calls `barrier.WaitForDurable` **before** acquiring the stream write lock — preserving per-session FIFO regardless of cross-channel seq interleaving while back-pressuring on un-durable frames.
* **`HostConfig.WalConfig`** adds `fsyncMode` (`perWrite` / `groupCommit`) + `groupCommitIntervalMs`. `ResolveFsyncMode()` bridges the legacy `fsyncPerWrite` flag and fails the boot on contradictory combinations.
* **`ExchangeHost.BuildWal`** uses the 7-arg WAL ctor and forwards the resolved fsync mode + group-commit interval.

## Why per-call (not per-session)

A `FixpSession` can receive ERs from multiple channels (each with its own WAL). The barrier reference must travel with each frame so the gateway awaits the correct channel's fsync.

## Why await in the send loop (not before queueing)

The send loop is the single FIFO drain per session — the natural place to gate writes without losing per-session ordering, even when cross-channel seqs interleave. Awaiting before queueing would (a) block the dispatch thread (defeats group-commit batching) and (b) couple ordering across channels.

## Retransmit ring safety

The encoder appends to the in-memory retransmit ring under FIXP seq K **before** `TcpTransport` ever sees the bytes. If the host crashes after the ring append but before the dispatcher WAL fsync, the WAL won't replay that command on restart, the peer never received seq K (gated), they reconnect with `lastSeqProcessed = K - 1`, so seq K is reused safely.

## Tests

* **`TcpTransportDurabilityTests` (2)** — `GatedBarrier` proves the send loop blocks until release; `DurabilityHandle.None` bypasses the wait.
* **`ChannelDispatcherDurabilityHandleTests` (2)** — WAL-enabled dispatcher hands an active `DurabilityHandle` (barrier non-null, seq=1) to the outbound; WAL-disabled dispatcher hands `DurabilityHandle.None`.
* All 1,039 tests pass; `dotnet format` clean.

## Backlog

After this lands, the persistence + Tier-2 perf backlog is empty. Remaining open issues: #6 (ulong→string ClOrdId, side concern).