### PR TITLE
perf: eliminate RestingOrder alloc on iceberg replenish

### DIFF
--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -12,7 +12,14 @@ internal sealed class RestingOrder
     public required Side Side { get; init; }
     public required long PriceMantissa { get; init; }
     public required uint EnteringFirm { get; init; }
-    public required ulong InsertTimestampNanos { get; init; }
+
+    /// <summary>
+    /// Wall-clock timestamp at which the order entered (or last re-entered)
+    /// the book. Mutable so iceberg replenishment can update it in-place to
+    /// the trade time without allocating a fresh <see cref="RestingOrder"/>.
+    /// Issue #211 follow-up.
+    /// </summary>
+    public ulong InsertTimestampNanos;
 
     /// <summary>
     /// TIF the order was originally accepted with (Day or Gtc — the only

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -702,21 +702,15 @@ public sealed class MatchingEngine
             var icebergSide = o.Side;
             long icebergPx = o.PriceMantissa;
             long icebergOid = o.OrderId;
+            // Mutate-in-place + re-Insert. Remove clears Level/Prev/Next and
+            // the by-order-id index; Insert re-adds at the tail of the same
+            // price level, so the order loses time priority while retaining
+            // its identity (no RestingOrder allocation).
             book.Remove(o);
-            var refreshed = new RestingOrder
-            {
-                OrderId = icebergOid,
-                ClOrdId = o.ClOrdId,
-                Side = icebergSide,
-                PriceMantissa = icebergPx,
-                EnteringFirm = o.EnteringFirm,
-                InsertTimestampNanos = txnNanos,
-                RemainingQuantity = newVisible,
-                Tif = o.Tif,
-                MaxFloor = o.MaxFloor,
-                HiddenQuantity = newHidden,
-            };
-            book.Insert(refreshed);
+            o.RemainingQuantity = newVisible;
+            o.HiddenQuantity = newHidden;
+            o.InsertTimestampNanos = txnNanos;
+            book.Insert(o);
             uint deleteSeq = NextRptSeq();
             uint addSeq = NextRptSeq();
             _sink.OnIcebergReplenished(new IcebergReplenishedEvent(
@@ -1506,30 +1500,17 @@ public sealed class MatchingEngine
                             long icebergPx = maker.PriceMantissa;
                             long icebergOid = maker.OrderId;
                             // Atomically: remove from current spot, mutate
-                            // visible/hidden counters, re-insert at tail of
-                            // same level. The book.Remove + book.Insert pair
-                            // is correct even if this is the only order at
-                            // the level (Insert recreates the level).
+                            // visible/hidden counters + insert timestamp,
+                            // re-insert at tail of same level. Mutating
+                            // `maker` in place avoids allocating a fresh
+                            // RestingOrder on every iceberg replenish hot
+                            // path; identity is preserved across the
+                            // Remove/Insert pair.
                             book.Remove(maker);
                             maker.RemainingQuantity = newVisible;
                             maker.HiddenQuantity = newHidden;
-                            // Reset insert timestamp to the trade time — the
-                            // replenished slice is logically a fresh entry at
-                            // the back of the queue.
-                            var refreshed = new RestingOrder
-                            {
-                                OrderId = icebergOid,
-                                ClOrdId = maker.ClOrdId,
-                                Side = icebergSide,
-                                PriceMantissa = icebergPx,
-                                EnteringFirm = maker.EnteringFirm,
-                                InsertTimestampNanos = cmd.EnteredAtNanos,
-                                RemainingQuantity = newVisible,
-                                Tif = maker.Tif,
-                                MaxFloor = maker.MaxFloor,
-                                HiddenQuantity = newHidden,
-                            };
-                            book.Insert(refreshed);
+                            maker.InsertTimestampNanos = cmd.EnteredAtNanos;
+                            book.Insert(maker);
                             uint deleteSeq = NextRptSeq();
                             uint addSeq = NextRptSeq();
                             _sink.OnIcebergReplenished(new IcebergReplenishedEvent(


### PR DESCRIPTION
Both iceberg-refill paths in `MatchingEngine` (continuous-matching inner loop and the standalone `HandleFill` branch) previously did:

```csharp
book.Remove(maker);
var refreshed = new RestingOrder { /* copy all fields */ };
book.Insert(refreshed);
```

The fresh allocation was pure ceremony: every field except `RemainingQuantity`, `HiddenQuantity`, and `InsertTimestampNanos` was copied verbatim from `maker`, and the new instance had identical `OrderId`.

**Change:** Promote `RestingOrder.InsertTimestampNanos` from init-only to a plain mutable field (matching the existing `RemainingQuantity` / `HiddenQuantity` pattern) and mutate `maker` in place between Remove and Insert.

### Correctness
- Identity preserved across Remove/Insert (`_byOrderId` is cleared then re-added under the same key).
- Time priority still lost: `Insert` appends to the tail of the price level.
- All 1100+ tests green, including the 153 in `B3.Exchange.Matching.Tests`.

### Closes
Round-2 perf finding #18.

### Out of scope
Other init-only fields on `RestingOrder` (`OrderId`, `ClOrdId`, `Side`, `PriceMantissa`, `EnteringFirm`, `MaxFloor`, `Tif`) stay immutable — they never change for a resting order's lifetime.