### PR TITLE
feat(host): single-stock halt/resume HTTP API + UMDF status frame (#322)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -59,6 +59,10 @@ public sealed partial class ChannelDispatcher
             item.PhaseCompletion?.TrySetException(
                 new InvalidOperationException(
                     $"channel {ChannelNumber} WAL-halted; phase command rejected"));
+            // Issue #322: same applies to halt/resume HTTP callers.
+            item.HaltCompletion?.TrySetException(
+                new InvalidOperationException(
+                    $"channel {ChannelNumber} WAL-halted; halt/resume command rejected"));
             return;
         }
 
@@ -99,6 +103,20 @@ public sealed partial class ChannelDispatcher
         if (item.Kind == WorkKind.OperatorUncrossAuction)
         {
             ProcessUncrossAuction(item.UncrossAuction!, item.PhaseCompletion);
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorHaltInstrument)
+        {
+            ProcessHalt(item.Halt!, item.HaltCompletion);
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorResumeInstrument)
+        {
+            ProcessResume(item.Resume!, item.HaltCompletion);
             OnAfterCommandFlushed(force: true);
             return;
         }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -225,6 +225,15 @@ public sealed partial class ChannelDispatcher
     {
         AssertOnLoopThread();
         _pendingAuctionPrint = null;
+        // Issue #322: halt overlay blocks operator phase commands. The
+        // engine itself doesn't know about the halt overlay's "blocks
+        // phase" semantics — the dispatcher enforces it so HTTP admin
+        // callers see a deterministic 409 instead of a silent no-op.
+        if (_haltSnapshot.ContainsKey(op.SecurityId))
+        {
+            completion?.TrySetException(new InvalidOperationException("instrument halted"));
+            return;
+        }
         try
         {
             B3.Exchange.Matching.TradingPhase prev;
@@ -275,6 +284,11 @@ public sealed partial class ChannelDispatcher
         AssertOnLoopThread();
         _pendingAuctionPrint = null;
         _packetWritten = 0;
+        if (_haltSnapshot.ContainsKey(op.SecurityId))
+        {
+            completion?.TrySetException(new InvalidOperationException("instrument halted"));
+            return;
+        }
         try
         {
             B3.Exchange.Matching.TradingPhase prev;
@@ -302,6 +316,158 @@ public sealed partial class ChannelDispatcher
             var current = _engine.GetTradingPhase(op.SecurityId);
             bool applied = current != prev;
             completion?.TrySetResult(new PhaseChangeOutcome(applied, prev, current, _pendingAuctionPrint));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Issue #322: enqueue an administrative halt for
+    /// <paramref name="securityId"/>. Sets the overlay on the dispatch
+    /// thread, emits an <c>InstrumentHaltedEvent</c> through the engine
+    /// (driving a UMDF <c>SecurityStatus_3</c>), and completes the
+    /// supplied task with the resulting <see cref="HaltOutcome"/>.
+    /// </summary>
+    public bool EnqueueOperatorHalt(long securityId, B3.Exchange.Matching.HaltReason reason, string? note,
+        TaskCompletionSource<HaltOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorHaltInstrument))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; HaltInstrument rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorHaltInstrument, default, 0, false,
+            0, 0, null, null, null, null,
+            Halt: new OperatorHalt(securityId, reason, note),
+            HaltCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; HaltInstrument rejected"));
+        return false;
+    }
+
+    /// <summary>
+    /// Issue #322: enqueue a resume for <paramref name="securityId"/>.
+    /// </summary>
+    public bool EnqueueOperatorResume(long securityId,
+        TaskCompletionSource<HaltOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorResumeInstrument))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; ResumeInstrument rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorResumeInstrument, default, 0, false,
+            0, 0, null, null, null, null,
+            Resume: new OperatorResume(securityId),
+            HaltCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; ResumeInstrument rejected"));
+        return false;
+    }
+
+    private void ProcessHalt(OperatorHalt op, TaskCompletionSource<HaltOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _packetWritten = 0;
+        try
+        {
+            B3.Exchange.Matching.HaltState prevState;
+            bool wasHalted = _engine.IsHalted(op.SecurityId, out prevState);
+            bool stateChanged;
+            try
+            {
+                stateChanged = _engine.HaltInstrument(op.SecurityId, op.Reason, op.Note, _nowNanos());
+            }
+            catch (KeyNotFoundException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            catch (InvalidOperationException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            if (stateChanged)
+            {
+                _haltSnapshot[op.SecurityId] = new HaltSnapshot(op.Reason, _engine.IsHalted(op.SecurityId, out var nowState) ? nowState.HaltedAtNanos : 0UL, op.Note);
+            }
+            if (_packetWritten > 0) FlushPacket();
+            // Re-read so the outcome reflects the canonical engine state
+            // (handles the no-op case where stateChanged=false but the
+            // instrument was already halted with a different reason/note).
+            _engine.IsHalted(op.SecurityId, out var current);
+            if (stateChanged)
+            {
+                completion?.TrySetResult(new HaltOutcome(
+                    StateChanged: true,
+                    IsHaltedNow: true,
+                    Reason: current.Reason,
+                    HaltedAtNanos: current.HaltedAtNanos,
+                    Note: current.Note));
+            }
+            else
+            {
+                completion?.TrySetResult(new HaltOutcome(
+                    StateChanged: false,
+                    IsHaltedNow: wasHalted,
+                    Reason: wasHalted ? prevState.Reason : null,
+                    HaltedAtNanos: wasHalted ? prevState.HaltedAtNanos : 0UL,
+                    Note: wasHalted ? prevState.Note : null));
+            }
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
+
+    private void ProcessResume(OperatorResume op, TaskCompletionSource<HaltOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _packetWritten = 0;
+        try
+        {
+            B3.Exchange.Matching.HaltState prevState;
+            bool wasHalted = _engine.IsHalted(op.SecurityId, out prevState);
+            bool stateChanged;
+            try
+            {
+                stateChanged = _engine.ResumeInstrument(op.SecurityId, _nowNanos());
+            }
+            catch (KeyNotFoundException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            catch (InvalidOperationException ex)
+            {
+                completion?.TrySetException(ex);
+                return;
+            }
+            if (stateChanged)
+            {
+                _haltSnapshot.TryRemove(op.SecurityId, out _);
+            }
+            if (_packetWritten > 0) FlushPacket();
+            completion?.TrySetResult(new HaltOutcome(
+                StateChanged: stateChanged,
+                IsHaltedNow: false,
+                Reason: null,
+                HaltedAtNanos: stateChanged && wasHalted ? prevState.HaltedAtNanos : 0UL,
+                Note: stateChanged && wasHalted ? prevState.Note : null));
         }
         catch (Exception ex)
         {

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -132,6 +132,21 @@ public sealed partial class ChannelDispatcher
             _phaseSnapshot[p.SecurityId] = p.Phase;
         }
 
+        // Issue #322: re-seed the halt overlay snapshot. Required so the
+        // HTTP/admin layer correctly rejects phase commands after a
+        // restart while an instrument is still administratively halted.
+        _haltSnapshot.Clear();
+        if (snapshot.Engine.Halts is { } halts)
+        {
+            foreach (var h in halts)
+            {
+                _haltSnapshot[h.SecurityId] = new HaltSnapshot(
+                    (B3.Exchange.Matching.HaltReason)h.Reason,
+                    h.HaltedAtNanos,
+                    h.Note);
+            }
+        }
+
         // Re-publish counters via the cross-thread-readable Volatile
         // backing fields so the HTTP scrape sees the restored values
         // immediately after the loop becomes ready.

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -163,6 +163,61 @@ public sealed partial class ChannelDispatcher
         Commit(n);
     }
 
+    /// <summary>
+    /// Issue #322: B3-aligned best-effort wire markers on
+    /// <c>securityTradingEvent</c> for halt and resume. The downstream
+    /// consumer just needs them to be distinct and non-NULL; the
+    /// <c>SecurityStatus_3</c> frame's <c>securityTradingStatus</c> still
+    /// carries the engine's preserved <see cref="TradingPhase"/> so the
+    /// post-resume phase is unambiguous.
+    /// </summary>
+    private const byte SecurityTradingEventHalt = 1;
+    private const byte SecurityTradingEventResume = 2;
+
+    public void OnInstrumentHalted(in InstrumentHaltedEvent e)
+    {
+        AssertOnLoopThread();
+        byte phaseByte = _phaseSnapshot.TryGetValue(e.SecurityId, out var phase)
+            ? (byte)phase
+            : (byte)TradingPhase.Open;
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SecurityStatusBlockLength);
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteSecurityStatusFrame(
+            dst,
+            securityId: e.SecurityId,
+            tradingSessionId: 0,
+            securityTradingStatus: phaseByte,
+            securityTradingEvent: SecurityTradingEventHalt,
+            tradeDate: 0,
+            tradSesOpenTimeNanos: 0,
+            transactTimeNanos: e.TransactTimeNanos,
+            rptSeq: e.RptSeq);
+        Commit(n);
+    }
+
+    public void OnInstrumentResumed(in InstrumentResumedEvent e)
+    {
+        AssertOnLoopThread();
+        byte phaseByte = _phaseSnapshot.TryGetValue(e.SecurityId, out var phase)
+            ? (byte)phase
+            : (byte)TradingPhase.Open;
+        var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+            + B3.Umdf.WireEncoder.WireOffsets.SecurityStatusBlockLength);
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteSecurityStatusFrame(
+            dst,
+            securityId: e.SecurityId,
+            tradingSessionId: 0,
+            securityTradingStatus: phaseByte,
+            securityTradingEvent: SecurityTradingEventResume,
+            tradeDate: 0,
+            tradSesOpenTimeNanos: 0,
+            transactTimeNanos: e.TransactTimeNanos,
+            rptSeq: e.RptSeq);
+        Commit(n);
+    }
+
     public void OnAuctionTopChanged(in AuctionTopChangedEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -34,6 +34,8 @@ public sealed partial class ChannelDispatcher
         "OperatorSetTradingPhase",
         "OperatorPersistSnapshot",
         "OperatorUncrossAuction",
+        "OperatorHaltInstrument",
+        "OperatorResumeInstrument",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -58,6 +60,9 @@ public sealed partial class ChannelDispatcher
         OperatorTradingPhase? TradingPhase = null,
         OperatorUncrossAuction? UncrossAuction = null,
         TaskCompletionSource<PhaseChangeOutcome>? PhaseCompletion = null,
+        OperatorHalt? Halt = null,
+        OperatorResume? Resume = null,
+        TaskCompletionSource<HaltOutcome>? HaltCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -94,6 +99,18 @@ public sealed partial class ChannelDispatcher
     /// (opening call) or FinalClosingCall→Close (closing call) target phase.
     /// </summary>
     internal sealed record OperatorUncrossAuction(long SecurityId, B3.Exchange.Matching.TradingPhase TargetPhase);
+
+    /// <summary>
+    /// Issue #322: operator-triggered halt payload — carries the
+    /// security to halt, the categorical reason, and an optional
+    /// free-form note for downstream observability.
+    /// </summary>
+    internal sealed record OperatorHalt(long SecurityId, B3.Exchange.Matching.HaltReason Reason, string? Note);
+
+    /// <summary>
+    /// Issue #322: operator-triggered resume payload.
+    /// </summary>
+    internal sealed record OperatorResume(long SecurityId);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -268,6 +268,18 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         = new();
 
     /// <summary>
+    /// Issue #322: per-securityId snapshot of the most-recently observed
+    /// administrative halt overlay. Written only on the dispatch loop
+    /// thread inside <see cref="ProcessHalt"/> / <see cref="ProcessResume"/>;
+    /// re-seeded by <see cref="RestoreChannelState"/>. Read from any
+    /// thread by <see cref="TryGetHaltSnapshot"/> so the HTTP admin
+    /// endpoint can resolve the current halt state without queueing a
+    /// synchronous query into the engine.
+    /// </summary>
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<long, HaltSnapshot> _haltSnapshot
+        = new();
+
+    /// <summary>
     /// Issue #321: latest <see cref="AuctionPrintInfo"/> captured by the
     /// <c>OnAuctionPrint</c> sink for the command currently being
     /// processed. Reset to <c>null</c> at the start of each Process*
@@ -382,6 +394,16 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     public bool TryGetPhaseSnapshot(long securityId, out B3.Exchange.Matching.TradingPhase phase)
         => _phaseSnapshot.TryGetValue(securityId, out phase);
+
+    /// <summary>
+    /// Issue #322: thread-safe snapshot of the most-recent administrative
+    /// halt state for <paramref name="securityId"/>. Returns <c>true</c>
+    /// when the instrument is currently halted; <c>false</c> when it is
+    /// either not halted or unknown to this channel. Safe to call from
+    /// any thread.
+    /// </summary>
+    public bool TryGetHaltSnapshot(long securityId, out HaltSnapshot state)
+        => _haltSnapshot.TryGetValue(securityId, out state);
 
     private static ulong DefaultNowNanos()
         => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;

--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -53,7 +53,7 @@ public sealed record ChannelStateSnapshot(
     EngineStateSnapshot Engine,
     IReadOnlyList<OrderOwnerSnapshot> Owners)
 {
-    public const int CurrentVersion = 2;
+    public const int CurrentVersion = 3;
 
     /// <summary>
     /// Issue #269: monotonic counter of commands the dispatcher has

--- a/src/B3.Exchange.Core/HaltOutcome.cs
+++ b/src/B3.Exchange.Core/HaltOutcome.cs
@@ -1,0 +1,29 @@
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Issue #322: structured outcome of an operator-driven halt or resume
+/// command (<see cref="ChannelDispatcher.EnqueueOperatorHalt"/> /
+/// <see cref="ChannelDispatcher.EnqueueOperatorResume"/>) returned to
+/// the HTTP admin endpoint via a
+/// <see cref="System.Threading.Tasks.TaskCompletionSource{TResult}"/>.
+/// </summary>
+public readonly record struct HaltOutcome(
+    bool StateChanged,
+    bool IsHaltedNow,
+    HaltReason? Reason,
+    ulong HaltedAtNanos,
+    string? Note);
+
+/// <summary>
+/// Issue #322: cross-thread snapshot of the dispatcher's view of the
+/// per-instrument halt overlay. Mirrors the engine's <c>HaltState</c>
+/// but lives in a <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+/// so callers off the dispatch thread (HTTP admin handler) can resolve
+/// the current halt state without piercing the engine.
+/// </summary>
+public readonly record struct HaltSnapshot(
+    HaltReason Reason,
+    ulong HaltedAtNanos,
+    string? Note);

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -441,6 +441,31 @@ public sealed class MetricsRegistry
     private readonly System.Collections.Concurrent.ConcurrentDictionary<(long, byte, byte, string), long> _phaseTransitions
         = new();
 
+    /// <summary>
+    /// Issue #322: process-wide counter of administrative single-stock
+    /// halts, keyed on <c>(security_id, reason)</c>. Atomic — safe to
+    /// call from any thread. Increments only when the engine reports an
+    /// actual state change (re-asserting an existing halt is a no-op).
+    /// </summary>
+    public void IncInstrumentHalted(long securityId, B3.Exchange.Matching.HaltReason reason)
+    {
+        var key = (securityId, (byte)reason);
+        _instrumentHalted.AddOrUpdate(key, 1L, static (_, prev) => prev + 1L);
+    }
+
+    /// <summary>
+    /// Issue #322: companion counter for resumes, keyed on
+    /// <c>security_id</c>. Increments only when the engine reports an
+    /// actual state change.
+    /// </summary>
+    public void IncInstrumentResumed(long securityId)
+    {
+        _instrumentResumed.AddOrUpdate(securityId, 1L, static (_, prev) => prev + 1L);
+    }
+
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<(long, byte), long> _instrumentHalted = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<long, long> _instrumentResumed = new();
+
     public void SetSessionProvider(ISessionMetricsProvider provider)
     {
         lock (_lock) _sessions = provider;
@@ -731,6 +756,8 @@ public sealed class MetricsRegistry
 
         EmitPhaseTransitions(sb);
 
+        EmitHaltMetrics(sb);
+
         EmitRuntimeMetrics(sb);
 
         return sb.ToString();
@@ -759,6 +786,42 @@ public sealed class MetricsRegistry
               .Append("\"} ")
               .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
               .Append('\n');
+        }
+    }
+
+    private void EmitHaltMetrics(StringBuilder sb)
+    {
+        // Issue #322: process-wide single-stock halt/resume counters.
+        var halts = _instrumentHalted.ToArray();
+        if (halts.Length > 0)
+        {
+            sb.Append("# HELP exch_instrument_halts_total Operator-driven instrument halts, per (security_id, reason). Issue #322.\n");
+            sb.Append("# TYPE exch_instrument_halts_total counter\n");
+            foreach (var kv in halts)
+            {
+                var (secId, reason) = kv.Key;
+                sb.Append("exch_instrument_halts_total{security_id=\"")
+                  .Append(secId.ToString(CultureInfo.InvariantCulture))
+                  .Append("\",reason=\"")
+                  .Append(((B3.Exchange.Matching.HaltReason)reason).ToString())
+                  .Append("\"} ")
+                  .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+                  .Append('\n');
+            }
+        }
+        var resumes = _instrumentResumed.ToArray();
+        if (resumes.Length > 0)
+        {
+            sb.Append("# HELP exch_instrument_resumes_total Operator-driven instrument resumes, per security_id. Issue #322.\n");
+            sb.Append("# TYPE exch_instrument_resumes_total counter\n");
+            foreach (var kv in resumes)
+            {
+                sb.Append("exch_instrument_resumes_total{security_id=\"")
+                  .Append(kv.Key.ToString(CultureInfo.InvariantCulture))
+                  .Append("\"} ")
+                  .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+                  .Append('\n');
+            }
         }
     }
 

--- a/src/B3.Exchange.Core/SnapshotMigrations.cs
+++ b/src/B3.Exchange.Core/SnapshotMigrations.cs
@@ -70,6 +70,11 @@ public sealed class SnapshotMigrationSet
     {
         var set = new SnapshotMigrationSet();
         set.Register(1, MigrateV1ToV2);
+        // Issue #322: v3 only adds an optional `Halts` collection on the
+        // engine snapshot. v2 trees are upgraded by stamping the version;
+        // STJ's missing-property tolerance leaves Halts at the default
+        // (null) on deserialise.
+        set.Register(2, MigrateV2ToV3);
         return set;
     }
 
@@ -77,6 +82,13 @@ public sealed class SnapshotMigrationSet
     {
         if (previous is JsonObject obj)
             obj["Version"] = 2;
+        return previous;
+    }
+
+    private static JsonNode MigrateV2ToV3(JsonNode previous)
+    {
+        if (previous is JsonObject obj)
+            obj["Version"] = 3;
         return previous;
     }
 

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -259,6 +259,12 @@ internal sealed class FixpOutboundEncoder
         RejectReason.FokUnfillable => 0u,
         RejectReason.SelfTradePrevention => 0u,
         RejectReason.MarketClosed => 13u,
+        // Issue #322: administrative single-stock halt is operationally a
+        // closed-market state for the affected instrument, so it maps to
+        // the same FIX OrdRejReason (13 = ExchangeClosed) as a phase-driven
+        // closure. Operators distinguish the two via the engine reason
+        // surfaced in the audit log.
+        RejectReason.InstrumentHalted => 13u,
         RejectReason.TimeInForceNotSupported => 11u,
         RejectReason.MinQtyNotMet => 0u,
         RejectReason.InvalidField => 11u,

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -235,6 +235,20 @@ public sealed class HttpServer : IAsyncDisposable
             async (long securityId, HttpContext ctx) =>
                 await HandleSetPhaseAsync(ctx, securityId).ConfigureAwait(false));
 
+        // Issue #322: operator-initiated single-stock halt and resume.
+        // Halt body: { "reason": "RegulatoryHalt"|..., "note": "..." }.
+        // Resume body: empty or { } — phase is preserved by the engine.
+        // 200 on state change with structured outcome; 409 when re-halt
+        // is a no-op (already halted) or resume targets an unhalted
+        // instrument; 404 unknown securityId; 503 inbound queue full;
+        // 400 malformed body; 504 dispatcher wedged.
+        app.MapPost("/admin/instruments/{securityId:long}/halt",
+            async (long securityId, HttpContext ctx) =>
+                await HandleHaltAsync(ctx, securityId).ConfigureAwait(false));
+        app.MapPost("/admin/instruments/{securityId:long}/resume",
+            async (long securityId, HttpContext ctx) =>
+                await HandleResumeAsync(ctx, securityId).ConfigureAwait(false));
+
         await app.StartAsync(ct).ConfigureAwait(false);
         _app = app;
 
@@ -668,6 +682,245 @@ public sealed class HttpServer : IAsyncDisposable
         public string? TargetPhase { get; set; }
         [System.Text.Json.Serialization.JsonPropertyName("asOf")]
         public ulong? AsOf { get; set; }
+    }
+
+    private sealed class HaltRequest
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("reason")]
+        public string? Reason { get; set; }
+        [System.Text.Json.Serialization.JsonPropertyName("note")]
+        public string? Note { get; set; }
+    }
+
+    private async Task<IResult> HandleHaltAsync(HttpContext ctx, long securityId)
+    {
+        if (!_instrumentRouting.TryGetValue(securityId, out var disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown securityId {securityId}\n", "text/plain");
+        }
+        HaltRequest? body;
+        try
+        {
+            body = await System.Text.Json.JsonSerializer.DeserializeAsync<HaltRequest>(
+                ctx.Request.Body, AdminJsonOptions, ctx.RequestAborted).ConfigureAwait(false);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"malformed body: {ex.Message}\n", "text/plain");
+        }
+        if (body is null || string.IsNullOrWhiteSpace(body.Reason))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("body must contain non-empty 'reason'\n", "text/plain");
+        }
+        if (!Enum.TryParse<B3.Exchange.Matching.HaltReason>(body.Reason, ignoreCase: true, out var reason)
+            || reason == default
+            || !Enum.IsDefined(typeof(B3.Exchange.Matching.HaltReason), reason))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"unknown reason '{body.Reason}'\n", "text/plain");
+        }
+
+        var tcs = new TaskCompletionSource<HaltOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!disp.EnqueueOperatorHalt(securityId, reason, body.Note, tcs))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {disp.ChannelNumber} inbound queue full\n", "text/plain");
+        }
+
+        HaltOutcome outcome;
+        try
+        {
+            outcome = await tcs.Task.WaitAsync(PhaseChangeTimeout, ctx.RequestAborted).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status504GatewayTimeout;
+            return Results.Text("timed out waiting for halt\n", "text/plain");
+        }
+        catch (KeyNotFoundException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"not found: {ex.Message}\n", "text/plain");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+            return Results.Text($"halt rejected: {ex.Message}\n", "text/plain");
+        }
+        catch (Exception ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"halt failed: {ex.Message}\n", "text/plain");
+        }
+
+        // Issue #322 review (gpt-5.5): halt is idempotent per the contract
+        // ("re-halt mesma reason = no-op + 200"). A no-op halt returns 200
+        // with alreadyHalted=true so operator tooling can distinguish a
+        // newly-applied halt from a redundant one without treating idempotent
+        // calls as errors. Resume keeps 409 for not-halted (handled below).
+        if (outcome.StateChanged) _metrics.IncInstrumentHalted(securityId, reason);
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        return Results.Text(SerializeHaltOutcome(outcome, alreadyHalted: !outcome.StateChanged), "application/json");
+    }
+
+    private sealed class ResumeRequest
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("phase")]
+        public string? Phase { get; set; }
+    }
+
+    private async Task<IResult> HandleResumeAsync(HttpContext ctx, long securityId)
+    {
+        if (!_instrumentRouting.TryGetValue(securityId, out var disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown securityId {securityId}\n", "text/plain");
+        }
+
+        // Issue #322 review (gpt-5.5): /resume optionally accepts a phase to
+        // chain a SetTradingPhase / UncrossAuction immediately after the
+        // resume succeeds. Previously the body was ignored, so callers got
+        // a misleading 200 with the phase unchanged. Body is optional;
+        // empty/missing skips the chain.
+        B3.Exchange.Matching.TradingPhase? requestedPhase = null;
+        if (ctx.Request.ContentLength > 0 || (ctx.Request.Headers.TryGetValue("Content-Type", out var ct) && ct.ToString().Contains("json", StringComparison.OrdinalIgnoreCase)))
+        {
+            ResumeRequest? body;
+            try
+            {
+                body = await System.Text.Json.JsonSerializer.DeserializeAsync<ResumeRequest>(
+                    ctx.Request.Body, AdminJsonOptions, ctx.RequestAborted).ConfigureAwait(false);
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return Results.Text($"malformed body: {ex.Message}\n", "text/plain");
+            }
+            if (body is { Phase: { Length: > 0 } phaseStr })
+            {
+                if (!Enum.TryParse<B3.Exchange.Matching.TradingPhase>(phaseStr, ignoreCase: true, out var parsed)
+                    || !Enum.IsDefined(typeof(B3.Exchange.Matching.TradingPhase), parsed))
+                {
+                    ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return Results.Text($"unknown phase '{phaseStr}'\n", "text/plain");
+                }
+                requestedPhase = parsed;
+            }
+        }
+
+        var tcs = new TaskCompletionSource<HaltOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (!disp.EnqueueOperatorResume(securityId, tcs))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {disp.ChannelNumber} inbound queue full\n", "text/plain");
+        }
+
+        HaltOutcome outcome;
+        try
+        {
+            outcome = await tcs.Task.WaitAsync(PhaseChangeTimeout, ctx.RequestAborted).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status504GatewayTimeout;
+            return Results.Text("timed out waiting for resume\n", "text/plain");
+        }
+        catch (KeyNotFoundException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"not found: {ex.Message}\n", "text/plain");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+            return Results.Text($"resume rejected: {ex.Message}\n", "text/plain");
+        }
+        catch (Exception ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"resume failed: {ex.Message}\n", "text/plain");
+        }
+
+        if (!outcome.StateChanged)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+            return Results.Text(SerializeHaltOutcome(outcome), "application/json");
+        }
+        _metrics.IncInstrumentResumed(securityId);
+
+        // Chain optional phase change. Errors here do NOT roll back the
+        // resume (already applied + persisted); we surface a 200 with a
+        // chainedPhaseError field so the caller can react.
+        string? chainedPhase = null;
+        string? chainError = null;
+        if (requestedPhase is { } target)
+        {
+            chainedPhase = target.ToString();
+            disp.TryGetPhaseSnapshot(securityId, out var current);
+            bool useUncross =
+                (current == B3.Exchange.Matching.TradingPhase.Reserved && target == B3.Exchange.Matching.TradingPhase.Open) ||
+                (current == B3.Exchange.Matching.TradingPhase.FinalClosingCall && target == B3.Exchange.Matching.TradingPhase.Close);
+            var phaseTcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+            bool enqueued = useUncross
+                ? disp.EnqueueOperatorUncrossAuction(securityId, target, phaseTcs)
+                : disp.EnqueueOperatorSetTradingPhase(securityId, target, phaseTcs);
+            if (!enqueued)
+            {
+                chainError = "queue full";
+            }
+            else
+            {
+                try
+                {
+                    var phaseOutcome = await phaseTcs.Task.WaitAsync(PhaseChangeTimeout, ctx.RequestAborted).ConfigureAwait(false);
+                    _metrics.IncPhaseTransition(securityId, phaseOutcome.PreviousPhase, phaseOutcome.CurrentPhase, "operator");
+                }
+                catch (Exception ex)
+                {
+                    chainError = ex.Message;
+                }
+            }
+        }
+
+        ctx.Response.StatusCode = StatusCodes.Status200OK;
+        return Results.Text(SerializeHaltOutcome(outcome, chainedPhase: chainedPhase, chainError: chainError), "application/json");
+    }
+
+    private static string SerializeHaltOutcome(HaltOutcome o, bool? alreadyHalted = null, string? chainedPhase = null, string? chainError = null)
+    {
+        var sb = new System.Text.StringBuilder(128);
+        sb.Append("{\"stateChanged\":").Append(o.StateChanged ? "true" : "false")
+          .Append(",\"isHaltedNow\":").Append(o.IsHaltedNow ? "true" : "false");
+        if (alreadyHalted is { } ah)
+        {
+            sb.Append(",\"alreadyHalted\":").Append(ah ? "true" : "false");
+        }
+        if (o.Reason is { } r)
+        {
+            sb.Append(",\"reason\":\"").Append(r.ToString()).Append('"');
+        }
+        if (o.HaltedAtNanos != 0UL)
+        {
+            sb.Append(",\"haltedAtNanos\":")
+              .Append(o.HaltedAtNanos.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        if (!string.IsNullOrEmpty(o.Note))
+        {
+            sb.Append(",\"note\":\"").Append(JsonEscape(o.Note)).Append('"');
+        }
+        if (!string.IsNullOrEmpty(chainedPhase))
+        {
+            sb.Append(",\"chainedPhase\":\"").Append(JsonEscape(chainedPhase)).Append('"');
+        }
+        if (!string.IsNullOrEmpty(chainError))
+        {
+            sb.Append(",\"chainedPhaseError\":\"").Append(JsonEscape(chainError)).Append('"');
+        }
+        sb.Append('}');
+        return sb.ToString();
     }
 
     private static IPEndPoint ParseEndpoint(string s)

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -87,6 +87,27 @@ public enum RejectReason : byte
     /// (e.g. <see cref="NewOrderCommand.MinQty"/> &gt;
     /// <see cref="NewOrderCommand.Quantity"/>). Issue #203.</summary>
     InvalidField,
+    /// <summary>The instrument has been administratively halted via the
+    /// halt/resume operator API (issue #322). New orders and replaces are
+    /// rejected with this reason; cancels are allowed so participants can
+    /// pull resting orders during the halt.</summary>
+    InstrumentHalted,
+}
+
+/// <summary>
+/// Reason an instrument was placed into administrative halt by the
+/// operator halt/resume API (issue #322). Carried on the outbound
+/// <c>SecurityStatus_3</c> frame's <c>securityTradingEvent</c> byte
+/// (best-effort mapping to FIX SecurityTradingEvent values) and on
+/// the engine-level <c>InstrumentHaltedEvent</c> for downstream
+/// observability.
+/// </summary>
+public enum HaltReason : byte
+{
+    RegulatoryHalt = 1,
+    VolatilityCircuitBreaker = 2,
+    NewsHold = 3,
+    PendingDisclosure = 4,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -26,11 +26,21 @@ public sealed record EngineStateSnapshot(
     uint RptSeq,
     IReadOnlyList<EngineStateSnapshot.PhaseEntry> Phases,
     IReadOnlyList<EngineStateSnapshot.BookSnapshot> Books,
-    IReadOnlyList<RestingStopRecord>? Stops = null)
+    IReadOnlyList<RestingStopRecord>? Stops = null,
+    IReadOnlyList<EngineStateSnapshot.HaltEntry>? Halts = null)
 {
     public sealed record PhaseEntry(long SecurityId, TradingPhase Phase);
 
     public sealed record BookSnapshot(long SecurityId, IReadOnlyList<RestingOrderRecord> Orders);
+
+    /// <summary>
+    /// Issue #322: per-instrument administrative-halt overlay entry.
+    /// Captured by <see cref="MatchingEngine.CaptureState"/> so a halted
+    /// instrument stays halted across a process restart. Snapshots
+    /// produced before #322 deserialise with <see cref="Halts"/> null →
+    /// treated as "no halts", preserving backward compatibility.
+    /// </summary>
+    public sealed record HaltEntry(long SecurityId, byte Reason, ulong HaltedAtNanos, string? Note);
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -312,6 +312,36 @@ public readonly record struct OrderModifiedEvent(
     uint RptSeq);
 
 /// <summary>
+/// Fired when an instrument is placed into administrative halt via
+/// <see cref="MatchingEngine.HaltInstrument"/> (issue #322). The
+/// integration layer translates this to a UMDF
+/// <c>SecurityStatus_3</c> frame carrying the current
+/// <see cref="TradingPhase"/> as <c>securityTradingStatus</c> and a
+/// halt-marker as <c>securityTradingEvent</c>. While halted the
+/// engine rejects new orders and replaces with
+/// <see cref="RejectReason.InstrumentHalted"/>; cancels of resting
+/// orders are still accepted.
+/// </summary>
+public readonly record struct InstrumentHaltedEvent(
+    long SecurityId,
+    HaltReason Reason,
+    string? Note,
+    ulong TransactTimeNanos,
+    uint RptSeq);
+
+/// <summary>
+/// Fired when an instrument is resumed from administrative halt via
+/// <see cref="MatchingEngine.ResumeInstrument"/> (issue #322). The
+/// integration layer translates this to a UMDF
+/// <c>SecurityStatus_3</c> frame with the engine's preserved phase
+/// and a resume-marker on <c>securityTradingEvent</c>.
+/// </summary>
+public readonly record struct InstrumentResumedEvent(
+    long SecurityId,
+    ulong TransactTimeNanos,
+    uint RptSeq);
+
+/// <summary>
 /// from any of these methods — the engine is single-threaded per channel and
 /// reentrant commands corrupt internal linked lists.
 /// </summary>
@@ -408,4 +438,19 @@ public interface IMatchingEventSink
     /// when the uncross drained no volume.
     /// </summary>
     void OnAuctionPrint(in AuctionPrintEvent e) { }
+
+    /// <summary>
+    /// Issue #322: fired when an instrument enters administrative halt.
+    /// Default no-op; the production <c>ChannelDispatcher</c> overrides
+    /// this to emit a UMDF <c>SecurityStatus_3</c> frame.
+    /// </summary>
+    void OnInstrumentHalted(in InstrumentHaltedEvent e) { }
+
+    /// <summary>
+    /// Issue #322: fired when an instrument is resumed from
+    /// administrative halt. Default no-op; the production
+    /// <c>ChannelDispatcher</c> overrides this to emit a UMDF
+    /// <c>SecurityStatus_3</c> frame.
+    /// </summary>
+    void OnInstrumentResumed(in InstrumentResumedEvent e) { }
 }

--- a/src/B3.Exchange.Matching/HaltState.cs
+++ b/src/B3.Exchange.Matching/HaltState.cs
@@ -1,0 +1,8 @@
+namespace B3.Exchange.Matching;
+
+/// <summary>
+/// Issue #322: per-instrument administrative-halt overlay carried by the
+/// <see cref="MatchingEngine"/>. Public so the dispatcher / HTTP layer
+/// can resolve halt details when reporting outcomes back to operators.
+/// </summary>
+public readonly record struct HaltState(HaltReason Reason, ulong HaltedAtNanos, string? Note);

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -84,6 +84,18 @@ public sealed class MatchingEngine
 
     private bool _dispatching;
 
+    // Issue #322: per-instrument administrative-halt overlay. While an
+    // entry is present here, Submit and Replace are short-circuited
+    // with RejectReason.InstrumentHalted before any other validation.
+    // Cancel paths are intentionally NOT gated so participants can pull
+    // resting orders during a halt (consistent with B3 behaviour). The
+    // engine's TradingPhase is preserved across halt/resume so resuming
+    // restores trading without losing the book.
+    private readonly Dictionary<long, HaltState> _haltById = new();
+
+    // HaltState lives at namespace scope — see HaltState.cs.
+
+
     // Single-thread invariant (issue #169). Latched on first call to any
     // mutation/read entry point (or eagerly via BindToDispatchThread) so
     // future call-site regressions are caught at test time. Production
@@ -171,7 +183,18 @@ public sealed class MatchingEngine
                     EnteredAtNanos: s.EnteredAtNanos));
             }
         }
