### PR TITLE
post-trade: sparse firm .idx + ReadByFirm reader API (#329 PR-3)

### DIFF
--- a/src/B3.Exchange.PostTrade/AuditIndexCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditIndexCodec.cs
@@ -1,0 +1,126 @@
+using System.Buffers.Binary;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Byte-level encoder/decoder for the sparse per-firm audit index
+/// (<c>.idx</c> sidecar) introduced in issue #329 PR-3.
+///
+/// The index does not encode individual records — instead, it carves the
+/// log into fixed-size record blocks (<see cref="DefaultBlockRecords"/>
+/// records per block) and stores, per block, the distinct set of firm IDs
+/// that participated in any record inside it. A firm-filtered reader can
+/// then skip whole blocks that have no entry for the queried firm and
+/// linearly scan only the candidate blocks.
+///
+/// File header (<see cref="FileHeaderSize"/> = 24 bytes):
+/// <code>
+///   magic              "B3PI" (4)
+///   schemaVersion      uint16(=1)
+///   reserved           uint16(=0)
+///   channelNumber      uint8
+///   pad                uint8[3](=0,0,0)
+///   tradeDate          ASCII "YYYY-MM-DD" (10)
+///   reserved2          uint16(=0)
+/// </code>
+///
+/// Block entry (variable):
+/// <code>
+///   entryLen           uint16  // bytes following this field (total - 2)
+///   blockLogOffset     uint64  // byte offset of first record inside the .log file
+///   recordCount        uint16  // records in this block (1..DefaultBlockRecords)
+///   firmCount          uint16  // distinct firm IDs in this block
+///   firmIds            uint32[firmCount] (sorted ascending, deduplicated)
+/// </code>
+/// Reader-side recovery uses <c>entryLen</c> to skip a torn entry at
+/// end-of-file, mirroring the log's append-only contract.
+/// </summary>
+public static class AuditIndexCodec
+{
+    public const ushort SchemaVersion = 1;
+    public const int FileHeaderSize = 24;
+    public const int DefaultBlockRecords = 64;
+    public const int BlockEntryFixedPrefix = 2 + 8 + 2 + 2; // entryLen + blockLogOffset + recordCount + firmCount
+
+    private const uint MagicB3PI = 0x4950_3342u; // "B3PI" little-endian
+
+    public static void WriteFileHeader(Span<byte> dst, byte channelNumber, DateOnly tradeDate)
+    {
+        if (dst.Length < FileHeaderSize)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{FileHeaderSize})", nameof(dst));
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), MagicB3PI);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4, 2), SchemaVersion);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(6, 2), 0);
+        dst[8] = channelNumber;
+        dst[9] = 0; dst[10] = 0; dst[11] = 0;
+        var iso = tradeDate.ToString("yyyy-MM-dd");
+        System.Text.Encoding.ASCII.GetBytes(iso, dst.Slice(12, 10));
+        dst[22] = 0; dst[23] = 0;
+    }
+
+    public static (byte ChannelNumber, DateOnly TradeDate) ReadFileHeader(ReadOnlySpan<byte> src)
+    {
+        if (src.Length < FileHeaderSize)
+            throw new InvalidDataException("audit index truncated in header");
+        var magic = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
+        if (magic != MagicB3PI)
+            throw new InvalidDataException($"audit index magic mismatch: 0x{magic:X8}");
+        var version = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(4, 2));
+        if (version != SchemaVersion)
+            throw new InvalidDataException($"audit index schema version {version} unsupported (this build expects {SchemaVersion})");
+        byte channel = src[8];
+        if (src[9] != 0 || src[10] != 0 || src[11] != 0 || src[22] != 0 || src[23] != 0)
+            throw new InvalidDataException("audit index reserved bytes non-zero");
+        var iso = System.Text.Encoding.ASCII.GetString(src.Slice(12, 10));
+        if (!DateOnly.TryParseExact(iso, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var date))
+            throw new InvalidDataException($"audit index tradeDate field invalid: '{iso}'");
+        return (channel, date);
+    }
+
+    /// <summary>Encodes one block entry into <paramref name="dst"/>. The
+    /// firm-ID list must be sorted ascending and deduplicated.</summary>
+    public static int EncodeBlockEntry(Span<byte> dst, ulong blockLogOffset, ushort recordCount, ReadOnlySpan<uint> firmIds)
+    {
+        int total = BlockEntryFixedPrefix + (firmIds.Length * 4);
+        if (dst.Length < total)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{total})", nameof(dst));
+        ushort entryLen = checked((ushort)(total - 2));
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(0, 2), entryLen);
+        BinaryPrimitives.WriteUInt64LittleEndian(dst.Slice(2, 8), blockLogOffset);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(10, 2), recordCount);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(12, 2), checked((ushort)firmIds.Length));
+        for (int i = 0; i < firmIds.Length; i++)
+            BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(14 + (i * 4), 4), firmIds[i]);
+        return total;
+    }
+
+    /// <summary>Reads a single block entry header (without the firm IDs).
+    /// Returns false (and leaves outputs at default) when the source span
+    /// is too short or declares an entry longer than the available bytes —
+    /// matching the torn-tail-tolerant log read contract.</summary>
+    public static bool TryReadBlockEntry(
+        ReadOnlySpan<byte> src,
+        out ulong blockLogOffset,
+        out ushort recordCount,
+        out ushort firmCount,
+        out int totalBytes)
+    {
+        blockLogOffset = 0; recordCount = 0; firmCount = 0; totalBytes = 0;
+        if (src.Length < BlockEntryFixedPrefix) return false;
+        ushort entryLen = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(0, 2));
+        int total = entryLen + 2;
+        if (src.Length < total) return false;
+        ulong off = BinaryPrimitives.ReadUInt64LittleEndian(src.Slice(2, 8));
+        ushort rc = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(10, 2));
+        ushort fc = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(12, 2));
+        if (BlockEntryFixedPrefix + (fc * 4) != total) return false;
+        blockLogOffset = off;
+        recordCount = rc;
+        firmCount = fc;
+        totalBytes = total;
+        return true;
+    }
+
+    public static uint ReadFirmId(ReadOnlySpan<byte> blockEntry, int firmIndex)
+        => BinaryPrimitives.ReadUInt32LittleEndian(blockEntry.Slice(14 + (firmIndex * 4), 4));
+}

