### PR TITLE
post-trade: persist audit watermark sidecar to gate replay re-emission (#329 PR-5)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -446,7 +446,20 @@ public sealed partial class ChannelDispatcher
             SellOrderId: aggressorIsBuyForAudit ? e.RestingOrderId : e.AggressorOrderId);
         try
         {
-            _postTradeSink.OnTrade(record);
+            // Issue #329 PR-5: during WAL replay, skip trades whose owning
+            // command was already fsync'd to the audit log pre-crash. The
+            // sidecar-persisted watermark was captured into
+            // _bootAuditDurableSeq at the start of ReplayWalOnLoopThread
+            // (the live path leaves it at long.MaxValue so this branch
+            // collapses outside replay).
+            if (_replayMode && _lastAppliedSeq <= _bootAuditDurableSeq)
+            {
+                _metrics?.IncAuditReplaySkipped();
+            }
+            else
+            {
+                _postTradeSink.OnTrade(record);
+            }
         }
         catch (Exception ex)
         {

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -286,6 +286,14 @@ public sealed partial class ChannelDispatcher
         int replayed = 0;
         int skipped = 0;
         _replayMode = true;
+        // Issue #329 PR-5: snapshot the audit sink's durability watermark
+        // BEFORE replay so OnTrade can gate duplicate emissions. We read
+        // the value here (not lazily inside OnTrade) so any later sink
+        // mutation by the replay itself cannot move the bar. A value of
+        // 0 (no sidecar / fresh install / sink without persistence)
+        // means every replayed trade is re-emitted — the conservative
+        // pre-PR-5 behaviour.
+        _bootAuditDurableSeq = _postTradeSink.DurableThroughCommandSeq;
         _packetSink = NoOpPacketSink;
         _outbound = NoOpOutbound;
         try
@@ -337,6 +345,7 @@ public sealed partial class ChannelDispatcher
         finally
         {
             _replayMode = false;
+            _bootAuditDurableSeq = long.MaxValue;
             _packetSink = _liveSink;
             _outbound = _liveOutbound;
         }

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -174,6 +174,23 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private bool _replayMode;
 
     /// <summary>
+    /// Issue #329 PR-5: snapshot of the audit sink's persisted durability
+    /// watermark, captured BEFORE WAL replay rebuilds engine state.
+    /// During replay (and only during replay), <see cref="ChannelDispatcher.OnTrade"/>
+    /// skips <c>_postTradeSink.OnTrade</c> for any trade whose owning
+    /// command's seq is &lt;= this value — those trades are already
+    /// fsync'd to the audit log, so re-emitting them would produce
+    /// duplicates. Trades from commands with seq strictly greater than
+    /// this watermark fall through to the sink as normal, re-recording
+    /// any tail lost between the last audit fsync and the crash.
+    /// Reset to <see cref="long.MaxValue"/> outside replay so the gate
+    /// has no effect on the live path (the comparison <c>_lastAppliedSeq
+    /// &lt;= MaxValue</c> is short-circuited by the <c>_replayMode</c>
+    /// check at the call site).
+    /// </summary>
+    private long _bootAuditDurableSeq = long.MaxValue;
+
+    /// <summary>
     /// Issue #312: snapshot of the durability barrier the outbound ER
     /// for the currently-dispatching command must wait on. Captured
     /// after <see cref="WalAppendIfEnabled"/> stamps <c>_lastAppliedSeq</c>

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -229,6 +229,18 @@ public sealed class ChannelMetrics
     public long WalHaltRejects => Interlocked.Read(ref _walHaltRejects);
     /// <summary>Issue #329 PR-4: see <see cref="IncAuditWalTruncateDeferred"/>.</summary>
     public long AuditWalTruncateDeferred => Interlocked.Read(ref _auditWalTruncateDeferred);
+
+    /// <summary>
+    /// Issue #329 PR-5: cumulative count of trades suppressed during WAL
+    /// replay because their owning command had been fsync'd to the audit
+    /// log pre-crash (<c>commandSeq &lt;= bootAuditDurableSeq</c>).
+    /// Always 0 outside replay. Useful as a boot-time sanity check that
+    /// the replay-into-audit-only gate is active and as a corroboration
+    /// of the persisted watermark.
+    /// </summary>
+    private long _auditReplaySkipped;
+    public long AuditReplaySkipped => Interlocked.Read(ref _auditReplaySkipped);
+    public void IncAuditReplaySkipped() => Interlocked.Increment(ref _auditReplaySkipped);
     public void IncWalAppend(long bytes)
     {
         Interlocked.Increment(ref _walAppends);
@@ -739,6 +751,9 @@ public sealed class MetricsRegistry
         EmitCounter(sb, "exch_audit_wal_truncate_deferred_total",
             "Issue #329 PR-4: WAL truncation attempts (sync or async snapshot-saved path) deferred because the post-trade audit watermark had not yet caught up with the snapshot's LastAppliedSeq, OR the audit-log Checkpoint itself threw. Always 0 when audit logging is disabled (the no-op sink reports DurableThroughCommandSeq=long.MaxValue). A sustained non-zero rate means audit-log durability lag is pinning the WAL size open and warrants investigation of audit storage latency.",
             channels, c => c.AuditWalTruncateDeferred);
+        EmitCounter(sb, "exch_audit_replay_skipped_total",
+            "Issue #329 PR-5: trades suppressed during WAL replay because their owning command had been fsync'd to the audit log pre-crash (commandSeq <= bootAuditDurableSeq from the watermark sidecar). Always 0 outside boot replay and 0 when audit logging is disabled. Boot-time corroboration that the replay-into-audit-only gate engaged.",
+            channels, c => c.AuditReplaySkipped);
 
         // Issue #270: cross-channel consistency check. Counts owner
         // entries silently dropped at restore because their SessionId

--- a/src/B3.Exchange.PostTrade/AuditWatermarkCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditWatermarkCodec.cs
@@ -1,0 +1,67 @@
+using System.Buffers.Binary;
+using System.IO.Hashing;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Sidecar codec for the per-channel audit watermark file (issue #329 PR-5).
+/// Persists the highest <c>commandSeq</c> whose trades have been fsync'd
+/// to the audit log, so a post-crash boot can gate <see cref="IPostTradeSink"/>
+/// during WAL replay and avoid duplicating already-recorded trades.
+///
+/// Layout (fixed 20 bytes):
+/// <list type="bullet">
+///   <item><description><c>magic</c> uint32 LE = 0x57503342 ("B3PW")</description></item>
+///   <item><description><c>schemaVersion</c> uint16 LE = 1</description></item>
+///   <item><description><c>reserved</c> uint16 = 0</description></item>
+///   <item><description><c>lastDurableCommandSeq</c> int64 LE</description></item>
+///   <item><description><c>crc32</c> uint32 LE — IEEE 802.3 of the first 16 bytes</description></item>
+/// </list>
+///
+/// Atomic update: writer encodes into a tmp file, fsyncs it, then
+/// <c>File.Move(..., overwrite: true)</c> — POSIX rename is atomic. A
+/// torn or partial file is rejected by the CRC check on read; callers
+/// treat that as "watermark unknown" → replay is conservative (re-emits
+/// every trade).
+/// </summary>
+public static class AuditWatermarkCodec
+{
+    public const uint MagicB3PW = 0x57503342u; // "B3PW" little-endian
+    public const ushort SchemaVersion = 1;
+    public const int FileSize = 20;
+    private const int CrcOffset = 16;
+
+    /// <summary>Encodes the watermark into <paramref name="buffer"/>
+    /// (must be at least <see cref="FileSize"/> bytes). Returns the number
+    /// of bytes written. The CRC is computed across the leading 16 bytes
+    /// and stored in the trailing 4 bytes.</summary>
+    public static int Encode(Span<byte> buffer, long lastDurableCommandSeq)
+    {
+        if (buffer.Length < FileSize)
+            throw new ArgumentException($"buffer must be at least {FileSize} bytes", nameof(buffer));
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer, MagicB3PW);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(4, 2), SchemaVersion);
+        BinaryPrimitives.WriteUInt16LittleEndian(buffer.Slice(6, 2), 0);
+        BinaryPrimitives.WriteInt64LittleEndian(buffer.Slice(8, 8), lastDurableCommandSeq);
+        uint crc = Crc32.HashToUInt32(buffer.Slice(0, CrcOffset));
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.Slice(CrcOffset, 4), crc);
+        return FileSize;
+    }
+
+    /// <summary>Validates the magic, schema version, reserved bytes, and
+    /// CRC and returns the persisted watermark. Returns false (and 0)
+    /// when any check fails — callers treat that as "watermark unknown".</summary>
+    public static bool TryDecode(ReadOnlySpan<byte> buffer, out long lastDurableCommandSeq)
+    {
+        lastDurableCommandSeq = 0;
+        if (buffer.Length < FileSize) return false;
+        if (BinaryPrimitives.ReadUInt32LittleEndian(buffer) != MagicB3PW) return false;
+        if (BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(4, 2)) != SchemaVersion) return false;
+        if (BinaryPrimitives.ReadUInt16LittleEndian(buffer.Slice(6, 2)) != 0) return false;
+        uint stored = BinaryPrimitives.ReadUInt32LittleEndian(buffer.Slice(CrcOffset, 4));
+        uint computed = Crc32.HashToUInt32(buffer.Slice(0, CrcOffset));
+        if (stored != computed) return false;
+        lastDurableCommandSeq = BinaryPrimitives.ReadInt64LittleEndian(buffer.Slice(8, 8));
+        return true;
+    }
+}

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -75,6 +75,56 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         // bound to avoid an OOB write in pathological cases).
         int maxFirmsPerBlock = Math.Min(indexBlockRecords * 2, ushort.MaxValue);
         _indexScratch = new byte[Math.Max(AuditIndexCodec.FileHeaderSize, AuditIndexCodec.BlockEntryFixedPrefix + (maxFirmsPerBlock * 4))];