-        return new EngineStateSnapshot(_nextOrderId, _nextTradeId, _rptSeq, phases, books, stops);
+        // Issue #322: capture per-instrument administrative halts so the
+        // overlay survives a restart. Empty list is collapsed to null at
+        // the codec layer to keep encode→decode→encode byte-stable for
+        // hosts that never halted anything.
+        List<EngineStateSnapshot.HaltEntry>? halts = null;
+        if (_haltById.Count > 0)
+        {
+            halts = new List<EngineStateSnapshot.HaltEntry>(_haltById.Count);
+            foreach (var kv in _haltById)
+                halts.Add(new EngineStateSnapshot.HaltEntry(kv.Key, (byte)kv.Value.Reason, kv.Value.HaltedAtNanos, kv.Value.Note));
+        }
+        return new EngineStateSnapshot(_nextOrderId, _nextTradeId, _rptSeq, phases, books, stops, halts);
     }
 
     /// <summary>
@@ -198,6 +221,8 @@ public sealed class MatchingEngine
         }
         if (_stopById.Count != 0)
             throw new InvalidOperationException("RestoreState requires no parked stops on the target engine");
+        if (_haltById.Count != 0)
+            throw new InvalidOperationException("RestoreState requires no halt overlay on the target engine");
 
         _nextOrderId = snapshot.NextOrderId;
         _nextTradeId = snapshot.NextTradeId;