--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -48,38 +48,37 @@ public static class AuditLogReader
     /// If a sibling <c>.idx</c> file exists, only blocks that the index marks
     /// as containing <paramref name="firmId"/> are scanned — yielding a
     /// significant speed-up versus a full-day scan on busy channels.
-    /// Falls back transparently to <see cref="ReadAll(string)"/>+filter when
-    /// the index is missing or corrupt (a corrupt index is never fatal —
-    /// the <c>.log</c> remains the source of truth).</summary>
+    /// The index is treated strictly as an optimization: any portion of the
+    /// log not covered by an intact index block is scanned linearly so the
+    /// reader can never return fewer records than <see cref="ReadAll(string)"/>
+    /// would. Possible reasons for unindexed coverage:
+    /// <list type="bullet">
+    /// <item>missing or unreadable <c>.idx</c> file (full fallback)</item>
+    /// <item>a writer's in-progress block not yet flushed to <c>.idx</c></item>
+    /// <item>a torn or self-inconsistent index entry mid-file</item>
+    /// </list></summary>
     public static IEnumerable<PostTradeRecord> ReadByFirm(string logPath, uint firmId)
     {
         var idxPath = Path.ChangeExtension(logPath, ".idx");
+        List<(ulong Offset, ushort RecordCount)> candidates;
+        long indexedEndOffset;
         if (!File.Exists(idxPath))
         {
-            foreach (var r in ReadAll(logPath))
-                if (r.BuyFirm == firmId || r.SellFirm == firmId)
-                    yield return r;
-            yield break;
+            candidates = new List<(ulong, ushort)>();
+            indexedEndOffset = AuditRecordCodec.FileHeaderSize;
         }
-
-        List<(ulong Offset, ushort RecordCount)>? candidates;
-        try
+        else
         {
-            candidates = LoadCandidateBlocks(idxPath, firmId);
-        }
-        catch (InvalidDataException)
-        {
-            // Corrupt or torn index — fall back to a full scan. The log is
-            // the source of truth; the index is an optimization only.
-            candidates = null;
-        }
-
-        if (candidates is null)
-        {
-            foreach (var r in ReadAll(logPath))
-                if (r.BuyFirm == firmId || r.SellFirm == firmId)
-                    yield return r;
-            yield break;
+            try
+            {
+                (candidates, indexedEndOffset) = LoadCandidateBlocks(idxPath, firmId);
+            }
+            catch (InvalidDataException)
+            {
+                // Index unusable (bad header) — full scan from start of records.
+                candidates = new List<(ulong, ushort)>();
+                indexedEndOffset = AuditRecordCodec.FileHeaderSize;
+            }
         }
 
         using var fs = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -90,23 +89,44 @@ public static class AuditLogReader
         _ = AuditRecordCodec.ReadFileHeader(header);
 
         var buffer = new byte[AuditRecordCodec.RecordSize];
+        // 1) Indexed candidates — seek directly to each block.
         foreach (var (offset, recordCount) in candidates)
         {
             fs.Seek((long)offset, SeekOrigin.Begin);
             for (int i = 0; i < recordCount; i++)
             {
                 int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
-                if (read < AuditRecordCodec.RecordSize) yield break;
-                if (!AuditRecordCodec.TryDecode(buffer, out var record)) yield break;
+                if (read < AuditRecordCodec.RecordSize) break;
+                if (!AuditRecordCodec.TryDecode(buffer, out var record)) break;
+                if (record.BuyFirm == firmId || record.SellFirm == firmId)
+                    yield return record;
+            }
+        }
+
+        // 2) Unindexed suffix — anything past the last byte the index claims
+        // to cover. Critical for correctness when (a) the index is stale by
+        // an in-progress block, (b) a malformed entry forced us to stop
+        // trusting the index mid-file, or (c) no index exists at all.
+        if (indexedEndOffset < fs.Length)
+        {
+            fs.Seek(indexedEndOffset, SeekOrigin.Begin);
+            while (true)
+            {
+                int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
+                if (read == 0) break;
+                if (read < AuditRecordCodec.RecordSize) break;
+                if (!AuditRecordCodec.TryDecode(buffer, out var record)) break;
                 if (record.BuyFirm == firmId || record.SellFirm == firmId)
                     yield return record;
             }
         }
     }
 
-    private static List<(ulong Offset, ushort RecordCount)> LoadCandidateBlocks(string idxPath, uint firmId)
+    private static (List<(ulong Offset, ushort RecordCount)> Candidates, long IndexedEndOffset)
+        LoadCandidateBlocks(string idxPath, uint firmId)
     {
         var candidates = new List<(ulong, ushort)>();
+        long indexedEndOffset = AuditRecordCodec.FileHeaderSize;
         using var ix = new FileStream(idxPath, FileMode.Open, FileAccess.Read, FileShare.Read);
         var header = new byte[AuditIndexCodec.FileHeaderSize];
         int hr = ReadFully(ix, header, 0, header.Length);
@@ -119,7 +139,7 @@ public static class AuditLogReader
         {
             int prefRead = ReadFully(ix, prefix, 0, prefix.Length);
             if (prefRead == 0) break;
-            if (prefRead < prefix.Length) break; // torn tail
+            if (prefRead < prefix.Length) break;
 
             ushort entryLen = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(0, 2));
             ulong off = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(prefix.AsSpan(2, 8));
@@ -127,18 +147,22 @@ public static class AuditLogReader
             ushort firmCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(12, 2));
             int total = entryLen + 2;
             int firmsBytes = total - AuditIndexCodec.BlockEntryFixedPrefix;
