### PR TITLE
post-trade: file writer + CRC32 + daily rollover (#329 PR-2)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
@@ -13,6 +12,7 @@
     <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="SbeSourceGenerator" Version="1.6.1" />
+    <PackageVersion Include="System.IO.Hashing" Version="10.0.8" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Sequential reader for post-trade audit log files written by
+/// <see cref="FileAuditLogWriter"/>. Returns records until the underlying
+/// file ends or the next record fails CRC/length validation — the latter
+/// is the documented signal for a torn write on the writer side and is
+/// treated as "log ends here" per the standard append-only convention
+/// (see <see cref="AuditRecordCodec.TryDecode"/> docs).
+///
+/// PR-2 scope: full-day scan only. Firm-filtered reads land in PR-3
+/// alongside the sparse <c>.idx</c> file.
+/// </summary>
+public static class AuditLogReader
+{
+    /// <summary>Opens <paramref name="path"/>, validates the file header,
+    /// and yields every record in order. Throws
+    /// <see cref="InvalidDataException"/> on an unreadable header
+    /// (mismatched magic/version/date) — that is unrecoverable corruption,
+    /// not a torn tail.</summary>
+    public static IEnumerable<PostTradeRecord> ReadAll(string path)
+    {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var header = new byte[AuditRecordCodec.FileHeaderSize];
+        int hr = ReadFully(fs, header, 0, header.Length);
+        if (hr != header.Length)
+            throw new InvalidDataException($"audit file '{path}' truncated in header (got {hr} bytes)");
+        _ = AuditRecordCodec.ReadFileHeader(header);
+
+        var buffer = new byte[AuditRecordCodec.RecordSize];
+        while (true)
+        {
+            int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
+            if (read == 0)
+                yield break;
+            if (read < AuditRecordCodec.RecordSize)
+                yield break; // torn tail — treat as end-of-log
+            if (!AuditRecordCodec.TryDecode(buffer, out var record))
+                yield break;
+            yield return record;
+        }
+    }
+
+    private static int ReadFully(Stream s, byte[] buffer, int offset, int count)
+    {
+        int total = 0;
+        while (total < count)
+        {
+            int n = s.Read(buffer, offset + total, count - total);
+            if (n == 0) break;
+            total += n;
+        }
+        return total;
+    }
+}

--- a/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
@@ -66,6 +66,11 @@ public static class AuditRecordCodec
         // tradeDate ASCII YYYY-MM-DD; ASCII is fixed-width and locale-independent.
         var iso = tradeDate.ToString("yyyy-MM-dd");
         System.Text.Encoding.ASCII.GetBytes(iso, dst.Slice(12, 10));
+        // Reserved trailer bytes — kept zero so future readers can validate
+        // them strictly. Required because the writer reuses a single scratch
+        // buffer for headers and records, so leaving these unwritten would
+        // leak bytes from the previously encoded record after a rollover.
+        dst[22] = 0; dst[23] = 0;
     }
 
     /// <summary>
@@ -83,6 +88,8 @@ public static class AuditRecordCodec
         if (version != SchemaVersion)
             throw new InvalidDataException($"audit file schema version {version} unsupported (this build expects {SchemaVersion})");
         byte channel = src[8];
+        if (src[9] != 0 || src[10] != 0 || src[11] != 0 || src[22] != 0 || src[23] != 0)
+            throw new InvalidDataException("audit file reserved bytes non-zero");
         var iso = System.Text.Encoding.ASCII.GetString(src.Slice(12, 10));
         if (!DateOnly.TryParseExact(iso, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var date))
             throw new InvalidDataException($"audit file tradeDate field invalid: '{iso}'");