@@ -257,6 +282,21 @@ public sealed class MatchingEngine
                 restoredStops++;
             }
         }
+        // Issue #322: rebuild administrative-halt overlay. Snapshots
+        // predating #322 carry null Halts, treated as empty so older
+        // state files keep loading.
+        if (snapshot.Halts is { } haltRecords)
+        {
+            foreach (var h in haltRecords)
+            {
+                if (!_phaseById.ContainsKey(h.SecurityId))
+                {
+                    _logger.LogWarning("RestoreState: ignoring halt entry for unknown securityId {SecurityId}", h.SecurityId);
+                    continue;
+                }
+                _haltById[h.SecurityId] = new HaltState((HaltReason)h.Reason, h.HaltedAtNanos, h.Note);
+            }
+        }
         _logger.LogInformation("RestoreState complete: nextOrderId={NextOrderId} nextTradeId={NextTradeId} rptSeq={RptSeq} restingOrders={RestingOrders} restingStops={RestingStops}",
             _nextOrderId, _nextTradeId, _rptSeq, restored, restoredStops);
     }
@@ -297,6 +337,7 @@ public sealed class MatchingEngine
         foreach (var book in _booksById.Values) book.Clear();
         foreach (var list in _stopsBySymbol.Values) list.Clear();
         _stopById.Clear();