-            if (firmsBytes != firmCount * 4) break; // self-inconsistent entry — treat as torn
+            if (firmsBytes != firmCount * 4) break;
 
             var firmBuf = firmsBytes == 0 ? Array.Empty<byte>() : new byte[firmsBytes];
             if (firmsBytes > 0)
             {
                 int fr = ReadFully(ix, firmBuf, 0, firmsBytes);
-                if (fr < firmsBytes) break; // torn tail in firm list
+                if (fr < firmsBytes) break;
             }
             if (firmCount > 0 && FirmListContains(firmBuf, firmCount, firmId))
                 candidates.Add((off, recCount));
+            // Index coverage advances only for fully-parsed entries; on any
+            // break above, indexedEndOffset stays at the previous block end,
+            // and the reader's suffix scan picks up from there.
+            indexedEndOffset = (long)off + ((long)recCount * AuditRecordCodec.RecordSize);
         }
-        return candidates;
+        return (candidates, indexedEndOffset);
     }
 
     private static bool FirmListContains(byte[] firmBytes, int firmCount, uint firmId)

--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -10,8 +10,7 @@ namespace B3.Exchange.PostTrade;
 /// treated as "log ends here" per the standard append-only convention
 /// (see <see cref="AuditRecordCodec.TryDecode"/> docs).
 ///
-/// PR-2 scope: full-day scan only. Firm-filtered reads land in PR-3
-/// alongside the sparse <c>.idx</c> file.
+/// PR-3 adds firm-filtered reads via the sparse <c>.idx</c> sidecar.
 /// </summary>
 public static class AuditLogReader
 {
@@ -36,11 +35,124 @@ public static class AuditLogReader
             if (read == 0)
                 yield break;
             if (read < AuditRecordCodec.RecordSize)
-                yield break; // torn tail — treat as end-of-log
+                yield break;
             if (!AuditRecordCodec.TryDecode(buffer, out var record))
                 yield break;
             yield return record;
         }