--- a/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
@@ -1,0 +1,169 @@
+using System.Buffers.Binary;
+using System.IO.Hashing;
+using B3.Exchange.Matching;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Byte-level encoder/decoder for the on-disk post-trade audit log
+/// (issue #329 PR-2). Wire layout is fixed-width little-endian and
+/// schema-versioned via the file header — the record body is identical
+/// across <see cref="SchemaVersion"/>=1 deployments.
+///
+/// File header (<see cref="FileHeaderSize"/> = 24 bytes):
+/// <code>
+///   magic "B3PT" (4)
+///   schemaVersion (uint16)
+///   reserved      (uint16)
+///   channelNumber (uint8)
+///   pad           (3 bytes)
+///   tradeDate ASCII YYYY-MM-DD (10 bytes)
+/// </code>
+///
+/// Record (<see cref="RecordSize"/> = 85 bytes total, including the
+/// length+crc header so the on-disk byte count matches the value
+/// returned by <see cref="Encode"/>):
+/// <code>
+///   recordLen          (uint32) bytes following this field (always 77)
+///   crc32             (uint32) over the body that follows
+///   tradeId            (uint32)
+///   transactTimeNanos  (uint64)
+///   securityId         (int64)
+///   aggressorSide      (uint8)  0=Buy, 1=Sell
+///   quantity           (int64)
+///   priceMantissa      (int64)
+///   buyClOrdId         (uint64)
+///   sellClOrdId        (uint64)
+///   buyFirm            (uint32)
+///   sellFirm           (uint32)
+///   buyOrderId         (int64)
+///   sellOrderId        (int64)
+/// </code>
+///
+/// CRC32 (IEEE 802.3) covers every byte after the crc field (i.e. the record body
+/// from tradeId through sellOrderId). recordLen and crc32 are NOT
+/// covered — recordLen is needed before reading the body, and crc32
+/// is obviously what's being verified.
+/// </summary>
+public static class AuditRecordCodec
+{
+    public const ushort SchemaVersion = 1;
+    public const int FileHeaderSize = 24;
+    public const int RecordBodySize = 77;
+    public const int RecordSize = RecordBodySize + 8; // +4 recordLen +4 crc32
+
+    private const uint MagicB3PT = 0x5450_3342u; // "B3PT" little-endian
+
+    public static void WriteFileHeader(Span<byte> dst, byte channelNumber, DateOnly tradeDate)
+    {
+        if (dst.Length < FileHeaderSize)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{FileHeaderSize})", nameof(dst));
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), MagicB3PT);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4, 2), SchemaVersion);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(6, 2), 0);
+        dst[8] = channelNumber;
+        dst[9] = 0; dst[10] = 0; dst[11] = 0;
+        // tradeDate ASCII YYYY-MM-DD; ASCII is fixed-width and locale-independent.
+        var iso = tradeDate.ToString("yyyy-MM-dd");
+        System.Text.Encoding.ASCII.GetBytes(iso, dst.Slice(12, 10));
+    }
+
+    /// <summary>
+    /// Decodes a file header. Throws <see cref="InvalidDataException"/> if
+    /// the magic, schema version, or trade-date encoding is corrupt.
+    /// </summary>
+    public static (byte ChannelNumber, DateOnly TradeDate) ReadFileHeader(ReadOnlySpan<byte> src)
+    {
+        if (src.Length < FileHeaderSize)
+            throw new InvalidDataException("audit file truncated in header");
+        var magic = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
+        if (magic != MagicB3PT)
+            throw new InvalidDataException($"audit file magic mismatch: 0x{magic:X8}");
+        var version = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(4, 2));
+        if (version != SchemaVersion)
+            throw new InvalidDataException($"audit file schema version {version} unsupported (this build expects {SchemaVersion})");
+        byte channel = src[8];
+        var iso = System.Text.Encoding.ASCII.GetString(src.Slice(12, 10));
+        if (!DateOnly.TryParseExact(iso, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var date))
+            throw new InvalidDataException($"audit file tradeDate field invalid: '{iso}'");
+        return (channel, date);
+    }
+
+    /// <summary>Encodes <paramref name="record"/> into <paramref name="dst"/>.
+    /// Returns the number of bytes written (always <see cref="RecordSize"/>).</summary>
+    public static int Encode(Span<byte> dst, in PostTradeRecord record)
+    {
+        if (dst.Length < RecordSize)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{RecordSize})", nameof(dst));
+
+        var body = dst.Slice(8, RecordBodySize);
+        int p = 0;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.TradeId); p += 4;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.TransactTimeNanos); p += 8;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(p, 8), record.SecurityId); p += 8;
+        body[p] = record.AggressorSide == Side.Buy ? (byte)0 : (byte)1; p += 1;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(p, 8), record.Quantity); p += 8;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(p, 8), record.PriceMantissa); p += 8;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.BuyClOrdId); p += 8;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.SellClOrdId); p += 8;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.BuyFirm); p += 4;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.SellFirm); p += 4;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(p, 8), record.BuyOrderId); p += 8;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(p, 8), record.SellOrderId); p += 8;
+        if (p != RecordBodySize)
+            throw new InvalidOperationException($"BUG: encoded {p} body bytes, expected {RecordBodySize}");
+
+        // recordLen counts everything after itself: crc(4) + body(77) = 81.
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), (uint)(RecordSize - 4));
+        var crc = ComputeCrc(body);
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(4, 4), crc);
+        return RecordSize;
+    }
+
+    /// <summary>Decodes one record. Returns false (and leaves
+    /// <paramref name="record"/> at default) when:
+    /// (a) the buffer is shorter than a full record, or
+    /// (b) the recordLen field declares a length other than the v1 layout, or
+    /// (c) the stored CRC32 (IEEE 802.3) does not match the body.
+    /// The (b) and (c) failures are the recovery signal a torn write on
+    /// the writer-side leaves behind. Callers reading a log to its end
+    /// MUST treat a false return as "log ends here" rather than as
+    /// corruption further down — this matches the standard append-only
+    /// log read pattern.</summary>
+    public static bool TryDecode(ReadOnlySpan<byte> src, out PostTradeRecord record)
+    {
+        record = default;
+        if (src.Length < RecordSize) return false;
+        uint declaredLen = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
+        if (declaredLen != RecordSize - 4) return false;
+        uint storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(4, 4));
+        var body = src.Slice(8, RecordBodySize);
+        if (ComputeCrc(body) != storedCrc) return false;
+
+        int p = 0;
+        uint tradeId = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong ts = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        long secId = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        Side side = body[p] == 0 ? Side.Buy : Side.Sell; p += 1;
+        long qty = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        long px = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        ulong buyClOrd = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        ulong sellClOrd = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        uint buyFirm = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        uint sellFirm = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        long buyOrderId = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        long sellOrderId = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        _ = p;
+
+        record = new PostTradeRecord(tradeId, ts, secId, side, qty, px,
+            buyClOrd, sellClOrd, buyFirm, sellFirm, buyOrderId, sellOrderId);
+        return true;
+    }
+
+    private static uint ComputeCrc(ReadOnlySpan<byte> data)
+    {
+        Span<byte> hash = stackalloc byte[4];
+        Crc32.Hash(data, hash);
+        return BinaryPrimitives.ReadUInt32LittleEndian(hash);
+    }
+}

