### PR TITLE
post-trade: scaffold B3.Exchange.PostTrade + IPostTradeSink wire (#329 PR-1)

### DIFF
--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -10,6 +10,7 @@
     <Project Path="src/B3.Exchange.Gateway/B3.Exchange.Gateway.csproj" />
     <Project Path="src/B3.Exchange.Core/B3.Exchange.Core.csproj" />
     <Project Path="src/B3.Exchange.Persistence/B3.Exchange.Persistence.csproj" />
+    <Project Path="src/B3.Exchange.PostTrade/B3.Exchange.PostTrade.csproj" />
     <Project Path="src/B3.Exchange.Host/B3.Exchange.Host.csproj" />
     <Project Path="src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj" />
   </Folder>
@@ -25,6 +26,7 @@
     <Project Path="tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Matching.Tests/B3.Exchange.Matching.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Persistence.Tests/B3.Exchange.Persistence.Tests.csproj" />
+    <Project Path="tests/B3.Exchange.PostTrade.Tests/B3.Exchange.PostTrade.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj" />

--- a/src/B3.Exchange.Core/B3.Exchange.Core.csproj
+++ b/src/B3.Exchange.Core/B3.Exchange.Core.csproj
@@ -9,6 +9,7 @@
     <ProjectReference Include="..\B3.Exchange.Contracts\B3.Exchange.Contracts.csproj" />
     <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
+    <ProjectReference Include="..\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
     <ProjectReference Include="..\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
   </ItemGroup>
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -1,5 +1,6 @@
 using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging;
 using Side = B3.Exchange.Matching.Side;
 
 namespace B3.Exchange.Core;
@@ -406,6 +407,42 @@ public sealed partial class ChannelDispatcher
             _outbound.WriteExecutionReportPassiveTrade(owner.Session, owner.ClOrdId, e.RestingOrderId,
                 e, leavesQty: restLeaves, cumQty: restCum, durability: CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.TradePassive);
+        }
+
+        // #329 PR-1: emit the per-trade audit record after both ER writes so
+        // the audit log's order matches the wire-published trade order. ClOrdId
+        // resolution: aggressor side uses _currentClOrdId when a session is
+        // bound; resting side uses the owner registry. A 0 on either side
+        // means "no resolvable owner" — never a valid clOrdId — which the
+        // on-disk schema in later PRs treats as unknown.
+        bool aggressorIsBuyForAudit = e.AggressorSide == Side.Buy;
+        ulong aggClOrdId = _hasCurrentSession ? _currentClOrdId : 0UL;
+        ulong restClOrdId = _orders.TryResolve(e.RestingOrderId, out var ownerForAudit) ? ownerForAudit.ClOrdId : 0UL;
+        var record = new B3.Exchange.PostTrade.PostTradeRecord(
+            TradeId: e.TradeId,
+            TransactTimeNanos: e.TransactTimeNanos,
+            SecurityId: e.SecurityId,
+            AggressorSide: e.AggressorSide,
+            Quantity: e.Quantity,
+            PriceMantissa: e.PriceMantissa,
+            BuyClOrdId: aggressorIsBuyForAudit ? aggClOrdId : restClOrdId,
+            SellClOrdId: aggressorIsBuyForAudit ? restClOrdId : aggClOrdId,
+            BuyFirm: aggressorIsBuyForAudit ? e.AggressorFirm : e.RestingFirm,
+            SellFirm: aggressorIsBuyForAudit ? e.RestingFirm : e.AggressorFirm,
+            BuyOrderId: aggressorIsBuyForAudit ? e.AggressorOrderId : e.RestingOrderId,
+            SellOrderId: aggressorIsBuyForAudit ? e.RestingOrderId : e.AggressorOrderId);
+        try
+        {
+            _postTradeSink.OnTrade(record);
+        }
+        catch (Exception ex)
+        {
+            // Audit-sink exceptions must not poison the dispatch loop. The
+            // durability watermark (PR-4) will surface persistent failures
+            // by refusing to advance auditDurableSeq, which in turn blocks
+            // WAL truncation — the operationally correct backpressure.
+            _logger.LogError(ex, "post-trade sink threw on channel {Channel} tradeId={TradeId}; record dropped",
+                ChannelNumber, e.TradeId);
         }
     }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -396,8 +396,15 @@ public sealed partial class ChannelDispatcher
         // Issue #319: per-order cum/leaves tracking lives in the
         // registry so multi-fill resting orders emit monotonic
         // (cumQty, leavesQty) and the final fill carries leaves=0.