+    }
+
+    /// <summary>Yields every record in <paramref name="logPath"/> whose
+    /// <see cref="PostTradeRecord.BuyFirm"/> or
+    /// <see cref="PostTradeRecord.SellFirm"/> matches <paramref name="firmId"/>.
+    /// If a sibling <c>.idx</c> file exists, only blocks that the index marks
+    /// as containing <paramref name="firmId"/> are scanned — yielding a
+    /// significant speed-up versus a full-day scan on busy channels.
+    /// Falls back transparently to <see cref="ReadAll(string)"/>+filter when
+    /// the index is missing or corrupt (a corrupt index is never fatal —
+    /// the <c>.log</c> remains the source of truth).</summary>
+    public static IEnumerable<PostTradeRecord> ReadByFirm(string logPath, uint firmId)
+    {
+        var idxPath = Path.ChangeExtension(logPath, ".idx");
+        if (!File.Exists(idxPath))
+        {
+            foreach (var r in ReadAll(logPath))
+                if (r.BuyFirm == firmId || r.SellFirm == firmId)
+                    yield return r;
+            yield break;
+        }
+
+        List<(ulong Offset, ushort RecordCount)>? candidates;
+        try
+        {
+            candidates = LoadCandidateBlocks(idxPath, firmId);
+        }
+        catch (InvalidDataException)
+        {
+            // Corrupt or torn index — fall back to a full scan. The log is
+            // the source of truth; the index is an optimization only.
+            candidates = null;
+        }
+
+        if (candidates is null)
+        {
+            foreach (var r in ReadAll(logPath))
+                if (r.BuyFirm == firmId || r.SellFirm == firmId)
+                    yield return r;
+            yield break;
+        }
+
+        using var fs = new FileStream(logPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var header = new byte[AuditRecordCodec.FileHeaderSize];
+        int hr = ReadFully(fs, header, 0, header.Length);
+        if (hr != header.Length)
+            throw new InvalidDataException($"audit file '{logPath}' truncated in header (got {hr} bytes)");
+        _ = AuditRecordCodec.ReadFileHeader(header);
+
+        var buffer = new byte[AuditRecordCodec.RecordSize];
+        foreach (var (offset, recordCount) in candidates)
+        {
+            fs.Seek((long)offset, SeekOrigin.Begin);
+            for (int i = 0; i < recordCount; i++)
+            {
+                int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
+                if (read < AuditRecordCodec.RecordSize) yield break;
+                if (!AuditRecordCodec.TryDecode(buffer, out var record)) yield break;
+                if (record.BuyFirm == firmId || record.SellFirm == firmId)
+                    yield return record;
+            }
+        }
+    }
+
+    private static List<(ulong Offset, ushort RecordCount)> LoadCandidateBlocks(string idxPath, uint firmId)
+    {
+        var candidates = new List<(ulong, ushort)>();
+        using var ix = new FileStream(idxPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var header = new byte[AuditIndexCodec.FileHeaderSize];
+        int hr = ReadFully(ix, header, 0, header.Length);
+        if (hr != header.Length)
+            throw new InvalidDataException($"audit index '{idxPath}' truncated in header (got {hr} bytes)");
+        _ = AuditIndexCodec.ReadFileHeader(header);
+
+        var prefix = new byte[AuditIndexCodec.BlockEntryFixedPrefix];
+        while (true)
+        {
+            int prefRead = ReadFully(ix, prefix, 0, prefix.Length);
+            if (prefRead == 0) break;
+            if (prefRead < prefix.Length) break; // torn tail
+
+            ushort entryLen = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(0, 2));
+            ulong off = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(prefix.AsSpan(2, 8));
+            ushort recCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(10, 2));
+            ushort firmCount = System.Buffers.Binary.BinaryPrimitives.ReadUInt16LittleEndian(prefix.AsSpan(12, 2));
+            int total = entryLen + 2;
+            int firmsBytes = total - AuditIndexCodec.BlockEntryFixedPrefix;
+            if (firmsBytes != firmCount * 4) break; // self-inconsistent entry — treat as torn
+
+            var firmBuf = firmsBytes == 0 ? Array.Empty<byte>() : new byte[firmsBytes];
+            if (firmsBytes > 0)
+            {
+                int fr = ReadFully(ix, firmBuf, 0, firmsBytes);
+                if (fr < firmsBytes) break; // torn tail in firm list
+            }
+            if (firmCount > 0 && FirmListContains(firmBuf, firmCount, firmId))
+                candidates.Add((off, recCount));
+        }
+        return candidates;
+    }
+
+    private static bool FirmListContains(byte[] firmBytes, int firmCount, uint firmId)
+    {
+        int lo = 0, hi = firmCount - 1;
+        while (lo <= hi)
+        {
+            int mid = (lo + hi) >>> 1;
+            uint v = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(firmBytes.AsSpan(mid * 4, 4));
+            if (v == firmId) return true;
+            if (v < firmId) lo = mid + 1;
+            else hi = mid - 1;
+        }
+        return false;
     }
 
     private static int ReadFully(Stream s, byte[] buffer, int offset, int count)

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -23,17 +23,37 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
 {
     private readonly string _rootDir;
     private readonly byte _channelNumber;
-    private readonly byte[] _scratch = new byte[Math.Max(AuditRecordCodec.RecordSize, AuditRecordCodec.FileHeaderSize)];
+    private readonly int _indexBlockRecords;
+    private readonly byte[] _scratch;
+    private readonly byte[] _indexScratch;
 
     private FileStream? _stream;
+    private FileStream? _indexStream;
     private DateOnly _currentDate;
     private long _recordsWritten;
 
-    public FileAuditLogWriter(string rootDir, byte channelNumber)
+    // Current in-progress index block. _blockFirmIds is kept sorted+distinct
+    // (linear insertion — typical session has well below 64 firms per block,
+    // so this is cheaper than a HashSet allocation per block).
+    private long _blockStartOffset;
+    private int _blockRecordCount;
+    private readonly List<uint> _blockFirmIds = new(capacity: 16);
+
+    public FileAuditLogWriter(string rootDir, byte channelNumber, int indexBlockRecords = AuditIndexCodec.DefaultBlockRecords)
     {
         ArgumentException.ThrowIfNullOrEmpty(rootDir);
+        if (indexBlockRecords <= 0 || indexBlockRecords > ushort.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(indexBlockRecords), "block size must be in [1, 65535]");
         _rootDir = rootDir;
         _channelNumber = channelNumber;
+        _indexBlockRecords = indexBlockRecords;
+        _scratch = new byte[Math.Max(AuditRecordCodec.RecordSize, AuditRecordCodec.FileHeaderSize)];
+        // Worst-case index entry: prefix + indexBlockRecords distinct firm IDs
+        // (the block can record at most 2*indexBlockRecords distinct firms but
+        // realistic concurrency stays well below that — clamp at a safe upper
+        // bound to avoid an OOB write in pathological cases).
+        int maxFirmsPerBlock = Math.Min(indexBlockRecords * 2, ushort.MaxValue);
+        _indexScratch = new byte[Math.Max(AuditIndexCodec.FileHeaderSize, AuditIndexCodec.BlockEntryFixedPrefix + (maxFirmsPerBlock * 4))];
     }
 
     /// <summary>Total records successfully appended since construction. Useful
@@ -51,14 +71,19 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         {
             RotateTo(recordDate);
         }
+        if (_blockRecordCount == 0)
+            _blockStartOffset = _stream!.Position;
+
         int n = AuditRecordCodec.Encode(_scratch, in record);
         _stream!.Write(_scratch, 0, n);
-        // Flush the managed FileStream buffer to the OS on every record so
-        // the documented contract holds: post-trade records are at minimum
-        // OS-buffer-visible immediately, with fsync deferred to rotation /
-        // Checkpoint() / PR-4's durability loop.
         _stream.Flush(flushToDisk: false);
         _recordsWritten++;
+
+        TrackFirm(record.BuyFirm);
+        TrackFirm(record.SellFirm);
+        _blockRecordCount++;
+        if (_blockRecordCount >= _indexBlockRecords)
+            FlushCurrentBlock();
     }
 
     /// <summary>Flushes OS buffers and forces <c>fsync</c> on the current