+
+        // Issue #329 PR-5: recover the durability watermark from the sidecar
+        // so the dispatcher can gate WAL-replay OnTrade emissions (skip every
+        // trade whose producing command was already fsync'd to the audit log
+        // pre-crash). A missing/torn sidecar is treated as "watermark unknown
+        // = 0", forcing the replay path to re-emit conservatively. Any
+        // resulting duplicates are bounded by the [snapshot, crash] window.
+        long recovered = TryReadWatermarkSidecar();
+        _pendingCommandSeq = recovered;
+        _durableCommandSeq = recovered;
+    }
+
+    private string WatermarkSidecarPath
+        => Path.Combine(_rootDir, _channelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture), "audit-watermark.bin");
+
+    private long TryReadWatermarkSidecar()
+    {
+        var path = WatermarkSidecarPath;
+        if (!File.Exists(path)) return 0;
+        try
+        {
+            Span<byte> buf = stackalloc byte[AuditWatermarkCodec.FileSize];
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            int read = fs.Read(buf);
+            if (read != buf.Length) return 0;
+            return AuditWatermarkCodec.TryDecode(buf, out var seq) ? seq : 0;
+        }
+        catch (IOException)
+        {
+            return 0;
+        }
+    }
+
+    private void WriteWatermarkSidecar(long lastDurableCommandSeq)
+    {
+        var path = WatermarkSidecarPath;
+        var dir = Path.GetDirectoryName(path)!;
+        Directory.CreateDirectory(dir);
+        var tmp = path + ".tmp";
+        Span<byte> buf = stackalloc byte[AuditWatermarkCodec.FileSize];
+        AuditWatermarkCodec.Encode(buf, lastDurableCommandSeq);
+        // Atomic update: write to tmp + fsync + rename. POSIX rename is
+        // atomic; Windows File.Move(overwrite: true) is too. A crash mid-
+        // write leaves the prior good sidecar (or no sidecar) intact.
+        using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+        {
+            fs.Write(buf);
+            fs.Flush(flushToDisk: true);
+        }
+        File.Move(tmp, path, overwrite: true);
     }
 
     /// <summary>Total records successfully appended since construction. Useful
