### PR TITLE
feat(host): phase transition HTTP API + automatic phase scheduler (#321)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -52,6 +52,13 @@ public sealed partial class ChannelDispatcher
         {
             _metrics?.IncWalHaltReject();
             LogWalHalted(ChannelNumber, item.Kind);
+            // Issue #321 review (gpt-5.5): a phase work item already in the
+            // queue when WAL flips to halted is dropped here — but the HTTP
+            // caller is awaiting item.PhaseCompletion. Fail the TCS so the
+            // request fails fast with a real reason instead of timing out.
+            item.PhaseCompletion?.TrySetException(
+                new InvalidOperationException(
+                    $"channel {ChannelNumber} WAL-halted; phase command rejected"));
             return;
         }
 
@@ -80,11 +87,18 @@ public sealed partial class ChannelDispatcher
 
         if (item.Kind == WorkKind.OperatorSetTradingPhase)
         {
-            ProcessSetTradingPhase(item.TradingPhase!);
+            ProcessSetTradingPhase(item.TradingPhase!, item.PhaseCompletion);
             // Persist after the phase mutation so the engine's per-symbol
             // _phaseById map (captured into EngineStateSnapshot.Phases)
             // and any RptSeq advance from SecurityStatus_3 emission
             // survive restart.
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorUncrossAuction)
+        {
+            ProcessUncrossAuction(item.UncrossAuction!, item.PhaseCompletion);
             OnAfterCommandFlushed(force: true);
             return;
         }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -163,23 +163,150 @@ public sealed partial class ChannelDispatcher
     /// if the inbound queue is full. Safe to call from any thread.
     /// </summary>
     public bool EnqueueOperatorSetTradingPhase(long securityId, B3.Exchange.Matching.TradingPhase phase)
+        => EnqueueOperatorSetTradingPhase(securityId, phase, completion: null);
+
+    /// <summary>
+    /// Issue #321: overload accepting a <see cref="TaskCompletionSource{TResult}"/>
+    /// that is completed on the dispatch thread once the phase change
+    /// has been applied (or faulted if the engine throws / the channel
+    /// is WAL-halted). HTTP admin endpoint uses this to <c>await</c> the
+    /// outcome with a bounded timeout.
+    /// </summary>
+    public bool EnqueueOperatorSetTradingPhase(long securityId, B3.Exchange.Matching.TradingPhase phase,
+        TaskCompletionSource<PhaseChangeOutcome>? completion)
     {
-        if (RejectIfWalHalted(WorkKind.OperatorSetTradingPhase)) return false;
-        return _inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorSetTradingPhase, default, 0, false,
+        if (RejectIfWalHalted(WorkKind.OperatorSetTradingPhase))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; SetTradingPhase rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorSetTradingPhase, default, 0, false,
             0, 0, null, null, null, null,
-            TradingPhase: new OperatorTradingPhase(securityId, phase)));
+            TradingPhase: new OperatorTradingPhase(securityId, phase),
+            PhaseCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; SetTradingPhase rejected"));
+        return false;
     }
 