@@ -66,25 +91,57 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// loop and from the operator-triggered checkpoint endpoint.</summary>
     public void Checkpoint()
     {
+        // Make any in-progress block visible to readers BEFORE fsync so a
+        // crash immediately after Checkpoint() returns leaves a consistent
+        // pair of files behind.
+        FlushCurrentBlock();
         _stream?.Flush(flushToDisk: true);
+        _indexStream?.Flush(flushToDisk: true);
+    }
+
+    private void TrackFirm(uint firmId)
+    {
+        // Keep _blockFirmIds sorted + distinct via binary insertion. The list
+        // is bounded by the firm-population in one block, which is small.
+        int idx = _blockFirmIds.BinarySearch(firmId);
+        if (idx < 0) _blockFirmIds.Insert(~idx, firmId);
+    }
+
+    private void FlushCurrentBlock()
+    {
+        if (_blockRecordCount == 0 || _indexStream is null) return;
+        Span<uint> firms = _blockFirmIds.Count == 0 ? Span<uint>.Empty : System.Runtime.InteropServices.CollectionsMarshal.AsSpan(_blockFirmIds);
+        int n = AuditIndexCodec.EncodeBlockEntry(
+            _indexScratch,
+            (ulong)_blockStartOffset,
+            checked((ushort)_blockRecordCount),
+            firms);
+        _indexStream.Write(_indexScratch, 0, n);
+        _indexStream.Flush(flushToDisk: false);
+        _blockRecordCount = 0;
+        _blockFirmIds.Clear();
     }
 
     private void RotateTo(DateOnly newDate)
     {
         if (_stream is not null)
         {
-            // Force an fsync on the closing file so the day's records are
-            // durable before subsequent records land in a new file — without
-            // this, a crash mid-rotation could leave both files with
-            // unflushed tails.
+            FlushCurrentBlock();
             _stream.Flush(flushToDisk: true);
             _stream.Dispose();
             _stream = null;
         }
+        if (_indexStream is not null)
+        {
+            _indexStream.Flush(flushToDisk: true);
+            _indexStream.Dispose();
+            _indexStream = null;
+        }
         var channelDir = Path.Combine(_rootDir, _channelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture));
         Directory.CreateDirectory(channelDir);
-        var path = Path.Combine(channelDir, $"fills-{newDate:yyyy-MM-dd}.log");
-        var fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+        var logPath = Path.Combine(channelDir, $"fills-{newDate:yyyy-MM-dd}.log");
+        var idxPath = Path.Combine(channelDir, $"fills-{newDate:yyyy-MM-dd}.idx");
+        var fs = new FileStream(logPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
         if (fs.Length == 0)
         {
             AuditRecordCodec.WriteFileHeader(_scratch, _channelNumber, newDate);
@@ -92,11 +149,6 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         }
         else
         {
-            // Recovery on append: validate the header, then scan forward to
-            // the last good record offset and truncate any torn tail before
-            // appending. Without this step, records appended after a torn
-            // tail would be permanently invisible to AuditLogReader, which
-            // (correctly) treats the first failed TryDecode as end-of-log.
             long goodEnd = ScanLastGoodEndOffset(fs);
             if (goodEnd != fs.Length)
                 fs.SetLength(goodEnd);
@@ -104,6 +156,65 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         fs.Seek(0, SeekOrigin.End);
         _stream = fs;
         _currentDate = newDate;
+        _blockRecordCount = 0;
+        _blockFirmIds.Clear();
+
+        // Always rebuild the .idx from scratch on (re)open. A partial block
+        // at end-of-log invalidates the trailing index entry anyway, and
+        // re-scanning is O(records) which the operator pays once per restart.
+        OpenAndRebuildIndex(idxPath, fs, newDate);
+    }
+
+    private void OpenAndRebuildIndex(string idxPath, FileStream logStream, DateOnly newDate)
+    {
+        if (File.Exists(idxPath)) File.Delete(idxPath);
+        var ix = new FileStream(idxPath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.Read);
+        AuditIndexCodec.WriteFileHeader(_indexScratch, _channelNumber, newDate);
+        ix.Write(_indexScratch, 0, AuditIndexCodec.FileHeaderSize);
+        _indexStream = ix;
+        if (logStream.Length <= AuditRecordCodec.FileHeaderSize) return;
+
+        long savedPos = logStream.Position;
+        try
+        {
+            logStream.Seek(AuditRecordCodec.FileHeaderSize, SeekOrigin.Begin);
+            Span<byte> rec = stackalloc byte[AuditRecordCodec.RecordSize];
+            long blockStart = logStream.Position;
+            int recsInBlock = 0;
+            var firmsInBlock = new List<uint>();
+            while (true)
+            {
+                if (recsInBlock == 0) blockStart = logStream.Position;
+                int read = logStream.Read(rec);
+                if (read != rec.Length) break;
+                if (!AuditRecordCodec.TryDecode(rec, out var decoded)) break;
+                int idx;
+                idx = firmsInBlock.BinarySearch(decoded.BuyFirm);
+                if (idx < 0) firmsInBlock.Insert(~idx, decoded.BuyFirm);
+                idx = firmsInBlock.BinarySearch(decoded.SellFirm);
+                if (idx < 0) firmsInBlock.Insert(~idx, decoded.SellFirm);
+                recsInBlock++;
+                if (recsInBlock >= _indexBlockRecords)
+                {
+                    var span = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(firmsInBlock);
+                    int n = AuditIndexCodec.EncodeBlockEntry(_indexScratch, (ulong)blockStart, (ushort)recsInBlock, span);
+                    ix.Write(_indexScratch, 0, n);
+                    recsInBlock = 0;
+                    firmsInBlock.Clear();
+                }
+            }
+            if (recsInBlock > 0)
+            {
+                var span = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(firmsInBlock);
+                int n = AuditIndexCodec.EncodeBlockEntry(_indexScratch, (ulong)blockStart, (ushort)recsInBlock, span);
+                ix.Write(_indexScratch, 0, n);
+            }
+            ix.Flush(flushToDisk: false);
+        }
+        finally
+        {
+            logStream.Seek(savedPos, SeekOrigin.Begin);
+        }
     }
 
     private long ScanLastGoodEndOffset(FileStream fs)
@@ -139,9 +250,16 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     {
         if (_stream is not null)
         {
+            FlushCurrentBlock();
             _stream.Flush(flushToDisk: true);
             _stream.Dispose();
             _stream = null;
+        }
+        if (_indexStream is not null)
+        {
+            _indexStream.Flush(flushToDisk: true);
+            _indexStream.Dispose();
+            _indexStream = null;
         }
     }
 }

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -172,6 +172,7 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         AuditIndexCodec.WriteFileHeader(_indexScratch, _channelNumber, newDate);
         ix.Write(_indexScratch, 0, AuditIndexCodec.FileHeaderSize);
         _indexStream = ix;
