### PR TITLE
perf: drop unused ClOrdId stringify on reject hot path (#16)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -309,8 +309,12 @@ public sealed partial class ChannelDispatcher
                 case WorkKind.DecodeError:
                     if (_hasCurrentSession)
                     {
+                        // RejectEvent.ClOrdId is unused by the encoder when
+                        // clOrdIdValue is passed explicitly (the encoder
+                        // prefers the ulong over ulong.TryParse(e.ClOrdId));
+                        // skip the alloc.
                         _outbound.WriteExecutionReportReject(_currentSession,
-                            new RejectEvent(_currentClOrdId.ToString(), 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
+                            new RejectEvent(string.Empty, 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
                             _currentClOrdId, CurrentDurability);
                         _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
                     }

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -203,7 +203,7 @@ public sealed class HostRouter : IInboundCommandSink
         _logger.LogWarning("rejecting clOrdId={ClOrdId} from session {Session}: unknown securityId={SecurityId}",
             clOrdIdValue, session, secId);
         _outbound.WriteExecutionReportReject(session,
-            new RejectEvent(ClOrdId: clOrdIdValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            new RejectEvent(ClOrdId: string.Empty,
                 SecurityId: secId, OrderIdOrZero: 0,
                 Reason: RejectReason.UnknownInstrument, TransactTimeNanos: _nowNanos()),
             clOrdIdValue);
@@ -214,7 +214,7 @@ public sealed class HostRouter : IInboundCommandSink
         _logger.LogWarning("rejecting clOrdId={ClOrdId} from session {Session}: unknown orderId / OrigClOrdID",
             clOrdIdValue, session);
         _outbound.WriteExecutionReportReject(session,
-            new RejectEvent(ClOrdId: clOrdIdValue.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            new RejectEvent(ClOrdId: string.Empty,
                 SecurityId: secId, OrderIdOrZero: 0,
                 Reason: RejectReason.UnknownOrderId, TransactTimeNanos: _nowNanos()),
             clOrdIdValue);


### PR DESCRIPTION
`FixpOutboundEncoder.WriteExecutionReportReject` prefers the explicit `clOrdIdValue` ulong argument over `ulong.TryParse(e.ClOrdId)` ([encoder line 71](https://github.com/pedrosakuma/B3MatchingPlatform/blob/main/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs#L71)). Every reject call site in this codebase already passes `clOrdIdValue` explicitly, so the string field on `RejectEvent` is allocated and immediately discarded — pure waste on the inbound-error hot path.

### Sites fixed
- `ChannelDispatcher.Loop.cs` (DecodeError): `_currentClOrdId.ToString()`
- `HostRouter.cs` (`RejectUnknownInstrument`): `clOrdIdValue.ToString(invariant)`
- `HostRouter.cs` (`RejectUnknownOrderId`): `clOrdIdValue.ToString(invariant)`

### Left alone
`EmitUnknownOrderIdReject` already forwards a pre-existing `cmd.ClOrdId` string — no incremental alloc.

### Behaviour
No observable change: the wire `ClOrdID` on outbound `ER_Reject` was already taken from the ulong arg, not from the string. All 1100+ tests pass.

### Closes
Round-2 perf finding #16.