-    private void ProcessSetTradingPhase(OperatorTradingPhase op)
+    /// <summary>
+    /// Issue #321: operator-issued auction uncross. Allowed transitions
+    /// are <c>Reserved → Open</c> (opening call) and
+    /// <c>FinalClosingCall → Close</c> (closing call); other transitions
+    /// fault the supplied completion source with
+    /// <see cref="InvalidOperationException"/>.
+    /// </summary>
+    public bool EnqueueOperatorUncrossAuction(long securityId, B3.Exchange.Matching.TradingPhase targetPhase,
+        TaskCompletionSource<PhaseChangeOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorUncrossAuction))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; UncrossAuction rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorUncrossAuction, default, 0, false,
+            0, 0, null, null, null, null,
+            UncrossAuction: new OperatorUncrossAuction(securityId, targetPhase),
+            PhaseCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; UncrossAuction rejected"));
+        return false;
+    }
+
+    private void ProcessSetTradingPhase(OperatorTradingPhase op, TaskCompletionSource<PhaseChangeOutcome>? completion)
     {
         AssertOnLoopThread();
-        // The engine emits the TradingPhaseChangedEvent inline (if the
-        // transition is non-trivial); the sink writes a SecurityStatus_3
-        // frame into the per-command packet buffer. Flush it as a
-        // single-message packet so consumers see the status update
-        // immediately, mirroring the trade-bust pattern.
+        _pendingAuctionPrint = null;
+        try
+        {
+            B3.Exchange.Matching.TradingPhase prev;
+            try { prev = _engine.GetTradingPhase(op.SecurityId); }
+            catch (KeyNotFoundException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            // The engine emits the TradingPhaseChangedEvent inline (if the
+            // transition is non-trivial); the sink writes a SecurityStatus_3
+            // frame into the per-command packet buffer. Flush it as a
+            // single-message packet so consumers see the status update
+            // immediately, mirroring the trade-bust pattern.
+            _packetWritten = 0;
+            bool applied;
+            try
+            {
+                applied = _engine.SetTradingPhase(op.SecurityId, op.Phase, _nowNanos());
+            }
+            catch (Exception ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            if (_packetWritten > 0) FlushPacket();
+            var current = _engine.GetTradingPhase(op.SecurityId);
+            completion?.TrySetResult(new PhaseChangeOutcome(applied, prev, current, UncrossPrint: null));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Issue #321: process a queued <see cref="OperatorUncrossAuction"/>.
+    /// Wraps <see cref="MatchingEngine.UncrossAuction"/>, captures the
+    /// previous/current phase snapshot for the outcome, and surfaces
+    /// engine validation faults
+    /// (<see cref="InvalidOperationException"/>,
+    /// <see cref="KeyNotFoundException"/>) through the optional
+    /// completion source instead of crashing the dispatch loop.
+    /// </summary>
+    private void ProcessUncrossAuction(OperatorUncrossAuction op, TaskCompletionSource<PhaseChangeOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _pendingAuctionPrint = null;
         _packetWritten = 0;
-        _engine.SetTradingPhase(op.SecurityId, op.Phase, _nowNanos());
-        if (_packetWritten > 0) FlushPacket();
+        try
+        {
+            B3.Exchange.Matching.TradingPhase prev;
+            try { prev = _engine.GetTradingPhase(op.SecurityId); }
+            catch (KeyNotFoundException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            try
+            {
+                _engine.UncrossAuction(op.SecurityId, op.TargetPhase, _nowNanos());
+            }
+            catch (InvalidOperationException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            catch (KeyNotFoundException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            if (_packetWritten > 0) FlushPacket();
+            var current = _engine.GetTradingPhase(op.SecurityId);
+            bool applied = current != prev;
+            completion?.TrySetResult(new PhaseChangeOutcome(applied, prev, current, _pendingAuctionPrint));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
     }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -122,6 +122,16 @@ public sealed partial class ChannelDispatcher
 
         _engine.RestoreState(snapshot.Engine);
 
+        // Issue #321 review (gpt-5.5): re-seed the cross-thread phase
+        // snapshot from restored engine state. Without this, the HTTP
+        // routing layer would still see the constructor-seeded Open phase
+        // and route Reserved→Open / FinalClosingCall→Close through plain
+        // SetTradingPhase, skipping the auction uncross.
+        foreach (var p in snapshot.Engine.Phases)
+        {
+            _phaseSnapshot[p.SecurityId] = p.Phase;
+        }
+
         // Re-publish counters via the cross-thread-readable Volatile
         // backing fields so the HTTP scrape sees the restored values
         // immediately after the loop becomes ready.

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -141,6 +141,10 @@ public sealed partial class ChannelDispatcher
     public void OnTradingPhaseChanged(in TradingPhaseChangedEvent e)
     {
         AssertOnLoopThread();
+        // Issue #321: maintain a thread-safe per-securityId phase snapshot
+        // so the HTTP admin endpoint can decide between SetPhase and
+        // UncrossAuction without piercing the engine off-thread.
+        _phaseSnapshot[e.SecurityId] = e.Phase;
         var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
             + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
             + B3.Umdf.WireEncoder.WireOffsets.SecurityStatusBlockLength);
@@ -206,6 +210,11 @@ public sealed partial class ChannelDispatcher
     public void OnAuctionPrint(in AuctionPrintEvent e)
     {
         AssertOnLoopThread();
+
+        // Issue #321: capture for the operator HTTP outcome. Only the
+        // most recent print for the currently-dispatching command is
+        // retained; reset to null at the start of each Process* method.
+        _pendingAuctionPrint = new AuctionPrintInfo(e.Kind, e.PriceMantissa, e.ClearedQuantity);
 
         if (e.Kind == AuctionPrintKind.Opening)
         {

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -33,6 +33,7 @@ public sealed partial class ChannelDispatcher
         "OperatorTradeBust",
         "OperatorSetTradingPhase",
         "OperatorPersistSnapshot",
+        "OperatorUncrossAuction",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -55,6 +56,8 @@ public sealed partial class ChannelDispatcher
         ResolvedMassCancel? MassCancel = null,
         OperatorTradeBust? TradeBust = null,
         OperatorTradingPhase? TradingPhase = null,
+        OperatorUncrossAuction? UncrossAuction = null,
+        TaskCompletionSource<PhaseChangeOutcome>? PhaseCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -84,6 +87,13 @@ public sealed partial class ChannelDispatcher
     /// engine remains single-threaded.
     /// </summary>
     internal sealed record OperatorTradingPhase(long SecurityId, B3.Exchange.Matching.TradingPhase Phase);
+
+    /// <summary>
+    /// Issue #321: operator-triggered auction uncross payload.
+    /// Drives <see cref="MatchingEngine.UncrossAuction"/> with a Reserved→Open
+    /// (opening call) or FinalClosingCall→Close (closing call) target phase.
+    /// </summary>
+    internal sealed record OperatorUncrossAuction(long SecurityId, B3.Exchange.Matching.TradingPhase TargetPhase);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -255,6 +255,27 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private long _aggressorOrigQty;
     private long _aggressorCumQty;
 
+    /// <summary>
+    /// Issue #321: per-securityId snapshot of the most-recently observed
+    /// trading phase. Written only on the dispatch loop thread inside
+    /// <c>OnTradingPhaseChanged</c>; seeded in the ctor from the engine's
+    /// initial phase map for each <c>seedSecurityIds</c> entry. Read from
+    /// any thread by <see cref="TryGetPhaseSnapshot"/> so the HTTP admin
+    /// endpoint can decide between SetPhase / UncrossAuction without
+    /// queueing a synchronous query into the engine.
+    /// </summary>
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<long, B3.Exchange.Matching.TradingPhase> _phaseSnapshot
+        = new();
+
+    /// <summary>
+    /// Issue #321: latest <see cref="AuctionPrintInfo"/> captured by the
+    /// <c>OnAuctionPrint</c> sink for the command currently being
+    /// processed. Reset to <c>null</c> at the start of each Process*
+    /// method so a subsequent uncross with no print yields
+    /// <c>UncrossPrint = null</c> in the outcome.
+    /// </summary>
+    private AuctionPrintInfo? _pendingAuctionPrint;
+
     private readonly CancellationTokenSource _cts = new();
     private Task? _loopTask;
     // Captured on entry to RunLoopAsync; used by AssertOnLoopThread() to
@@ -291,7 +312,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         IChannelWriteAheadLog? wal = null,
         WalAppendFailurePolicy walAppendFailurePolicy = WalAppendFailurePolicy.Continue,
         Func<string, bool>? sessionExists = null,
-        OrphanSessionPolicy orphanPolicy = OrphanSessionPolicy.Drop)
+        OrphanSessionPolicy orphanPolicy = OrphanSessionPolicy.Drop,
+        IReadOnlyList<long>? seedSecurityIds = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -340,7 +362,26 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
                 FullMode = System.Threading.Channels.BoundedChannelFullMode.Wait,
             });
         _engine = engineFactory(this);
+        if (seedSecurityIds is not null)
+        {
+            foreach (var secId in seedSecurityIds)
+            {
+                try { _phaseSnapshot[secId] = _engine.GetTradingPhase(secId); }
+                catch (KeyNotFoundException) { /* engine doesn't know this id; skip */ }
+            }
+        }
     }
+
+    /// <summary>
+    /// Issue #321: thread-safe snapshot of the most-recently observed
+    /// trading phase for <paramref name="securityId"/>. Returns
+    /// <c>true</c> with the phase out value if the dispatcher has ever
+    /// observed (or been seeded with) a phase for the security; returns
+    /// <c>false</c> when the security is unknown to this channel. Safe
+    /// to call from any thread.
+    /// </summary>
+    public bool TryGetPhaseSnapshot(long securityId, out B3.Exchange.Matching.TradingPhase phase)
+        => _phaseSnapshot.TryGetValue(securityId, out phase);
 
     private static ulong DefaultNowNanos()
         => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -418,6 +418,29 @@ public sealed class MetricsRegistry
         }
     }
 
+    /// <summary>
+    /// Issue #321: process-wide counter for operator/scheduler-driven
+    /// trading-phase transitions. Keyed by
+    /// <c>(securityId, fromPhase, toPhase, trigger)</c> so dashboards can
+    /// alert on a specific instrument's missing scheduled transition or
+    /// quantify operator overrides per session. <paramref name="trigger"/>
+    /// is a low-cardinality label
+    /// (typically <c>"operator"</c> or <c>"scheduled"</c>).
+    /// Atomic — safe to call from any thread.
+    /// </summary>
+    public void IncPhaseTransition(long securityId,
+        B3.Exchange.Matching.TradingPhase fromPhase,
+        B3.Exchange.Matching.TradingPhase toPhase,
+        string trigger)
+    {
+        ArgumentNullException.ThrowIfNull(trigger);
+        var key = (securityId, (byte)fromPhase, (byte)toPhase, trigger);
+        _phaseTransitions.AddOrUpdate(key, 1L, static (_, prev) => prev + 1L);
+    }
+
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<(long, byte, byte, string), long> _phaseTransitions
+        = new();
+
     public void SetSessionProvider(ISessionMetricsProvider provider)
     {
         lock (_lock) _sessions = provider;
@@ -706,9 +729,37 @@ public sealed class MetricsRegistry
 
         EmitSessionFirmCounters(sb);
 
+        EmitPhaseTransitions(sb);
+
         EmitRuntimeMetrics(sb);
 
         return sb.ToString();
+    }
+
+    private void EmitPhaseTransitions(StringBuilder sb)
+    {
+        // Issue #321: process-wide trading-phase transition counter.
+        // Snapshot the dictionary once so the rendered output is
+        // self-consistent even if a transition fires mid-render.
+        var snap = _phaseTransitions.ToArray();
+        if (snap.Length == 0) return;
+        sb.Append("# HELP exch_phase_transitions_total Operator and scheduler-driven trading-phase transitions, per (security_id, from, to, trigger). trigger=\"operator\" for HTTP-driven changes; trigger=\"scheduled\" for the daily PhaseScheduler. Issue #321.\n");
+        sb.Append("# TYPE exch_phase_transitions_total counter\n");
+        foreach (var kv in snap)
+        {
+            var (secId, from, to, trigger) = kv.Key;
+            sb.Append("exch_phase_transitions_total{security_id=\"")
+              .Append(secId.ToString(CultureInfo.InvariantCulture))
+              .Append("\",from=\"")
+              .Append(((B3.Exchange.Matching.TradingPhase)from).ToString())
+              .Append("\",to=\"")
+              .Append(((B3.Exchange.Matching.TradingPhase)to).ToString())
+              .Append("\",trigger=\"")
+              .Append(EscapeLabel(trigger))
+              .Append("\"} ")
+              .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
     }
 
     private void EmitSessionFirmCounters(StringBuilder sb)

--- a/src/B3.Exchange.Core/PhaseChangeOutcome.cs
+++ b/src/B3.Exchange.Core/PhaseChangeOutcome.cs
@@ -1,0 +1,26 @@
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #321: structured outcome of an operator-driven phase transition
+/// (plain <see cref="MatchingEngine.SetTradingPhase"/> or
+/// <see cref="MatchingEngine.UncrossAuction"/>) returned to the HTTP
+/// admin endpoint via a <see cref="System.Threading.Tasks.TaskCompletionSource{TResult}"/>.
+/// </summary>
+public readonly record struct PhaseChangeOutcome(
+    bool TransitionApplied,
+    TradingPhase PreviousPhase,
+    TradingPhase CurrentPhase,
+    AuctionPrintInfo? UncrossPrint);
+
+/// <summary>
+/// Issue #321: snapshot of the auction print produced by an
+/// <see cref="MatchingEngine.UncrossAuction"/> call. Mirrors the values
+/// captured from <c>AuctionPrintEvent</c> by the dispatcher's
+/// <c>OnAuctionPrint</c> sink.
+/// </summary>
+public readonly record struct AuctionPrintInfo(
+    AuctionPrintKind Kind,
+    long PriceMantissa,
+    long ClearedQuantity);

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -44,6 +44,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private HostRouter? _router;
     private HttpServer? _http;
     private DailyResetScheduler? _dailyReset;
+    private PhaseScheduler? _phaseScheduler;
     private readonly List<B3.Exchange.Persistence.DataDirLock> _dataDirLocks = new();
     private B3.Exchange.Gateway.Persistence.FileFixpRetransmitPersister? _retransmitPersister;
 
@@ -196,7 +197,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 wal: wal,
                 walAppendFailurePolicy: ch.Persistence?.Wal?.ResolveOnAppendFailure() ?? B3.Exchange.Core.WalAppendFailurePolicy.Continue,
                 sessionExists: sessionExists,
-                orphanPolicy: orphanPolicy);
+                orphanPolicy: orphanPolicy,
+                seedSecurityIds: instruments.Select(i => i.SecurityId).ToArray());
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -379,7 +381,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 firms: firmInfos,
                 dailyResetTrigger: () => TriggerDailyReset("http-trigger"),
                 persisters: _persistersByChannel,
-                wals: _walsByChannel);
+                wals: _walsByChannel,
+                instrumentRouting: routing);
             await _http.StartAsync().ConfigureAwait(false);
         }
 