+        _haltById.Clear();
         _rptSeq = 0;
     }
 
@@ -361,6 +402,72 @@ public sealed class MatchingEngine
             TransactTimeNanos: txnNanos,
             RptSeq: ++_rptSeq));
         return true;
+    }
+
+    /// <summary>
+    /// <summary>
+    /// Issue #322: places <paramref name="securityId"/> into administrative
+    /// halt. Idempotent — returns <c>true</c> if the call flipped the
+    /// instrument from "not halted" to "halted" (and emitted an
+    /// <see cref="InstrumentHaltedEvent"/>); returns <c>false</c> if the
+    /// instrument was already halted (no event emitted, no state change).
+    /// While halted, Submit and Replace are rejected with
+    /// <see cref="RejectReason.InstrumentHalted"/>; Cancel is allowed.
+    /// Throws <see cref="KeyNotFoundException"/> if the security is
+    /// unknown to this channel. Must run on the dispatch thread; not
+    /// re-entrant from inside a sink callback.
+    /// </summary>
+    public bool HaltInstrument(long securityId, HaltReason reason, string? note, ulong txnNanos)
+    {
+        AssertOnOwnerThread();
+        if (_dispatching)
+            throw new InvalidOperationException("HaltInstrument called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
+        if (!_phaseById.ContainsKey(securityId))
+            throw new KeyNotFoundException($"unknown securityId {securityId}");
+        if (_haltById.ContainsKey(securityId)) return false;
+        _haltById[securityId] = new HaltState(reason, txnNanos, note);
+        _sink.OnInstrumentHalted(new InstrumentHaltedEvent(
+            SecurityId: securityId,
+            Reason: reason,
+            Note: note,
+            TransactTimeNanos: txnNanos,
+            RptSeq: ++_rptSeq));
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #322: resumes <paramref name="securityId"/> from administrative
+    /// halt. Idempotent — returns <c>true</c> if the call flipped the
+    /// instrument from halted to not-halted (and emitted an
+    /// <see cref="InstrumentResumedEvent"/>); returns <c>false</c> if the
+    /// instrument was not halted (no event emitted, no state change).
+    /// Throws <see cref="KeyNotFoundException"/> if the security is
+    /// unknown to this channel.
+    /// </summary>
+    public bool ResumeInstrument(long securityId, ulong txnNanos)
+    {
+        AssertOnOwnerThread();
+        if (_dispatching)
+            throw new InvalidOperationException("ResumeInstrument called from inside a sink callback. Operator commands must not interleave with engine dispatch.");
+        if (!_phaseById.ContainsKey(securityId))
+            throw new KeyNotFoundException($"unknown securityId {securityId}");
+        if (!_haltById.Remove(securityId)) return false;
+        _sink.OnInstrumentResumed(new InstrumentResumedEvent(
+            SecurityId: securityId,
+            TransactTimeNanos: txnNanos,
+            RptSeq: ++_rptSeq));
+        return true;
+    }
+
+    /// <summary>
+    /// Issue #322: returns <c>true</c> with the populated halt state when
+    /// <paramref name="securityId"/> is currently halted, <c>false</c>
+    /// otherwise. Read on the dispatch thread.
+    /// </summary>
+    public bool IsHalted(long securityId, out HaltState state)
+    {
+        AssertOnOwnerThread();
+        return _haltById.TryGetValue(securityId, out state);
     }
 
     /// <summary>
@@ -640,6 +747,15 @@ public sealed class MatchingEngine
                 return;
             }
 
+            // Issue #322: administrative halt overlay short-circuits before
+            // any other validation. Cancels of resting orders remain
+            // permitted (handled in Cancel below).
+            if (_haltById.ContainsKey(cmd.SecurityId))
+            {
+                Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InstrumentHalted, cmd.EnteredAtNanos);
+                return;
+            }
+
             // #201: trading-phase gating combined with #202 TIF semantics.
             // Day/IOC/FOK/GTC require Open. AtClose requires FinalClosingCall.
             // GoodForAuction requires Reserved (pre-open auction). GTD is
