### PR TITLE
diagnostics: surface BusinessMessageReject in EntryPointClient (#326 follow-up)

### DIFF
--- a/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/EntryPointClient.cs
@@ -84,6 +84,7 @@ public sealed class EntryPointClient : IAsyncDisposable
         EntryPointFrameReader.TidExecutionReportCancel => 182,
         EntryPointFrameReader.TidExecutionReportTrade => 174,
         EntryPointFrameReader.TidExecutionReportReject => 164,
+        EntryPointFrameReader.TidBusinessMessageReject => 36,
         _ => -1,
     };
 
@@ -105,6 +106,17 @@ public sealed class EntryPointClient : IAsyncDisposable
     public event Action<ExecReportTrade>? OnTrade;
     public event Action<ExecReportCancel>? OnCancel;
     public event Action<ExecReportReject>? OnReject;
+    /// <summary>
+    /// Fires when the gateway emits a session-layer <c>BusinessMessageReject</c>
+    /// (templateId 206) against an inbound business message — e.g. wrong
+    /// sessionID in the business header, throttle exceeded, or varData
+    /// validation failure. Distinct from <see cref="OnReject"/>, which
+    /// fires only on <c>ExecutionReport.Reject</c> (templateId 207, an
+    /// engine-level rejection). Before issue #326 these frames were
+    /// silently ignored on the recv loop, leaving tests with no signal
+    /// when the gateway rejected an order pre-engine.
+    /// </summary>
+    public event Action<BusinessMessageReject>? OnBusinessReject;
     public event Action<string>? OnDisconnect;
 
     public bool IsOpen => Interlocked.Read(ref _isOpen) == 1;
@@ -319,6 +331,19 @@ public sealed class EntryPointClient : IAsyncDisposable
         OrderId: BinaryPrimitives.ReadInt64LittleEndian(body.Slice(ErRejectOrderId, 8)),
         OrigClOrdId: BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(ErRejectOrigClOrdId, 8)),
         RejectReason: body[ErRejectReason]);
+
+    /// <summary>Decodes a <c>BusinessMessageReject</c> (templateId 206)
+    /// fixed block. Body layout (V0): OutboundBusinessHeader(18) +
+    /// refMsgType(1) + padding(1) + refSeqNum(uint32 @20) +
+    /// businessRejectRefID(uint64 @24) + businessRejectReason(uint32 @32).
+    /// Text varData is intentionally skipped here — callers that need it
+    /// can subscribe to <see cref="OnBusinessReject"/> and parse the raw
+    /// frame separately.</summary>
+    internal static BusinessMessageReject DecodeBusinessMessageReject(ReadOnlySpan<byte> body) => new(
+        RefMsgType: body.Length > 18 ? body[18] : (byte)0,
+        RefSeqNum: body.Length >= 24 ? BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(20, 4)) : 0u,
+        BusinessRejectRefId: body.Length >= 32 ? BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(24, 8)) : 0UL,
+        BusinessRejectReason: body.Length >= 36 ? BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(32, 4)) : 0u);
 
     private bool Enqueue(byte[] frame)
     {
@@ -555,6 +580,13 @@ public sealed class EntryPointClient : IAsyncDisposable
                         OnReject?.Invoke(er);
                         break;
                     }
+                case EntryPointFrameReader.TidBusinessMessageReject:
+                    {
+                        var bmr = DecodeBusinessMessageReject(slice);
+                        _logWarn?.Invoke($"recv BMR refMsgType={bmr.RefMsgType} refSeqNum={bmr.RefSeqNum} refId={bmr.BusinessRejectRefId} reason={bmr.BusinessRejectReason}");
+                        OnBusinessReject?.Invoke(bmr);
+                        break;
+                    }
                 default:
                     _logDebug?.Invoke($"recv ignored tid={templateId} v={version}");
                     break;
@@ -621,3 +653,4 @@ public readonly record struct ExecReportTrade(ulong ClOrdId, long SecurityId, Or
     long LastQty, long LastPxMantissa, long LeavesQty, long CumQty);
 public readonly record struct ExecReportCancel(ulong ClOrdId, long SecurityId, OrderSide Side, long OrderId);
 public readonly record struct ExecReportReject(ulong ClOrdId, long SecurityId, long OrderId, ulong OrigClOrdId, byte RejectReason);
+public readonly record struct BusinessMessageReject(byte RefMsgType, uint RefSeqNum, ulong BusinessRejectRefId, uint BusinessRejectReason);

--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -89,6 +89,12 @@ public class MultiSessionReplayTests
             ["firmA"] = clientA,
             ["firmB"] = clientB,
         };