+        ix.Flush(flushToDisk: false);
         if (logStream.Length <= AuditRecordCodec.FileHeaderSize) return;
 
         long savedPos = logStream.Position;

--- a/tests/B3.Exchange.PostTrade.Tests/AuditIndexCodecTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditIndexCodecTests.cs
@@ -1,0 +1,86 @@
+using System.Buffers.Binary;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+public class AuditIndexCodecTests
+{
+    [Fact]
+    public void FileHeader_RoundTrips()
+    {
+        Span<byte> buf = stackalloc byte[AuditIndexCodec.FileHeaderSize];
+        AuditIndexCodec.WriteFileHeader(buf, channelNumber: 9, tradeDate: new DateOnly(2026, 5, 18));
+        var (ch, date) = AuditIndexCodec.ReadFileHeader(buf);
+        Assert.Equal(9, ch);
+        Assert.Equal(new DateOnly(2026, 5, 18), date);
+    }
+
+    [Fact]
+    public void FileHeader_BadMagic_Throws()
+    {
+        var buf = new byte[AuditIndexCodec.FileHeaderSize];
+        AuditIndexCodec.WriteFileHeader(buf, 1, new DateOnly(2026, 5, 18));
+        buf[0] ^= 0xFF;
+        Assert.Throws<InvalidDataException>(() => AuditIndexCodec.ReadFileHeader(buf));
+    }
+
+    [Fact]
+    public void FileHeader_ReservedBytesNonZero_Throws()
+    {
+        var buf = new byte[AuditIndexCodec.FileHeaderSize];
+        AuditIndexCodec.WriteFileHeader(buf, 1, new DateOnly(2026, 5, 18));
+        buf[23] = 1;
+        Assert.Throws<InvalidDataException>(() => AuditIndexCodec.ReadFileHeader(buf));
+    }
+
+    [Fact]
+    public void BlockEntry_RoundTrips_WithFirms()
+    {
+        var firms = new uint[] { 1, 7, 42, 1234 };
+        Span<byte> buf = stackalloc byte[AuditIndexCodec.BlockEntryFixedPrefix + (firms.Length * 4)];
+        int written = AuditIndexCodec.EncodeBlockEntry(buf, blockLogOffset: 24UL, recordCount: 17, firms);
+        Assert.Equal(buf.Length, written);
+
+        byte[] copy = buf.ToArray();
+        Assert.True(AuditIndexCodec.TryReadBlockEntry(copy, out var off, out var rc, out var fc, out var total));
+        Assert.Equal(24UL, off);
+        Assert.Equal(17, rc);
+        Assert.Equal(firms.Length, fc);
+        Assert.Equal(buf.Length, total);
+        for (int i = 0; i < firms.Length; i++)
+            Assert.Equal(firms[i], AuditIndexCodec.ReadFirmId(copy, i));
+    }
+
+    [Fact]
+    public void BlockEntry_EmptyFirmList_RoundTrips()
+    {
+        Span<byte> buf = stackalloc byte[AuditIndexCodec.BlockEntryFixedPrefix];
+        int n = AuditIndexCodec.EncodeBlockEntry(buf, 100UL, 5, ReadOnlySpan<uint>.Empty);
+        Assert.Equal(buf.Length, n);
+        byte[] copy = buf.ToArray();
+        Assert.True(AuditIndexCodec.TryReadBlockEntry(copy, out var off, out var rc, out var fc, out var total));
+        Assert.Equal(100UL, off);
+        Assert.Equal(5, rc);
+        Assert.Equal(0, fc);
+        Assert.Equal(buf.Length, total);
+    }
+
+    [Fact]
+    public void BlockEntry_Truncated_ReturnsFalse()
+    {
+        var firms = new uint[] { 1, 2, 3 };
+        var buf = new byte[AuditIndexCodec.BlockEntryFixedPrefix + (firms.Length * 4)];
+        AuditIndexCodec.EncodeBlockEntry(buf, 0, 1, firms);
+        Assert.False(AuditIndexCodec.TryReadBlockEntry(buf.AsSpan(0, buf.Length - 1), out _, out _, out _, out _));
+    }
+
+    [Fact]
+    public void BlockEntry_WrongEntryLen_ReturnsFalse()
+    {
+        var firms = new uint[] { 5 };
+        var buf = new byte[AuditIndexCodec.BlockEntryFixedPrefix + (firms.Length * 4)];
+        AuditIndexCodec.EncodeBlockEntry(buf, 0, 1, firms);
+        BinaryPrimitives.WriteUInt16LittleEndian(buf.AsSpan(0, 2), 999); // declare wrong length
+        Assert.False(AuditIndexCodec.TryReadBlockEntry(buf, out _, out _, out _, out _));
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterIndexTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterIndexTests.cs
@@ -1,0 +1,165 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+public class FileAuditLogWriterIndexTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileAuditLogWriterIndexTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeIdxTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+
+    private static PostTradeRecord Make(uint id, uint buyFirm, uint sellFirm) => new(
+        TradeId: id, TransactTimeNanos: Day0Nanos + id, SecurityId: 900_000_000_001L,
+        AggressorSide: id % 2 == 0 ? Side.Buy : Side.Sell,
+        Quantity: 100, PriceMantissa: 10_0000L + id,
+        BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+        BuyFirm: buyFirm, SellFirm: sellFirm,
+        BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    [Fact]
+    public void Writer_EmitsSidecarIdxAlongsideLog()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 1, indexBlockRecords: 4))
+            for (uint i = 1; i <= 10; i++)
+                w.OnTrade(Make(i, buyFirm: 10, sellFirm: 20));
+
+        var logPath = Path.Combine(_root, "1", "fills-2026-05-18.log");
+        var idxPath = Path.Combine(_root, "1", "fills-2026-05-18.idx");
+        Assert.True(File.Exists(logPath));
+        Assert.True(File.Exists(idxPath));
+        // Index header (24) + 3 entries (2 full blocks of 4 + 1 partial of 2),
+        // each entry = prefix(14) + 2 distinct firms*4 = 22 bytes.
+        var idxLen = new FileInfo(idxPath).Length;
+        Assert.Equal(AuditIndexCodec.FileHeaderSize + (3 * (AuditIndexCodec.BlockEntryFixedPrefix + (2 * 4))), idxLen);
+    }
+
+    [Fact]
+    public void ReadByFirm_ReturnsOnlyMatchingRecords()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 2, indexBlockRecords: 4))
+        {
+            // Block A (records 1-4): firms 10/20
+            for (uint i = 1; i <= 4; i++) w.OnTrade(Make(i, 10, 20));
+            // Block B (5-8): firms 30/40 — firm 10 must NOT match this block
+            for (uint i = 5; i <= 8; i++) w.OnTrade(Make(i, 30, 40));
+            // Block C (9-10): firms 10/50 — firm 10 matches again
+            for (uint i = 9; i <= 10; i++) w.OnTrade(Make(i, 10, 50));
+        }
+        var logPath = Path.Combine(_root, "2", "fills-2026-05-18.log");
+        var got = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3, 4, 9, 10 }, got);
+    }
+
+    [Fact]
+    public void ReadByFirm_NoMatch_ReturnsEmpty()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 3, indexBlockRecords: 4))
+            for (uint i = 1; i <= 10; i++) w.OnTrade(Make(i, 10, 20));
+        var logPath = Path.Combine(_root, "3", "fills-2026-05-18.log");
+        Assert.Empty(AuditLogReader.ReadByFirm(logPath, firmId: 99));
+    }
+
+    [Fact]
+    public void ReadByFirm_FallsBackToFullScan_WhenIdxMissing()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 4, indexBlockRecords: 4))
+            for (uint i = 1; i <= 6; i++) w.OnTrade(Make(i, i <= 3 ? 10u : 50u, 20));
+        var logPath = Path.Combine(_root, "4", "fills-2026-05-18.log");
+        var idxPath = Path.ChangeExtension(logPath, ".idx");
+        File.Delete(idxPath);
+        var got = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3 }, got);
+    }
+
+    [Fact]
+    public void ReadByFirm_FallsBackToFullScan_WhenIdxCorrupt()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 5, indexBlockRecords: 4))
+            for (uint i = 1; i <= 6; i++) w.OnTrade(Make(i, i <= 3 ? 10u : 50u, 20));
+        var logPath = Path.Combine(_root, "5", "fills-2026-05-18.log");
+        var idxPath = Path.ChangeExtension(logPath, ".idx");
+        // Corrupt the index magic — reader must fall back, not throw.
+        using (var fs = new FileStream(idxPath, FileMode.Open, FileAccess.Write))
+        {
+            fs.WriteByte(0xFF);
+        }
+        var got = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3 }, got);
+    }
+
+    [Fact]
+    public void Writer_Reopen_RebuildsIndexFromLog()
+    {
+        // First session writes blocks A and B.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 6, indexBlockRecords: 4))
+        {
+            for (uint i = 1; i <= 4; i++) w.OnTrade(Make(i, 10, 20));
+            for (uint i = 5; i <= 8; i++) w.OnTrade(Make(i, 30, 40));
+        }
+        // Simulate operator wiping the index but keeping the log.
+        var logPath = Path.Combine(_root, "6", "fills-2026-05-18.log");
+        var idxPath = Path.ChangeExtension(logPath, ".idx");
+        File.Delete(idxPath);
+
+        // Second session reopens; rebuild happens during RotateTo + then we
+        // append one more block (just 2 records, partial).
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 6, indexBlockRecords: 4))
+        {
+            for (uint i = 9; i <= 10; i++) w.OnTrade(Make(i, 10, 50));
+        }
+        Assert.True(File.Exists(idxPath));
+        var firm10 = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3, 4, 9, 10 }, firm10);
+        var firm30 = AuditLogReader.ReadByFirm(logPath, firmId: 30).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 5, 6, 7, 8 }, firm30);
+    }
+
+    [Fact]
+    public void Writer_Reopen_RebuildIndex_DiscardsStaleIdx()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 7, indexBlockRecords: 4))
+            for (uint i = 1; i <= 6; i++) w.OnTrade(Make(i, 10, 20));
+        var idxPath = Path.Combine(_root, "7", "fills-2026-05-18.idx");
+        var beforeLen = new FileInfo(idxPath).Length;
+
+        // Reopen without adding records: writer recreates a fresh .idx that
+        // covers exactly the records present on disk.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 7, indexBlockRecords: 4))
+            w.OnTrade(Make(7, 10, 20));
+        var afterLen = new FileInfo(idxPath).Length;
+
+        // The new file must NOT be the byte-for-byte concatenation of the
+        // old (which would be the bug of "kept appending to stale idx").
+        // After reopen+1 record we have 2 full blocks of 4 (rebuilt) + a
+        // partial block of 1 from the new record's Dispose flush.
+        var expected = AuditIndexCodec.FileHeaderSize
+            + (AuditIndexCodec.BlockEntryFixedPrefix + (2 * 4))  // rebuilt block A
+            + (AuditIndexCodec.BlockEntryFixedPrefix + (2 * 4))  // rebuilt block B (partial of 2 records, still 2 firms)
+            + (AuditIndexCodec.BlockEntryFixedPrefix + (2 * 4)); // new partial block (record 7) with firms 10/20
+        Assert.Equal(expected, afterLen);
+        Assert.NotEqual(beforeLen * 2, afterLen);
+    }
+
+    [Fact]
+    public void ReadByFirm_AfterCheckpoint_SeesInProgressBlock()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 8, indexBlockRecords: 64);
+        for (uint i = 1; i <= 3; i++) w.OnTrade(Make(i, 10, 20));
+        w.Checkpoint();
+        var logPath = Path.Combine(_root, "8", "fills-2026-05-18.log");
+        var got = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3 }, got);
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterIndexTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterIndexTests.cs
@@ -162,4 +162,54 @@ public class FileAuditLogWriterIndexTests : IDisposable
         var got = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
         Assert.Equal(new uint[] { 1, 2, 3 }, got);
     }
