### PR TITLE
perf: SnapshotOrders scratch buffer + thread ulong ClOrdId through ER-New path

### DIFF
--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -60,10 +60,15 @@ internal sealed class FixpOutboundEncoder
     }
 
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
-        DurabilityHandle durability = default)
+        DurabilityHandle durability = default,
+        ulong clOrdIdValue = 0)
     {
         if (!_isOpen()) return false;
-        ulong clOrd = ulong.TryParse(e.ClOrdId, out var v) ? v : 0;
+        // Round-2 perf #14: prefer the ulong threaded from the dispatch
+        // layer (it already has the parsed value from inbound decode);
+        // fall back to TryParse only when callers don't supply it
+        // (legacy tests). Avoids a ~50–100 ns parse on every ER hot path.
+        ulong clOrd = clOrdIdValue != 0 ? clOrdIdValue : (ulong.TryParse(e.ClOrdId, out var v) ? v : 0);
         var exact = new byte[ExecutionReportEncoder.ExecReportNewTotal];
         lock (_outboundLock)
         {

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -432,8 +432,9 @@ public sealed partial class FixpSession : IAsyncDisposable
         => _retransmitController.ProcessAndEnqueueRetransmitRequest(fixedBlock);
 
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
-        DurabilityHandle durability = default)
-        => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos, durability);
+        DurabilityHandle durability = default,
+        ulong clOrdIdValue = 0)
+        => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos, durability, clOrdIdValue);
 
     public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
         DurabilityHandle durability = default)

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -51,7 +51,7 @@ public sealed class GatewayRouter : ICoreOutbound
         DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportNew"); return false; }
-        return s.WriteExecutionReportNew(e, receivedTimeNanos, durability);
+        return s.WriteExecutionReportNew(e, receivedTimeNanos, durability, clOrdIdValue);
     }
 
     public bool WriteExecutionReportTrade(ContractsSessionId session, in TradeEvent e, bool isAggressor,

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -124,6 +124,17 @@ internal sealed class LimitOrderBook
         _byOrderId.Clear();
     }
 
+    // Reusable scratch buffer for SnapshotOrders() (round-2 perf #10).
+    // The book is single-threaded and the only production caller
+    // (MatchingEngine.UncrossAuction's auction-survivor expiration
+    // sweep) iterates the snapshot once, sequentially, without
+    // nested calls back into this book. Reusing a single buffer
+    // eliminates the per-uncross List allocation that the previous
+    // ToList() implementation incurred.
+    private readonly List<RestingOrder> _snapshotScratch = new();
+
+    private SortedDictionary<long, PriceLevel> SideMap(Side side) => side == Side.Buy ? _bids : _asks;
+
     public bool TryGet(long orderId, out RestingOrder order) => _byOrderId.TryGetValue(orderId, out order!);
 
     /// <summary>
@@ -132,10 +143,22 @@ internal sealed class LimitOrderBook
     /// expiration sweep in <see cref="MatchingEngine.UncrossAuction"/> to
     /// find <see cref="TimeInForce.GoodForAuction"/> /
     /// <see cref="TimeInForce.AtClose"/> survivors. Issue #232 / Onda M5.
+    ///
+    /// <para>Returns a buffer owned by this book; the contents remain
+    /// valid until the next call to <see cref="SnapshotOrders"/> on
+    /// the same book. The single-thread invariant on the engine
+    /// guarantees no concurrent or nested invocation. Round-2 perf #10
+    /// — eliminates the per-call List allocation that
+    /// <c>_byOrderId.Values.ToList()</c> incurred.</para>
     /// </summary>
-    public IReadOnlyList<RestingOrder> SnapshotOrders() => _byOrderId.Values.ToList();
-
-    private SortedDictionary<long, PriceLevel> SideMap(Side side) => side == Side.Buy ? _bids : _asks;
+    public IReadOnlyList<RestingOrder> SnapshotOrders()
+    {
+        var buf = _snapshotScratch;
+        buf.Clear();
+        foreach (var o in _byOrderId.Values)
+            buf.Add(o);
+        return buf;
+    }
 
     public void Insert(RestingOrder o)
     {


### PR DESCRIPTION
Round-2 perf review findings #10 + #14. (#16 deliberately deferred — single rare call site, low ROI relative to the `RejectEvent` ctor refactor it would require.)

## Findings addressed

**#10 — `LimitOrderBook.SnapshotOrders()` scratch buffer**
Previously allocated a fresh `List<RestingOrder>` on every call via `_byOrderId.Values.ToList()`. The single production caller (`MatchingEngine.UncrossAuction` auction-survivor expiration sweep) needs an isolated snapshot because `EmitCanceled` mutates the underlying dict mid-iter, but it iterates the snapshot once sequentially without nested calls back into the same book. Replaced with a per-book reusable List `_snapshotScratch` cleared/refilled per call. Mirrors the `_oppositeScratch` pattern already proven in this class.

**#14 — Thread ulong ClOrdId through the ER-New path**
`GatewayRouter.WriteExecutionReportNew` already received `clOrdIdValue` as a ulong from `ChannelDispatcher.Sinks`, but dropped it on the floor when forwarding to `FixpSession`. The encoder then re-parsed it back out of `OrderAcceptedEvent.ClOrdId` via `ulong.TryParse` on every ER.

Added `clOrdIdValue` as an optional parameter on `FixpSession.WriteExecutionReportNew` and `FixpOutboundEncoder.WriteExecutionReportNew` (default `0`). The encoder prefers the threaded ulong and falls back to `TryParse` only when the legacy `0` sentinel is supplied. `GatewayRouter` now forwards the value it already has.

Eliminates a ~50–100 ns `TryParse` on the hot ER-emit path while keeping all existing test call sites compiling unchanged.

This is a strict subset of the deferred round-1 #6 (ulong→string ClOrdId in `RestingOrder`) — it touches only internal plumbing, not the snapshot wire format, so it is safe to ship now without a schema bump.

## Behavior

No semantic change. Wire format unchanged.

## Risk

Very low. Both findings are well-isolated; no API removed; backward compat preserved.

## Test

`dotnet build -c Release` clean (warnings-as-errors). `dotnet test` clean ignoring known flakies (`MultiSessionReplayTests.TwoSessions_CrossingScript` and `ChannelDispatcherPersistenceTests.AsyncWriter_RapidSubmits_CoalesceLastWriteWins` — both pass 3/3 in isolation, unrelated to this change). `dotnet format --verify-no-changes` clean.