--- a/src/B3.Exchange.PostTrade/B3.Exchange.PostTrade.csproj
+++ b/src/B3.Exchange.PostTrade/B3.Exchange.PostTrade.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="System.IO.Hashing" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -1,0 +1,112 @@
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Append-only file writer for post-trade audit records (issue #329 PR-2).
+///
+/// Layout: one file per channel per UTC business date, located at
+/// <c>{rootDir}/{channelNumber}/fills-YYYY-MM-DD.log</c>. The date is
+/// derived from each record's <see cref="PostTradeRecord.TransactTimeNanos"/>
+/// rather than wall-clock so the rollover is deterministic across replay
+/// and across time-warped scenario tests.
+///
+/// Threading model: not thread-safe. Designed to be installed as the
+/// per-channel <see cref="IPostTradeSink"/> and invoked exclusively on
+/// the <c>ChannelDispatcher</c>'s single dispatch thread.
+///
+/// Durability: writes are flushed to the OS buffer on every record but
+/// NOT fsynced. <see cref="Checkpoint"/> calls <c>FileStream.Flush(true)</c>
+/// — wire it from PR-4's interval-bounded watermark loop. PR-2 leaves the
+/// dispatcher's hot path free of fsync to avoid a regression before the
+/// durability infrastructure exists.
+/// </summary>
+public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
+{
+    private readonly string _rootDir;
+    private readonly byte _channelNumber;
+    private readonly byte[] _scratch = new byte[Math.Max(AuditRecordCodec.RecordSize, AuditRecordCodec.FileHeaderSize)];
+
+    private FileStream? _stream;
+    private DateOnly _currentDate;
+    private long _recordsWritten;
+
+    public FileAuditLogWriter(string rootDir, byte channelNumber)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(rootDir);
+        _rootDir = rootDir;
+        _channelNumber = channelNumber;
+    }
+
+    /// <summary>Total records successfully appended since construction. Useful
+    /// for tests and for PR-4's durability watermark accounting.</summary>
+    public long RecordsWritten => _recordsWritten;
+
+    /// <summary>UTC date of the currently-open log file, or <c>null</c> when
+    /// no record has been written yet.</summary>
+    public DateOnly? CurrentTradeDate => _stream is null ? null : _currentDate;
+
+    public void OnTrade(in PostTradeRecord record)
+    {
+        var recordDate = ToUtcDate(record.TransactTimeNanos);
+        if (_stream is null || recordDate != _currentDate)
+        {
+            RotateTo(recordDate);
+        }
+        int n = AuditRecordCodec.Encode(_scratch, in record);
+        _stream!.Write(_scratch, 0, n);
+        _recordsWritten++;
+    }
+
+    /// <summary>Flushes OS buffers and forces <c>fsync</c> on the current
+    /// file (if any). PR-4 will call this from the durability-watermark
+    /// loop and from the operator-triggered checkpoint endpoint.</summary>
+    public void Checkpoint()
+    {
+        _stream?.Flush(flushToDisk: true);
+    }
+
+    private void RotateTo(DateOnly newDate)
+    {
+        if (_stream is not null)
+        {
+            // Force an fsync on the closing file so the day's records are
+            // durable before subsequent records land in a new file — without
+            // this, a crash mid-rotation could leave both files with
+            // unflushed tails.
+            _stream.Flush(flushToDisk: true);
+            _stream.Dispose();
+            _stream = null;
+        }
+        var channelDir = Path.Combine(_rootDir, _channelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(channelDir);
+        var path = Path.Combine(channelDir, $"fills-{newDate:yyyy-MM-dd}.log");
+        var fs = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
+        // Only write the header on a brand-new file. An existing file is
+        // safe to keep appending to under the v1 schema because the writer
+        // never rewrites records — the recovery contract is "read until
+        // TryDecode returns false, that's where the log truncates to".
+        if (fs.Length == 0)
+        {
+            AuditRecordCodec.WriteFileHeader(_scratch, _channelNumber, newDate);
+            fs.Write(_scratch, 0, AuditRecordCodec.FileHeaderSize);
+        }
+        _stream = fs;
+        _currentDate = newDate;
+    }
+
+    private static DateOnly ToUtcDate(ulong nanosSinceUnixEpoch)
+    {
+        long ticks = (long)(nanosSinceUnixEpoch / 100UL);
+        var dt = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks(ticks);
+        return DateOnly.FromDateTime(dt);
+    }
+
+    public void Dispose()
+    {
+        if (_stream is not null)
+        {
+            _stream.Flush(flushToDisk: true);
+            _stream.Dispose();
+            _stream = null;
+        }
+    }
+}

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -53,6 +53,11 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         }
         int n = AuditRecordCodec.Encode(_scratch, in record);
         _stream!.Write(_scratch, 0, n);