+        // Capture any BusinessMessageReject from the gateway so #326-style
+        // silent failures (BMR was previously discarded by the recv loop)
+        // surface in the failure dump. See EntryPointClient OnBusinessReject.
+        var bmrLog = new System.Collections.Concurrent.ConcurrentQueue<string>();
+        clientA.OnBusinessReject += b => bmrLog.Enqueue($"firmA BMR refMsgType={b.RefMsgType} refSeqNum={b.RefSeqNum} refId={b.BusinessRejectRefId} reason={b.BusinessRejectReason}");
+        clientB.OnBusinessReject += b => bmrLog.Enqueue($"firmB BMR refMsgType={b.RefMsgType} refSeqNum={b.RefSeqNum} refId={b.BusinessRejectRefId} reason={b.BusinessRejectReason}");
         var runner = new ReplayRunner(sessions, "firmA", new SystemClock(speed: 10.0), capture);
 
         // firmA posts a resting bid; firmB hits it with a marketable IOC sell.
@@ -135,6 +141,8 @@ public class MultiSessionReplayTests
         // Dump captured tape on failure to make this test self-diagnosing
         // (the previous incarnations of #146 left no clue what was missing).
         var dump = "captured tape:\n  " + string.Join("\n  ", lines);
+        if (!bmrLog.IsEmpty)
+            dump += "\nBusinessMessageRejects observed:\n  " + string.Join("\n  ", bmrLog);
 
         Assert.True(lines.Any(l => l.Contains("\"session\":\"firmA\"") && l.Contains("submit_new") && l.Contains("clOrdId=1")), dump);
         Assert.True(lines.Any(l => l.Contains("\"session\":\"firmB\"") && l.Contains("submit_new") && l.Contains("clOrdId=1")), dump);

--- a/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/WireFormatCompatTests.cs
@@ -188,4 +188,24 @@ public class WireFormatCompatTests
         Assert.Equal(clOrd, er.ClOrdId);
         Assert.Equal(secId, er.SecurityId);
     }
+
+    [Fact]
+    public void BusinessMessageReject_HostEncodes_SynthTraderDecodesIdentical()
+    {
+        Span<byte> frame = stackalloc byte[BusinessMessageRejectEncoder.TotalSize(0)];
+        const uint refSeq = 0xABCD1234u;
+        const ulong refId = 0xDEADBEEFCAFEBABEUL;
+        BusinessMessageRejectEncoder.EncodeBusinessMessageReject(frame,
+            sessionId: 1, msgSeqNum: 2, sendingTimeNanos: 3,
+            refMsgType: 17, refSeqNum: refSeq, businessRejectRefId: refId,
+            businessRejectReason: BusinessMessageRejectEncoder.Reason.SystemBusy,
+            textAscii: ReadOnlySpan<byte>.Empty);
+
+        var body = frame.Slice(SbeHeaderSize, BusinessMessageRejectEncoder.BusinessRejectBlock);
+        var bmr = EntryPointClient.DecodeBusinessMessageReject(body);
+        Assert.Equal((byte)17, bmr.RefMsgType);
+        Assert.Equal(refSeq, bmr.RefSeqNum);
+        Assert.Equal(refId, bmr.BusinessRejectRefId);
+        Assert.Equal(BusinessMessageRejectEncoder.Reason.SystemBusy, bmr.BusinessRejectReason);
+    }
 }


### PR DESCRIPTION
## What

Adds a recv-loop case for FIXP `BusinessMessageReject` (templateId 206) in `EntryPointClient`, with a new `OnBusinessReject` event and `BusinessMessageReject` record. Captures BMRs in the flaky `MultiSessionReplayTests.TwoSessions_CrossingScript_LandsErTradesOnBothSides` failure dump.

## Why

Investigation of #326 found that the test's silent-drop fingerprint (firmB sends NewOrder, gets zero observable response) matches exactly what would happen if the gateway emitted a BMR — because the client recv loop dropped BMRs into `default: ignored tid=`, invisible to the test.

Gateway BMR emission paths include:
- `TryAcceptBusinessHeaderSessionId` mismatch (reason 33003)
- `WriteSystemBusyReject` on dispatcher backpressure (reason 8)
- `TryAcceptInboundThrottle`
- varData `ValidateDetailed` length-exceeded / CR-LF

This PR does **not** claim to fix the root cause of #326 (still ~10% on cold-start). It makes the next recurrence diagnosable instead of opaque.

## Test

- New `BusinessMessageReject_HostEncodes_SynthTraderDecodesIdentical` in `WireFormatCompatTests` round-trips encoder→decoder.
- Full suite green locally (1300+ tests), `dotnet format --verify-no-changes` clean.

Refs #326.