@@ -913,6 +1029,10 @@ public sealed class MatchingEngine
         {
             if (!_rulesById.TryGetValue(cmd.SecurityId, out var rules))
             { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnknownInstrument, cmd.EnteredAtNanos); return; }
+            // Issue #322: replace under an administrative halt is rejected
+            // before mutating the resting order. Cancel remains allowed.
+            if (_haltById.ContainsKey(cmd.SecurityId))
+            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.InstrumentHalted, cmd.EnteredAtNanos); return; }
             var book = _booksById[cmd.SecurityId];
             if (!book.TryGet(cmd.OrderId, out var resting))
             { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnknownOrderId, cmd.EnteredAtNanos); return; }

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -124,6 +124,30 @@ public static class BinaryChannelStateSnapshotCodec
         w.WriteUVarInt((ulong)snapshot.Owners.Count);
         foreach (var o in snapshot.Owners) WriteOwner(w, o);
 
+        // Issue #322 (codec v3): per-instrument administrative-halt
+        // overlay. Older snapshots (v1/v2) never carried halts; skip
+        // writing the section so encode→decode→encode is byte-stable
+        // for legacy fixtures.
+        if (snapshot.Version >= 3)
+        {
+            var halts = engine.Halts;
+            if (halts is null)
+            {
+                w.WriteUVarInt(0);
+            }
+            else
+            {
+                w.WriteUVarInt((ulong)halts.Count);
+                foreach (var h in halts)
+                {
+                    w.WriteInt64(h.SecurityId);
+                    w.WriteByte(h.Reason);
+                    w.WriteUInt64(h.HaltedAtNanos);
+                    w.WriteString(h.Note);
+                }
+            }
+        }
+
         // Issue #285: append a 4-byte little-endian Crc32C footer
         // covering every preceding byte. Loaders compare the
         // computed CRC against this footer before invoking the
