### PR TITLE
post-trade: audit durability watermark + WAL truncation gating (#329 PR-4)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -398,6 +398,11 @@ public sealed partial class ChannelDispatcher
     /// </summary>
     private void OnAfterCommandFlushed(bool force = false)
     {
+        // Issue #329 PR-4: tag the command boundary on the audit sink so
+        // the durability watermark can advance on the next Checkpoint.
+        // Done before any early-return so the sink sees boundaries even
+        // when no persister is wired (cheap when the sink is the no-op).
+        _postTradeSink.OnCommandBoundary(_lastAppliedSeq);
         if (_persister is null) return;
         long nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         if (!force)
@@ -450,7 +455,7 @@ public sealed partial class ChannelDispatcher
             // the WAL on the dispatch thread. After this point the
             // on-disk WAL is empty and a crash falls through to the
             // (just-saved) snapshot for recovery.
-            TruncateWalAfterSyncSave();
+            TruncateWalAfterSyncSave(snap.LastAppliedSeq);
         }
         catch (Exception ex)
         {

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -135,10 +135,21 @@ public sealed partial class ChannelDispatcher
     /// Truncates the WAL after a successful synchronous snapshot
     /// persist. Called from <c>OnAfterCommandFlushed</c> on the
     /// dispatch thread.
+    ///
+    /// <para>Issue #329 PR-4: gated on the post-trade audit watermark.
+    /// The truncate proceeds only when every WAL record up to
+    /// <paramref name="snapshotLastAppliedSeq"/> has produced trades
+    /// that are fsync'd to the audit log. If not, the truncate is
+    /// deferred — the WAL keeps growing until the next snapshot, at
+    /// which point we try again. The no-op audit sink reports
+    /// <see cref="long.MaxValue"/> so this is a no-op gate when audit
+    /// is disabled (default).</para>
     /// </summary>
-    private void TruncateWalAfterSyncSave()
+    private void TruncateWalAfterSyncSave(long snapshotLastAppliedSeq)
     {
         if (_wal is null) return;
+        if (!CheckpointAndGateAuditWatermark(snapshotLastAppliedSeq, async: false))
+            return;
         try
         {
             _wal.Truncate();
@@ -158,10 +169,16 @@ public sealed partial class ChannelDispatcher
     /// on the writer thread when async-writer mode is enabled. Truncates
     /// the WAL on that thread so the on-disk WAL only loses records that
     /// the matching snapshot has already absorbed.
+    ///
+    /// <para>Issue #329 PR-4: gated on the audit watermark (see
+    /// <see cref="TruncateWalAfterSyncSave(long)"/>). The audit sink's
+    /// Checkpoint is safe to call cross-thread.</para>
     /// </summary>
-    private void OnAsyncSnapshotSaved(ChannelStateSnapshot _)
+    private void OnAsyncSnapshotSaved(ChannelStateSnapshot snap)
     {
         if (_wal is null) return;
+        if (!CheckpointAndGateAuditWatermark(snap.LastAppliedSeq, async: true))
+            return;
         try
         {
             _wal.Truncate();
@@ -174,6 +191,39 @@ public sealed partial class ChannelDispatcher
                 "channel {ChannelNumber}: WAL truncation failed after async snapshot save",
                 ChannelNumber);
         }
+    }
+
+    /// <summary>
+    /// Issue #329 PR-4 audit-watermark gate. Forces an audit-log
+    /// <c>Checkpoint</c> (fsync) and returns true iff the watermark
+    /// covers <paramref name="snapshotLastAppliedSeq"/>. On Checkpoint
+    /// failure (I/O fault) the watermark stays put and we deny the
+    /// truncate — the WAL keeps the records the audit log might not have.
+    /// </summary>
+    private bool CheckpointAndGateAuditWatermark(long snapshotLastAppliedSeq, bool async)
+    {
+        try
+        {
+            _postTradeSink.Checkpoint();
+        }
+        catch (Exception ex)
+        {
+            _metrics?.IncAuditWalTruncateDeferred();
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: audit log Checkpoint failed ({Path}); WAL truncation deferred (snapshotSeq={SnapshotSeq})",
+                ChannelNumber, async ? "async" : "sync", snapshotLastAppliedSeq);
+            return false;
+        }
+        long durable = _postTradeSink.DurableThroughCommandSeq;
+        if (durable < snapshotLastAppliedSeq)
+        {
+            _metrics?.IncAuditWalTruncateDeferred();
+            _logger.LogWarning(
+                "channel {ChannelNumber}: WAL truncation deferred — audit watermark behind snapshot (durable={Durable}, snapshotSeq={SnapshotSeq}, path={Path})",
+                ChannelNumber, durable, snapshotLastAppliedSeq, async ? "async" : "sync");
+            return false;
+        }
+        return true;
     }
 
     /// <summary>

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -196,6 +196,16 @@ public sealed class ChannelMetrics
     /// alert correctly.
     /// </summary>
     private long _walHaltRejects;
+    /// <summary>
+    /// Issue #329 PR-4: cumulative count of WAL truncation attempts
+    /// (sync or async snapshot-saved path) deferred because the
+    /// post-trade audit watermark had not yet caught up with the
+    /// snapshot's <c>LastAppliedSeq</c>, OR because the audit
+    /// Checkpoint itself threw. Operators alert on a sustained
+    /// non-zero rate — it indicates audit-log durability lag
+    /// pinning the WAL size open.
+    /// </summary>
+    private long _auditWalTruncateDeferred;
     public long WalAppends => Interlocked.Read(ref _walAppends);
     public long WalBytesAppended => Interlocked.Read(ref _walBytesAppended);
     public long WalTruncations => Interlocked.Read(ref _walTruncations);
@@ -217,6 +227,8 @@ public sealed class ChannelMetrics
     /// dispatcher has been WAL-halted. Always 0 unless the channel is
     /// configured with <see cref="WalAppendFailurePolicy.Halt"/>.</summary>
     public long WalHaltRejects => Interlocked.Read(ref _walHaltRejects);
+    /// <summary>Issue #329 PR-4: see <see cref="IncAuditWalTruncateDeferred"/>.</summary>
+    public long AuditWalTruncateDeferred => Interlocked.Read(ref _auditWalTruncateDeferred);
     public void IncWalAppend(long bytes)
     {
         Interlocked.Increment(ref _walAppends);
@@ -237,6 +249,10 @@ public sealed class ChannelMetrics
     }
     public void IncWalAppendFailure() => Interlocked.Increment(ref _walAppendFailures);
     public void IncWalHaltReject() => Interlocked.Increment(ref _walHaltRejects);
+    /// <summary>Issue #329 PR-4: bumped from <c>ChannelDispatcher</c>'s WAL
+    /// truncation gate when the audit watermark is behind the snapshot seq
+    /// (or the audit Checkpoint threw). See <see cref="_auditWalTruncateDeferred"/>.</summary>
+    public void IncAuditWalTruncateDeferred() => Interlocked.Increment(ref _auditWalTruncateDeferred);
 
     /// <summary>Issue #291: current on-disk WAL size in bytes
     /// (gauge). Updated by the dispatcher after every successful
@@ -720,6 +736,9 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_wal_drops_on_full_total",
             "Issue #291: WAL Append() calls silently skipped because persistence.wal.maxBytes was reached and persistence.wal.onFull=drop. Distinct from exch_wal_append_failures_total so on-call can route a capacity-exhaustion alert separately from a generic IO-fault alert. Non-zero means the durability contract has been silently relaxed on this channel.",
             channels, c => c.WalDropsOnFull);
+        EmitCounter(sb, "exch_audit_wal_truncate_deferred_total",
+            "Issue #329 PR-4: WAL truncation attempts (sync or async snapshot-saved path) deferred because the post-trade audit watermark had not yet caught up with the snapshot's LastAppliedSeq, OR the audit-log Checkpoint itself threw. Always 0 when audit logging is disabled (the no-op sink reports DurableThroughCommandSeq=long.MaxValue). A sustained non-zero rate means audit-log durability lag is pinning the WAL size open and warrants investigation of audit storage latency.",
+            channels, c => c.AuditWalTruncateDeferred);
 
         // Issue #270: cross-channel consistency check. Counts owner
         // entries silently dropped at restore because their SessionId

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -44,6 +44,15 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     private long _pendingCommandSeq;
     private long _durableCommandSeq;
 
+    // Issue #329 PR-4 (HIGH review finding): once an OnTrade write throws,
+    // the audit log has a known hole — every subsequent OnCommandBoundary
+    // and Checkpoint MUST refuse to advance the watermark so the WAL
+    // truncation gate stays closed and operators can recover from the
+    // on-disk WAL. Mirrors the WalAppendFailurePolicy.Halt model in
+    // ChannelDispatcher (issue #286). Sticky for the lifetime of this
+    // writer instance — only a restart/rebuild clears it.
+    private bool _writeFault;
+
     // Current in-progress index block. _blockFirmIds is kept sorted+distinct
     // (linear insertion — typical session has well below 64 firms per block,
     // so this is cheaper than a HashSet allocation per block).
@@ -80,35 +89,56 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     {
         lock (_checkpointLock)
         {
-            var recordDate = ToUtcDate(record.TransactTimeNanos);
-            if (_stream is null || recordDate != _currentDate)
+            // If a prior write already failed, refuse silently — the audit
+            // log is in a known-broken state and further writes would only
+            // deepen the hole. ChannelDispatcher's OnTrade catches and
+            // swallows post-trade sink exceptions, so throwing here would
+            // not even reach the operator; the deferred-truncate metric
+            // (bumped on every Checkpoint attempt below) is the alert path.
+            if (_writeFault) return;
+            try
             {
-                RotateTo(recordDate);
+                var recordDate = ToUtcDate(record.TransactTimeNanos);
+                if (_stream is null || recordDate != _currentDate)
+                {
+                    RotateTo(recordDate);
+                }
+                if (_blockRecordCount == 0)
+                    _blockStartOffset = _stream!.Position;
+
+                int n = AuditRecordCodec.Encode(_scratch, in record);
+                _stream!.Write(_scratch, 0, n);
+                _stream.Flush(flushToDisk: false);
+                _recordsWritten++;
+
+                TrackFirm(record.BuyFirm);
+                TrackFirm(record.SellFirm);
+                _blockRecordCount++;
+                if (_blockRecordCount >= _indexBlockRecords)
+                    FlushCurrentBlock();
             }
-            if (_blockRecordCount == 0)
-                _blockStartOffset = _stream!.Position;
-
-            int n = AuditRecordCodec.Encode(_scratch, in record);
-            _stream!.Write(_scratch, 0, n);
-            _stream.Flush(flushToDisk: false);
-            _recordsWritten++;
-
-            TrackFirm(record.BuyFirm);
-            TrackFirm(record.SellFirm);
-            _blockRecordCount++;
-            if (_blockRecordCount >= _indexBlockRecords)
-                FlushCurrentBlock();
+            catch
+            {
+                // Poison the watermark for the rest of this writer's life.
+                // Any subsequent OnCommandBoundary/Checkpoint will refuse to
+                // advance _durableCommandSeq, keeping the WAL truncation
+                // gate permanently closed until the operator restarts.
+                _writeFault = true;
+                throw;
+            }
         }
     }
 
     /// <summary>Tags every record OnTrade'd since the previous boundary as
     /// "produced by <paramref name="commandSeq"/>". The watermark advances
     /// from pending to durable on the next <see cref="Checkpoint"/> call.
-    /// Dispatch-thread-only; cheap (single store under the shared lock).</summary>
+    /// Dispatch-thread-only; cheap (single store under the shared lock).
+    /// No-op when the writer is in write-fault state.</summary>
     public void OnCommandBoundary(long commandSeq)
     {
         lock (_checkpointLock)
         {
+            if (_writeFault) return;
             // Monotonic: tolerate replay paths that resubmit lower seqs.
             if (commandSeq > _pendingCommandSeq) _pendingCommandSeq = commandSeq;
         }
@@ -119,11 +149,18 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// <see cref="OnCommandBoundary"/> value. Safe to call from any thread
     /// (the lock serializes against OnTrade/OnCommandBoundary on the
     /// dispatch thread). If the fsync throws the watermark is NOT advanced
-    /// — callers must treat that as "audit not durable; defer truncation".</summary>
+    /// — callers must treat that as "audit not durable; defer truncation".
+    /// Throws when the writer is in write-fault state so the WAL truncation
+    /// gate stays closed.</summary>
     public void Checkpoint()
     {
         lock (_checkpointLock)
         {
+            if (_writeFault)
+            {
+                throw new IOException(
+                    "audit log writer in write-fault state — refusing to advance durability watermark; restart the host after investigating the prior OnTrade failure");
+            }
             // Snapshot the pending boundary BEFORE the fsync — any
             // concurrent OnCommandBoundary call would have to acquire
             // this lock so the value is stable while we fsync.
@@ -141,6 +178,16 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// fsync'd to disk. Read cross-thread by the WAL truncation gate;
     /// uses Volatile.Read for a torn-safe 64-bit read on ARM.</summary>
     public long DurableThroughCommandSeq => Volatile.Read(ref _durableCommandSeq);
+
+    /// <summary>True once an OnTrade write has thrown; the writer is
+    /// permanently broken and the watermark will not advance. Exposed
+    /// for regression tests of the issue #329 PR-4 write-fault contract.</summary>
+    internal bool WriteFault => _writeFault;
+
+    /// <summary>Test-only hook to force the writer into write-fault state
+    /// without engineering a real I/O failure. Exercises the watermark
+    /// poisoning contract.</summary>
+    internal void ForceWriteFaultForTests() { lock (_checkpointLock) { _writeFault = true; } }
 
     private void TrackFirm(uint firmId)
     {

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -9,15 +9,18 @@ namespace B3.Exchange.PostTrade;
 /// rather than wall-clock so the rollover is deterministic across replay
 /// and across time-warped scenario tests.
 ///
-/// Threading model: not thread-safe. Designed to be installed as the
-/// per-channel <see cref="IPostTradeSink"/> and invoked exclusively on
-/// the <c>ChannelDispatcher</c>'s single dispatch thread.
+/// Threading model: OnTrade and OnCommandBoundary are called exclusively on
+/// the <c>ChannelDispatcher</c>'s dispatch thread. Checkpoint MAY be called
+/// from another thread (the async snapshot writer's onSaved callback runs on
+/// the writer thread). A single private lock serializes Checkpoint against
+/// OnTrade/OnCommandBoundary; the lock is uncontended in steady state since
+/// Checkpoint fires at snapshot intervals.
 ///
-/// Durability: writes are flushed to the OS buffer on every record but
-/// NOT fsynced. <see cref="Checkpoint"/> calls <c>FileStream.Flush(true)</c>
-/// — wire it from PR-4's interval-bounded watermark loop. PR-2 leaves the
-/// dispatcher's hot path free of fsync to avoid a regression before the
-/// durability infrastructure exists.
+/// Durability watermark (issue #329 PR-4): each <see cref="OnCommandBoundary"/>
+/// records the engine's <c>commandSeq</c> as the highest seq covered by the
+/// records OnTrade'd so far. <see cref="Checkpoint"/> fsyncs both files and
+/// promotes that pending value into <see cref="DurableThroughCommandSeq"/>,
+/// which the WAL truncation gate reads before dropping WAL records.
 /// </summary>
 public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
 {
@@ -26,11 +29,20 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     private readonly int _indexBlockRecords;
     private readonly byte[] _scratch;
     private readonly byte[] _indexScratch;
+    private readonly object _checkpointLock = new();
 
     private FileStream? _stream;
     private FileStream? _indexStream;
     private DateOnly _currentDate;
     private long _recordsWritten;
+
+    // Durability watermark (issue #329 PR-4). _pendingCommandSeq tracks the
+    // highest commandSeq tagged via OnCommandBoundary since the last Checkpoint;
+    // _durableCommandSeq is advanced to it on every successful Checkpoint.
+    // Read cross-thread by ChannelDispatcher's WAL truncation gate, hence
+    // Volatile/Interlocked access.
+    private long _pendingCommandSeq;
+    private long _durableCommandSeq;
 
     // Current in-progress index block. _blockFirmIds is kept sorted+distinct
     // (linear insertion — typical session has well below 64 firms per block,
@@ -66,38 +78,69 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
 
     public void OnTrade(in PostTradeRecord record)
     {
-        var recordDate = ToUtcDate(record.TransactTimeNanos);
-        if (_stream is null || recordDate != _currentDate)
+        lock (_checkpointLock)
         {
-            RotateTo(recordDate);
+            var recordDate = ToUtcDate(record.TransactTimeNanos);
+            if (_stream is null || recordDate != _currentDate)
+            {
+                RotateTo(recordDate);
+            }
+            if (_blockRecordCount == 0)
+                _blockStartOffset = _stream!.Position;
+
+            int n = AuditRecordCodec.Encode(_scratch, in record);
+            _stream!.Write(_scratch, 0, n);
+            _stream.Flush(flushToDisk: false);
+            _recordsWritten++;
+
+            TrackFirm(record.BuyFirm);
+            TrackFirm(record.SellFirm);
+            _blockRecordCount++;
+            if (_blockRecordCount >= _indexBlockRecords)
+                FlushCurrentBlock();
         }
-        if (_blockRecordCount == 0)
-            _blockStartOffset = _stream!.Position;
-
-        int n = AuditRecordCodec.Encode(_scratch, in record);
-        _stream!.Write(_scratch, 0, n);
-        _stream.Flush(flushToDisk: false);
-        _recordsWritten++;
-
-        TrackFirm(record.BuyFirm);
-        TrackFirm(record.SellFirm);
-        _blockRecordCount++;
-        if (_blockRecordCount >= _indexBlockRecords)
-            FlushCurrentBlock();
     }
 
-    /// <summary>Flushes OS buffers and forces <c>fsync</c> on the current
-    /// file (if any). PR-4 will call this from the durability-watermark
-    /// loop and from the operator-triggered checkpoint endpoint.</summary>
+    /// <summary>Tags every record OnTrade'd since the previous boundary as
+    /// "produced by <paramref name="commandSeq"/>". The watermark advances
+    /// from pending to durable on the next <see cref="Checkpoint"/> call.
+    /// Dispatch-thread-only; cheap (single store under the shared lock).</summary>
+    public void OnCommandBoundary(long commandSeq)
+    {
+        lock (_checkpointLock)
+        {
+            // Monotonic: tolerate replay paths that resubmit lower seqs.
+            if (commandSeq > _pendingCommandSeq) _pendingCommandSeq = commandSeq;
+        }
+    }
+
+    /// <summary>Flushes OS buffers, forces <c>fsync</c> on both files, and
+    /// advances <see cref="DurableThroughCommandSeq"/> to the most recent
+    /// <see cref="OnCommandBoundary"/> value. Safe to call from any thread
+    /// (the lock serializes against OnTrade/OnCommandBoundary on the
+    /// dispatch thread). If the fsync throws the watermark is NOT advanced
+    /// — callers must treat that as "audit not durable; defer truncation".</summary>
     public void Checkpoint()
     {
-        // Make any in-progress block visible to readers BEFORE fsync so a
-        // crash immediately after Checkpoint() returns leaves a consistent
-        // pair of files behind.
-        FlushCurrentBlock();
-        _stream?.Flush(flushToDisk: true);
-        _indexStream?.Flush(flushToDisk: true);
+        lock (_checkpointLock)
+        {
+            // Snapshot the pending boundary BEFORE the fsync — any
+            // concurrent OnCommandBoundary call would have to acquire
+            // this lock so the value is stable while we fsync.
+            long pending = _pendingCommandSeq;
+            FlushCurrentBlock();
+            _stream?.Flush(flushToDisk: true);
+            _indexStream?.Flush(flushToDisk: true);
+            // Advance only on success; if any Flush threw we propagate
+            // without touching _durableCommandSeq so the gate stays closed.
+            Volatile.Write(ref _durableCommandSeq, pending);
+        }
     }
+
+    /// <summary>Highest commandSeq whose OnTrade records are guaranteed
+    /// fsync'd to disk. Read cross-thread by the WAL truncation gate;
+    /// uses Volatile.Read for a torn-safe 64-bit read on ARM.</summary>
+    public long DurableThroughCommandSeq => Volatile.Read(ref _durableCommandSeq);
 
     private void TrackFirm(uint firmId)
     {
@@ -249,18 +292,21 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
 
     public void Dispose()
     {
-        if (_stream is not null)
+        lock (_checkpointLock)
         {
-            FlushCurrentBlock();
-            _stream.Flush(flushToDisk: true);
-            _stream.Dispose();
-            _stream = null;
-        }
-        if (_indexStream is not null)
-        {
-            _indexStream.Flush(flushToDisk: true);
-            _indexStream.Dispose();
-            _indexStream = null;
+            if (_stream is not null)
+            {
+                FlushCurrentBlock();
+                _stream.Flush(flushToDisk: true);
+                _stream.Dispose();
+                _stream = null;
+            }
+            if (_indexStream is not null)
+            {
+                _indexStream.Flush(flushToDisk: true);
+                _indexStream.Dispose();
+                _indexStream = null;
+            }
         }
     }
 }

--- a/src/B3.Exchange.PostTrade/IPostTradeSink.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeSink.cs
@@ -54,6 +54,46 @@ public readonly record struct PostTradeRecord(
 public interface IPostTradeSink
 {
     void OnTrade(in PostTradeRecord record);
+
+    /// <summary>
+    /// Tags every <see cref="OnTrade"/> emitted since the previous boundary
+    /// (or since construction) as belonging to <paramref name="commandSeq"/>.
+    /// Called by <c>ChannelDispatcher.OnAfterCommandFlushed</c> on the
+    /// dispatch thread once the engine has finished processing a command and
+    /// the corresponding UMDF packet has been published.
+    ///
+    /// <para>Implementations MUST be non-blocking — this runs on the engine
+    /// hot path. The <see cref="Checkpoint"/> method is the slow fsync hook.</para>
+    /// </summary>
+    void OnCommandBoundary(long commandSeq);
+
+    /// <summary>
+    /// Flushes any in-progress index block, calls <c>fsync</c> on the
+    /// underlying files, and advances <see cref="DurableThroughCommandSeq"/>
+    /// to the most recent boundary observed via <see cref="OnCommandBoundary"/>.
+    /// On exception the watermark is NOT advanced — callers (the WAL
+    /// truncation gate) must treat that as "audit not durable; defer".
+    ///
+    /// <para>Implementations MUST be safe to call from a thread other than
+    /// the dispatch thread (the async snapshot writer invokes it from its
+    /// dedicated writer thread). The expected concurrency cost is a brief
+    /// lock acquisition; the fsync itself runs under the lock so the
+    /// dispatch hot path stalls only for the fsync duration when both
+    /// happen to overlap.</para>
+    /// </summary>
+    void Checkpoint();
+
+    /// <summary>
+    /// Highest <c>commandSeq</c> for which every <see cref="OnTrade"/>
+    /// record produced by that command is guaranteed fsync'd to disk.
+    /// Read by the WAL truncation gate (<c>ChannelDispatcher.Wal.cs</c>):
+    /// truncation may only drop WAL records with seq &lt;= this value.
+    ///
+    /// <para>For the no-op sink this is <see cref="long.MaxValue"/> so a
+    /// dispatcher with audit disabled (the default) is never gated — the
+    /// pre-#329 truncate-everything behaviour is preserved exactly.</para>
+    /// </summary>
+    long DurableThroughCommandSeq { get; }
 }
 
 /// <summary>
@@ -67,4 +107,7 @@ public sealed class NullPostTradeSink : IPostTradeSink
     public static readonly NullPostTradeSink Instance = new();
     private NullPostTradeSink() { }
     public void OnTrade(in PostTradeRecord record) { }
+    public void OnCommandBoundary(long commandSeq) { }
+    public void Checkpoint() { }
+    public long DurableThroughCommandSeq => long.MaxValue;
 }

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
@@ -11,7 +11,22 @@ public partial class ChannelDispatcherTests
     private sealed class RecordingPostTradeSink : IPostTradeSink
     {
         public List<PostTradeRecord> Records { get; } = new();
+        public List<long> Boundaries { get; } = new();
+        public int CheckpointCount { get; private set; }
+        private long _durable;
+        private long _pending;
         public void OnTrade(in PostTradeRecord record) => Records.Add(record);
+        public void OnCommandBoundary(long commandSeq)
+        {
+            Boundaries.Add(commandSeq);
+            if (commandSeq > _pending) _pending = commandSeq;
+        }
+        public void Checkpoint()
+        {
+            CheckpointCount++;
+            _durable = _pending;
+        }
+        public long DurableThroughCommandSeq => _durable;
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
@@ -1,0 +1,227 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using B3.Exchange.PostTrade;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrderType = B3.Exchange.Matching.OrderType;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #329 PR-4: WAL truncation must be gated by the post-trade audit
+/// log's durability watermark. These tests use a controllable
+/// <see cref="IPostTradeSink"/> to pin the dispatcher's behaviour on both
+/// the sync (dispatch-thread) and async (writer-thread) truncation paths.
+/// </summary>
+public class ChannelDispatcherAuditWatermarkTests
+{
+    private const long Sec = 900_000_000_002L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class NoOpOutbound : ICoreOutbound
+    {
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong rc, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sid, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rs, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
+    }
+
+    private sealed class InMemoryPersister : IChannelStatePersister
+    {
+        public Dictionary<byte, ChannelStateSnapshot> Last { get; } = new();
+        public int SaveCount;
+        public ChannelStateSnapshot? TryLoad(byte n)
+            => Last.TryGetValue(n, out var s) ? s : null;
+        public long Save(ChannelStateSnapshot s)
+        {
+            SaveCount++;
+            Last[s.ChannelNumber] = s;
+            return 1;
+        }
+    }
+
+    /// <summary>Controllable sink: exposes manual watermark advancement so the
+    /// test can hold DurableThroughCommandSeq below the dispatcher's
+    /// snapshotSeq and observe truncation deferral.</summary>
+    private sealed class ManualPostTradeSink : IPostTradeSink
+    {
+        public int CheckpointCount;
+        public List<long> Boundaries { get; } = new();
+        private long _pending;
+        public long DurableOverride = -1;
+        public void OnTrade(in PostTradeRecord record) { }
+        public void OnCommandBoundary(long commandSeq)
+        {
+            Boundaries.Add(commandSeq);
+            if (commandSeq > _pending) _pending = commandSeq;
+        }
+        public void Checkpoint() => CheckpointCount++;
+        // When DurableOverride >= 0 the test pins the watermark; otherwise we
+        // honour OnCommandBoundary as the durable seq (i.e. Checkpoint trivially
+        // promotes pending → durable).
+        public long DurableThroughCommandSeq
+            => DurableOverride >= 0 ? DurableOverride : _pending;
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; }
+        public TempDir()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+                "wm-tests-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+        }
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { } }
+    }
+
+    private static ChannelDispatcher BuildDispatcher(
+        IChannelStatePersister persister,
+        IChannelWriteAheadLog wal,
+        ChannelMetrics metrics,
+        IPostTradeSink postTradeSink)
+        => new(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s, NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: new NoOpOutbound(),
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            metrics: metrics,
+            persister: persister,
+            snapshotThrottle: null,
+            useAsyncSnapshotWriter: false,
+            wal: wal,
+            postTradeSink: postTradeSink);
+
+    private static bool EnqueueOrder(ChannelDispatcher disp, string clOrdId, ulong clOrdIdValue, ulong nanos)
+        => disp.EnqueueNewOrder(
+            new NewOrderCommand(clOrdId, Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, nanos),
+            new SessionId("10101"), enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    [Fact]
+    public void SyncTruncate_DeferredWhenAuditWatermarkBehind()
+    {
+        using var dir = new TempDir();
+        var persister = new InMemoryPersister();
+        var wal = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var metrics = new ChannelMetrics(84);
+        var sink = new ManualPostTradeSink { DurableOverride = 0 };
+        var disp = BuildDispatcher(persister, wal, metrics, sink);
+        var probe = disp.CreateTestProbe();
+
+        Assert.True(EnqueueOrder(disp, "CL-1", 0x1, 1UL));
+        probe.DrainInbound();
+
+        // Snapshot ran (SaveCount=1) and Checkpoint was attempted, but the
+        // watermark stayed at 0 (< snapshot's LastAppliedSeq=1) so truncate
+        // was deferred. The WAL record must still be on disk.
+        Assert.Equal(1, persister.SaveCount);
+        Assert.True(sink.CheckpointCount >= 1);
+        Assert.Equal(0, metrics.WalTruncations);
+        Assert.True(metrics.AuditWalTruncateDeferred >= 1);
+        Assert.Single(wal.ReadAll());
+        wal.Dispose();
+    }
+
+    [Fact]
+    public void SyncTruncate_ProceedsOnceAuditWatermarkCatchesUp()
+    {
+        using var dir = new TempDir();
+        var persister = new InMemoryPersister();
+        var wal = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var metrics = new ChannelMetrics(84);
+        var sink = new ManualPostTradeSink { DurableOverride = 0 };
+        var disp = BuildDispatcher(persister, wal, metrics, sink);
+        var probe = disp.CreateTestProbe();
+
+        // Cmd 1: watermark behind → deferred.
+        Assert.True(EnqueueOrder(disp, "CL-1", 0x1, 1UL));
+        probe.DrainInbound();
+        Assert.Equal(1, metrics.AuditWalTruncateDeferred);
+        Assert.Equal(0, metrics.WalTruncations);
+
+        // Operator catches up the watermark to cover everything we've
+        // processed so far; the next command's snapshot must now truncate.
+        sink.DurableOverride = long.MaxValue;
+        Assert.True(EnqueueOrder(disp, "CL-2", 0x2, 2UL));
+        probe.DrainInbound();
+        Assert.True(metrics.WalTruncations >= 1);
+        Assert.Empty(wal.ReadAll());
+        wal.Dispose();
+    }
+
+    [Fact]
+    public void SyncTruncate_NoGate_WhenSinkIsNullPostTradeSink()
+    {
+        // Regression: a channel with audit disabled (default) must keep the
+        // pre-#329 truncate-everything behaviour — the no-op sink reports
+        // DurableThroughCommandSeq=long.MaxValue.
+        using var dir = new TempDir();
+        var persister = new InMemoryPersister();
+        var wal = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var metrics = new ChannelMetrics(84);
+        var disp = BuildDispatcher(persister, wal, metrics, NullPostTradeSink.Instance);
+        var probe = disp.CreateTestProbe();
+
+        Assert.True(EnqueueOrder(disp, "CL-1", 0x1, 1UL));
+        probe.DrainInbound();
+
+        Assert.True(metrics.WalTruncations >= 1);
+        Assert.Equal(0, metrics.AuditWalTruncateDeferred);
+        Assert.Empty(wal.ReadAll());
+        wal.Dispose();
+    }
+
+    [Fact]
+    public void Dispatcher_ForwardsCommandSeq_ToSinkBoundaries()
+    {
+        // Pins the contract that OnCommandBoundary fires after every command
+        // with the dispatcher's _lastAppliedSeq value.
+        using var dir = new TempDir();
+        var persister = new InMemoryPersister();
+        var wal = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var metrics = new ChannelMetrics(84);
+        var sink = new ManualPostTradeSink { DurableOverride = long.MaxValue };
+        var disp = BuildDispatcher(persister, wal, metrics, sink);
+        var probe = disp.CreateTestProbe();
+
+        Assert.True(EnqueueOrder(disp, "CL-1", 0x1, 1UL));
+        Assert.True(EnqueueOrder(disp, "CL-2", 0x2, 2UL));
+        Assert.True(EnqueueOrder(disp, "CL-3", 0x3, 3UL));
+        probe.DrainInbound();
+
+        // 3 commands → 3 boundaries, monotonically increasing from 1.
+        Assert.Equal(new long[] { 1, 2, 3 }, sink.Boundaries);
+        wal.Dispose();
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
@@ -89,7 +89,8 @@ public class ChannelDispatcherWalTests
         out CountingOutbound outbound,
         ChannelMetrics? metrics = null,
         SnapshotThrottlePolicy? throttle = null,
-        bool useAsyncSnapshotWriter = false)
+        bool useAsyncSnapshotWriter = false,
+        B3.Exchange.PostTrade.IPostTradeSink? postTradeSink = null)
     {
         var localSink = sink = new NoOpPacketSink();
         var localOutbound = outbound = new CountingOutbound();
@@ -104,7 +105,8 @@ public class ChannelDispatcherWalTests
             persister: persister,
             snapshotThrottle: throttle,
             useAsyncSnapshotWriter: useAsyncSnapshotWriter,
-            wal: wal);
+            wal: wal,
+            postTradeSink: postTradeSink);
     }
 
     private static bool EnqueueOrder(ChannelDispatcher disp, SessionId session,

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs
@@ -150,4 +150,34 @@ public class FileAuditLogWriterWatermarkTests : IDisposable
         Assert.True(w.DurableThroughCommandSeq > 0);
         Assert.True(w.DurableThroughCommandSeq <= 200);
     }
+
+    [Fact]
+    public void WriteFault_FreezesWatermark_AndCheckpointThrows()
+    {
+        // Issue #329 PR-4 (HIGH review finding): once an OnTrade fails the
+        // writer marks itself "broken" — OnCommandBoundary must not advance
+        // _pendingCommandSeq, Checkpoint must throw (so the WAL gate stays
+        // closed), and DurableThroughCommandSeq must never advance past
+        // the failed command's seq.
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.OnCommandBoundary(1);
+        w.Checkpoint();
+        Assert.Equal(1, w.DurableThroughCommandSeq);
+
+        w.ForceWriteFaultForTests();
+        Assert.True(w.WriteFault);
+
+        // Subsequent boundary tries to bump pending → must be ignored.
+        w.OnCommandBoundary(42);
+        // Subsequent OnTrade must silently drop (so dispatcher can keep
+        // running) — pinning the contract that the audit log already has
+        // a known hole and further writes only deepen it.
+        w.OnTrade(Make(2, Day0Nanos));
+        // Checkpoint must throw — the WAL gate translates that to a
+        // deferred truncation and bumps exch_audit_wal_truncate_deferred_total.
+        Assert.Throws<IOException>(() => w.Checkpoint());
+        // Watermark must NOT have advanced past the last good command.
+        Assert.Equal(1, w.DurableThroughCommandSeq);
+    }
 }

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs
@@ -1,0 +1,153 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>
+/// Issue #329 PR-4: durability watermark contract on
+/// <see cref="FileAuditLogWriter"/>. The watermark gates WAL truncation
+/// in <c>ChannelDispatcher</c>; these tests pin the writer-side semantics.
+/// </summary>
+public class FileAuditLogWriterWatermarkTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileAuditLogWriterWatermarkTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeWmTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private const ulong OneDayNanos = 86_400UL * 1_000_000_000UL;
+
+    private static PostTradeRecord Make(uint id, ulong ts) => new(
+        TradeId: id, TransactTimeNanos: ts, SecurityId: 900_000_000_001L,
+        AggressorSide: id % 2 == 0 ? Side.Buy : Side.Sell,
+        Quantity: 100 + id, PriceMantissa: 10_0000L + id,
+        BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+        BuyFirm: 7, SellFirm: 8,
+        BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    [Fact]
+    public void DurableThroughCommandSeq_StartsAtZero()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        Assert.Equal(0, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void Checkpoint_WithoutBoundary_DurableStaysAtZero()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.Checkpoint();
+        Assert.Equal(0, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void OnCommandBoundary_AloneDoesNotAdvanceDurable()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.OnCommandBoundary(42);
+        // The boundary marks pending — only Checkpoint() promotes it.
+        Assert.Equal(0, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void Checkpoint_AfterBoundary_AdvancesDurableToBoundarySeq()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.OnCommandBoundary(42);
+        w.Checkpoint();
+        Assert.Equal(42, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void OnCommandBoundary_IsMonotonic_LowerSeqIgnored()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnCommandBoundary(50);
+        w.OnCommandBoundary(40); // stale (replay-style); must not regress
+        w.Checkpoint();
+        Assert.Equal(50, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void Checkpoint_OnEmptyWriter_DoesNotThrow_AndDurableAdvances()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnCommandBoundary(7);
+        w.Checkpoint(); // no records yet — both streams may be null
+        Assert.Equal(7, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void Checkpoint_PreservesWatermark_AcrossDailyRotation()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        w.OnTrade(Make(1, Day0Nanos));
+        w.OnCommandBoundary(10);
+        w.Checkpoint();
+        Assert.Equal(10, w.DurableThroughCommandSeq);
+
+        // Crossing the UTC day boundary rotates files internally — the
+        // watermark belongs to the writer instance, not the file, and
+        // must survive rotation.
+        w.OnTrade(Make(2, Day0Nanos + OneDayNanos));
+        w.OnCommandBoundary(20);
+        w.Checkpoint();
+        Assert.Equal(20, w.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void NullPostTradeSink_DurableThroughCommandSeq_IsMaxValue()
+    {
+        // Contract: a dispatcher with audit disabled (default) must never
+        // be gated by the watermark — the no-op sink reports +∞.
+        IPostTradeSink sink = NullPostTradeSink.Instance;
+        Assert.Equal(long.MaxValue, sink.DurableThroughCommandSeq);
+        sink.OnCommandBoundary(123);
+        sink.Checkpoint();
+        Assert.Equal(long.MaxValue, sink.DurableThroughCommandSeq);
+    }
+
+    [Fact]
+    public void Checkpoint_FromAnotherThread_IsSafeAgainstOnTrade()
+    {
+        // The async-snapshot-writer path calls Checkpoint from its writer
+        // thread while OnTrade keeps running on the dispatch thread.
+        // The internal lock must keep both honest. We don't assert
+        // performance here — just that no exception or corruption arises
+        // and the watermark advances at least to the last observed boundary.
+        using var w = new FileAuditLogWriter(_root, channelNumber: 1);
+        var stop = false;
+        var producer = new System.Threading.Thread(() =>
+        {
+            for (uint i = 1; i <= 200 && !stop; i++)
+            {
+                w.OnTrade(Make(i, Day0Nanos));
+                w.OnCommandBoundary(i);
+                System.Threading.Thread.Yield();
+            }
+        });
+        producer.Start();
+        for (int i = 0; i < 20; i++)
+        {
+            w.Checkpoint();
+            System.Threading.Thread.Sleep(1);
+        }
+        stop = true;
+        producer.Join(TimeSpan.FromSeconds(5));
+        w.Checkpoint();
+        Assert.True(w.DurableThroughCommandSeq > 0);
+        Assert.True(w.DurableThroughCommandSeq <= 200);
+    }
+}


### PR DESCRIPTION
Part 4 of the #329 post-trade audit log series. Follows #344 (PR-1 skeleton), #345 (PR-2 file writer), #346 (PR-3 sparse firm index).

## Goal

Prevent the dispatcher from dropping WAL records whose trades have not yet been fsync'd to the audit log. Without this gate, a crash between snapshot save and audit fsync can silently lose trades that the consumer side already observed.

## Interface (`IPostTradeSink`)

- `OnCommandBoundary(long commandSeq)` — dispatch-thread tag for the records emitted since the previous boundary.
- `Checkpoint()` — promoted to interface. Fsyncs the audit files and advances the watermark.
- `DurableThroughCommandSeq` — the gate value. `NullPostTradeSink` returns `long.MaxValue` so a channel with audit disabled (the default) keeps the pre-#329 truncate-everything behaviour exactly.

## Writer (`FileAuditLogWriter`)

- `_pendingCommandSeq` / `_durableCommandSeq` (Volatile-read).
- One private lock serializes `Checkpoint` (called cross-thread from `BackgroundSnapshotWriter`'s `onSaved`) against `OnTrade` / `OnCommandBoundary` (dispatch thread). Uncontended in steady state — Checkpoint fires at snapshot intervals.

## Dispatcher (`ChannelDispatcher`)

- `OnAfterCommandFlushed` calls `_postTradeSink.OnCommandBoundary(_lastAppliedSeq)` before any early-return so the boundary is observed even when no persister is wired.
- Both `TruncateWalAfterSyncSave(snapshotLastAppliedSeq)` (sync, dispatch thread) and `OnAsyncSnapshotSaved(snap)` (async, writer thread) call the shared `CheckpointAndGateAuditWatermark`: force-Checkpoint the sink, gate the truncate on `DurableThroughCommandSeq >= snapshotLastAppliedSeq`. Deferral is observable, not data-losing: the WAL keeps the records and the next snapshot retries.

## Observability

- New per-channel counter `exch_audit_wal_truncate_deferred_total`. Non-zero indicates audit durability lag pinning WAL size open — actionable alert signal.

## Out of scope (deferred follow-ups)

- Periodic interval-bounded fsync timer (currently audit fsync only fires at snapshot intervals — bounded by the snapshot interval).
- Operator HTTP endpoint to force a checkpoint.
- Restart replay-into-audit-only mode (= PR-5).

## Tests (+13)

`FileAuditLogWriterWatermarkTests` (9):
- start state, boundary-without-checkpoint, checkpoint-advances-durable
- monotonicity (replay-style lower seq ignored)
- empty-writer Checkpoint
- daily-rotation preservation
- `NullPostTradeSink` contract (`long.MaxValue`)
- thread-safe `Checkpoint` vs `OnTrade` (producer + checkpointer threads)

`ChannelDispatcherAuditWatermarkTests` (4):
- sync truncate deferred when watermark behind → WAL still has records, deferred-counter bumped
- truncate proceeds once watermark catches up
- `NullPostTradeSink` preserves pre-#329 truncate-everything behaviour
- dispatcher forwards command seqs to sink boundaries (1, 2, 3 in order)

## CI gate

Pre-PR checklist (matches CI):
```
dotnet restore SbeB3Exchange.slnx
dotnet build   SbeB3Exchange.slnx --no-restore -c Release   # 0 warnings
dotnet test    SbeB3Exchange.slnx --no-build   -c Release   # 1112+ tests pass
dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
```
All four green locally.