+        ulong restClOrdIdForAudit = 0UL;
         if (_orders.TryResolve(e.RestingOrderId, out var owner))
         {
+            // Snapshot the resting ClOrdId here so the audit record below
+            // sees the same owner the passive ER did, even if the owning
+            // session is concurrently evicted by HostRouter.OnSessionClosed
+            // before we build the audit record (the registry is backed by
+            // ConcurrentDictionary, so this is observable).
+            restClOrdIdForAudit = owner.ClOrdId;
             long restCum, restLeaves;
             if (!_orders.OnTrade(e.RestingOrderId, e.Quantity, out restCum, out restLeaves))
             {
@@ -410,14 +417,20 @@ public sealed partial class ChannelDispatcher
         }
 
         // #329 PR-1: emit the per-trade audit record after both ER writes so
-        // the audit log's order matches the wire-published trade order. ClOrdId
-        // resolution: aggressor side uses _currentClOrdId when a session is
-        // bound; resting side uses the owner registry. A 0 on either side
-        // means "no resolvable owner" — never a valid clOrdId — which the
-        // on-disk schema in later PRs treats as unknown.
+        // the audit log's order matches the wire-published trade order.
+        //
+        // Aggressor ClOrdId resolution policy: prefer the registry lookup
+        // on AggressorOrderId because operator/auction work runs without a
+        // bound session (HasSession=false → _currentClOrdId is stale), yet
+        // both legs of the cross are real registered orders. Fall back to
+        // _currentClOrdId only when the aggressor side is not in the
+        // registry (e.g. a transient cross/internal print the dispatcher
+        // never registered). Resting ClOrdId is taken from the snapshot
+        // captured above to avoid the close-race second-lookup window.
+        ulong aggClOrdIdForAudit = _orders.TryResolve(e.AggressorOrderId, out var aggOwner)
+            ? aggOwner.ClOrdId
+            : (_hasCurrentSession ? _currentClOrdId : 0UL);
         bool aggressorIsBuyForAudit = e.AggressorSide == Side.Buy;
-        ulong aggClOrdId = _hasCurrentSession ? _currentClOrdId : 0UL;
-        ulong restClOrdId = _orders.TryResolve(e.RestingOrderId, out var ownerForAudit) ? ownerForAudit.ClOrdId : 0UL;
         var record = new B3.Exchange.PostTrade.PostTradeRecord(
             TradeId: e.TradeId,
             TransactTimeNanos: e.TransactTimeNanos,
@@ -425,8 +438,8 @@ public sealed partial class ChannelDispatcher
             AggressorSide: e.AggressorSide,
             Quantity: e.Quantity,
             PriceMantissa: e.PriceMantissa,
-            BuyClOrdId: aggressorIsBuyForAudit ? aggClOrdId : restClOrdId,
-            SellClOrdId: aggressorIsBuyForAudit ? restClOrdId : aggClOrdId,
+            BuyClOrdId: aggressorIsBuyForAudit ? aggClOrdIdForAudit : restClOrdIdForAudit,
+            SellClOrdId: aggressorIsBuyForAudit ? restClOrdIdForAudit : aggClOrdIdForAudit,
             BuyFirm: aggressorIsBuyForAudit ? e.AggressorFirm : e.RestingFirm,
             SellFirm: aggressorIsBuyForAudit ? e.RestingFirm : e.AggressorFirm,
             BuyOrderId: aggressorIsBuyForAudit ? e.AggressorOrderId : e.RestingOrderId,

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -206,6 +206,10 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     private readonly Func<string, bool>? _sessionExists;
     private readonly OrphanSessionPolicy _orphanPolicy;
+    // Per-channel post-trade audit sink (#329 PR-1). Defaults to
+    // NullPostTradeSink.Instance so existing callers see no behaviour
+    // change; subsequent PRs install a real append-only writer.
+    private readonly B3.Exchange.PostTrade.IPostTradeSink _postTradeSink;
     // Throttle bookkeeping (issue #267). Mutated only on the dispatch
     // loop thread → no Interlocked needed.
     private long _commandsSincePersist;
@@ -325,7 +329,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         WalAppendFailurePolicy walAppendFailurePolicy = WalAppendFailurePolicy.Continue,
         Func<string, bool>? sessionExists = null,
         OrphanSessionPolicy orphanPolicy = OrphanSessionPolicy.Drop,
-        IReadOnlyList<long>? seedSecurityIds = null)
+        IReadOnlyList<long>? seedSecurityIds = null,
+        B3.Exchange.PostTrade.IPostTradeSink? postTradeSink = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -345,6 +350,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _walAppendFailurePolicy = walAppendFailurePolicy;
         _sessionExists = sessionExists;
         _orphanPolicy = orphanPolicy;
+        _postTradeSink = postTradeSink ?? B3.Exchange.PostTrade.NullPostTradeSink.Instance;
         _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
         // Issue #268: opt-in async snapshot writer. Off by default so
         // pre-existing deployments keep the synchronous in-loop persist

--- a/src/B3.Exchange.PostTrade/B3.Exchange.PostTrade.csproj
+++ b/src/B3.Exchange.PostTrade/B3.Exchange.PostTrade.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>B3.Exchange.PostTrade</RootNamespace>
+    <AssemblyName>B3.Exchange.PostTrade</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="B3.Exchange.PostTrade.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/B3.Exchange.PostTrade/IPostTradeSink.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeSink.cs
@@ -1,0 +1,70 @@
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Self-contained, per-trade audit record. One <see cref="PostTradeRecord"/>
+/// is emitted on the dispatch thread for every <see cref="TradeEvent"/> the
+/// engine produces, immediately after the matching ER_Trade / UMDF
+/// <c>Trade_53</c> wire frames are appended to the outbound packet — so
+/// the audit-log ordering is identical to the published trade order
+/// (issue #329, ADR 0001 §2).
+///
+/// Field semantics:
+/// - <see cref="TradeId"/>: engine-monotonic per channel (from <see cref="TradeEvent.TradeId"/>).
+/// - <see cref="TransactTimeNanos"/>: nanosecond UTC of the match. The on-disk
+///   schema in subsequent PRs may quantize to microseconds per the ADR; the
+///   in-memory record carries the full nanosecond precision the engine
+///   already has so downstream consumers can choose.
+/// - <see cref="BuyClOrdId"/> / <see cref="SellClOrdId"/>: 0 when the
+///   corresponding side has no resolvable owner (e.g. cross/internal print
+///   where one leg pre-dates the registry or has already deregistered).
+///   The on-disk schema treats 0 as "unknown" — never as a valid order id.
+/// - <see cref="BuyFirm"/> / <see cref="SellFirm"/>: always present
+///   (sourced from the engine's <see cref="TradeEvent"/>).
+/// </summary>
+public readonly record struct PostTradeRecord(
+    uint TradeId,
+    ulong TransactTimeNanos,
+    long SecurityId,
+    Side AggressorSide,
+    long Quantity,
+    long PriceMantissa,
+    ulong BuyClOrdId,
+    ulong SellClOrdId,
+    uint BuyFirm,
+    uint SellFirm,
+    long BuyOrderId,
+    long SellOrderId);
+
+/// <summary>
+/// Per-channel post-trade audit log sink. Implementations MUST be safe to
+/// invoke on the <c>ChannelDispatcher</c>'s single dispatch thread and
+/// MUST NOT block on I/O in <see cref="OnTrade"/> long enough to push the
+/// dispatcher off its latency budget — the durable-flush should happen on
+/// a background writer (see <see cref="IAuditDurabilityTracker"/>, added
+/// in the watermark PR).
+///
+/// Skeleton contract (#329 PR-1). Subsequent PRs add: append-only file
+/// writer with CRC32C + daily rollover (PR-2), firm sparse index (PR-3),
+/// durability watermark gating WAL truncation (PR-4), restart
+/// replay-into-audit-only mode (PR-5), and operator config / RUNBOOK
+/// (PR-6).
+/// </summary>
+public interface IPostTradeSink
+{
+    void OnTrade(in PostTradeRecord record);
+}
+
+/// <summary>
+/// No-op sink installed by default when <see cref="ChannelDispatcher"/> is
+/// constructed without an explicit <see cref="IPostTradeSink"/>. Keeps the
+/// dispatcher's OnTrade hot-path branch-free of null-checks and lets the
+/// existing 1300+ tests run unchanged while the feature is in flight.
+/// </summary>
+public sealed class NullPostTradeSink : IPostTradeSink
+{
+    public static readonly NullPostTradeSink Instance = new();
+    private NullPostTradeSink() { }
+    public void OnTrade(in PostTradeRecord record) { }
+}

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
@@ -69,4 +69,46 @@ public partial class ChannelDispatcherTests
         Assert.Single(maker.Trades);
         Assert.Single(taker.Trades);
     }