+        // Flush the managed FileStream buffer to the OS on every record so
+        // the documented contract holds: post-trade records are at minimum
+        // OS-buffer-visible immediately, with fsync deferred to rotation /
+        // Checkpoint() / PR-4's durability loop.
+        _stream.Flush(flushToDisk: false);
         _recordsWritten++;
     }
 
@@ -79,18 +84,48 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         var channelDir = Path.Combine(_rootDir, _channelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture));
         Directory.CreateDirectory(channelDir);
         var path = Path.Combine(channelDir, $"fills-{newDate:yyyy-MM-dd}.log");
-        var fs = new FileStream(path, FileMode.Append, FileAccess.Write, FileShare.Read);
-        // Only write the header on a brand-new file. An existing file is
-        // safe to keep appending to under the v1 schema because the writer
-        // never rewrites records — the recovery contract is "read until
-        // TryDecode returns false, that's where the log truncates to".
+        var fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
         if (fs.Length == 0)
         {
             AuditRecordCodec.WriteFileHeader(_scratch, _channelNumber, newDate);
             fs.Write(_scratch, 0, AuditRecordCodec.FileHeaderSize);
         }
+        else
+        {
+            // Recovery on append: validate the header, then scan forward to
+            // the last good record offset and truncate any torn tail before
+            // appending. Without this step, records appended after a torn
+            // tail would be permanently invisible to AuditLogReader, which
+            // (correctly) treats the first failed TryDecode as end-of-log.
+            long goodEnd = ScanLastGoodEndOffset(fs);
+            if (goodEnd != fs.Length)
+                fs.SetLength(goodEnd);
+        }
+        fs.Seek(0, SeekOrigin.End);
         _stream = fs;
         _currentDate = newDate;