@@ -395,6 +398,16 @@ public sealed class ExchangeHost : IAsyncDisposable
                 action: () => _listener?.TerminateAllSessions("daily-reset"),
                 logger: _loggerFactory.CreateLogger<DailyResetScheduler>());
             _dailyReset.Start();
+        }
+
+        if (_config.PhaseScheduler is { Enabled: true } pcfg)
+        {
+            _phaseScheduler = new PhaseScheduler(
+                pcfg,
+                routing,
+                _metrics,
+                _loggerFactory.CreateLogger<PhaseScheduler>());
+            _phaseScheduler.Start();
         }
 
         _startupProbe.MarkReady();
@@ -690,6 +703,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     {
         await StopAsync().ConfigureAwait(false);
         if (_dailyReset != null) await _dailyReset.DisposeAsync().ConfigureAwait(false);
+        if (_phaseScheduler != null) await _phaseScheduler.DisposeAsync().ConfigureAwait(false);
         if (_http != null) await _http.DisposeAsync().ConfigureAwait(false);
         foreach (var t in _snapshotTimers) await t.DisposeAsync().ConfigureAwait(false);
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -16,6 +16,7 @@ public sealed class HostConfig
     [JsonPropertyName("sessions")] public List<SessionConfig> Sessions { get; set; } = new();
     [JsonPropertyName("http")] public HttpConfig? Http { get; set; }
     [JsonPropertyName("dailyReset")] public DailyResetConfig? DailyReset { get; set; }
+    [JsonPropertyName("phaseScheduler")] public PhaseSchedulerConfig? PhaseScheduler { get; set; }
     [JsonPropertyName("shutdown")] public ShutdownConfig Shutdown { get; set; } = new();
     [JsonPropertyName("channels")] public List<ChannelConfig> Channels { get; set; } = new();
 
@@ -210,6 +211,47 @@ public sealed class DailyResetConfig
     /// platform's <c>TimeZoneInfo</c> store must recognize the value
     /// (Linux containers ship with the IANA database).</summary>
     [JsonPropertyName("timezone")] public string Timezone { get; set; } = "America/Sao_Paulo";
+}
+
+/// <summary>
+/// Issue #321: scheduled trading-phase transitions. When
+/// <see cref="Enabled"/> is <c>true</c>, each <see cref="PhaseSchedulerGroup"/>
+/// runs its <see cref="PhaseSchedulerGroup.Schedule"/> entries against the
+/// listed instruments at the configured local time.
+/// </summary>
+public sealed record PhaseSchedulerConfig
+{
+    [JsonPropertyName("enabled")] public bool Enabled { get; init; }
+    [JsonPropertyName("groups")] public IReadOnlyList<PhaseSchedulerGroup> Groups { get; init; } = Array.Empty<PhaseSchedulerGroup>();
+}
+
+/// <summary>
+/// Issue #321: a named bundle of instruments + a list of scheduled
+/// transitions (e.g. all equities, B3 cash-equity day plan).
+/// </summary>
+public sealed record PhaseSchedulerGroup
+{
+    [JsonPropertyName("name")] public string Name { get; init; } = "default";
+    [JsonPropertyName("timezone")] public string Timezone { get; init; } = "America/Sao_Paulo";
+    /// <summary>SecurityIds the schedule applies to. Empty list ⇒ all
+    /// instruments routed by the host.</summary>
+    [JsonPropertyName("instruments")] public IReadOnlyList<long> Instruments { get; init; } = Array.Empty<long>();
+    [JsonPropertyName("schedule")] public IReadOnlyList<PhaseSchedulerEntry> Schedule { get; init; } = Array.Empty<PhaseSchedulerEntry>();
+}
+
+/// <summary>
+/// Issue #321: one scheduled transition. <see cref="At"/> is HH:mm in the
+/// owning <see cref="PhaseSchedulerGroup.Timezone"/>.
+/// <see cref="Action"/> is either <c>"EnterPhase"</c> (plain SetPhase) or
+/// <c>"UncrossAuction"</c> (Reserved→Open / FinalClosingCall→Close).
+/// <see cref="Target"/> is a <c>TradingPhase</c> enum name
+/// (e.g. <c>"Open"</c>).
+/// </summary>
+public sealed record PhaseSchedulerEntry
+{
+    [JsonPropertyName("at")] public string At { get; init; } = "";
+    [JsonPropertyName("action")] public string Action { get; init; } = "EnterPhase";
+    [JsonPropertyName("target")] public string Target { get; init; } = "";
 }
 
 public sealed class ChannelConfig

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -28,6 +28,7 @@ namespace B3.Exchange.Host;
 public sealed class HttpServer : IAsyncDisposable
 {
     private readonly HttpConfig _config;
+    private readonly IReadOnlyDictionary<long, ChannelDispatcher> _instrumentRouting;
     private readonly MetricsRegistry _metrics;
     private readonly IReadOnlyList<IReadinessProbe> _probes;
     private readonly IReadOnlyDictionary<byte, ChannelDispatcher> _dispatchers;
@@ -47,7 +48,8 @@ public sealed class HttpServer : IAsyncDisposable
         IReadOnlyList<FirmInfo>? firms = null,
         Func<int>? dailyResetTrigger = null,
         IReadOnlyDictionary<byte, IChannelStatePersister>? persisters = null,
-        IReadOnlyDictionary<byte, IChannelWriteAheadLog>? wals = null)
+        IReadOnlyDictionary<byte, IChannelWriteAheadLog>? wals = null,
+        IReadOnlyDictionary<long, ChannelDispatcher>? instrumentRouting = null)
     {
         _config = config;
         _metrics = metrics;
@@ -58,6 +60,7 @@ public sealed class HttpServer : IAsyncDisposable
         _dailyResetTrigger = dailyResetTrigger;
         _persisters = persisters ?? new Dictionary<byte, IChannelStatePersister>();
         _wals = wals ?? new Dictionary<byte, IChannelWriteAheadLog>();
+        _instrumentRouting = instrumentRouting ?? new Dictionary<long, ChannelDispatcher>();
         _log = log;
     }
 
