### PR TITLE
perf(dispatch): skip Activity start when no listeners + cached WorkKind tag strings

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
@@ -24,6 +24,11 @@ public sealed partial class ChannelDispatcher
     private System.Diagnostics.Activity? StartEnqueueSpan(
         WorkKind kind, SessionId session, uint enteringFirm, ulong clOrdId, long securityId)
     {
+        // Fast path: skip the virtual StartActivity call when no listeners
+        // are attached to the ActivitySource (round-2 perf #11). When
+        // listeners are present, StartActivity may still return null due
+        // to sampling — handled below.
+        if (!ExchangeTelemetry.Source.HasListeners()) return null;
         var act = ExchangeTelemetry.Source.StartActivity(
             ExchangeTelemetry.SpanDispatchEnqueue,
             System.Diagnostics.ActivityKind.Producer);
@@ -31,7 +36,7 @@ public sealed partial class ChannelDispatcher
         act.SetTag(ExchangeTelemetry.TagChannel, (int)ChannelNumber);
         act.SetTag(ExchangeTelemetry.TagSession, session.Value);
         act.SetTag(ExchangeTelemetry.TagFirm, (long)enteringFirm);
-        act.SetTag(ExchangeTelemetry.TagWorkKind, kind.ToString());
+        act.SetTag(ExchangeTelemetry.TagWorkKind, WorkKindName(kind));
         if (clOrdId != 0) act.SetTag(ExchangeTelemetry.TagClOrdId, (long)clOrdId);
         if (securityId != 0) act.SetTag(ExchangeTelemetry.TagSecurityId, securityId);
         return act;

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -128,16 +128,22 @@ public sealed partial class ChannelDispatcher
         // span captured at enqueue time. The dispatch loop crosses thread
         // boundaries from the gateway IO thread, so propagation must be
         // explicit — Activity.Current would not carry the context here.
-        using var engineSpan = ExchangeTelemetry.Source.StartActivity(
-            ExchangeTelemetry.SpanEngineProcess,
-            System.Diagnostics.ActivityKind.Internal,
-            item.ParentContext);
-        if (engineSpan is not null)
+        // Fast path: skip the virtual StartActivity call when no listeners
+        // are attached (round-2 perf #11).
+        System.Diagnostics.Activity? engineSpan = null;
+        if (ExchangeTelemetry.Source.HasListeners())
         {
-            engineSpan.SetTag(ExchangeTelemetry.TagChannel, (int)ChannelNumber);
-            engineSpan.SetTag(ExchangeTelemetry.TagWorkKind, item.Kind.ToString());
-            if (item.HasSession) engineSpan.SetTag(ExchangeTelemetry.TagSession, item.Session.Value);
-            if (item.ClOrdId != 0) engineSpan.SetTag(ExchangeTelemetry.TagClOrdId, (long)item.ClOrdId);
+            engineSpan = ExchangeTelemetry.Source.StartActivity(
+                ExchangeTelemetry.SpanEngineProcess,
+                System.Diagnostics.ActivityKind.Internal,
+                item.ParentContext);
+            if (engineSpan is not null)
+            {
+                engineSpan.SetTag(ExchangeTelemetry.TagChannel, (int)ChannelNumber);
+                engineSpan.SetTag(ExchangeTelemetry.TagWorkKind, WorkKindName(item.Kind));
+                if (item.HasSession) engineSpan.SetTag(ExchangeTelemetry.TagSession, item.Session.Value);
+                if (item.ClOrdId != 0) engineSpan.SetTag(ExchangeTelemetry.TagClOrdId, (long)item.ClOrdId);
+            }
         }
         try
         {
@@ -292,16 +298,23 @@ public sealed partial class ChannelDispatcher
             if (succeeded)
             {
                 long flushStart = engineEnd;
-                using (var flushSpan = ExchangeTelemetry.Source.StartActivity(
-                    ExchangeTelemetry.SpanOutboundEmit,
-                    System.Diagnostics.ActivityKind.Producer))
+                // Fast path: skip the virtual StartActivity call when no
+                // listeners are attached (round-2 perf #11).
+                if (ExchangeTelemetry.Source.HasListeners())
                 {
+                    using var flushSpan = ExchangeTelemetry.Source.StartActivity(
+                        ExchangeTelemetry.SpanOutboundEmit,
+                        System.Diagnostics.ActivityKind.Producer);
                     if (flushSpan is not null)
                         flushSpan.SetTag(ExchangeTelemetry.TagChannel, (int)ChannelNumber);
                     int bytes = _packetWritten;
                     FlushPacket();
                     if (flushSpan is not null)
                         flushSpan.SetTag(ExchangeTelemetry.TagBytes, bytes);
+                }
+                else
+                {
+                    FlushPacket();
                 }
                 if (_metrics != null)
                     _metrics.OutboundEmit.ObserveTicks(System.Diagnostics.Stopwatch.GetTimestamp() - flushStart);
@@ -321,6 +334,7 @@ public sealed partial class ChannelDispatcher
             _currentClOrdId = 0;
             _currentOrigClOrdId = 0;
             _currentReceivedTimeNanos = ulong.MaxValue;
+            engineSpan?.Dispose();
         }
     }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -12,6 +12,35 @@ public sealed partial class ChannelDispatcher
 {
     internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot }
 
+    /// <summary>
+    /// Pre-allocated string names for <see cref="WorkKind"/> used as
+    /// Activity tag values on the dispatch hot path. Avoids the
+    /// per-command <c>Enum.ToString()</c> allocation (round-2 perf #12)
+    /// when telemetry listeners are attached.
+    /// Indexed by <c>(byte)WorkKind</c>; keep in sync with the enum.
+    /// </summary>
+    private static readonly string[] WorkKindNames =
+    {
+        "New",
+        "Cancel",
+        "Replace",
+        "Cross",
+        "MassCancel",
+        "DecodeError",
+        "SnapshotRotation",
+        "OperatorSnapshotNow",
+        "OperatorBumpVersion",
+        "OperatorTradeBust",
+        "OperatorSetTradingPhase",
+        "OperatorPersistSnapshot",
+    };
+
+    private static string WorkKindName(WorkKind kind)
+    {
+        int idx = (int)kind;
+        return (uint)idx < (uint)WorkKindNames.Length ? WorkKindNames[idx] : kind.ToString();
+    }
+
     internal sealed record WorkItem(
         WorkKind Kind,
         SessionId Session,


### PR DESCRIPTION
Round-2 perf review findings #11 + #12 from the latest hot-path audit (post #310/#311/#312/#313).

## Findings addressed

**#11 — `Activity.StartActivity` allocation guard**
Three call sites (`dispatch.enqueue`, `engine.process`, `outbound.emit`) on the per-command hot path now short-circuit on `ExchangeTelemetry.Source.HasListeners()` before invoking the virtual `StartActivity`. When no listener is attached (production benchmarks, most tests), the cost drops to a single inlined volatile read.

**#12 — `WorkKind.ToString()` boxing in tag values**
`Enum.ToString()` was allocating ~40 B/command on every `engine.process` and `dispatch.enqueue` span. Replaced with a static `string[]` indexed by `(byte)WorkKind` (`WorkKindNames` in `ChannelDispatcher.WorkItem.cs`). At 100k ops/sec with telemetry on, this removes ~8 MB/s of Gen0 churn (2 spans × 40 B × 100k).

## Behavior

No change. When listeners are attached, every span name and tag that existed before is emitted unchanged.

## Risk

Very low. Pure optimization on a well-isolated path.

## Test

`dotnet build -c Release` clean (warnings-as-errors). `dotnet test` clean ignoring the known flaky `MultiSessionReplayTests.TwoSessions_CrossingScript_LandsErTradesOnBothSides` (passes 3/3 in isolation; unrelated to this change). `dotnet format --verify-no-changes` clean.