+
+    [Fact]
+    public async Task PostTradeSink_OperatorUncrossAuction_ResolvesBothClOrdIdsFromRegistry()
+    {
+        // Regression for PR #344 review: auction uncross runs with
+        // _hasCurrentSession=false, so the audit record must NOT fall back
+        // to _currentClOrdId for the aggressor side. Both legs are
+        // registered orders → both ClOrdIds must be resolved from the
+        // owner registry.
+        var pkt = new RecordingPacketSink();
+        var outbound = new RecordingOutbound();
+        var audit = new RecordingPostTradeSink();
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL, tradeDate: 19_000,
+            postTradeSink: audit);
+        var maker = new FakeSession(outbound) { EnteringFirm = 7 };
+        var taker = new FakeSession(outbound) { EnteringFirm = 8 };
+
+        Assert.True(disp.EnqueueOperatorSetTradingPhase(Petr, B3.Exchange.Matching.TradingPhase.Reserved));
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("M", Petr, Side.Sell, OrderType.Limit, TimeInForce.GoodForAuction, Px(10m), 200, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 111UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("T", Petr, Side.Buy, OrderType.Limit, TimeInForce.GoodForAuction, Px(10m), 200, 8, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 222UL);
+        DrainInbound(disp);
+
+        var tcs = new TaskCompletionSource<PhaseChangeOutcome>(TaskCreationOptions.RunContinuationsAsynchronously);
+        Assert.True(disp.EnqueueOperatorUncrossAuction(Petr, B3.Exchange.Matching.TradingPhase.Open, tcs));
+        DrainInbound(disp);
+        await tcs.Task;
+
+        var record = Assert.Single(audit.Records);
+        Assert.NotEqual(0UL, record.BuyClOrdId);
+        Assert.NotEqual(0UL, record.SellClOrdId);
+        Assert.Equal(new HashSet<ulong> { 111UL, 222UL }, new HashSet<ulong> { record.BuyClOrdId, record.SellClOrdId });
+        Assert.Equal(new HashSet<uint> { 7u, 8u }, new HashSet<uint> { record.BuyFirm, record.SellFirm });
+    }
 }

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
@@ -1,0 +1,72 @@
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Core.Tests;
+
+public partial class ChannelDispatcherTests
+{
+    private sealed class RecordingPostTradeSink : IPostTradeSink
+    {
+        public List<PostTradeRecord> Records { get; } = new();
+        public void OnTrade(in PostTradeRecord record) => Records.Add(record);
+    }
+
+    [Fact]
+    public void PostTradeSink_Crossing_EmitsAuditRecord_WithCorrectBuySellMapping()
+    {
+        var pkt = new RecordingPacketSink();
+        var outbound = new RecordingOutbound();
+        var audit = new RecordingPostTradeSink();
+        var disp = new ChannelDispatcher(channelNumber: 1,
+            engineFactory: sink => new MatchingEngine(new[] { Petr4 }, sink, NullLogger<MatchingEngine>.Instance),
+            packetSink: pkt,
+            outbound: outbound,
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            nowNanos: () => 1_000_000_000UL, tradeDate: 19_000,
+            postTradeSink: audit);
+        var maker = new FakeSession(outbound) { EnteringFirm = 7 };
+        var taker = new FakeSession(outbound) { EnteringFirm = 8 };
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 111UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 222UL);
+        DrainInbound(disp);
+
+        var record = Assert.Single(audit.Records);
+        Assert.Equal(Petr, record.SecurityId);
+        Assert.Equal(Side.Buy, record.AggressorSide);
+        Assert.Equal(100, record.Quantity);
+        Assert.Equal(Px(10m), record.PriceMantissa);
+        // Aggressor=Buy → taker (firm 8, clOrdId 222) is BuySide;
+        // resting=Sell → maker (firm 7, clOrdId 111) is SellSide.
+        Assert.Equal(8u, record.BuyFirm);
+        Assert.Equal(7u, record.SellFirm);
+        Assert.Equal(222UL, record.BuyClOrdId);
+        Assert.Equal(111UL, record.SellClOrdId);
+    }
+
+    [Fact]
+    public void PostTradeSink_NotProvided_DefaultsToNullSink_NoCrash()
+    {
+        // Regression guard: existing dispatcher constructions that do not
+        // pass postTradeSink must continue to behave identically.
+        var (disp, _, outbound) = NewDispatcher();
+        var maker = new FakeSession(outbound);
+        var taker = new FakeSession(outbound);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 2UL);
+        DrainInbound(disp);
+
+        Assert.Single(maker.Trades);
+        Assert.Single(taker.Trades);
+    }
+}

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Exchange.Core.Tests;
 