@@ -222,6 +225,15 @@ public sealed class HttpServer : IAsyncDisposable
         //   exists; 503 when no persister is wired.
         app.MapPost("/admin/channels/{ch:int}/snapshot/validate", (int ch, HttpContext ctx) =>
             HandleAdminValidate(ctx, ch));
+
+        // Issue #321: operator-initiated trading-phase transition for a
+        // single instrument. Body: { "targetPhase": "...", "asOf": <opt> }.
+        // 200 with structured outcome on success; 404 unknown securityId;
+        // 409 invalid transition (e.g. Open → Reserved); 503 inbound
+        // queue full; 400 malformed body or unknown phase.
+        app.MapPost("/admin/instruments/{securityId:long}/phase",
+            async (long securityId, HttpContext ctx) =>
+                await HandleSetPhaseAsync(ctx, securityId).ConfigureAwait(false));
 
         await app.StartAsync(ct).ConfigureAwait(false);
         _app = app;
@@ -541,6 +553,122 @@ public sealed class HttpServer : IAsyncDisposable
             new System.Text.Json.Serialization.JsonStringEnumConverter(),
         },
     };
+
+    /// <summary>
+    /// Issue #321: max time the HTTP request blocks waiting for the
+    /// dispatch-thread completion of the phase change. Generous enough to
+    /// absorb a transient queue spike but bounded so a wedged dispatcher
+    /// surfaces as a 504 instead of hanging the operator's tooling.
+    /// </summary>
+    private static readonly TimeSpan PhaseChangeTimeout = TimeSpan.FromSeconds(5);
+
+    private async Task<IResult> HandleSetPhaseAsync(HttpContext ctx, long securityId)
+    {
+        if (!_instrumentRouting.TryGetValue(securityId, out var disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown securityId {securityId}\n", "text/plain");
+        }
+        SetPhaseRequest? body;
+        try
+        {
+            body = await System.Text.Json.JsonSerializer.DeserializeAsync<SetPhaseRequest>(
+                ctx.Request.Body, AdminJsonOptions, ctx.RequestAborted).ConfigureAwait(false);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"malformed body: {ex.Message}\n", "text/plain");
+        }
+        if (body is null || string.IsNullOrWhiteSpace(body.TargetPhase))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("body must contain non-empty 'targetPhase'\n", "text/plain");
+        }
+        if (!Enum.TryParse<B3.Exchange.Matching.TradingPhase>(body.TargetPhase, ignoreCase: true, out var target))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"unknown targetPhase '{body.TargetPhase}'\n", "text/plain");
+        }
+        if (!disp.TryGetPhaseSnapshot(securityId, out var current))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown securityId {securityId} (no phase snapshot)\n", "text/plain");
+        }
+        bool useUncross =
+            (current == B3.Exchange.Matching.TradingPhase.Reserved && target == B3.Exchange.Matching.TradingPhase.Open) ||
+            (current == B3.Exchange.Matching.TradingPhase.FinalClosingCall && target == B3.Exchange.Matching.TradingPhase.Close);
+
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        bool enqueued = useUncross
+            ? disp.EnqueueOperatorUncrossAuction(securityId, target, tcs)
+            : disp.EnqueueOperatorSetTradingPhase(securityId, target, tcs);
+        if (!enqueued)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {disp.ChannelNumber} inbound queue full\n", "text/plain");
+        }
+
+        PhaseChangeOutcome outcome;
+        try
+        {
+            outcome = await tcs.Task.WaitAsync(PhaseChangeTimeout, ctx.RequestAborted).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status504GatewayTimeout;
+            return Results.Text("timed out waiting for phase change\n", "text/plain");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+            return Results.Text($"invalid transition: {ex.Message}\n", "text/plain");
+        }
+        catch (KeyNotFoundException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"not found: {ex.Message}\n", "text/plain");
+        }
+        catch (Exception ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"phase change failed: {ex.Message}\n", "text/plain");
+        }
+
+        _metrics.IncPhaseTransition(securityId, outcome.PreviousPhase, outcome.CurrentPhase, "operator");
+
+        var responseJson = SerializePhaseOutcome(outcome);
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        return Results.Text(responseJson, "application/json");
+    }
+
+    private static string SerializePhaseOutcome(PhaseChangeOutcome o)
+    {
+        var sb = new System.Text.StringBuilder(96);
+        sb.Append("{\"previousPhase\":\"").Append(o.PreviousPhase.ToString())
+          .Append("\",\"currentPhase\":\"").Append(o.CurrentPhase.ToString())
+          .Append("\"");
+        if (o.UncrossPrint is { } p)
+        {
+            sb.Append(",\"uncrossPrint\":{\"kind\":\"")
+              .Append(p.Kind.ToString())
+              .Append("\",\"priceMantissa\":")
+              .Append(p.PriceMantissa.ToString(System.Globalization.CultureInfo.InvariantCulture))
+              .Append(",\"clearedQuantity\":")
+              .Append(p.ClearedQuantity.ToString(System.Globalization.CultureInfo.InvariantCulture))
+              .Append('}');
+        }
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    private sealed class SetPhaseRequest
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("targetPhase")]
+        public string? TargetPhase { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("asOf")]
+        public ulong? AsOf { get; set; }
+    }
 
     private static IPEndPoint ParseEndpoint(string s)
     {

--- a/src/B3.Exchange.Host/PhaseScheduler.cs
+++ b/src/B3.Exchange.Host/PhaseScheduler.cs
@@ -1,0 +1,281 @@
+using System.Globalization;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// Issue #321: target abstraction for <see cref="PhaseScheduler"/>. The
+/// scheduler does not know whether the underlying enqueue is wired to a
+/// <see cref="ChannelDispatcher"/> or a test double; it only sees the
+/// security set it can route to and the two enqueue verbs.
+/// </summary>
+public interface IPhaseScheduledTarget
+{
+    /// <summary>Every securityId the host can route through to a channel.
+    /// Used as the implicit target list for empty
+    /// <c>PhaseSchedulerGroup.Instruments</c>.</summary>
+    IReadOnlyCollection<long> RoutedSecurityIds { get; }
+
+    /// <summary>Returns <c>false</c> if the security is unknown / queue
+    /// rejected the enqueue.</summary>
+    bool EnqueueSetPhase(long securityId, TradingPhase target);
+
+    /// <summary>Returns <c>false</c> if the security is unknown / queue
+    /// rejected the enqueue.</summary>
+    bool EnqueueUncrossAuction(long securityId, TradingPhase target);
+}
+
+internal sealed class DispatcherRoutingPhaseTarget : IPhaseScheduledTarget
+{
+    private readonly IReadOnlyDictionary<long, ChannelDispatcher> _routing;
+
+    public DispatcherRoutingPhaseTarget(IReadOnlyDictionary<long, ChannelDispatcher> routing)
+    {
+        _routing = routing;
+    }
+
+    public IReadOnlyCollection<long> RoutedSecurityIds => (IReadOnlyCollection<long>)_routing.Keys;
+
+    public bool EnqueueSetPhase(long securityId, TradingPhase target)
+        => _routing.TryGetValue(securityId, out var disp)
+            && disp.EnqueueOperatorSetTradingPhase(securityId, target);
+
+    public bool EnqueueUncrossAuction(long securityId, TradingPhase target)
+        => _routing.TryGetValue(securityId, out var disp)
+            && disp.EnqueueOperatorUncrossAuction(securityId, target);
+}
+
+/// <summary>
+/// Issue #321: arms a <see cref="Timer"/> per
+/// <see cref="PhaseSchedulerEntry"/> in the configured groups so the host
+/// drives the daily phase plan automatically (e.g. at 10:00 → uncross
+/// opening auction; at 17:25 → enter FinalClosingCall; etc.). Modeled on
+/// <see cref="DailyResetScheduler"/>: each entry computes its next firing
+/// instant by interpreting <c>HH:mm</c> in the configured IANA timezone
+/// and re-arms after each fire.
+/// </summary>
+public sealed class PhaseScheduler : IAsyncDisposable
+{
+    private readonly PhaseSchedulerConfig _config;
+    private readonly IPhaseScheduledTarget _target;
+    private readonly MetricsRegistry? _metrics;
+    private readonly ILogger<PhaseScheduler> _logger;
+    private readonly Func<DateTimeOffset> _utcNow;
+    private readonly List<ScheduledEntry> _entries = new();
+    private int _disposed;
+
+    public PhaseScheduler(PhaseSchedulerConfig config, IReadOnlyDictionary<long, ChannelDispatcher> routing,
+        MetricsRegistry? metrics, ILogger<PhaseScheduler> logger,
+        Func<DateTimeOffset>? utcNowOverride = null)
+        : this(config, new DispatcherRoutingPhaseTarget(routing), metrics, logger, utcNowOverride)
+    { }
+
+    public PhaseScheduler(PhaseSchedulerConfig config, IPhaseScheduledTarget target,
+        MetricsRegistry? metrics, ILogger<PhaseScheduler> logger,
+        Func<DateTimeOffset>? utcNowOverride = null)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(target);
+        ArgumentNullException.ThrowIfNull(logger);
+        _config = config;
+        _target = target;
+        _metrics = metrics;
+        _logger = logger;
+        _utcNow = utcNowOverride ?? (() => DateTimeOffset.UtcNow);
+        BuildEntries();
+    }
+
+    private void BuildEntries()
+    {
+        foreach (var group in _config.Groups)
+        {
+            var tz = ResolveTimezone(group.Timezone);
+            IReadOnlyList<long> instruments = group.Instruments.Count == 0
+                ? _target.RoutedSecurityIds.ToArray()
+                : group.Instruments;
+            foreach (var entry in group.Schedule)
+            {
+                var local = ParseHHmm(entry.At);
+                var action = ParseAction(entry.Action);
+                var target = ParsePhase(entry.Target);
+                _entries.Add(new ScheduledEntry(group.Name, tz, local, action, target, instruments));
+            }
+        }
+    }
+
+    public IReadOnlyList<ScheduledEntry> Entries => _entries;
+
+    public void Start()
+    {
+        var now = _utcNow();
+        foreach (var entry in _entries) ArmEntry(entry, now);
+        _logger.LogInformation("phase scheduler armed: entries={Count}", _entries.Count);
+    }
+
+    /// <summary>
+    /// Test seam: enqueue every entry whose next firing instant is
+    /// &lt;= the current (overridden) clock without waiting for a
+    /// <see cref="Timer"/>. Re-arming is skipped — the test owns the
+    /// clock. Returns the count of entries fired.
+    /// </summary>
+    public int RunDueNow()
+    {
+        var now = _utcNow();
+        int fired = 0;
+        foreach (var entry in _entries)
+        {
+            var next = ComputeNextFiringUtc(now.AddSeconds(-1), entry.LocalTime, entry.Timezone);
+            if (next <= now)
+            {
+                FireEntry(entry);
+                fired++;
+            }
+        }
+        return fired;
+    }
+
+    private void ArmEntry(ScheduledEntry entry, DateTimeOffset now)
+    {
+        var next = ComputeNextFiringUtc(now, entry.LocalTime, entry.Timezone);
+        var delay = next - now;
+        if (delay < TimeSpan.Zero) delay = TimeSpan.Zero;
+        entry.Timer?.Dispose();
+        entry.Timer = new Timer(_ => OnTimer(entry), null, delay, Timeout.InfiniteTimeSpan);
+        _logger.LogInformation(
+            "phase scheduler entry armed: group={Group} action={Action} target={Target} at={At:hh\\:mm} tz={Tz} next-firing-utc={Next:o}",
+            entry.GroupName, entry.Action, entry.TargetPhase, entry.LocalTime, entry.Timezone.Id, next);
+    }
+
+    private void OnTimer(ScheduledEntry entry)
+    {
+        if (Volatile.Read(ref _disposed) != 0) return;
+        try { FireEntry(entry); }
+        finally
+        {
+            if (Volatile.Read(ref _disposed) == 0)
+                ArmEntry(entry, _utcNow());
+        }
+    }
+
+    private void FireEntry(ScheduledEntry entry)
+    {
+        foreach (var secId in entry.Instruments)
+        {
+            bool ok;
+            try
+            {
+                ok = entry.Action == ScheduledAction.UncrossAuction
+                    ? _target.EnqueueUncrossAuction(secId, entry.TargetPhase)
+                    : _target.EnqueueSetPhase(secId, entry.TargetPhase);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "phase scheduler fire threw: group={Group} action={Action} target={Target} secId={SecurityId}",
+                    entry.GroupName, entry.Action, entry.TargetPhase, secId);
+                continue;
+            }
+            if (!ok)
+            {
+                _logger.LogWarning(
+                    "phase scheduler enqueue rejected: group={Group} action={Action} target={Target} secId={SecurityId}",
+                    entry.GroupName, entry.Action, entry.TargetPhase, secId);
+                continue;
+            }
+            // The trigger label distinguishes scheduler-driven transitions
+            // from operator HTTP overrides. We do not know the previous
+            // phase off-thread; record TargetPhase for both labels so
+            // operators can still pivot on the target distribution.
+            _metrics?.IncPhaseTransition(secId, entry.TargetPhase, entry.TargetPhase, "scheduled");
+            _logger.LogInformation(
+                "phase scheduler fired: group={Group} action={Action} target={Target} secId={SecurityId}",
+                entry.GroupName, entry.Action, entry.TargetPhase, secId);
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) return ValueTask.CompletedTask;
+        foreach (var entry in _entries)
+        {
+            try { entry.Timer?.Dispose(); }
+            catch { }
+            entry.Timer = null;
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public sealed class ScheduledEntry
+    {
+        public string GroupName { get; }
+        public TimeZoneInfo Timezone { get; }
+        public TimeSpan LocalTime { get; }
+        public ScheduledAction Action { get; }
+        public TradingPhase TargetPhase { get; }
+        public IReadOnlyList<long> Instruments { get; }
+        internal Timer? Timer { get; set; }
+
+        internal ScheduledEntry(string groupName, TimeZoneInfo tz, TimeSpan localTime,
+            ScheduledAction action, TradingPhase targetPhase, IReadOnlyList<long> instruments)
+        {
+            GroupName = groupName;
+            Timezone = tz;
+            LocalTime = localTime;
+            Action = action;
+            TargetPhase = targetPhase;
+            Instruments = instruments;
+        }
+    }
+
+    public enum ScheduledAction { EnterPhase, UncrossAuction }
+
+    private static ScheduledAction ParseAction(string s)
+    {
+        if (string.Equals(s, "EnterPhase", StringComparison.OrdinalIgnoreCase)) return ScheduledAction.EnterPhase;
+        if (string.Equals(s, "UncrossAuction", StringComparison.OrdinalIgnoreCase)) return ScheduledAction.UncrossAuction;
+        throw new FormatException($"phaseScheduler.action '{s}' is not a recognized action (EnterPhase|UncrossAuction)");
+    }
+
+    private static TradingPhase ParsePhase(string s)
+    {
+        if (Enum.TryParse<TradingPhase>(s, ignoreCase: true, out var phase))
+            return phase;
+        throw new FormatException($"phaseScheduler.target '{s}' is not a recognized TradingPhase");
+    }
+
+    private static TimeSpan ParseHHmm(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s))
+            throw new ArgumentException("phaseScheduler.at must be a non-empty 'HH:mm' string", nameof(s));
+        if (!TimeSpan.TryParseExact(s, @"h\:mm", CultureInfo.InvariantCulture, out var ts) &&
+            !TimeSpan.TryParseExact(s, @"hh\:mm", CultureInfo.InvariantCulture, out ts))
+        {
+            throw new FormatException($"phaseScheduler.at '{s}' is not a valid 'HH:mm' value");
+        }
+        if (ts < TimeSpan.Zero || ts >= TimeSpan.FromHours(24))
+            throw new FormatException($"phaseScheduler.at '{s}' must be within [00:00,24:00)");
+        return ts;
+    }
+
+    private static TimeZoneInfo ResolveTimezone(string id)
+    {
+        if (string.IsNullOrWhiteSpace(id))
+            throw new ArgumentException("phaseScheduler.timezone must be a non-empty IANA identifier", nameof(id));
+        try { return TimeZoneInfo.FindSystemTimeZoneById(id); }
+        catch (TimeZoneNotFoundException ex)
+        {
+            throw new ArgumentException(
+                $"phaseScheduler.timezone '{id}' is not recognized. On Linux, ensure tzdata is installed.",
+                nameof(id), ex);
+        }
+    }
+
+    /// <summary>
+    /// Same DST-aware computation as <see cref="DailyResetScheduler.ComputeNextFiringUtc"/>.
+    /// </summary>
+    public static DateTimeOffset ComputeNextFiringUtc(
+        DateTimeOffset nowUtc, TimeSpan localTime, TimeZoneInfo tz)
+        => DailyResetScheduler.ComputeNextFiringUtc(nowUtc, localTime, tz);
+}

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -778,4 +778,116 @@ public class ChannelDispatcherTests
         Assert.Equal(2, maker.TradeQty.Count);
         Assert.Equal((0L, 200L), maker.TradeQty[^1]);
     }