@@ -229,6 +253,28 @@ public static class BinaryChannelStateSnapshotCodec
         var owners = new OrderOwnerSnapshot[ownerCount];
         for (ulong i = 0; i < ownerCount; i++) owners[i] = ReadOwner(ref r, version);
 
+        // Issue #322 (codec v3): halts overlay appears only in v3+ files.
+        // Older snapshots round-trip with no halts (none could exist).
+        IReadOnlyList<EngineStateSnapshot.HaltEntry>? halts = null;
+        if (version >= 3)
+        {
+            ulong haltCount = ReadBoundedCount(ref r, bytes.Length, "halt");
+            if (haltCount > 0)
+            {
+                var arr = new EngineStateSnapshot.HaltEntry[haltCount];
+                for (ulong i = 0; i < haltCount; i++)
+                {
+                    long secId = r.ReadInt64();
+                    byte reason = r.ReadByte();
+                    ulong ts = r.ReadUInt64();
+                    string note = r.ReadString();
+                    arr[i] = new EngineStateSnapshot.HaltEntry(
+                        secId, reason, ts, string.IsNullOrEmpty(note) ? null : note);
+                }
+                halts = arr;
+            }
+        }
+
         if (hasVerifiedFooter)
         {
             // CRC was already verified by Decode(); the body span
@@ -273,7 +319,7 @@ public static class BinaryChannelStateSnapshotCodec
             }
         }
 
-        var engine = new EngineStateSnapshot(nextOrderId, nextTradeId, rptSeq, phases, books, stops);
+        var engine = new EngineStateSnapshot(nextOrderId, nextTradeId, rptSeq, phases, books, stops, halts);
         // Issue #319: a v1 file is wire-compatible with v2 except every
         // owner record is missing the trailing OriginalQty/CumQty pair —
         // ReadOwner handles that by defaulting both to 0, and the
@@ -283,7 +329,10 @@ public static class BinaryChannelStateSnapshotCodec
         // version check accept the migrated payload without a separate
         // JSON-style migration shim (none is needed because no field
         // semantics changed).
-        int effectiveVersion = version == 1 ? ChannelStateSnapshot.CurrentVersion : version;
+        // Issue #322: v2 → v3 is also a clean migration — v2 files have no
+        // halts section, and the decoder above leaves <c>halts</c> null,
+        // so re-stamping here is safe.
+        int effectiveVersion = (version == 1 || version == 2) ? ChannelStateSnapshot.CurrentVersion : version;
         return new ChannelStateSnapshot(effectiveVersion, channelNumber, sequenceNumber, sequenceVersion, engine, owners)
         {
             LastAppliedSeq = lastAppliedSeq,

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -890,4 +890,78 @@ public class ChannelDispatcherTests
         Assert.True(disp.TryGetPhaseSnapshot(Petr, out var phase));
         Assert.Equal(B3.Exchange.Matching.TradingPhase.Pause, phase);
     }
+
+    // ===== Issue #322 =====
+
+    [Fact]
+    public async Task Issue322_OperatorHaltInstrument_RejectsSubsequentOrdersAndPopulatesSnapshot()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var session = new FakeSession(outbound);
+
+        var tcs = new TaskCompletionSource<HaltOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorHalt(Petr, B3.Exchange.Matching.HaltReason.RegulatoryHalt, "manual", tcs));
+        DrainInbound(disp);
+
+        var outcome = await tcs.Task;
+        Assert.True(outcome.StateChanged);
+        Assert.True(outcome.IsHaltedNow);
+        Assert.Equal(B3.Exchange.Matching.HaltReason.RegulatoryHalt, outcome.Reason);
+        Assert.Equal("manual", outcome.Note);
+
+        Assert.True(disp.TryGetHaltSnapshot(Petr, out var snap));
+        Assert.Equal(B3.Exchange.Matching.HaltReason.RegulatoryHalt, snap.Reason);
+
+        // Subsequent NewOrder is rejected back to the originating session.
+        session.Rejects.Clear();
+        disp.EnqueueNewOrder(new NewOrderCommand("X", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, session.EnteringFirm, 1_000UL),
+            session.Id, session.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        var rej = Assert.Single(session.Rejects);
+        Assert.Equal(B3.Exchange.Matching.RejectReason.InstrumentHalted, rej.Reason);
+    }
+
+    [Fact]
+    public async Task Issue322_OperatorResumeInstrument_RestoresOrderAcceptanceAndClearsSnapshot()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var session = new FakeSession(outbound);
+
+        Assert.True(disp.EnqueueOperatorHalt(Petr, B3.Exchange.Matching.HaltReason.NewsHold, null));
+        DrainInbound(disp);
+        Assert.True(disp.TryGetHaltSnapshot(Petr, out _));
+
+        var resumeTcs = new TaskCompletionSource<HaltOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorResume(Petr, resumeTcs));
+        DrainInbound(disp);
+
+        var outcome = await resumeTcs.Task;
+        Assert.True(outcome.StateChanged);
+        Assert.False(outcome.IsHaltedNow);
+        Assert.False(disp.TryGetHaltSnapshot(Petr, out _));
+
+        // New order now accepted again.
+        session.News.Clear();
+        session.Rejects.Clear();
+        disp.EnqueueNewOrder(new NewOrderCommand("Y", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, session.EnteringFirm, 2_000UL),
+            session.Id, session.EnteringFirm, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+        Assert.Empty(session.Rejects);
+        Assert.Single(session.News);
+    }
+
+    [Fact]
+    public void Issue322_OperatorPhaseChange_WhileHalted_FaultsCompletionWithInvalidOperation()
+    {
+        var (disp, _, _) = NewDispatcher();
+        Assert.True(disp.EnqueueOperatorHalt(Petr, B3.Exchange.Matching.HaltReason.RegulatoryHalt, null));
+        DrainInbound(disp);
+
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Pause, tcs));
+        DrainInbound(disp);
+
+        Assert.True(tcs.Task.IsFaulted);
+        Assert.IsType<InvalidOperationException>(tcs.Task.Exception!.InnerException);
+    }
 }