+
+    [Fact]
+    public void ReadByFirm_BeforeBlockFlush_ScansUnindexedTail()
+    {
+        // Records are present in .log (each OnTrade flushes to OS buffer)
+        // but no block entry has been written to .idx yet because we are
+        // mid-block. ReadByFirm must still surface them via the unindexed
+        // suffix scan; otherwise live readers see a stale view.
+        using var w = new FileAuditLogWriter(_root, channelNumber: 9, indexBlockRecords: 64);
+        for (uint i = 1; i <= 5; i++) w.OnTrade(Make(i, 10, 20));
+        var logPath = Path.Combine(_root, "9", "fills-2026-05-18.log");
+        var idxPath = Path.ChangeExtension(logPath, ".idx");
+        // Sanity: .idx contains header only at this point.
+        Assert.Equal(AuditIndexCodec.FileHeaderSize, new FileInfo(idxPath).Length);
+        var got = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3, 4, 5 }, got);
+    }
+
+    [Fact]
+    public void ReadByFirm_MalformedIdxEntryMidFile_StillReturnsLaterRecords()
+    {
+        // Write 3 blocks (4+4+4 = 12 records) so the .idx has 3 entries,
+        // then corrupt the middle entry so the index parser stops there.
+        // The reader must still return records from the third block via
+        // the unindexed-suffix scan.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 10, indexBlockRecords: 4))
+        {
+            for (uint i = 1; i <= 4; i++) w.OnTrade(Make(i, 10, 20));
+            for (uint i = 5; i <= 8; i++) w.OnTrade(Make(i, 10, 30));
+            for (uint i = 9; i <= 12; i++) w.OnTrade(Make(i, 10, 40));
+        }
+        var logPath = Path.Combine(_root, "10", "fills-2026-05-18.log");
+        var idxPath = Path.ChangeExtension(logPath, ".idx");
+        // Corrupt the second block entry's recordCount to a value that
+        // makes the entry self-inconsistent (firmsBytes != firmCount*4).
+        // Layout per entry: header(24) + entry1(22) + entry2(22) + entry3(22).
+        var corruptOffset = AuditIndexCodec.FileHeaderSize + (AuditIndexCodec.BlockEntryFixedPrefix + 8) + 12;
+        using (var fs = new FileStream(idxPath, FileMode.Open, FileAccess.Write))
+        {
+            fs.Seek(corruptOffset, SeekOrigin.Begin);
+            fs.WriteByte(0xFF); fs.WriteByte(0xFF);
+        }
+
+        var got = AuditLogReader.ReadByFirm(logPath, firmId: 40).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 9, 10, 11, 12 }, got);
+        // And firm-10 (which appears in all three blocks) must still be
+        // fully visible: indexed block 1 + suffix scan covering blocks 2+3.
+        var firm10 = AuditLogReader.ReadByFirm(logPath, firmId: 10).Select(r => r.TradeId).ToList();
+        Assert.Equal(new uint[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, firm10);
+    }
 }