+
+    // ===== Issue #321 =====
+
+    [Fact]
+    public async Task Issue321_OperatorUncrossAuction_ReservedToOpen_EmitsAuctionPrintAndPhaseChange()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var maker = new FakeSession(outbound);
+        var taker = new FakeSession(outbound);
+
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Reserved));
+        DrainInbound(disp);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("M", Petr, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10m), 200, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("T", Petr, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10m), 200, 8, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorUncrossAuction(Petr, B3.Exchange.Matching.TradingPhase.Open, tcs));
+        DrainInbound(disp);
+
+        Assert.True(tcs.Task.IsCompletedSuccessfully);
+        var outcome = await tcs.Task;
+        Assert.True(outcome.TransitionApplied);
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.Reserved, outcome.PreviousPhase);
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.Open, outcome.CurrentPhase);
+        Assert.NotNull(outcome.UncrossPrint);
+        Assert.Equal(AuctionPrintKind.Opening, outcome.UncrossPrint!.Value.Kind);
+        Assert.Equal(200L, outcome.UncrossPrint.Value.ClearedQuantity);
+        Assert.Equal(Px(10m), outcome.UncrossPrint.Value.PriceMantissa);
+    }
+
+    [Fact]
+    public async Task Issue321_OperatorUncrossAuction_FCCToClose_EmitsClosingPrint()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var maker = new FakeSession(outbound);
+        var taker = new FakeSession(outbound);
+
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.FinalClosingCall));
+        DrainInbound(disp);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("M", Petr, Side.Sell, OrderType.Limit, TimeInForce.AtClose, Px(10m), 100, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("T", Petr, Side.Buy, OrderType.Limit, TimeInForce.AtClose, Px(10m), 100, 8, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorUncrossAuction(Petr, B3.Exchange.Matching.TradingPhase.Close, tcs));
+        DrainInbound(disp);
+
+        var outcome = await tcs.Task;
+        Assert.True(outcome.TransitionApplied);
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.FinalClosingCall, outcome.PreviousPhase);
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.Close, outcome.CurrentPhase);
+        Assert.NotNull(outcome.UncrossPrint);
+        Assert.Equal(AuctionPrintKind.Closing, outcome.UncrossPrint!.Value.Kind);
+        Assert.Equal(100L, outcome.UncrossPrint.Value.ClearedQuantity);
+    }
+
+    [Fact]
+    public void Issue321_OperatorUncrossAuction_InvalidTransition_FailsCompletionWithInvalidOperation()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        _ = new FakeSession(outbound);
+
+        // Default phase is Open; uncross to Reserved is not a permitted target.
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorUncrossAuction(Petr, B3.Exchange.Matching.TradingPhase.Reserved, tcs));
+        DrainInbound(disp);
+
+        Assert.True(tcs.Task.IsFaulted);
+        Assert.IsType<InvalidOperationException>(tcs.Task.Exception!.InnerException);
+    }
+
+    [Fact]
+    public async Task Issue321_OperatorSetTradingPhase_WithCompletion_ReturnsOutcome()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        _ = new FakeSession(outbound);
+
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Pause));
+        DrainInbound(disp);
+
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Open, tcs));
+        DrainInbound(disp);
+
+        Assert.True(tcs.Task.IsCompletedSuccessfully);
+        var outcome = await tcs.Task;
+        Assert.True(outcome.TransitionApplied);
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.Pause, outcome.PreviousPhase);
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.Open, outcome.CurrentPhase);
+        Assert.Null(outcome.UncrossPrint);
+    }
+
+    [Fact]
+    public void Issue321_PhaseSnapshot_ReflectsLatestTransition()
+    {
+        var (disp, _, _) = NewDispatcher();
+
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Pause));
+        DrainInbound(disp);
+
+        Assert.True(disp.TryGetPhaseSnapshot(Petr, out var phase));
+        Assert.Equal(B3.Exchange.Matching.TradingPhase.Pause, phase);
+    }
 }