-public class ChannelDispatcherTests
+public partial class ChannelDispatcherTests
 {
     private const long Petr = 900_000_000_001L;
 

--- a/tests/B3.Exchange.PostTrade.Tests/B3.Exchange.PostTrade.Tests.csproj
+++ b/tests/B3.Exchange.PostTrade.Tests/B3.Exchange.PostTrade.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.Exchange.PostTrade.Tests/NullPostTradeSinkTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/NullPostTradeSinkTests.cs
@@ -1,0 +1,47 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+public class NullPostTradeSinkTests
+{
+    [Fact]
+    public void NullSink_OnTrade_DoesNotThrow_AndIsSingleton()
+    {
+        var a = NullPostTradeSink.Instance;
+        var b = NullPostTradeSink.Instance;
+        Assert.Same(a, b);
+
+        var record = new PostTradeRecord(
+            TradeId: 42, TransactTimeNanos: 1_000UL, SecurityId: 900_000_000_001L,
+            AggressorSide: Side.Buy, Quantity: 100, PriceMantissa: 320_000,
+            BuyClOrdId: 7UL, SellClOrdId: 9UL, BuyFirm: 7, SellFirm: 8,
+            BuyOrderId: 1, SellOrderId: 2);
+
+        a.OnTrade(record);
+    }
+
+    [Fact]
+    public void PostTradeRecord_RoundTripsAllFields()
+    {
+        var record = new PostTradeRecord(
+            TradeId: 12345, TransactTimeNanos: 9_876_543_210UL,
+            SecurityId: 900_000_000_006L,
+            AggressorSide: Side.Sell, Quantity: 250, PriceMantissa: 1_234_5678L,
+            BuyClOrdId: 111UL, SellClOrdId: 222UL, BuyFirm: 33, SellFirm: 44,
+            BuyOrderId: 555, SellOrderId: 666);
+
+        Assert.Equal(12345u, record.TradeId);
+        Assert.Equal(9_876_543_210UL, record.TransactTimeNanos);
+        Assert.Equal(900_000_000_006L, record.SecurityId);
+        Assert.Equal(Side.Sell, record.AggressorSide);
+        Assert.Equal(250, record.Quantity);
+        Assert.Equal(1_234_5678L, record.PriceMantissa);
+        Assert.Equal(111UL, record.BuyClOrdId);
+        Assert.Equal(222UL, record.SellClOrdId);
+        Assert.Equal(33u, record.BuyFirm);
+        Assert.Equal(44u, record.SellFirm);
+        Assert.Equal(555, record.BuyOrderId);
+        Assert.Equal(666, record.SellOrderId);
+    }
+}


### PR DESCRIPTION
## What

PR-1 of 6 for issue #329 (per-trade append-only audit log, ADR 0001 §2). Pure infra skeleton:

- New project `B3.Exchange.PostTrade` (sibling of `Persistence`, depends only on `Matching`).
- `PostTradeRecord` struct + `IPostTradeSink` interface + `NullPostTradeSink` singleton.
- Wire `ChannelDispatcher` ctor → optional `postTradeSink` (defaults to null sink, zero behaviour change for existing callers).
- Invoke sink at the end of `OnTrade` (after both ER writes), so audit-log ordering matches the published trade order.
- Sink exceptions caught and logged — the dispatch loop must not die on audit-sink failure. PR-4 will gate WAL truncation on durability so persistent failures backpressure correctly.

## Out of scope (subsequent PRs)

| PR | Scope |
| -- | ----- |
| **2** | Append-only file writer + CRC32C + schema header + daily rollover + property test round-trip. |
| **3** | Sparse `.idx` firm index + reader API (full-day + firm-filtered). |
| **4** | `auditDurableSeq` watermark gating WAL truncation + crash-recovery regression test. |
| **5** | Restart replay-into-audit-only mode for trades beyond `auditDurableSeq`. |
| **6** | Retention config + dispatcher latency bench comparison + RUNBOOK section. |

## Tests

- `B3.Exchange.PostTrade.Tests` (new project): record round-trip + null-sink smoke.
- `ChannelDispatcherPostTradeTests`: crossing scenario asserts buy/sell firm + ClOrdId mapping; regression guard that the default null sink keeps existing Crossing behaviour.
- Full suite green locally (1300+ tests), `dotnet format --verify-no-changes` clean.

Refs #329.