### PR DESCRIPTION
PR-3 of the 6-PR series for #329.

## What
Adds a per-firm lookup path on top of PR-2's file writer, via a sparse `.idx` sidecar.

**Index file** (`{root}/{channel}/fills-YYYY-MM-DD.idx`):
- Header (24B, magic `B3PI` + schema=1 + channel + tradeDate)
- Variable entries, one per record block (default 64 records / block):
  `entryLen(2) | blockLogOffset(8) | recordCount(2) | firmCount(2) | firmIds(uint32 × N, sorted asc)`

**Writer side** (`FileAuditLogWriter`):
- Tracks the in-progress block's distinct firm set (sorted insertion). Flushes to `.idx` on block fill / rotation / `Checkpoint()` / `Dispose`.
- On reopen of an existing `.log`, discards any existing `.idx` and rebuilds it by re-scanning the truncated log. O(records), once per restart, avoids a stale entry pointing at records that no longer exist.
- New ctor param `indexBlockRecords` (default 64).

**Reader API** (`AuditLogReader.ReadByFirm(logPath, firmId)`):
- Loads candidate blocks from `.idx` (binary search over each block's sorted firm list), seeks only to those offsets, linearly scans within each candidate block.
- Transparent fallback to a full-day scan when `.idx` is missing or corrupt — the `.log` is the source of truth; the index is an optimization only.

## Tests (15 new, 34 total in B3.Exchange.PostTrade.Tests)
- `AuditIndexCodecTests` — header round-trip + bad magic + reserved bytes + block entry round-trip with firms / empty / truncated / wrong entryLen
- `FileAuditLogWriterIndexTests` — sidecar emitted at expected size; `ReadByFirm` returns only matching blocks; no-match → empty; fallback when `.idx` missing or corrupt; reopen rebuilds (not concatenated) `.idx`; `Checkpoint()` makes the in-progress block immediately visible

## Out of scope (later PRs in #329)
- PR-4: `auditDurableSeq` watermark + WAL truncation gating
- PR-5: restart replay-into-audit-only
- PR-6: retention + bench + RUNBOOK

## Verification
```
dotnet build  SbeB3Exchange.slnx -c Release            # 0 warnings, 0 errors
dotnet test   SbeB3Exchange.slnx --no-build -c Release # all green
dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn  # clean
```