--- a/tests/B3.Exchange.Host.Tests/HttpServerPhaseTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerPhaseTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #321: end-to-end tests for POST /admin/instruments/{id}/phase.
+/// Reuses the bootstrap pattern from <see cref="HttpServerTests"/>.
+/// </summary>
+public class HttpServerPhaseTests
+{
+    private sealed class RecordingSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath}");
+    }
+
+    private static (HostConfig cfg, IUmdfPacketSink sink) BuildConfig()
+    {
+        var cfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 10_000 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 91,
+                    IncrementalGroup = "239.255.42.91",
+                    IncrementalPort = 30191,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+        return (cfg, new RecordingSink());
+    }
+
+    private static long FirstSecurityId(HostConfig cfg)
+    {
+        var path = cfg.Channels[0].InstrumentsFile;
+        var instruments = B3.Exchange.Instruments.InstrumentLoader.LoadFromFile(path);
+        return instruments[0].SecurityId;
+    }
+
+    [Fact]
+    public async Task SetPhase_UnknownSecurityId_Returns404()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync("/admin/instruments/9999999999/phase",
+            new { targetPhase = "Open" });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SetPhase_UnknownTargetPhase_Returns400()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/phase",
+            new { targetPhase = "NotAPhase" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task SetPhase_ValidSetPhaseTransition_Returns200()
+    {
+        // The HTTP layer routes plain phase changes through SetPhase; the
+        // engine accepts every (current,target) pair so we exercise a
+        // representative round-trip and assert the structured outcome.
+        // A genuine 409 (engine InvalidOperationException) is only
+        // reachable via UncrossAuction with a non-whitelisted pair, which
+        // the routing prevents — covered by the dispatcher unit test.
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/phase",
+            new { targetPhase = "Pause" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("\"previousPhase\":\"Open\"", body);
+        Assert.Contains("\"currentPhase\":\"Pause\"", body);
+    }
+
+    [Fact]
+    public async Task SetPhase_ReservedToOpen_UnctrossesAuctionAndReturns200()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        // Move to Reserved (plain SetPhase).
+        var toReserved = await client.PostAsJsonAsync($"/admin/instruments/{secId}/phase",
+            new { targetPhase = "Reserved" });
+        Assert.Equal(HttpStatusCode.OK, toReserved.StatusCode);
+        var toReservedBody = await toReserved.Content.ReadAsStringAsync();
+        Assert.Contains("\"currentPhase\":\"Reserved\"", toReservedBody);
+
+        // Move Reserved → Open: routes through UncrossAuction. No orders on
+        // the book means no UncrossPrint is emitted, but the response must
+        // still be 200 with currentPhase=Open.
+        var toOpen = await client.PostAsJsonAsync($"/admin/instruments/{secId}/phase",
+            new { targetPhase = "Open" });
+        Assert.Equal(HttpStatusCode.OK, toOpen.StatusCode);
+        var toOpenBody = await toOpen.Content.ReadAsStringAsync();
+        Assert.Contains("\"previousPhase\":\"Reserved\"", toOpenBody);
+        Assert.Contains("\"currentPhase\":\"Open\"", toOpenBody);
+    }
+
+    [Fact]
+    public async Task SetPhase_MalformedBody_Returns400()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        using var content = new StringContent("not json", System.Text.Encoding.UTF8, "application/json");
+        var resp = await client.PostAsync($"/admin/instruments/{secId}/phase", content);
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/PhaseSchedulerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/PhaseSchedulerTests.cs
@@ -1,0 +1,164 @@
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #321: unit tests for <see cref="PhaseScheduler"/>. Uses a fake
+/// <see cref="IPhaseScheduledTarget"/> and the <c>RunDueNow</c> test seam
+/// so we never wait on real timers or wall-clock.
+/// </summary>
+public class PhaseSchedulerTests
+{
+    private sealed class FakeTarget : IPhaseScheduledTarget
+    {
+        public List<(long SecId, TradingPhase Target, bool Uncross)> Calls { get; } = new();
+        private readonly long[] _ids;
+        public FakeTarget(params long[] ids) { _ids = ids; }
+        public IReadOnlyCollection<long> RoutedSecurityIds => _ids;
+        public bool EnqueueSetPhase(long securityId, TradingPhase target)
+        {
+            Calls.Add((securityId, target, false));
+            return true;
+        }
+        public bool EnqueueUncrossAuction(long securityId, TradingPhase target)
+        {
+            Calls.Add((securityId, target, true));
+            return true;
+        }
+    }
+
+    private static PhaseSchedulerConfig CfgWith(params PhaseSchedulerEntry[] schedule)
+        => new()
+        {
+            Enabled = true,
+            Groups = new[]
+            {
+                new PhaseSchedulerGroup
+                {
+                    Name = "test",
+                    Timezone = "UTC",
+                    Schedule = schedule,
+                },
+            },
+        };
+
+    [Fact]
+    public async Task RunDueNow_FiresEntryAtItsLocalTime_RoutingByAction()
+    {
+        var fake = new FakeTarget(101L, 102L);
+        var cfg = CfgWith(
+            new PhaseSchedulerEntry { At = "10:00", Action = "UncrossAuction", Target = "Open" },
+            new PhaseSchedulerEntry { At = "12:00", Action = "EnterPhase", Target = "Pause" });
+        // utcNow == 10:00:00.5 UTC: only the 10:00 entry should fire.
+        var clock = new DateTimeOffset(2025, 1, 6, 10, 0, 0, 500, TimeSpan.Zero);
+        await using var sched = new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance, utcNowOverride: () => clock);
+
+        var fired = sched.RunDueNow();
+
+        Assert.Equal(1, fired); // one entry fires; instrument fan-out is in Calls
+        Assert.Equal(2, fake.Calls.Count);
+        Assert.All(fake.Calls, c => Assert.True(c.Uncross));
+        Assert.All(fake.Calls, c => Assert.Equal(TradingPhase.Open, c.Target));
+        Assert.Contains(fake.Calls, c => c.SecId == 101L);
+        Assert.Contains(fake.Calls, c => c.SecId == 102L);
+    }
+
+    [Fact]
+    public async Task RunDueNow_FiresOnlyEntriesInCurrentSecondWindow()
+    {
+        var fake = new FakeTarget(7L);
+        var cfg = CfgWith(
+            new PhaseSchedulerEntry { At = "09:00", Action = "EnterPhase", Target = "Reserved" },
+            new PhaseSchedulerEntry { At = "10:00", Action = "UncrossAuction", Target = "Open" });
+        var clock = new DateTimeOffset(2025, 1, 6, 9, 0, 0, 500, TimeSpan.Zero);
+        await using var sched = new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance, utcNowOverride: () => clock);
+
+        Assert.Equal(1, sched.RunDueNow());
+        Assert.Single(fake.Calls);
+        Assert.Equal(TradingPhase.Reserved, fake.Calls[0].Target);
+        Assert.False(fake.Calls[0].Uncross);
+
+        // Advance clock to the second entry's window.
+        clock = new DateTimeOffset(2025, 1, 6, 10, 0, 0, 500, TimeSpan.Zero);
+        Assert.Equal(1, sched.RunDueNow());
+        Assert.Equal(2, fake.Calls.Count);
+        Assert.Equal(TradingPhase.Open, fake.Calls[1].Target);
+        Assert.True(fake.Calls[1].Uncross);
+    }
+
+    [Fact]
+    public async Task RunDueNow_FiresNothing_BeforeFirstEntry()
+    {
+        var fake = new FakeTarget(1L);
+        var cfg = CfgWith(
+            new PhaseSchedulerEntry { At = "10:00", Action = "EnterPhase", Target = "Open" });
+        var clock = new DateTimeOffset(2025, 1, 6, 9, 30, 0, TimeSpan.Zero);
+        await using var sched = new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance, utcNowOverride: () => clock);
+
+        Assert.Equal(0, sched.RunDueNow());
+        Assert.Empty(fake.Calls);
+    }
+
+    [Fact]
+    public async Task RunDueNow_ExplicitInstrumentList_OverridesRoutedDefault()
+    {
+        var fake = new FakeTarget(1L, 2L, 3L);
+        var cfg = new PhaseSchedulerConfig
+        {
+            Enabled = true,
+            Groups = new[]
+            {
+                new PhaseSchedulerGroup
+                {
+                    Name = "subset",
+                    Timezone = "UTC",
+                    Instruments = new[] { 2L },
+                    Schedule = new[]
+                    {
+                        new PhaseSchedulerEntry { At = "10:00", Action = "EnterPhase", Target = "Open" },
+                    },
+                },
+            },
+        };
+        var clock = new DateTimeOffset(2025, 1, 6, 10, 0, 0, 500, TimeSpan.Zero);
+        await using var sched = new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance, utcNowOverride: () => clock);
+
+        sched.RunDueNow();
+
+        Assert.Single(fake.Calls);
+        Assert.Equal(2L, fake.Calls[0].SecId);
+    }
+
+    [Fact]
+    public void Ctor_RejectsBadHHmm()
+    {
+        var fake = new FakeTarget(1L);
+        var cfg = CfgWith(new PhaseSchedulerEntry { At = "25:99", Action = "EnterPhase", Target = "Open" });
+        Assert.ThrowsAny<Exception>(() => new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance));
+    }
+
+    [Fact]
+    public void Ctor_RejectsBadAction()
+    {
+        var fake = new FakeTarget(1L);
+        var cfg = CfgWith(new PhaseSchedulerEntry { At = "10:00", Action = "Bogus", Target = "Open" });
+        Assert.Throws<FormatException>(() => new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance));
+    }
+
+    [Fact]
+    public void Ctor_RejectsBadPhase()
+    {
+        var fake = new FakeTarget(1L);
+        var cfg = CfgWith(new PhaseSchedulerEntry { At = "10:00", Action = "EnterPhase", Target = "Bogus" });
+        Assert.Throws<FormatException>(() => new PhaseScheduler(cfg, fake, metrics: null,
+            logger: NullLogger<PhaseScheduler>.Instance));
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -158,6 +158,34 @@ public class ChannelDispatcherPersistenceTests
     }
 
     [Fact]