+    }
+
+    private long ScanLastGoodEndOffset(FileStream fs)
+    {
+        fs.Seek(0, SeekOrigin.Begin);
+        Span<byte> hdr = stackalloc byte[AuditRecordCodec.FileHeaderSize];
+        if (fs.Read(hdr) != hdr.Length)
+            throw new InvalidDataException($"audit file '{fs.Name}' truncated in header");
+        var (channel, _) = AuditRecordCodec.ReadFileHeader(hdr);
+        if (channel != _channelNumber)
+            throw new InvalidDataException($"audit file '{fs.Name}' channel mismatch (file={channel}, writer={_channelNumber})");
+
+        long goodEnd = AuditRecordCodec.FileHeaderSize;
+        Span<byte> rec = stackalloc byte[AuditRecordCodec.RecordSize];
+        while (true)
+        {
+            int read = fs.Read(rec);
+            if (read != rec.Length) break;
+            if (!AuditRecordCodec.TryDecode(rec, out _)) break;
+            goodEnd += rec.Length;
+        }
+        return goodEnd;
     }
 
     private static DateOnly ToUtcDate(ulong nanosSinceUnixEpoch)

--- a/src/B3.Exchange.PostTrade/IPostTradeSink.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeSink.cs
@@ -46,7 +46,7 @@ public readonly record struct PostTradeRecord(
 /// in the watermark PR).
 ///
 /// Skeleton contract (#329 PR-1). Subsequent PRs add: append-only file
-/// writer with CRC32C + daily rollover (PR-2), firm sparse index (PR-3),
+/// writer with CRC32 (IEEE 802.3) + daily rollover (PR-2), firm sparse index (PR-3),
 /// durability watermark gating WAL truncation (PR-4), restart
 /// replay-into-audit-only mode (PR-5), and operator config / RUNBOOK
 /// (PR-6).

--- a/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
@@ -1,0 +1,87 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+public class AuditRecordCodecTests
+{
+    private static PostTradeRecord Sample() => new(
+        TradeId: 42, TransactTimeNanos: 1_700_000_000_000_000_000UL,
+        SecurityId: 900_000_000_001L, AggressorSide: Side.Sell,
+        Quantity: 250, PriceMantissa: 12_345_678L,
+        BuyClOrdId: 111UL, SellClOrdId: 222UL,
+        BuyFirm: 7, SellFirm: 8,
+        BuyOrderId: 1001, SellOrderId: 1002);
+
+    [Fact]
+    public void Encode_Then_TryDecode_RoundTripsAllFields()
+    {
+        var src = Sample();
+        Span<byte> buf = stackalloc byte[AuditRecordCodec.RecordSize];
+        int n = AuditRecordCodec.Encode(buf, in src);
+        Assert.Equal(AuditRecordCodec.RecordSize, n);
+
+        Assert.True(AuditRecordCodec.TryDecode(buf, out var dst));
+        Assert.Equal(src, dst);
+    }
+
+    [Fact]
+    public void TryDecode_ReturnsFalse_OnTruncatedBuffer()
+    {
+        var src = Sample();
+        var buf = new byte[AuditRecordCodec.RecordSize];
+        AuditRecordCodec.Encode(buf, in src);
+        Assert.False(AuditRecordCodec.TryDecode(buf.AsSpan(0, buf.Length - 1), out _));
+    }
+
+    [Fact]
+    public void TryDecode_ReturnsFalse_OnCorruptedBody()
+    {
+        var src = Sample();
+        var buf = new byte[AuditRecordCodec.RecordSize];
+        AuditRecordCodec.Encode(buf, in src);
+        // Flip a single body bit (somewhere past the crc field).
+        buf[20] ^= 0x01;
+        Assert.False(AuditRecordCodec.TryDecode(buf, out _));
+    }
+
+    [Fact]
+    public void TryDecode_ReturnsFalse_OnWrongRecordLen()
+    {
+        var src = Sample();
+        var buf = new byte[AuditRecordCodec.RecordSize];
+        AuditRecordCodec.Encode(buf, in src);
+        // Pretend an older schema wrote a shorter record.
+        buf[0] = 0; buf[1] = 0; buf[2] = 0; buf[3] = 0;
+        Assert.False(AuditRecordCodec.TryDecode(buf, out _));
+    }
+
+    [Fact]
+    public void FileHeader_RoundTripsChannelAndDate()
+    {
+        var buf = new byte[AuditRecordCodec.FileHeaderSize];
+        var date = new DateOnly(2026, 5, 18);
+        AuditRecordCodec.WriteFileHeader(buf, channelNumber: 84, tradeDate: date);
+        var (ch, d) = AuditRecordCodec.ReadFileHeader(buf);
+        Assert.Equal((byte)84, ch);
+        Assert.Equal(date, d);
+    }
+
+    [Fact]
+    public void FileHeader_ReadFails_OnWrongMagic()
+    {
+        var buf = new byte[AuditRecordCodec.FileHeaderSize];
+        AuditRecordCodec.WriteFileHeader(buf, 1, new DateOnly(2026, 1, 1));
+        buf[0] ^= 0xFF;
+        Assert.Throws<InvalidDataException>(() => AuditRecordCodec.ReadFileHeader(buf));
+    }
+
+    [Fact]
+    public void FileHeader_ReadFails_OnUnknownSchemaVersion()
+    {
+        var buf = new byte[AuditRecordCodec.FileHeaderSize];
+        AuditRecordCodec.WriteFileHeader(buf, 1, new DateOnly(2026, 1, 1));
+        buf[4] = 99; buf[5] = 0;
+        Assert.Throws<InvalidDataException>(() => AuditRecordCodec.ReadFileHeader(buf));
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterTests.cs
@@ -1,0 +1,162 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+public class FileAuditLogWriterTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileAuditLogWriterTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    // 2026-05-18 00:00:00 UTC
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private const ulong OneDayNanos = 86_400UL * 1_000_000_000UL;
+
+    private static PostTradeRecord Make(uint id, ulong ts, long secId = 900_000_000_001L) => new(
+        TradeId: id, TransactTimeNanos: ts, SecurityId: secId, AggressorSide: id % 2 == 0 ? Side.Buy : Side.Sell,
+        Quantity: 100 + id, PriceMantissa: 10_0000L + id,
+        BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+        BuyFirm: 7, SellFirm: 8,
+        BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    [Fact]
+    public void Writer_PersistsRecord_AndReaderRoundTrips()
+    {
+        var rec = Make(1, Day0Nanos);
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 42))
+        {
+            w.OnTrade(rec);
+            Assert.Equal(1, w.RecordsWritten);
+        }
+        var path = Path.Combine(_root, "42", "fills-2026-05-18.log");
+        Assert.True(File.Exists(path));
+        var read = AuditLogReader.ReadAll(path).ToList();
+        var only = Assert.Single(read);
+        Assert.Equal(rec, only);
+    }
+
+    [Fact]
+    public void Writer_DailyRollover_OpensNewFileAtUtcMidnight()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 7);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.OnTrade(Make(2, Day0Nanos + 12UL * 3600UL * 1_000_000_000UL)); // same day
+        w.OnTrade(Make(3, Day0Nanos + OneDayNanos));                     // next day
+        w.OnTrade(Make(4, Day0Nanos + OneDayNanos + 1_000_000UL));       // same next day
+        w.Dispose();
+
+        var day0 = Path.Combine(_root, "7", "fills-2026-05-18.log");
+        var day1 = Path.Combine(_root, "7", "fills-2026-05-19.log");
+        Assert.True(File.Exists(day0));
+        Assert.True(File.Exists(day1));
+        var read0 = AuditLogReader.ReadAll(day0).Select(r => r.TradeId).ToList();
+        var read1 = AuditLogReader.ReadAll(day1).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2 }, read0);
+        Assert.Equal(new uint[] { 3, 4 }, read1);
+    }
+
+    [Fact]
+    public void Writer_Append_PreservesPreviousRecords_NoDuplicateHeader()
+    {
+        using (var w1 = new FileAuditLogWriter(_root, channelNumber: 1))
+            w1.OnTrade(Make(10, Day0Nanos));
+        using (var w2 = new FileAuditLogWriter(_root, channelNumber: 1))
+            w2.OnTrade(Make(11, Day0Nanos));
+        var path = Path.Combine(_root, "1", "fills-2026-05-18.log");
+        var read = AuditLogReader.ReadAll(path).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 10, 11 }, read);
+        // File size: 1 header + 2 records, NOT 2 headers + 2 records.
+        var expected = AuditRecordCodec.FileHeaderSize + 2 * AuditRecordCodec.RecordSize;
+        Assert.Equal(expected, new FileInfo(path).Length);
+    }
+
+    [Fact]
+    public void Writer_ReaderStopsAtTornTail_NoException()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 2))
+        {
+            w.OnTrade(Make(1, Day0Nanos));
+            w.OnTrade(Make(2, Day0Nanos));
+        }
+        var path = Path.Combine(_root, "2", "fills-2026-05-18.log");
+        // Truncate mid-record (header + 1 record + half of the next).
+        var len = AuditRecordCodec.FileHeaderSize + AuditRecordCodec.RecordSize + (AuditRecordCodec.RecordSize / 2);
+        using (var fs = new FileStream(path, FileMode.Open, FileAccess.Write))
+            fs.SetLength(len);
+        var read = AuditLogReader.ReadAll(path).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1 }, read);
+    }
+
+    [Fact]
+    public void Writer_Checkpoint_FlushesToDisk_NoThrow()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 3);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.Checkpoint();
+        // No assertion on fsync (OS-dependent); we only verify the call is
+        // legal in any state, including before the next OnTrade.
+        w.Checkpoint();
+    }
+
+    /// <summary>Property-style round-trip: a deterministic pseudo-random
+    /// sequence of records is written, the writer is disposed, the file
+    /// is reopened, and the read-back sequence must equal the input
+    /// exactly (issue #329 acceptance criterion).</summary>
+    [Theory]
+    [InlineData(1, 100)]
+    [InlineData(42, 500)]
+    [InlineData(2026, 1_000)]
+    public void Writer_PropertyRoundTrip_RandomSequence_Equal(int seed, int count)
+    {
+        var rng = new Random(seed);
+        var generated = new List<PostTradeRecord>(count);
+        // Records spread over up to 3 UTC business days to exercise rollover.
+        for (int i = 0; i < count; i++)
+        {
+            ulong dayOffset = (ulong)rng.Next(0, 3) * OneDayNanos;
+            ulong intraDay = (ulong)rng.Next(0, 86_400) * 1_000_000_000UL;
+            generated.Add(new PostTradeRecord(
+                TradeId: (uint)(i + 1),
+                TransactTimeNanos: Day0Nanos + dayOffset + intraDay,
+                SecurityId: 900_000_000_000L + rng.Next(1, 20),
+                AggressorSide: rng.Next(2) == 0 ? Side.Buy : Side.Sell,
+                Quantity: rng.Next(1, 10_000),
+                PriceMantissa: rng.Next(1, int.MaxValue),
+                BuyClOrdId: (ulong)rng.NextInt64(),
+                SellClOrdId: (ulong)rng.NextInt64(),
+                BuyFirm: (uint)rng.Next(1, 256),
+                SellFirm: (uint)rng.Next(1, 256),
+                BuyOrderId: rng.NextInt64(),
+                SellOrderId: rng.NextInt64()));
+        }
+        // Order chronologically so the writer's date-based rollover is monotonic.
+        generated.Sort((a, b) => a.TransactTimeNanos.CompareTo(b.TransactTimeNanos));
+
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 99))
+        {
+            foreach (var r in generated)
+                w.OnTrade(r);
+        }
+
+        var perDay = generated.GroupBy(r => DateOnly.FromDateTime(
+            new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddTicks((long)(r.TransactTimeNanos / 100UL))));
+
+        var readBack = new List<PostTradeRecord>();
+        foreach (var g in perDay.OrderBy(g => g.Key))
+        {
+            var path = Path.Combine(_root, "99", $"fills-{g.Key:yyyy-MM-dd}.log");
+            readBack.AddRange(AuditLogReader.ReadAll(path));
+        }
+        Assert.Equal(generated, readBack);
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterTests.cs
@@ -13,6 +13,50 @@ public class FileAuditLogWriterTests : IDisposable
         Directory.CreateDirectory(_root);
     }
 
