### PR TITLE
fix(core): emit cumulative cumQty/leavesQty in ER_Trade (#319)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -149,7 +149,7 @@ public sealed partial class ChannelDispatcher
         {
             switch (item.Kind)
             {
-                case WorkKind.New: _metrics?.IncOrdersIn(); _engine.Submit(item.NewOrder!); break;
+                case WorkKind.New: _metrics?.IncOrdersIn(); BeginAggressor(item.NewOrder!.Quantity); _engine.Submit(item.NewOrder!); break;
                 case WorkKind.Cancel:
                     {
                         _metrics?.IncOrdersIn();
@@ -217,6 +217,7 @@ public sealed partial class ChannelDispatcher
                             _metrics?.IncOrdersIn();
                             _currentClOrdId = prioClOrd;
                             _crossSweepFilledQty = 0;
+                            BeginAggressor(sweepLeg.Quantity);
                             _engine.Submit(sweepLeg);
                             long swept = _crossSweepFilledQty.GetValueOrDefault();
                             _crossSweepFilledQty = null;
@@ -229,6 +230,7 @@ public sealed partial class ChannelDispatcher
                             {
                                 _metrics?.IncOrdersIn();
                                 _currentClOrdId = prioClOrd;
+                                BeginAggressor(residual);
                                 _engine.Submit(prioLeg with { Quantity = residual });
                             }
 
@@ -238,6 +240,7 @@ public sealed partial class ChannelDispatcher
                             // (price-time priority handles the rest).
                             _metrics?.IncOrdersIn();
                             _currentClOrdId = otherClOrd;
+                            BeginAggressor(otherLeg.Quantity);
                             _engine.Submit(otherLeg);
                         }
                         else
@@ -248,9 +251,11 @@ public sealed partial class ChannelDispatcher
                             // cross price.
                             _metrics?.IncOrdersIn();
                             _currentClOrdId = prioClOrd;
+                            BeginAggressor(prioLeg.Quantity);
                             _engine.Submit(prioLeg);
                             _metrics?.IncOrdersIn();
                             _currentClOrdId = otherClOrd;
+                            BeginAggressor(otherLeg.Quantity);
                             _engine.Submit(otherLeg);
                         }
                         break;
@@ -334,8 +339,26 @@ public sealed partial class ChannelDispatcher
             _currentClOrdId = 0;
             _currentOrigClOrdId = 0;
             _currentReceivedTimeNanos = ulong.MaxValue;
+            _aggressorOrigQty = 0;
+            _aggressorCumQty = 0;
             engineSpan?.Dispose();
         }
+    }
+
+    /// <summary>
+    /// Issue #319: rebinds the outermost-command aggressor tracker to a
+    /// new submit (NewOrder, or one leg of a Cross). Resets
+    /// <c>_aggressorCumQty</c> to 0 and stamps
+    /// <c>_aggressorOrigQty</c> with the order quantity the engine is
+    /// about to process. Subsequent <c>OnTrade</c> sink invocations on
+    /// the aggressor side accumulate against this counter so
+    /// <c>ER_Trade</c> emits monotonically-cumulative
+    /// <c>cumQty</c>/<c>leavesQty</c>.
+    /// </summary>
+    private void BeginAggressor(long originalQty)
+    {
+        _aggressorOrigQty = originalQty;
+        _aggressorCumQty = 0;
     }
 
     private void EmitUnknownOrderIdReject(string clOrdId, long securityId, ulong nowNanos)

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -57,7 +57,17 @@ public sealed partial class ChannelDispatcher
                 Firm: entry.State.Firm,
                 ClOrdId: entry.State.ClOrdId,
                 Side: entry.State.Side,
-                SecurityId: entry.State.SecurityId));
+                SecurityId: entry.State.SecurityId)
+            {
+                // Issue #319: persist cum/orderQty so multi-fill
+                // wire values survive restart. Owners captured by a
+                // pre-#319 dispatcher serialise as 0/0, which the
+                // restore path treats as "infer from engine
+                // remainingQty" via the ChannelStateSnapshot v1→v2
+                // migration.
+                OriginalQty = entry.State.OriginalQty,
+                CumQty = entry.State.CumQty,
+            });
         }
         if (dropped > 0)
         {
@@ -124,6 +134,28 @@ public sealed partial class ChannelDispatcher
 
         long droppedOrphans = 0;
 
+        // Issue #319: build a (orderId -> remainingQty) lookup from the
+        // restored engine state so owners persisted with OriginalQty=0
+        // (legacy v1 snapshots, or v2 snapshots whose dispatcher never
+        // stamped the field) can fall back to "OrderQty = remainingQty
+        // + cumQty" — preserves any cum the snapshot did persist while
+        // recovering a sane denominator for leaves on subsequent fills.
+        Dictionary<long, long>? remainingByOrderId = null;
+        foreach (var o in snapshot.Owners)
+        {
+            if (o.OriginalQty != 0) continue;
+            if (remainingByOrderId is null)
+            {
+                remainingByOrderId = new Dictionary<long, long>();
+                foreach (var book in snapshot.Engine.Books)
+                    foreach (var ro in book.Orders)
+                        remainingByOrderId[ro.OrderId] = ro.RemainingQuantity;
+                if (snapshot.Engine.Stops is { } stops)
+                    foreach (var s in stops)
+                        remainingByOrderId[s.OrderId] = s.Quantity;
+            }
+        }
+
         foreach (var o in snapshot.Owners)
         {
             // Issue #270: cross-channel consistency check. Skip owners
@@ -143,7 +175,14 @@ public sealed partial class ChannelDispatcher
                     ChannelNumber, o.OrderId, o.SessionValue);
                 continue;
             }