--- a/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/EnumMappingTests.cs
@@ -200,6 +200,7 @@ public class EnumMappingTests
         MatchingRejectReason.InvalidTimeInForceForMarket => OrdRejReason.UnsupportedOrderCharacteristic,
         MatchingRejectReason.SelfTradePrevention => OrdRejReason.Other,
         MatchingRejectReason.MarketClosed => OrdRejReason.ExchangeClosed,
+        MatchingRejectReason.InstrumentHalted => OrdRejReason.ExchangeClosed,
         MatchingRejectReason.TimeInForceNotSupported => OrdRejReason.UnsupportedOrderCharacteristic,
         MatchingRejectReason.MinQtyNotMet => OrdRejReason.Other,
         MatchingRejectReason.InvalidField => OrdRejReason.UnsupportedOrderCharacteristic,

--- a/tests/B3.Exchange.Host.Tests/HttpServerHaltTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerHaltTests.cs
@@ -1,0 +1,252 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using B3.Exchange.Core;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #322: end-to-end tests for POST /admin/instruments/{id}/halt and
+/// /resume. Mirrors <see cref="HttpServerPhaseTests"/>.
+/// </summary>
+public class HttpServerHaltTests
+{
+    private sealed class RecordingSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath}");
+    }
+
+    private static (HostConfig cfg, IUmdfPacketSink sink) BuildConfig()
+    {
+        var cfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 10_000 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 92,
+                    IncrementalGroup = "239.255.42.92",
+                    IncrementalPort = 30192,
+                    Ttl = 0,
+                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+        return (cfg, new RecordingSink());
+    }
+
+    private static long FirstSecurityId(HostConfig cfg)
+    {
+        var path = cfg.Channels[0].InstrumentsFile;
+        var instruments = B3.Exchange.Instruments.InstrumentLoader.LoadFromFile(path);
+        return instruments[0].SecurityId;
+    }
+
+    [Fact]
+    public async Task Halt_UnknownSecurityId_Returns404()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync("/admin/instruments/9999999999/halt",
+            new { reason = "RegulatoryHalt" });
+        Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Halt_UnknownReason_Returns400()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "NotARealReason" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Halt_MissingReason_Returns400()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt", new { });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Halt_FreshInstrument_Returns200WithStateChange()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "RegulatoryHalt", note = "manual" });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("\"stateChanged\":true", body);
+        Assert.Contains("\"isHaltedNow\":true", body);
+        Assert.Contains("\"reason\":\"RegulatoryHalt\"", body);
+        Assert.Contains("\"note\":\"manual\"", body);
+    }
+
+    [Fact]
+    public async Task Halt_AlreadyHalted_Returns200WithAlreadyHaltedTrue()
+    {
+        // Issue #322 review (gpt-5.5): halt is idempotent per the contract
+        // ("re-halt mesma reason = no-op + 200"). Re-halting must return
+        // 200 with alreadyHalted=true, NOT 409.
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var first = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "RegulatoryHalt" });
+        Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+
+        var second = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "NewsHold" });
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+        var body = await second.Content.ReadAsStringAsync();
+        Assert.Contains("\"stateChanged\":false", body);
+        Assert.Contains("\"isHaltedNow\":true", body);
+        Assert.Contains("\"alreadyHalted\":true", body);
+    }
+
+    [Fact]
+    public async Task Resume_AfterHalt_Returns200WithStateChange()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "RegulatoryHalt" });
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/resume", new { });
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("\"stateChanged\":true", body);
+        Assert.Contains("\"isHaltedNow\":false", body);
+    }
+
+    [Fact]
+    public async Task Resume_NotHalted_Returns409NoStateChange()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/resume", new { });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("\"stateChanged\":false", body);
+    }
+
+    [Fact]
+    public async Task SetPhase_WhileHalted_Returns409()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "RegulatoryHalt" });
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/phase",
+            new { targetPhase = "Pause" });
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Halt_NumericReasonString_Returns400()
+    {
+        // Issue #322 review (gpt-5.5): Enum.TryParse accepts numeric
+        // strings for any byte value; ensure undefined enum values are
+        // rejected at the API boundary so they don't reach _haltById.
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "200" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Resume_WithChainedPhase_AppliesPhaseAndReports()
+    {
+        // Issue #322 review (gpt-5.5): /resume body { phase } chains a
+        // SetTradingPhase after the resume completes.
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        // Halt then resume with chained phase=Pause.
+        var haltResp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "RegulatoryHalt" });
+        Assert.Equal(HttpStatusCode.OK, haltResp.StatusCode);
+
+        var resumeResp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/resume",
+            new { phase = "Pause" });
+        Assert.Equal(HttpStatusCode.OK, resumeResp.StatusCode);
+        var body = await resumeResp.Content.ReadAsStringAsync();
+        Assert.Contains("\"chainedPhase\":\"Pause\"", body);
+        Assert.DoesNotContain("\"chainedPhaseError\"", body);
+    }
+
+    [Fact]
+    public async Task Resume_WithUnknownChainedPhase_Returns400()
+    {
+        var (cfg, sink) = BuildConfig();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+        await host.StartAsync();
+        long secId = FirstSecurityId(cfg);
+        using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+        await client.PostAsJsonAsync($"/admin/instruments/{secId}/halt",
+            new { reason = "RegulatoryHalt" });
+
+        var resp = await client.PostAsJsonAsync($"/admin/instruments/{secId}/resume",
+            new { phase = "Bogus" });
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/InstrumentHaltTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/InstrumentHaltTests.cs
@@ -1,0 +1,149 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #322: per-instrument administrative-halt overlay on the engine.
+/// These tests pin the contract independent of the dispatcher /
+/// HTTP layer so any future refactor of the wire transport must keep
+/// the engine semantics identical.
+/// </summary>
+public class InstrumentHaltTests
+{
+    [Fact]
+    public void HaltInstrument_FirstCall_EmitsEventAndReportsHalted()
+    {
+        var eng = NewEngine(out var sink);
+        bool changed = eng.HaltInstrument(PetrSecId, HaltReason.RegulatoryHalt, "manual", txnNanos: 1000UL);
+        Assert.True(changed);
+        var evt = Assert.Single(sink.Halted);
+        Assert.Equal(PetrSecId, evt.SecurityId);
+        Assert.Equal(HaltReason.RegulatoryHalt, evt.Reason);
+        Assert.Equal("manual", evt.Note);
+        Assert.Equal(1000UL, evt.TransactTimeNanos);
+        Assert.True(eng.IsHalted(PetrSecId, out var state));
+        Assert.Equal(HaltReason.RegulatoryHalt, state.Reason);
+        Assert.Equal(1000UL, state.HaltedAtNanos);
+        Assert.Equal("manual", state.Note);
+    }
+
+    [Fact]
+    public void HaltInstrument_RepeatedCall_IsIdempotentNoEvent()
+    {
+        var eng = NewEngine(out var sink);
+        eng.HaltInstrument(PetrSecId, HaltReason.RegulatoryHalt, null, 1000UL);
+        sink.Clear();
+        bool changed = eng.HaltInstrument(PetrSecId, HaltReason.NewsHold, "ignored", 2000UL);
+        Assert.False(changed);
+        Assert.Empty(sink.Halted);
+        Assert.True(eng.IsHalted(PetrSecId, out var state));
+        // First-write-wins: re-halt does not overwrite reason/note.
+        Assert.Equal(HaltReason.RegulatoryHalt, state.Reason);
+        Assert.Equal(1000UL, state.HaltedAtNanos);
+    }
+
+    [Fact]
+    public void HaltInstrument_UnknownSecurity_Throws()
+    {
+        var eng = NewEngine(out _);
+        Assert.Throws<KeyNotFoundException>(() =>
+            eng.HaltInstrument(securityId: 999_999L, HaltReason.RegulatoryHalt, null, 1000UL));
+    }
+
+    [Fact]
+    public void Submit_WhileHalted_RejectsWithInstrumentHaltedReason()
+    {
+        var eng = NewEngine(out var sink);
+        eng.HaltInstrument(PetrSecId, HaltReason.VolatilityCircuitBreaker, null, 1000UL);
+        sink.Clear();
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day,
+            Px(10m), 100, 11, 2000));
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InstrumentHalted, rej.Reason);
+        Assert.Empty(sink.Accepted);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void Replace_WhileHalted_RejectsWithInstrumentHaltedReason()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day,
+            Px(10m), 100, 11, 1000));
+        var orderId = Assert.Single(sink.Accepted).OrderId;
+        eng.HaltInstrument(PetrSecId, HaltReason.NewsHold, null, 2000UL);
+        sink.Clear();
+        eng.Replace(new ReplaceOrderCommand("c1r", PetrSecId, orderId, Px(11m), 100, 3000UL));
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InstrumentHalted, rej.Reason);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void Cancel_WhileHalted_StillAllowed()
+    {
+        // Per spec: traders can pull resting orders during halt.
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day,
+            Px(10m), 100, 11, 1000));
+        var orderId = Assert.Single(sink.Accepted).OrderId;
+        eng.HaltInstrument(PetrSecId, HaltReason.PendingDisclosure, null, 2000UL);
+        sink.Clear();
+        eng.Cancel(new CancelOrderCommand("x", PetrSecId, orderId, 3000UL));
+        Assert.Single(sink.Canceled);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void ResumeInstrument_AfterHalt_EmitsEventAndAllowsNewOrders()
+    {
+        var eng = NewEngine(out var sink);
+        eng.HaltInstrument(PetrSecId, HaltReason.RegulatoryHalt, null, 1000UL);
+        sink.Clear();
+        bool changed = eng.ResumeInstrument(PetrSecId, txnNanos: 2000UL);
+        Assert.True(changed);
+        var evt = Assert.Single(sink.Resumed);
+        Assert.Equal(PetrSecId, evt.SecurityId);
+        Assert.Equal(2000UL, evt.TransactTimeNanos);
+        Assert.False(eng.IsHalted(PetrSecId, out _));
+        sink.Clear();
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day,
+            Px(10m), 100, 11, 3000));
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void ResumeInstrument_WhenNotHalted_IsNoOp()
+    {
+        var eng = NewEngine(out var sink);
+        bool changed = eng.ResumeInstrument(PetrSecId, txnNanos: 1000UL);
+        Assert.False(changed);
+        Assert.Empty(sink.Resumed);
+    }
+
+    [Fact]
+    public void CaptureRestoreState_RoundTripsHaltOverlay()
+    {
+        var eng = NewEngine(out _);
+        eng.HaltInstrument(PetrSecId, HaltReason.VolatilityCircuitBreaker, "circuit-break", 5000UL);
+        var snap = eng.CaptureState();
+        Assert.NotNull(snap.Halts);
+        var entry = Assert.Single(snap.Halts!);
+        Assert.Equal(PetrSecId, entry.SecurityId);
+        Assert.Equal((byte)HaltReason.VolatilityCircuitBreaker, entry.Reason);
+        Assert.Equal(5000UL, entry.HaltedAtNanos);
+        Assert.Equal("circuit-break", entry.Note);
+
+        var fresh = NewEngine(out var sink2);
+        fresh.RestoreState(snap);
+        Assert.True(fresh.IsHalted(PetrSecId, out var state));
+        Assert.Equal(HaltReason.VolatilityCircuitBreaker, state.Reason);
+        Assert.Equal("circuit-break", state.Note);
+        // Submit after restore is still rejected.
+        fresh.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day,
+            Px(10m), 100, 11, 6000));
+        Assert.Equal(RejectReason.InstrumentHalted, Assert.Single(sink2.Rejects).Reason);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -48,6 +48,8 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<StopOrderCanceledEvent> StopCanceled => Events.OfType<StopOrderCanceledEvent>().ToList();
     public List<AuctionTopChangedEvent> AuctionTops => Events.OfType<AuctionTopChangedEvent>().ToList();
     public List<AuctionPrintEvent> AuctionPrints => Events.OfType<AuctionPrintEvent>().ToList();