+    [Fact]
+    public void Writer_Reopen_TruncatesTornTail_AndAppendsAreReadable()
+    {
+        // Write two clean records, then simulate a torn tail by appending
+        // a half-record of garbage. After reopening, the writer must
+        // truncate the torn tail so subsequent appends remain readable.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 5))
+        {
+            w.OnTrade(Make(1, Day0Nanos));
+            w.OnTrade(Make(2, Day0Nanos));
+        }
+        var path = Path.Combine(_root, "5", "fills-2026-05-18.log");
+        using (var fs = new FileStream(path, FileMode.Append, FileAccess.Write))
+            fs.Write(new byte[AuditRecordCodec.RecordSize / 2], 0, AuditRecordCodec.RecordSize / 2);
+        var truncatedLen = new FileInfo(path).Length;
+
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 5))
+            w.OnTrade(Make(3, Day0Nanos));
+
+        var finalLen = new FileInfo(path).Length;
+        Assert.True(finalLen < truncatedLen + AuditRecordCodec.RecordSize,
+            "torn tail should have been truncated before appending");
+        var read = AuditLogReader.ReadAll(path).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3 }, read);
+    }
+
+    [Fact]
+    public void Writer_Reopen_RejectsHeaderWithChannelMismatch()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 6))
+            w.OnTrade(Make(1, Day0Nanos));
+        var path = Path.Combine(_root, "6", "fills-2026-05-18.log");
+        // Move the file under a different channel directory to simulate a
+        // operator misconfiguration; the writer must refuse to silently
+        // append records with the wrong channel number.
+        var otherDir = Path.Combine(_root, "60");
+        Directory.CreateDirectory(otherDir);
+        var moved = Path.Combine(otherDir, "fills-2026-05-18.log");
+        File.Move(path, moved);
+        var w2 = new FileAuditLogWriter(_root, channelNumber: 60);
+        Assert.Throws<InvalidDataException>(() => w2.OnTrade(Make(2, Day0Nanos)));
+        w2.Dispose();
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);