-            _orders.Register(o.OrderId, new SessionId(o.SessionValue), o.ClOrdId, o.Firm, o.Side, o.SecurityId);
+            long origQty = o.OriginalQty;
+            if (origQty == 0 && remainingByOrderId is not null
+                && remainingByOrderId.TryGetValue(o.OrderId, out var remaining))
+            {
+                origQty = remaining + o.CumQty;
+            }
+            _orders.Register(o.OrderId, new SessionId(o.SessionValue), o.ClOrdId, o.Firm, o.Side, o.SecurityId,
+                originalQty: origQty, cumQty: o.CumQty);
         }
         if (droppedOrphans > 0) _metrics?.AddOwnerOrphansDropped(droppedOrphans);
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -34,7 +34,21 @@ public sealed partial class ChannelDispatcher
             // thread (single writer) BEFORE emitting the ER so any passive
             // trade fired in the same dispatch turn can resolve owner ↦
             // session locally.
-            _orders.Register(e.OrderId, _currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId);
+            // Issue #319: also stamp the aggressor's running cumQty into
+            // the registry so post-resting passive fills continue from
+            // where the (partial-fill-then-rest) aggressor left off
+            // instead of resetting cum to 0. If the OrderId is already
+            // registered (e.g. a parked stop that just triggered and
+            // partially filled before resting), preserve its existing
+            // tracking — the dispatcher's _aggressor* counters belong to
+            // the outermost trade-causing command, not to the
+            // re-executed stop.
+            if (!_orders.TryResolve(e.OrderId, out _))
+            {
+                _orders.Register(e.OrderId, _currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId,
+                    originalQty: _aggressorOrigQty > 0 ? _aggressorOrigQty : e.RemainingQuantity,
+                    cumQty: _aggressorCumQty);
+            }
             _outbound.WriteExecutionReportNew(_currentSession, _currentFirm, _currentClOrdId, e, _currentReceivedTimeNanos, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.New);
         }
@@ -90,6 +104,13 @@ public sealed partial class ChannelDispatcher
         // identity is rotated.
         if (newClOrdId != 0 && newClOrdId != origClOrdId)
             _orders.Reregister(e.OrderId, newClOrdId);
+
+        // Issue #319: a Replace can change the wire OrderQty. The new
+        // OrderQty equals previously-executed (cumQty) plus the engine's
+        // new remaining quantity; refresh the registry so subsequent
+        // passive fills emit leavesQty against the right denominator.
+        if (_orders.TryResolve(e.OrderId, out var refreshed))
+            _orders.UpdateOriginalQty(e.OrderId, refreshed.CumQty + e.NewRemainingQuantity);
     }
 
     public void OnOrderBookSideEmpty(in OrderBookSideEmptyEvent e)
@@ -282,23 +303,44 @@ public sealed partial class ChannelDispatcher
         Commit(n);
 
         // ER_Trade for the aggressor side: routed to the active session by
-        // SessionId. We do not maintain per-aggressor cum/leaves tracking
-        // here; integration tests are scope-limited to single-fill scenarios.
+        // SessionId. Issue #319: cumQty/leavesQty are accumulated across
+        // every fill of the outermost command's aggressor (set by
+        // BeginAggressor in the dispatch loop) so multi-fill scenarios
+        // emit monotonically-cumulative wire values per the FIX/B3
+        // contract. _aggressorOrigQty == 0 means the aggressor was a
+        // re-entrant submit the dispatcher did not stamp (e.g. a
+        // triggered stop the engine rolled internally) — fall back to
+        // the per-trade quantity rather than a misleading negative
+        // leaves.
         if (_hasCurrentSession)
         {
+            _aggressorCumQty += e.Quantity;
+            long aggCum = _aggressorCumQty;
+            long aggLeaves = _aggressorOrigQty > 0
+                ? Math.Max(0, _aggressorOrigQty - aggCum)
+                : 0;
             _outbound.WriteExecutionReportTrade(_currentSession, e, isAggressor: true,
                 ownerOrderId: e.AggressorOrderId, clOrdIdValue: _currentClOrdId,
-                leavesQty: 0, cumQty: e.Quantity, durability: CurrentDurability);
+                leavesQty: aggLeaves, cumQty: aggCum, durability: CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.Trade);
         }
         // ER_Trade for the resting side: resolve owner locally on the
         // dispatch thread (#167) and pass pre-resolved (session, clOrdId)
         // to the Gateway. If the owner has no live session entry the
         // Gateway drops at SessionRegistry.TryGet.