@@ -168,6 +218,14 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
             FlushCurrentBlock();
             _stream?.Flush(flushToDisk: true);
             _indexStream?.Flush(flushToDisk: true);
+            // Issue #329 PR-5: persist the watermark sidecar so a post-crash
+            // boot can recover it and gate replay-mode OnTrade emissions.
+            // Order matters: sidecar update happens AFTER the .log/.idx
+            // fsyncs so the sidecar can never claim durability the underlying
+            // files don't already have. If the sidecar write itself throws
+            // we propagate without advancing _durableCommandSeq so the gate
+            // stays closed and the next Checkpoint retries.
+            WriteWatermarkSidecar(pending);
             // Advance only on success; if any Flush threw we propagate
             // without touching _durableCommandSeq so the gate stays closed.
             Volatile.Write(ref _durableCommandSeq, pending);

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
@@ -67,14 +67,16 @@ public class ChannelDispatcherAuditWatermarkTests
 
     /// <summary>Controllable sink: exposes manual watermark advancement so the
     /// test can hold DurableThroughCommandSeq below the dispatcher's
-    /// snapshotSeq and observe truncation deferral.</summary>
+    /// snapshotSeq and observe truncation deferral. Also counts OnTrade
+    /// invocations so PR-5 tests can assert the replay-mode gate.</summary>
     private sealed class ManualPostTradeSink : IPostTradeSink
     {
         public int CheckpointCount;
+        public int OnTradeCount;
         public List<long> Boundaries { get; } = new();
         private long _pending;
         public long DurableOverride = -1;
-        public void OnTrade(in PostTradeRecord record) { }
+        public void OnTrade(in PostTradeRecord record) { OnTradeCount++; }
         public void OnCommandBoundary(long commandSeq)
         {
             Boundaries.Add(commandSeq);
@@ -123,6 +125,12 @@ public class ChannelDispatcherAuditWatermarkTests
             new NewOrderCommand(clOrdId, Sec, Side.Buy, OrderType.Limit,
                 TimeInForce.Day, Px(10.00m), 100, 100, nanos),
             new SessionId("10101"), enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    private static bool EnqueueSideOrder(ChannelDispatcher disp, Side side, string clOrdId, ulong clOrdIdValue, ulong nanos, uint firm = 700, string sessionId = "10101")
+        => disp.EnqueueNewOrder(
+            new NewOrderCommand(clOrdId, Sec, side, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, firm, nanos),
+            new SessionId(sessionId), enteringFirm: firm, clOrdIdValue: clOrdIdValue);
 
     [Fact]
     public void SyncTruncate_DeferredWhenAuditWatermarkBehind()
@@ -223,5 +231,116 @@ public class ChannelDispatcherAuditWatermarkTests
         // 3 commands → 3 boundaries, monotonically increasing from 1.
         Assert.Equal(new long[] { 1, 2, 3 }, sink.Boundaries);
         wal.Dispose();
+    }
+
+    [Fact]
+    public async Task Replay_SuppressesOnTrade_ForCommands_AtOrBelow_BootDurableSeq()
+    {
+        // Issue #329 PR-5: during WAL replay the audit sink must NOT see
+        // OnTrade for any trade whose owning command was already fsync'd
+        // pre-crash. Phase 1 uses the live (DrainInbound) path to stage
+        // WAL records that cross. Phase 2 uses the REAL replay path
+        // (disp.Start → LoadPersistedStateOnLoopThread → ReplayWalOnLoopThread)
+        // with a sink whose recovered watermark covers both commands;
+        // OnTrade must not be invoked and AuditReplaySkipped must bump.
+        using var dir = new TempDir();
+        // Phase 1 — populate the WAL with cross-producing commands.
+        // DurableOverride=0 PREVENTS the post-snapshot WAL truncation
+        // (PR-4 gate) so phase 2 has the staged records to replay.
+        {
+            var wal = new FileChannelWriteAheadLog(dir.Path, 84,
+                NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+            var sink = new ManualPostTradeSink { DurableOverride = 0 };
+            var disp = BuildDispatcher(new InMemoryPersister(),
+                wal, new ChannelMetrics(84), sink);
+            var probe = disp.CreateTestProbe();
+            // Different firms to keep this independent of any future
+            // self-trade-prevention default.
+            Assert.True(EnqueueSideOrder(disp, Side.Sell, "S-1", 0x10, 1UL, firm: 7, sessionId: "10101"));
+            Assert.True(EnqueueSideOrder(disp, Side.Buy, "B-1", 0x11, 2UL, firm: 8, sessionId: "10102"));
+            probe.DrainInbound();
+            Assert.Equal(new long[] { 1, 2 }, sink.Boundaries);
+            // CRITICAL: this trade must actually happen for the gate test
+            // below to be meaningful. If this regresses (e.g. matching
+            // engine changes default phase, or this test's crossing setup
+            // becomes invalid) we fail here loudly instead of in phase 2.
+            Assert.Equal(1, sink.OnTradeCount);
+            wal.Dispose();
+        }
+
+        // Phase 2 — real replay. Sink claims watermark=2 (covers both
+        // staged commands) → the gate must skip the trade's OnTrade call.
+        var metrics2 = new ChannelMetrics(84);
+        var sink2 = new ManualPostTradeSink { DurableOverride = 2 };
+        var wal2 = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        // Sanity: phase 1 actually wrote both records to the WAL so
+        // there is something for the replay path to consume.
+        var files = string.Join(", ", Directory.GetFiles(dir.Path, "*", SearchOption.AllDirectories)
+            .Select(f => $"{Path.GetRelativePath(dir.Path, f)}({new FileInfo(f).Length}B)"));
+        Assert.True(wal2.ReadAll().Count == 2, $"expected 2 WAL records; files=[{files}]");
+        var persister2 = new InMemoryPersister();
+        var disp2 = BuildDispatcher(persister2, wal2, metrics2, sink2);
+
+        disp2.Start();
+        // Quiescence: AddWalReplays runs AFTER the entire WAL replay
+        // foreach completes. SaveCount bumps mid-replay (each command's
+        // OnAfterCommandFlushed under the AlwaysPersist throttle) so it
+        // is NOT a reliable post-replay barrier. Poll WalReplays
+        // directly.
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (metrics2.WalReplays < 2 && DateTime.UtcNow < deadline)
+            Thread.Sleep(10);
+
+        // The replay path itself emits a trade event the gate must
+        // suppress. Boundaries still fire (they don't go through the gate).
+        Assert.Equal(2, metrics2.WalReplays);
+        Assert.Equal(0, sink2.OnTradeCount);
+        Assert.True(metrics2.AuditReplaySkipped >= 1,
+            $"expected AuditReplaySkipped>=1, got {metrics2.AuditReplaySkipped}");
+
+        await disp2.DisposeAsync();
+        wal2.Dispose();
+    }
+
+    [Fact]
+    public async Task Replay_AllowsOnTrade_ForCommands_Above_BootDurableSeq()
+    {
+        // Mirror with watermark BELOW the trade's command seq: the
+        // gate must let the trade through so the audit log is repaired.
+        using var dir = new TempDir();
+        {
+            var wal = new FileChannelWriteAheadLog(dir.Path, 84,
+                NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+            // DurableOverride=0 prevents PR-4 truncation, preserving the
+            // WAL records phase 2 needs to replay.
+            var sink = new ManualPostTradeSink { DurableOverride = 0 };
+            var disp = BuildDispatcher(new InMemoryPersister(),
+                wal, new ChannelMetrics(84), sink);
+            var probe = disp.CreateTestProbe();
+            Assert.True(EnqueueSideOrder(disp, Side.Sell, "S-1", 0x10, 1UL, firm: 7, sessionId: "10101"));
+            Assert.True(EnqueueSideOrder(disp, Side.Buy, "B-1", 0x11, 2UL, firm: 8, sessionId: "10102"));
+            probe.DrainInbound();
+            wal.Dispose();
+        }
+
+        var metrics2 = new ChannelMetrics(84);
+        // Watermark=1 → command 2 (the trade) is NOT covered.
+        var sink2 = new ManualPostTradeSink { DurableOverride = 1 };
+        var wal2 = new FileChannelWriteAheadLog(dir.Path, 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var persister2 = new InMemoryPersister();
+        var disp2 = BuildDispatcher(persister2, wal2, metrics2, sink2);
+
+        disp2.Start();
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (metrics2.WalReplays < 2 && DateTime.UtcNow < deadline)
+            Thread.Sleep(10);
+
+        Assert.Equal(0, metrics2.AuditReplaySkipped);
+        Assert.Equal(2, metrics2.WalReplays);
+
+        await disp2.DisposeAsync();
+        wal2.Dispose();
     }
 }

--- a/tests/B3.Exchange.PostTrade.Tests/AuditWatermarkCodecTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditWatermarkCodecTests.cs
@@ -1,0 +1,200 @@
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTrade.Tests;
+
+/// <summary>
+/// Tests for the issue #329 PR-5 audit-watermark sidecar codec and the
+/// FileAuditLogWriter's reload-on-construction behaviour.
+/// </summary>
+public class AuditWatermarkCodecTests
+{
+    [Fact]
+    public void Encode_Then_Decode_RoundTrips_PositiveSeq()
+    {
+        Span<byte> buf = stackalloc byte[AuditWatermarkCodec.FileSize];
+        int written = AuditWatermarkCodec.Encode(buf, 0x0123_4567_89AB_CDEFL);
+        Assert.Equal(AuditWatermarkCodec.FileSize, written);
+        Assert.True(AuditWatermarkCodec.TryDecode(buf, out var seq));
+        Assert.Equal(0x0123_4567_89AB_CDEFL, seq);
+    }
+
+    [Fact]
+    public void Encode_Then_Decode_RoundTrips_Zero()
+    {
+        Span<byte> buf = stackalloc byte[AuditWatermarkCodec.FileSize];
+        AuditWatermarkCodec.Encode(buf, 0L);
+        Assert.True(AuditWatermarkCodec.TryDecode(buf, out var seq));
+        Assert.Equal(0L, seq);
+    }
+
+    [Fact]
+    public void TryDecode_BadMagic_ReturnsFalse()
+    {
+        var buf = new byte[AuditWatermarkCodec.FileSize];
+        AuditWatermarkCodec.Encode(buf, 42L);
+        buf[0] ^= 0xFF;
+        Assert.False(AuditWatermarkCodec.TryDecode(buf, out var seq));
+        Assert.Equal(0L, seq);
+    }
+
+    [Fact]
+    public void TryDecode_CrcMismatch_ReturnsFalse()
+    {
+        var buf = new byte[AuditWatermarkCodec.FileSize];
+        AuditWatermarkCodec.Encode(buf, 12345L);
+        // Flip a byte in the payload region (offset 8..15 = seq field)
+        buf[8] ^= 0x01;
+        Assert.False(AuditWatermarkCodec.TryDecode(buf, out var seq));
+        Assert.Equal(0L, seq);
+    }
+
+    [Fact]
+    public void TryDecode_BadSchemaVersion_ReturnsFalse()
+    {
+        var buf = new byte[AuditWatermarkCodec.FileSize];
+        AuditWatermarkCodec.Encode(buf, 1L);
+        // Schema version is uint16 LE at offset 4.
+        buf[4] = 0xFE;
+        // Recompute CRC so the CRC check passes; we want the schema check
+        // to be the one that rejects the buffer.
+        uint crc = System.IO.Hashing.Crc32.HashToUInt32(buf.AsSpan(0, 16));
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(buf.AsSpan(16, 4), crc);
+        Assert.False(AuditWatermarkCodec.TryDecode(buf, out _));
+    }
+
+    [Fact]
+    public void TryDecode_ShortBuffer_ReturnsFalse()
+    {
+        Assert.False(AuditWatermarkCodec.TryDecode(new byte[AuditWatermarkCodec.FileSize - 1], out _));
+    }
+
+    [Fact]
+    public void Writer_Reopen_RecoversDurableWatermarkFromSidecar()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "audit-wm-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            byte channel = 7;
+            using (var w = new FileAuditLogWriter(root, channel))
+            {
+                Assert.Equal(0, w.DurableThroughCommandSeq);
+                w.OnTrade(MakeRec(tradeId: 100));
+                w.OnCommandBoundary(commandSeq: 11);
+                w.OnTrade(MakeRec(tradeId: 101));
+                w.OnCommandBoundary(commandSeq: 12);
+                w.Checkpoint();
+                Assert.Equal(12, w.DurableThroughCommandSeq);
+            }
+
+            using (var w2 = new FileAuditLogWriter(root, channel))
+            {
+                // Recovered from sidecar.
+                Assert.Equal(12, w2.DurableThroughCommandSeq);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Writer_Reopen_WithMissingSidecar_StartsAtZero()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "audit-wm-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            byte channel = 3;
+            using (var w = new FileAuditLogWriter(root, channel))
+            {
+                w.OnTrade(MakeRec(tradeId: 1));
+                w.OnCommandBoundary(commandSeq: 5);
+                // No Checkpoint() — so no sidecar is written.
+            }
+            using (var w2 = new FileAuditLogWriter(root, channel))
+            {
+                Assert.Equal(0, w2.DurableThroughCommandSeq);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Writer_Reopen_WithCorruptSidecar_FallsBackToZero()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "audit-wm-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            byte channel = 4;
+            using (var w = new FileAuditLogWriter(root, channel))
+            {
+                w.OnCommandBoundary(99);
+                w.Checkpoint();
+                Assert.Equal(99, w.DurableThroughCommandSeq);
+            }
+            // Corrupt the sidecar (flip one byte of the seq field).
+            var sidecar = Path.Combine(root, channel.ToString(System.Globalization.CultureInfo.InvariantCulture), "audit-watermark.bin");
+            Assert.True(File.Exists(sidecar));
+            var bytes = File.ReadAllBytes(sidecar);
+            bytes[8] ^= 0xFF;
+            File.WriteAllBytes(sidecar, bytes);
+
+            using (var w2 = new FileAuditLogWriter(root, channel))
+            {
+                Assert.Equal(0, w2.DurableThroughCommandSeq);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public void Writer_Checkpoint_OverwritesSidecarAtomically()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "audit-wm-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            byte channel = 9;
+            using var w = new FileAuditLogWriter(root, channel);
+            w.OnCommandBoundary(1);
+            w.Checkpoint();
+            w.OnCommandBoundary(2);
+            w.Checkpoint();
+            w.OnCommandBoundary(7);
+            w.Checkpoint();
+            Assert.Equal(7, w.DurableThroughCommandSeq);
+
+            var sidecar = Path.Combine(root, channel.ToString(System.Globalization.CultureInfo.InvariantCulture), "audit-watermark.bin");
+            Assert.True(File.Exists(sidecar));
+            // No leftover .tmp from atomic-rename
+            Assert.False(File.Exists(sidecar + ".tmp"));
+            var bytes = File.ReadAllBytes(sidecar);
+            Assert.Equal(AuditWatermarkCodec.FileSize, bytes.Length);
+            Assert.True(AuditWatermarkCodec.TryDecode(bytes, out var seq));
+            Assert.Equal(7, seq);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best-effort */ }
+        }
+    }
+
+    private static PostTradeRecord MakeRec(long tradeId) => new(
+        TradeId: (uint)tradeId,
+        TransactTimeNanos: (ulong)(1_700_000_000_000_000_000L + tradeId),
+        SecurityId: 1234,
+        AggressorSide: B3.Exchange.Matching.Side.Buy,
+        Quantity: 10,
+        PriceMantissa: 100_000,
+        BuyClOrdId: (ulong)tradeId,
+        SellClOrdId: (ulong)tradeId + 1,
+        BuyFirm: 11,
+        SellFirm: 22,
+        BuyOrderId: tradeId,
+        SellOrderId: tradeId + 1);
+}


### PR DESCRIPTION
Issue #329 PR-5 of 6 (PRs #344, #345, #346, #347 merged).

## Problem
Post-crash WAL replay re-runs every command between the last snapshot and the crash. Each replayed cross re-fires `MatchingEngine.OnTrade`, which until now would unconditionally write a duplicate per-trade audit record — every record that was already fsync'd to the audit log pre-crash gets emitted a second time.

## Approach (Option A — sidecar, user-approved)
A separate sidecar file per channel persists the highest `commandSeq` whose trades are guaranteed durable on the audit log. On boot the dispatcher captures this watermark before replay and gates `OnTrade`: trades whose owning command is at or below the watermark are skipped.

The sidecar lives next to the daily `.log`/`.idx` (`{root}/{channel}/audit-watermark.bin`). It is per-channel (not per-day) and is written atomically (`.tmp` + fsync + rename) by `FileAuditLogWriter.Checkpoint` AFTER both files are fsync'd and BEFORE the in-memory `_durableCommandSeq` advances — so a sidecar write failure leaves the gate closed and replay falls back to the conservative (re-emit-everything) behaviour. The format is 20 bytes: magic `B3PW` (4) + schema v1 (2) + reserved (2) + lastDurableCommandSeq i64 (8) + CRC32 (4).

## Gate semantics
- `_bootAuditDurableSeq` is captured in `ReplayWalOnLoopThread` right after `_replayMode = true` and reset to `long.MaxValue` in `finally`.
- Outside replay the leading `_replayMode` check short-circuits the new branch — zero overhead on the live path.
- New counter: `exch_audit_replay_skipped_total`.

## Tests
`AuditWatermarkCodecTests` (+9) covers round-trip, bad magic / bad CRC / bad schema / short buffer, writer reopen recovers the watermark, missing sidecar -> 0, corrupt sidecar -> 0, atomic overwrite leaves no `.tmp` leftover.

`ChannelDispatcherAuditWatermarkTests` (+2) drives the real replay path (`disp.Start` -> `LoadPersistedStateOnLoopThread` -> `ReplayWalOnLoopThread`). One asserts the gate suppresses when the watermark covers the trade's command; the other asserts the gate allows when the watermark is behind. Quiescence polls `metrics.WalReplays` rather than `persister.SaveCount` because per-command snapshot saves bump `SaveCount` mid-replay, racing `AddWalReplays`.

## Pre-PR checklist
- `dotnet build -c Release` — clean (warnings-as-errors)
- `dotnet test -c Release` — all suites green (137+439+132+...)
- `dotnet format --verify-no-changes` — clean
- `Replay_Sup*` test stress-run 12/12 ✓ after fixing the SaveCount race

## Next
PR-6 (final): retention + bench + RUNBOOK.