+    public void Issue321_RestoreChannelState_ReseedsPhaseSnapshot()
+    {
+        // Issue #321 review (gpt-5.5 finding): if RestoreChannelState
+        // didn't reseed _phaseSnapshot from the restored engine state,
+        // the HTTP routing layer would still see the constructor-seeded
+        // Open phase after restart and route Reserved→Open through plain
+        // SetTradingPhase, skipping the auction uncross.
+        var persister = new InMemoryPersister();
+
+        // Round 1: dispatcher A, transition PETR4 to Reserved and persist.
+        var dispA = BuildDispatcher(persister, out _);
+        var probe = dispA.CreateTestProbe();
+        Assert.True(dispA.EnqueueOperatorSetTradingPhase(Sec, TradingPhase.Reserved));
+        probe.DrainInbound();
+        Assert.True(dispA.TryGetPhaseSnapshot(Sec, out var aPhase));
+        Assert.Equal(TradingPhase.Reserved, aPhase);
+
+        // Round 2: brand-new dispatcher restored from the persisted snapshot.
+        var dispB = BuildDispatcher(persister, out _);
+        var loaded = persister.TryLoad(84);
+        Assert.NotNull(loaded);
+        dispB.RestoreChannelState(loaded!);
+
+        Assert.True(dispB.TryGetPhaseSnapshot(Sec, out var bPhase));
+        Assert.Equal(TradingPhase.Reserved, bPhase);
+    }
+
+    [Fact]
     public void RestoreChannelState_RejectsMismatchedChannelNumber()
     {
         var persister = new InMemoryPersister();


### PR DESCRIPTION
Closes #321.

## What

Adds a synchronous operator HTTP surface for trading-phase transitions and a configurable scheduler so clients see the realistic pre-open → opening uncross → continuous → closing call → closing uncross cycle.

### Endpoint

```
POST /admin/instruments/{securityId:long}/phase
  body { "targetPhase": "Open|Reserved|FinalClosingCall|Close|Pause|Forbidden", "asOf"?: ulong-nanos }
  → 200 { previousPhase, currentPhase, uncrossPrint? }
  → 404 unknown securityId
  → 409 invalid transition
  → 503 queue full / WAL halted
  → 504 dispatch timeout
```

`Reserved→Open` and `FinalClosingCall→Close` route through the engine `UncrossAuction` path (drains crossing volume, emits `AuctionPrint` + `SecurityStatus`); everything else uses plain `SetTradingPhase`. Both return synchronously via a `TaskCompletionSource<PhaseChangeOutcome>` carried on the dispatcher `WorkItem`.

### PhaseScheduler

Modeled on `DailyResetScheduler`. Config:

```json
"phaseScheduler": {
  "enabled": true,
  "groups": [{
    "timezone": "America/Sao_Paulo",
    "instruments": [...],
    "schedule": [
      { "at": "09:45", "action": "EnterPhase",     "target": "Reserved" },
      { "at": "10:00", "action": "UncrossAuction", "target": "Open" },
      { "at": "16:55", "action": "EnterPhase",     "target": "FinalClosingCall" },
      { "at": "17:00", "action": "UncrossAuction", "target": "Close" }
    ]
  }]
}
```

### Observability

- `matching_phase_transition_total{security_id,from,to,trigger}` counter emitted by both HTTP and scheduler paths so operators can distinguish manual vs scheduled.

## Review (gpt-5.5)

Two issues raised by code-review and fixed in this PR before mark-ready:

1. **High** — `RestoreChannelState` did not re-seed `_phaseSnapshot` from the persisted engine phases. After a restart from snapshot in `Reserved`/`FinalClosingCall`, the HTTP layer would still see the constructor-seeded `Open` and skip the uncross. Fixed in `ChannelDispatcher.Persistence.cs` + regression test in `ChannelDispatcherPersistenceTests`.
2. **Medium** — WAL-halted loop-side drop did not complete the phase TCS. Fixed in `ChannelDispatcher.Loop.cs` so the HTTP caller fails fast with a real reason.

## Tests

1050 tests green, format clean. New tests:
- `ChannelDispatcherTests`: 5 dispatcher-level tests (uncross success, invalid transition, completion plumbing).
- `HttpServerPhaseTests`: 5 HTTP tests (200, 404, 400, etc.).
- `PhaseSchedulerTests`: 7 scheduler tests with fake clock.
- `ChannelDispatcherPersistenceTests`: 1 regression for the snapshot reseed bug.