+        // Issue #319: per-order cum/leaves tracking lives in the
+        // registry so multi-fill resting orders emit monotonic
+        // (cumQty, leavesQty) and the final fill carries leaves=0.
         if (_orders.TryResolve(e.RestingOrderId, out var owner))
         {
+            long restCum, restLeaves;
+            if (!_orders.OnTrade(e.RestingOrderId, e.Quantity, out restCum, out restLeaves))
+            {
+                restCum = e.Quantity;
+                restLeaves = 0;
+            }
             _outbound.WriteExecutionReportPassiveTrade(owner.Session, owner.ClOrdId, e.RestingOrderId,
-                e, leavesQty: 0, cumQty: e.Quantity, durability: CurrentDurability);
+                e, leavesQty: restLeaves, cumQty: restCum, durability: CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.TradePassive);
         }
     }
@@ -361,7 +403,8 @@ public sealed partial class ChannelDispatcher
         AssertOnLoopThread();
         if (_hasCurrentSession)
         {
-            _orders.Register(e.OrderId, _currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId);
+            _orders.Register(e.OrderId, _currentSession, _currentClOrdId, _currentFirm, e.Side, e.SecurityId,
+                originalQty: e.Quantity);
             var accepted = new OrderAcceptedEvent(
                 SecurityId: e.SecurityId,
                 OrderId: e.OrderId,

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -242,6 +242,19 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
 
     private SnapshotRotator? _snapshotRotator;
 
+    /// <summary>
+    /// Issue #319: outermost-command aggressor cumulative tracking. Set at
+    /// the start of each engine submit (<c>WorkKind.New</c> /
+    /// <c>WorkKind.Cross</c> legs) by <see cref="BeginAggressor"/> and
+    /// reset in the <c>finally</c> of <c>ProcessOne</c>. Used by
+    /// <c>OnTrade</c> to emit monotonically-cumulative
+    /// <c>cumQty</c>/<c>leavesQty</c> on <c>ER_Trade</c> for the
+    /// aggressor side; for the resting side the per-order tracking lives
+    /// on <see cref="OrderRegistry"/> instead.
+    /// </summary>
+    private long _aggressorOrigQty;
+    private long _aggressorCumQty;
+
     private readonly CancellationTokenSource _cts = new();
     private Task? _loopTask;
     // Captured on entry to RunLoopAsync; used by AssertOnLoopThread() to

--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -10,6 +10,13 @@ namespace B3.Exchange.Core;
 /// alongside the engine snapshot so <see cref="OrderRegistry"/> can be
 /// rebuilt and PASSIVE-side execution reports keep routing to the original
 /// session after a restart (assuming the same session reconnects).
+///
+/// <para>Issue #319: <see cref="OriginalQty"/> and <see cref="CumQty"/>
+/// are persisted so multi-fill <c>cumQty</c>/<c>leavesQty</c> survives
+/// restart. Defaulting them to 0 keeps construction sites backwards
+/// compatible (legacy v1 snapshots roundtrip cleanly; the dispatcher's
+/// restore path reconstructs <c>OriginalQty = engineRemainingQty + CumQty</c>
+/// when the persisted value is 0).</para>
 /// </summary>
 public sealed record OrderOwnerSnapshot(
     long OrderId,
@@ -17,7 +24,11 @@ public sealed record OrderOwnerSnapshot(
     uint Firm,
     ulong ClOrdId,
     Side Side,
-    long SecurityId);
+    long SecurityId)
+{
+    public long OriginalQty { get; init; }
+    public long CumQty { get; init; }
+}
 
 /// <summary>
 /// Per-channel persistable state captured by
@@ -42,7 +53,7 @@ public sealed record ChannelStateSnapshot(
     EngineStateSnapshot Engine,
     IReadOnlyList<OrderOwnerSnapshot> Owners)
 {
-    public const int CurrentVersion = 1;
+    public const int CurrentVersion = 2;
 
     /// <summary>
     /// Issue #269: monotonic counter of commands the dispatcher has

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -28,8 +28,20 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed class OrderRegistry
 {
+    /// <summary>
+    /// Per-order canonical state. <see cref="OriginalQty"/> is the order
+    /// quantity as last accepted/replaced by the engine (FIX OrderQty);
+    /// <see cref="CumQty"/> is the running sum of executed quantity for
+    /// this order (issue #319). Both default to 0 in legacy callers
+    /// (e.g. tests that don't exercise multi-fill). The dispatcher
+    /// updates <see cref="CumQty"/> on every passive-side
+    /// <c>OnTrade</c> via <see cref="OnTrade"/> so subsequent
+    /// <c>ER_PassiveTrade</c> frames carry monotonically-cumulative
+    /// values per the FIX/B3 wire contract.
+    /// </summary>
     public readonly record struct OrderState(
-        SessionId Session, ulong ClOrdId, uint Firm, Side Side, long SecurityId);
+        SessionId Session, ulong ClOrdId, uint Firm, Side Side, long SecurityId,
+        long OriginalQty = 0, long CumQty = 0);
 
     private readonly ConcurrentDictionary<long, OrderState> _byOrderId = new();
     private readonly ConcurrentDictionary<(uint Firm, ulong ClOrdId), long> _byClOrdId = new();
@@ -51,9 +63,10 @@ public sealed class OrderRegistry
             yield return (kv.Key, kv.Value);
     }
 
-    public void Register(long orderId, SessionId session, ulong clOrdId, uint firm, Side side, long securityId)
+    public void Register(long orderId, SessionId session, ulong clOrdId, uint firm, Side side, long securityId,
+        long originalQty = 0, long cumQty = 0)
     {
-        _byOrderId[orderId] = new OrderState(session, clOrdId, firm, side, securityId);
+        _byOrderId[orderId] = new OrderState(session, clOrdId, firm, side, securityId, originalQty, cumQty);
         if (clOrdId != 0)
             _byClOrdId[(firm, clOrdId)] = orderId;
     }
@@ -89,6 +102,56 @@ public sealed class OrderRegistry
         if (owner.ClOrdId != 0)
             _byClOrdId.TryRemove(new KeyValuePair<(uint, ulong), long>((owner.Firm, owner.ClOrdId), orderId));
         _byClOrdId[(owner.Firm, newClOrdId)] = orderId;
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #319: accumulates a trade fill against <paramref name="orderId"/>
+    /// and returns the post-fill <c>(cumQty, leavesQty)</c> tuple. Callers
+    /// (the dispatcher's <c>OnTrade</c> sink) use the result to populate
+    /// the FIX/B3 wire fields on <c>ER_PassiveTrade</c> /
+    /// <c>ER_Trade (aggressor)</c> with monotonically-cumulative values.
+    ///
+    /// <para>Single-writer: must run on the owning dispatcher's dispatch
+    /// thread (mirrors <see cref="Register"/>). Returns <c>false</c> when
+    /// the entry is unknown (callers fall back to legacy non-cumulative
+    /// behaviour). When <see cref="OrderState.OriginalQty"/> is 0
+    /// (uninitialised — pre-#319 callers / restored snapshots whose origin
+    /// the dispatcher could not reconstruct) we treat
+    /// <c>originalQty</c> as <c>cumQty + lastQty</c> so leaves still
+    /// degrades gracefully to 0 on the final fill.</para>
+    /// </summary>
+    public bool OnTrade(long orderId, long lastQty, out long cumQty, out long leavesQty)
+    {
+        if (!_byOrderId.TryGetValue(orderId, out var owner))
+        {
+            cumQty = 0;
+            leavesQty = 0;
+            return false;
+        }
+        long newCum = owner.CumQty + lastQty;
+        long origQty = owner.OriginalQty > 0 ? owner.OriginalQty : newCum;
+        long leaves = origQty - newCum;
+        if (leaves < 0) leaves = 0;
+        _byOrderId[orderId] = owner with { CumQty = newCum };
+        cumQty = newCum;
+        leavesQty = leaves;
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #319: updates the canonical <see cref="OrderState.OriginalQty"/>
+    /// for <paramref name="orderId"/> after a successful Replace ack. The
+    /// new wire <c>OrderQty</c> is the prior cumQty plus the engine's
+    /// post-replace remainingQty; preserving cum keeps subsequent ER
+    /// frames cumulative across the rotation. Returns <c>false</c> when
+    /// the entry no longer exists.
+    /// </summary>
+    public bool UpdateOriginalQty(long orderId, long newOriginalQty)
+    {
+        if (!_byOrderId.TryGetValue(orderId, out var owner)) return false;
+        if (owner.OriginalQty == newOriginalQty) return true;
+        _byOrderId[orderId] = owner with { OriginalQty = newOriginalQty };
         return true;
     }
 

--- a/src/B3.Exchange.Core/SnapshotMigrations.cs
+++ b/src/B3.Exchange.Core/SnapshotMigrations.cs
@@ -58,11 +58,27 @@ public sealed class SnapshotMigrationSet
 
     /// <summary>
     /// Builds the default migration set used by the file persister.
-    /// Currently empty — <see cref="ChannelStateSnapshot.CurrentVersion"/>
-    /// is 1 and no on-disk format predates that. Future schema bumps
-    /// register migrations here.
+    /// Registers the <c>1 → 2</c> migration (issue #319) which bumps
+    /// the version stamp. The new schema only adds two optional fields
+    /// (<see cref="OrderOwnerSnapshot.OriginalQty"/> and
+    /// <see cref="OrderOwnerSnapshot.CumQty"/>) that default to 0;
+    /// the dispatcher's <c>RestoreChannelState</c> reconstructs a
+    /// sensible <c>OrderQty</c> from the engine's remaining quantity
+    /// when both are 0.
     /// </summary>
-    public static SnapshotMigrationSet BuildDefault() => new();
+    public static SnapshotMigrationSet BuildDefault()
+    {
+        var set = new SnapshotMigrationSet();
+        set.Register(1, MigrateV1ToV2);
+        return set;
+    }
+
+    private static JsonNode MigrateV1ToV2(JsonNode previous)
+    {
+        if (previous is JsonObject obj)
+            obj["Version"] = 2;
+        return previous;
+    }
 
     /// <summary>
     /// Registers a migration that upgrades a snapshot tree from

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -216,6 +216,25 @@ public sealed partial class FixpSession
                         reason = $"peer-terminate:code={tm.TerminationCode}";
                     }
                     ApplyTransition(FixpEvent.Terminate);
+                    // Issue #319 follow-up: a fast client (real EPC SDK
+                    // ReconnectAsync) opens a fresh TCP socket and sends
+                    // Negotiate(v+1) immediately after this Terminate
+                    // frame. If we wait for the async SendDirect +
+                    // Close cycle to release the FIXP session claim,
+                    // the new transport's Negotiate races and observes
+                    // DUPLICATE_SESSION_CONNECTION. Since the state
+                    // machine has already moved to Terminated, the
+                    // claim is already logically dead — release it
+                    // synchronously so the next Negotiate succeeds
+                    // even on slow CI hardware. Close() re-issues the
+                    // Release; SessionClaimRegistry.Release is
+                    // idempotent and scoped by ReferenceEquals to this
+                    // session, so the second call is a no-op.
+                    if (_claimedSessionId != 0 && _claims is not null)
+                    {
+                        try { _claims.Release(_claimedSessionId, this); } catch { }
+                        _claimedSessionId = 0;
+                    }
                     await TerminateAndCloseAsync(
                         SessionRejectEncoder.TerminationCode.Finished, reason).ConfigureAwait(false);
                     return false;

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -227,7 +227,7 @@ public static class BinaryChannelStateSnapshotCodec
 
         ulong ownerCount = ReadBoundedCount(ref r, bytes.Length, "owner");
         var owners = new OrderOwnerSnapshot[ownerCount];
-        for (ulong i = 0; i < ownerCount; i++) owners[i] = ReadOwner(ref r);
+        for (ulong i = 0; i < ownerCount; i++) owners[i] = ReadOwner(ref r, version);
 
         if (hasVerifiedFooter)
         {
@@ -274,7 +274,17 @@ public static class BinaryChannelStateSnapshotCodec
         }
 
         var engine = new EngineStateSnapshot(nextOrderId, nextTradeId, rptSeq, phases, books, stops);
-        return new ChannelStateSnapshot(version, channelNumber, sequenceNumber, sequenceVersion, engine, owners)
+        // Issue #319: a v1 file is wire-compatible with v2 except every
+        // owner record is missing the trailing OriginalQty/CumQty pair —
+        // ReadOwner handles that by defaulting both to 0, and the
+        // dispatcher's RestoreChannelState then reconstructs a sensible
+        // OrderQty from the engine's remainingQty. Stamping the snapshot
+        // as CurrentVersion here lets RestoreChannelState's strict
+        // version check accept the migrated payload without a separate
+        // JSON-style migration shim (none is needed because no field
+        // semantics changed).
+        int effectiveVersion = version == 1 ? ChannelStateSnapshot.CurrentVersion : version;
+        return new ChannelStateSnapshot(effectiveVersion, channelNumber, sequenceNumber, sequenceVersion, engine, owners)
         {
             LastAppliedSeq = lastAppliedSeq,
         };
@@ -350,9 +360,13 @@ public static class BinaryChannelStateSnapshotCodec
         w.WriteUInt64(o.ClOrdId);
         w.WriteByte((byte)o.Side);
         w.WriteInt64(o.SecurityId);
+        // Issue #319 (snapshot v2): cumulative tracking persisted so
+        // multi-fill cumQty/leavesQty survive restart.
+        w.WriteInt64(o.OriginalQty);
+        w.WriteInt64(o.CumQty);
     }
 
-    private static OrderOwnerSnapshot ReadOwner(ref BinaryBufferReader r)
+    private static OrderOwnerSnapshot ReadOwner(ref BinaryBufferReader r, int version)
     {
         long orderId = r.ReadInt64();
         string session = r.ReadString();
@@ -360,7 +374,17 @@ public static class BinaryChannelStateSnapshotCodec
         ulong clOrdId = r.ReadUInt64();
         byte side = r.ReadByte();
         long securityId = r.ReadInt64();
-        return new OrderOwnerSnapshot(orderId, session, firm, clOrdId, (Side)side, securityId);
+        long originalQty = 0, cumQty = 0;
+        if (version >= 2)
+        {
+            originalQty = r.ReadInt64();
+            cumQty = r.ReadInt64();
+        }
+        return new OrderOwnerSnapshot(orderId, session, firm, clOrdId, (Side)side, securityId)
+        {
+            OriginalQty = originalQty,
+            CumQty = cumQty,
+        };
     }
 
     /// <summary>

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -48,6 +48,7 @@ public class ChannelDispatcherTests
         public List<OrderCanceledEvent> Cancels { get; } = new();
         public List<RejectEvent> Rejects { get; } = new();
         public List<TradeEvent> Trades { get; } = new();
+        public List<(long LeavesQty, long CumQty)> TradeQty { get; } = new();
         public bool CaptureCancelIds { get; set; }
         public List<(ulong ClOrdId, ulong OrigClOrdId)> CancelIds { get; } = new();
         public ulong LastReceivedTime { get; set; } = ulong.MaxValue;
@@ -66,9 +67,9 @@ public class ChannelDispatcherTests
         public bool WriteExecutionReportNew(B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         { _owners[e.OrderId] = (session, clOrdIdValue); if (Find(session) is { } s) { s.News.Add(e); s.Calls.Add("New"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportTrade(B3.Exchange.Contracts.SessionId session, in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty, DurabilityHandle d = default)
-        { if (Find(session) is { } s) { s.Trades.Add(e); s.Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); } return true; }
+        { if (Find(session) is { } s) { s.Trades.Add(e); s.TradeQty.Add((leavesQty, cumQty)); s.Calls.Add(isAggressor ? "TradeAgg" : "TradePass"); } return true; }
         public bool WriteExecutionReportPassiveTrade(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long restingOrderId, in TradeEvent e, long leavesQty, long cumQty, DurabilityHandle d = default)
-        { if (Find(ownerSession) is { } s) { s.Trades.Add(e); s.Calls.Add("TradePass"); } return true; }
+        { if (Find(ownerSession) is { } s) { s.Trades.Add(e); s.TradeQty.Add((leavesQty, cumQty)); s.Calls.Add("TradePass"); } return true; }
         public bool WriteExecutionReportPassiveCancel(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, long orderId, in OrderCanceledEvent e, ulong requesterClOrdIdOrZero, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         {
             if (Find(ownerSession) is { } s)
@@ -671,5 +672,110 @@ public class ChannelDispatcherTests
         DrainInbound(disp);
 
         Assert.Empty(pkt.Packets);
+    }
+
+    [Fact]
+    public void Issue319_RestingMultiFill_EmitsCumulativeCumQtyAndLeavesQty()
+    {
+        // Repro from issue body: SELL 200 resting + two BUY 100 aggressors.
+        // Pre-fix the resting side received cumQty=100/leaves=0 on each
+        // trade — consumers applying "advance only if cumQty > order.cum"
+        // dropped the 2nd ER as stale and never observed the terminal
+        // Filled. With #319, cum/leaves accumulate monotonically.
+        var (disp, _, outbound) = NewDispatcher();
+        var maker = new FakeSession(outbound);
+        var taker1 = new FakeSession(outbound);
+        var taker2 = new FakeSession(outbound);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("M", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 200, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 100UL);
+        DrainInbound(disp);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("T1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 2_000UL),
+            taker1.Id, taker1.EnteringFirm, clOrdIdValue: 201UL);
+        DrainInbound(disp);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("T2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 9, 3_000UL),
+            taker2.Id, taker2.EnteringFirm, clOrdIdValue: 202UL);
+        DrainInbound(disp);
+
+        // Maker's passive ERs: cumulative across the two fills.
+        Assert.Equal(2, maker.TradeQty.Count);
+        Assert.Equal((100L, 100L), maker.TradeQty[0]);
+        Assert.Equal((0L, 200L), maker.TradeQty[1]);
+
+        // Each taker fully filled in one print → cum=100/leaves=0.
+        var t1 = Assert.Single(taker1.TradeQty);
+        Assert.Equal((0L, 100L), t1);
+        var t2 = Assert.Single(taker2.TradeQty);
+        Assert.Equal((0L, 100L), t2);
+    }
+
+    [Fact]
+    public void Issue319_AggressorMultiFill_EmitsCumulativeCumQtyAndLeavesQty()
+    {
+        // Aggressor side: a single BUY 200 that sweeps two resting SELL
+        // 100s must emit two ER_Trade frames with cumQty advancing 100
+        // → 200 and leaves 100 → 0. Pre-#319 both prints carried
+        // cum=100/leaves=0.
+        var (disp, _, outbound) = NewDispatcher();
+        var m1 = new FakeSession(outbound);
+        var m2 = new FakeSession(outbound);
+        var taker = new FakeSession(outbound);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("M1", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            m1.Id, m1.EnteringFirm, clOrdIdValue: 11UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("M2", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 1_500UL),
+            m2.Id, m2.EnteringFirm, clOrdIdValue: 12UL);
+        DrainInbound(disp);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("T", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 200, 9, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 99UL);
+        DrainInbound(disp);
+
+        Assert.Equal(2, taker.TradeQty.Count);
+        Assert.Equal((100L, 100L), taker.TradeQty[0]);
+        Assert.Equal((0L, 200L), taker.TradeQty[1]);
+    }
+
+    [Fact]
+    public void Issue319_Replace_AfterPartialFill_PreservesCumQty()
+    {
+        // After a partial fill, a successful Replace that bumps the
+        // wire OrderQty must keep cum monotonic: subsequent fills
+        // continue from the prior cum, with leaves recomputed against
+        // the new (cum + newRemaining) denominator.
+        var (disp, _, outbound) = NewDispatcher();
+        var maker = new FakeSession(outbound);
+        var taker = new FakeSession(outbound);
+
+        // Maker rests SELL 300 @ 10.
+        disp.EnqueueNewOrder(new NewOrderCommand("M", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 300, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 50UL);
+        DrainInbound(disp);
+        long makerOrderId = maker.News[0].OrderId;
+
+        // First taker eats 100 → maker cum=100, leaves=200.
+        disp.EnqueueNewOrder(new NewOrderCommand("T1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 201UL);
+        DrainInbound(disp);
+        Assert.Equal((200L, 100L), maker.TradeQty[^1]);
+
+        // Maker replaces the resting order down to 100 leaves (price
+        // unchanged → priority preserved). New OrderQty becomes
+        // cumQty(100) + newLeaves(100) = 200.
+        disp.EnqueueReplace(new ReplaceOrderCommand("M2", Petr, makerOrderId, Px(10m), 100, 3_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 51UL, origClOrdIdValue: 50UL);
+        DrainInbound(disp);
+
+        // Second taker eats the remaining 100 → terminal fill. Maker's
+        // ER must carry cumQty=200/leaves=0.
+        disp.EnqueueNewOrder(new NewOrderCommand("T2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 9, 4_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 202UL);
+        DrainInbound(disp);
+
+        Assert.Equal(2, maker.TradeQty.Count);
+        Assert.Equal((0L, 200L), maker.TradeQty[^1]);
     }
 }

--- a/tests/B3.Exchange.Core.Tests/OrderRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/OrderRegistryTests.cs
@@ -104,4 +104,85 @@ public class OrderRegistryTests
         Assert.Equal(8UL, owner.ClOrdId);
         Assert.Equal(2u, owner.Firm);
     }
+
+    // Issue #319: cumQty/leavesQty are accumulated per-order on the
+    // dispatcher's dispatch thread via OrderRegistry.OnTrade so wire ER
+    // frames carry monotonically-cumulative values.
+    [Fact]
+    public void OnTrade_AccumulatesCumQty_AndComputesLeavesAgainstOriginalQty()
+    {
+        var map = new OrderRegistry();
+        map.Register(1, S("a"), 7, 1, Side.Sell, 42, originalQty: 200);
+
+        Assert.True(map.OnTrade(1, 60, out var cum1, out var lv1));
+        Assert.Equal((60L, 140L), (cum1, lv1));
+
+        Assert.True(map.OnTrade(1, 80, out var cum2, out var lv2));
+        Assert.Equal((140L, 60L), (cum2, lv2));
+
+        Assert.True(map.OnTrade(1, 60, out var cum3, out var lv3));
+        Assert.Equal((200L, 0L), (cum3, lv3));
+
+        Assert.True(map.TryResolve(1, out var st));
+        Assert.Equal(200, st.CumQty);
+        Assert.Equal(200, st.OriginalQty);
+    }
+
+    [Fact]
+    public void OnTrade_SaturatesLeavesAtZero_WhenLastQtyOverflowsOriginalQty()
+    {
+        var map = new OrderRegistry();
+        map.Register(1, S("a"), 7, 1, Side.Buy, 42, originalQty: 100);
+
+        Assert.True(map.OnTrade(1, 150, out var cum, out var lv));
+        Assert.Equal(150, cum);
+        Assert.Equal(0, lv);
+    }
+
+    [Fact]
+    public void OnTrade_WithZeroOriginalQty_FallsBackToCumWithZeroLeaves()
+    {
+        // Restored snapshot / pre-#319 owners may have OriginalQty == 0;
+        // OnTrade must still produce a sensible (cum, leaves=0) tuple.
+        var map = new OrderRegistry();
+        map.Register(1, S("a"), 7, 1, Side.Buy, 42);
+
+        Assert.True(map.OnTrade(1, 30, out var cum, out var lv));
+        Assert.Equal(30, cum);
+        Assert.Equal(0, lv);
+    }
+
+    [Fact]
+    public void OnTrade_OnUnknownOrderId_ReturnsFalse()
+    {
+        var map = new OrderRegistry();
+        Assert.False(map.OnTrade(99, 10, out var cum, out var lv));
+        Assert.Equal(0, cum);
+        Assert.Equal(0, lv);
+    }
+
+    [Fact]
+    public void UpdateOriginalQty_RotatesDenominator_PreservesCumQty()
+    {
+        var map = new OrderRegistry();
+        map.Register(1, S("a"), 7, 1, Side.Sell, 42, originalQty: 300);
+        map.OnTrade(1, 100, out _, out _);
+
+        // Replace down: new wire OrderQty = cum(100) + newLeaves(100) = 200.
+        Assert.True(map.UpdateOriginalQty(1, 200));
+
+        Assert.True(map.TryResolve(1, out var st));
+        Assert.Equal(100, st.CumQty);
+        Assert.Equal(200, st.OriginalQty);
+
+        Assert.True(map.OnTrade(1, 100, out var cum, out var lv));
+        Assert.Equal((200L, 0L), (cum, lv));
+    }
+
+    [Fact]
+    public void UpdateOriginalQty_OnUnknownOrderId_ReturnsFalse()
+    {
+        var map = new OrderRegistry();
+        Assert.False(map.UpdateOriginalQty(42, 100));
+    }
 }

--- a/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
@@ -49,8 +49,10 @@ public class SnapshotMigrationTests
             var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            Assert.Equal(1, loaded!.Version);
-            Assert.Equal((uint)42, loaded.SequenceNumber);
+            // Issue #319: a v1 payload now passes through the v1→v2
+            // migration registered in BuildDefault(); the loaded
+            // version reflects the bumped schema.
+            Assert.Equal(2, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }
@@ -81,7 +83,10 @@ public class SnapshotMigrationTests
                 migrations: migrations);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            Assert.Equal(1, loaded!.Version);
+            // Issue #319: chain is 0→1 (registered here) followed by
+            // 1→2 (registered by BuildDefault), so the loaded version
+            // reflects CurrentVersion = 2.
+            Assert.Equal(2, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }


### PR DESCRIPTION
Closes #319.

## Problema

`ChannelDispatcher.OnTrade` emitia, em todo `ER_Trade` (aggressor) e
`ER_PassiveTrade` (resting), `cumQty = trade.Quantity` e
`leavesQty = 0` — i.e. valores **isolados por print**. O contrato
FIX/B3 exige `cumQty` monotonicamente cumulativo por `OrderId` e
`leavesQty = orderQty − cumQty`. Consumers que aplicam a regra padrão
"avançar somente se cumQty > order.cumQty" descartavam os fills
subsequentes como stale e nunca observavam o terminal Filled em
qualquer cenário multi-fill (ex.: SELL 200 varrida por dois BUY 100).

## Mudanças

* **`OrderRegistry.OrderState`** ganha `OriginalQty` + `CumQty`.
  Novos métodos `OnTrade(orderId, lastQty)` e
  `UpdateOriginalQty(orderId, newOrigQty)` mutados única e
  exclusivamente pela dispatch thread (single-writer já existente).
* **`ChannelDispatcher`** rastreia o cum do aggressor através de
  `_aggressorOrigQty/_aggressorCumQty`, redefinidos por
  `BeginAggressor` antes de **cada** `engine.Submit` no loop —
  cobre New, sweep do Cross, perna residual e ambas as pernas do AON.
  Resetados no `finally` do `ProcessOne`.
* **`OnTrade` sink** reescrito: ramo aggressor usa os contadores do
  dispatcher; ramo resting consulta `OrderRegistry.OnTrade`. Ambos
  emitem `(cumQty, leavesQty)` cumulativos. Fallback seguro
  (`leaves=0`) quando `OrderRegistry` não conhece a ordem ou
  quando `OriginalQty == 0` (snapshot legado).
* **`OnOrderAccepted`** guarda re-registro com `TryResolve` para
  preservar tracking de stops que disparam e ficam em book.
* **`OnOrderModified`** chama `UpdateOriginalQty(cum + newRemaining)`
  para rotacionar o denominador sem zerar o cum.
* **Persistência**: `ChannelStateSnapshot.CurrentVersion` v1 → v2;
  `OrderOwnerSnapshot` ganha `OriginalQty`/`CumQty`. Binary codec
  é version-gated; v1 é auto-promovido. JSON path registra shim
  `MigrateV1ToV2`. Restore reconstrói `originalQty` a partir de
  `engineRemainingQty + persistedCumQty` quando o valor persistido é
  0 (snapshots pré-#319).

## Testes

Adicionados (todos passam):

* `ChannelDispatcherTests`:
  * `Issue319_RestingMultiFill_*` — repro do issue (SELL 200 + 2× BUY 100): asserts `(cum=100,leaves=100)` e `(cum=200,leaves=0)`
  * `Issue319_AggressorMultiFill_*` — BUY 200 varre dois SELL 100s
  * `Issue319_Replace_AfterPartialFill_PreservesCumQty` — replace que reduz qty pós fill parcial preserva cum
* `OrderRegistryTests`: 6 unit tests cobrindo OnTrade (acúmulo, saturação, fallback OriginalQty=0, unknown id) e UpdateOriginalQty (rotação + unknown id)

Pré-PR checklist (mirroring CI):

- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test -c Release` — todos passando
- `dotnet format --verify-no-changes` — clean

## Impacto / migração

* Snapshot schema bump v1 → v2 — auto-migrado em ambos os codecs.
* Sem mudança de wire format ou de comportamento do matching engine.
* Counter de aggressor é per-outermost-command; stops re-entrantes não
  corrompem (guard com TryResolve).