### PR DESCRIPTION
PR-2 of the 6-PR series for #329.

## What
- `AuditRecordCodec` — schema-versioned binary layout (file header 24B; record 85B = 4 recordLen + 4 crc32 + 77 body). CRC32 (IEEE 802.3) covers the record body only.
- `FileAuditLogWriter` (`IPostTradeSink`) — opens `{root}/{channel}/fills-YYYY-MM-DD.log` lazily, rotates on the UTC date of the record's TransactTimeNanos (deterministic, not wall clock), fsyncs on rotation, writes file header only on brand-new files (append-safe after crash).
- `AuditLogReader` — sequential `ReadAll`; throws on header corruption, treats torn-tail record as end-of-log (standard append-only recovery contract).

## Tests
17 in `B3.Exchange.PostTrade.Tests`:
- codec round-trip, tampering, truncation, file-header round-trip + bad magic / wrong version
- writer round-trip, daily rollover across UTC midnight (multi-day sequence reads back per file)
- append after crash does not duplicate header (file size = header + N×record)
- torn tail tolerated by reader
- `Checkpoint()` idempotent
- property-style: 3 seeds × up to 1000 records spread across 3 UTC dates round-trip

## Out of scope (later PRs in #329)
- PR-3: sparse firm `.idx` + reader API
- PR-4: `auditDurableSeq` watermark + periodic / operator-triggered fsync loop, gates WAL truncation
- PR-5: restart replay-into-audit-only for trades > auditDurableSeq
- PR-6: retention config + bench + RUNBOOK

## Verification
```
dotnet build SbeB3Exchange.slnx -c Release  # 0 warnings, 0 errors
dotnet test  SbeB3Exchange.slnx --no-build -c Release  # all green
dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn  # clean
```