+    public List<InstrumentHaltedEvent> Halted => Events.OfType<InstrumentHaltedEvent>().ToList();
+    public List<InstrumentResumedEvent> Resumed => Events.OfType<InstrumentResumedEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -65,4 +67,6 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnStopOrderCanceled(in StopOrderCanceledEvent e) => Events.Add(e);
     public void OnAuctionTopChanged(in AuctionTopChangedEvent e) => Events.Add(e);
     public void OnAuctionPrint(in AuctionPrintEvent e) => Events.Add(e);
+    public void OnInstrumentHalted(in InstrumentHaltedEvent e) => Events.Add(e);
+    public void OnInstrumentResumed(in InstrumentResumedEvent e) => Events.Add(e);
 }

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -186,6 +186,33 @@ public class ChannelDispatcherPersistenceTests
     }
 
     [Fact]
+    public void Issue322_RestoreChannelState_ReseedsHaltOverlay()
+    {
+        // Issue #322: same reasoning as #321 phase reseed — the HTTP
+        // routing/admin layers consult _haltSnapshot to gate phase
+        // commands and surface 409s. After restart the overlay must be
+        // rebuilt from the engine's persisted halt list.
+        var persister = new InMemoryPersister();
+
+        var dispA = BuildDispatcher(persister, out _);
+        var probe = dispA.CreateTestProbe();
+        Assert.True(dispA.EnqueueOperatorHalt(Sec, B3.Exchange.Matching.HaltReason.RegulatoryHalt, "circuit-A"));
+        probe.DrainInbound();
+        Assert.True(dispA.TryGetHaltSnapshot(Sec, out var aSnap));
+        Assert.Equal(B3.Exchange.Matching.HaltReason.RegulatoryHalt, aSnap.Reason);
+        Assert.Equal("circuit-A", aSnap.Note);
+
+        var dispB = BuildDispatcher(persister, out _);
+        var loaded = persister.TryLoad(84);
+        Assert.NotNull(loaded);
+        dispB.RestoreChannelState(loaded!);
+
+        Assert.True(dispB.TryGetHaltSnapshot(Sec, out var bSnap));
+        Assert.Equal(B3.Exchange.Matching.HaltReason.RegulatoryHalt, bSnap.Reason);
+        Assert.Equal("circuit-A", bSnap.Note);
+    }
+
+    [Fact]
     public void RestoreChannelState_RejectsMismatchedChannelNumber()
     {
         var persister = new InMemoryPersister();

--- a/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
@@ -49,10 +49,9 @@ public class SnapshotMigrationTests
             var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #319: a v1 payload now passes through the v1→v2
-            // migration registered in BuildDefault(); the loaded
-            // version reflects the bumped schema.
-            Assert.Equal(2, loaded!.Version);
+            // Issue #322: chain now upgrades to v3, the new
+            // CurrentVersion (was v2 in #319).
+            Assert.Equal(3, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }
@@ -83,10 +82,10 @@ public class SnapshotMigrationTests
                 migrations: migrations);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #319: chain is 0→1 (registered here) followed by
-            // 1→2 (registered by BuildDefault), so the loaded version
-            // reflects CurrentVersion = 2.
-            Assert.Equal(2, loaded!.Version);
+            // Issue #322: chain is 0→1 (registered here) followed by
+            // 1→2 and 2→3 (registered by BuildDefault), so the loaded
+            // version reflects CurrentVersion = 3.
+            Assert.Equal(3, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }


### PR DESCRIPTION
Implements operator halt/resume for individual instruments. See commit message for details.

Closes #322