### PR TITLE
post-trade: retention prune + hot-path bench + RUNBOOK section (#329 PR-6)

### DIFF
--- a/bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj
+++ b/bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/bench/B3.Exchange.Bench/PostTradeAuditBenchmarks.cs
+++ b/bench/B3.Exchange.Bench/PostTradeAuditBenchmarks.cs
@@ -1,0 +1,87 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+using BenchmarkDotNet.Attributes;
+
+namespace B3.Exchange.Bench;
+
+/// <summary>
+/// Issue #329 PR-6: hot-path benchmark for the post-trade audit log
+/// writer. The dispatcher invokes <see cref="FileAuditLogWriter.OnTrade"/>
+/// synchronously on the dispatch thread for every matched trade, so
+/// any per-call regression directly inflates engine latency.
+///
+/// <para>Two scenarios:</para>
+/// <list type="bullet">
+///   <item><b>OnTrade_NoCheckpoint</b> — steady-state append cost. No
+///   fsync runs (writer batches via <c>FileStream</c>'s OS buffer); this
+///   isolates serialization + index bookkeeping from disk-flush cost.</item>
+///   <item><b>OnTrade_PerCallCheckpoint</b> — worst-case durability
+///   (fsync after every record). Models a paranoid "fsync-per-trade"
+///   policy and pins the upper bound on per-trade audit overhead.</item>
+/// </list>
+///
+/// <para>The benchmark writes to a temp directory under
+/// <see cref="GlobalSetup"/> / <see cref="GlobalCleanup"/>; the same
+/// writer instance is reused across iterations so file-open and header
+/// costs do not skew per-call numbers. Use
+/// <c>dotnet run -c Release --project bench/B3.Exchange.Bench -- --filter '*PostTradeAudit*'</c>.</para>
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5)]
+public class PostTradeAuditBenchmarks
+{
+    private string _root = null!;
+    private FileAuditLogWriter _writer = null!;
+    private FileAuditLogWriter _checkpointingWriter = null!;
+    private PostTradeRecord _record;
+    private ulong _ts;
+    private uint _tradeId;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeBench_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _writer = new FileAuditLogWriter(_root, channelNumber: 1);
+        _checkpointingWriter = new FileAuditLogWriter(_root, channelNumber: 2);
+        _ts = (ulong)(new DateTime(2026, 5, 18, 12, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+        _tradeId = 1;
+        _record = NextRecord();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _writer.Dispose();
+        _checkpointingWriter.Dispose();
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    [Benchmark(Baseline = true)]
+    public void OnTrade_NoCheckpoint()
+    {
+        _writer.OnTrade(NextRecord());
+    }
+
+    [Benchmark]
+    public void OnTrade_PerCallCheckpoint()
+    {
+        _checkpointingWriter.OnTrade(NextRecord());
+        _checkpointingWriter.OnCommandBoundary(_tradeId);
+        _checkpointingWriter.Checkpoint();
+    }
+
+    private PostTradeRecord NextRecord()
+    {
+        var id = ++_tradeId;
+        // Stay within a single UTC day so RotateTo is never invoked; the
+        // bench is measuring the steady-state hot path, not rollover.
+        return new PostTradeRecord(
+            TradeId: id, TransactTimeNanos: _ts, SecurityId: BenchInstruments.PetrSecId,
+            AggressorSide: (id & 1) == 0 ? Side.Buy : Side.Sell,
+            Quantity: 100, PriceMantissa: BenchInstruments.Px(32.00m),
+            BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+            BuyFirm: 7, SellFirm: 8,
+            BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+    }
+}

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -963,6 +963,16 @@ abandon the on-disk state.
 
 ### 7.8 Post-trade audit log (issue [#329](https://github.com/pedrosakuma/B3MatchingPlatform/issues/329))
 
+> ⚠️ **Status (as of this section landing): the writer/dispatcher
+> plumbing is fully implemented and unit-tested, but
+> `FileAuditLogWriter` is not yet constructed by `ExchangeHost`. A
+> default host run still uses `NullPostTradeSink`, so no audit files
+> are written and the recovery procedure below has nothing to
+> replay against.** Operators wanting to exercise the audit log
+> today must construct the writer programmatically and pass it as
+> the `postTradeSink` when wiring `ChannelDispatcher`. Host config
+> + factory + retention timer are tracked as a follow-up.
+
 The post-trade audit log is the legally-authoritative per-trade record
 the simulator emits alongside the wire-published `Trade_53` /
 `ER_Trade` frames. **It is a separate durability domain from the WAL:**

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -153,7 +153,7 @@ when the bounded queue is full (`DropWrite`).
 | --- | --- | --- |
 | `/channel/{ch}/snapshot-now` | POST | Force the next snapshot rotation tick to fire. Useful for triggering a recovery-bootstrap window for a freshly connected MD consumer. |
 | `/channel/{ch}/bump-version` | POST | Advance the channel's `SessionVerId` (snapshot generation), forcing consumers to re-bootstrap. |
-| `/channel/{ch}/trade-bust/{tradeId}` | POST | Publish a `TradeBust_57` (trade reversal) on the incremental channel. Required query: `securityId`. Optional: `priceMantissa`, `size`, `tradeDate` (LocalMktDate; days since 1970-01-01, default = today UTC). The simulator does not retain a per-trade audit log — the operator supplies the echo fields the consumer audits. The bust frame is stamped with the engine's next `RptSeq` so the per-instrument sequence stays dense. |
+| `/channel/{ch}/trade-bust/{tradeId}` | POST | Publish a `TradeBust_57` (trade reversal) on the incremental channel. Required query: `securityId`. Optional: `priceMantissa`, `size`, `tradeDate` (LocalMktDate; days since 1970-01-01, default = today UTC). The bust does not reach back into the post-trade audit log (issue #329) — the operator supplies the echo fields the consumer audits, and operators reconcile against the original `fills-YYYY-MM-DD.log` record offline. The bust frame is stamped with the engine's next `RptSeq` so the per-instrument sequence stays dense. |
 
 ### 2.5 Daily reset — `/admin/daily-reset`
 
@@ -961,7 +961,106 @@ with a forward-version error. Switch the format *before* the schema
 bump, or use `/admin/channels/{ch}/snapshot/reset?force=true` to
 abandon the on-disk state.
 
-### 7.8 Common persistence headaches
+### 7.8 Post-trade audit log (issue [#329](https://github.com/pedrosakuma/B3MatchingPlatform/issues/329))
+
+The post-trade audit log is the legally-authoritative per-trade record
+the simulator emits alongside the wire-published `Trade_53` /
+`ER_Trade` frames. **It is a separate durability domain from the WAL:**
+the WAL exists to recover engine state on restart and is deliberately
+short-lived (truncated on every successful snapshot); the audit log is
+append-only, daily-rolled by UTC business date, and intended to be
+retained for the compliance horizon (typically 5 years for B3 fills).
+
+**On-disk layout** (one set per channel, under
+`{auditDir}/{channel}/`):
+
+| File | Purpose |
+| --- | --- |
+| `fills-YYYY-MM-DD.log` | CRC32-protected, length-prefixed audit records; the schema is versioned in the file header. |
+| `fills-YYYY-MM-DD.idx` | Sparse firm index (PR-3, #346): one block entry per N records, keyed by both `buyFirm` and `sellFirm` so per-firm filtered scans skip irrelevant blocks. |
+| `audit-watermark.bin` | Per-channel sidecar (20 B): magic `B3PW` + schema v1 + `lastDurableCommandSeq` + CRC32. Persisted atomically (`.tmp` + fsync + rename) on every successful `Checkpoint`. |
+
+**Durability watermark (PRs #347 / #350).** `ChannelDispatcher`
+publishes a `commandSeq` boundary to the audit sink after every
+flushed command. `Checkpoint` fsyncs the `.log` and `.idx`, then
+writes the sidecar atomically, then advances the in-memory
+`DurableThroughCommandSeq`. The WAL truncation gate refuses to drop
+any record whose `commandSeq` exceeds this watermark, so a crash
+between `OnTrade` and a successful `Checkpoint` is recovered by WAL
+replay rather than silently dropped. On boot the writer seeds the
+watermark from the sidecar; the dispatcher captures it once at the
+start of replay and skips re-emitting any trade whose owning command
+is at or below it — preventing duplicate audit records when the WAL
+contains commands that were already fsync'd to the audit log
+pre-crash. A missing or corrupt sidecar collapses to "watermark
+unknown = 0", which is conservative: every replayed trade is
+re-emitted (idempotency is enforced by the file-pair pattern; the
+worst-case overshoot is bounded by the `[snapshot, crash]` window).
+
+**Retention (PR-6).** `FileAuditLogWriter.PruneOldDays(todayUtc,
+retentionDays)` deletes `fills-YYYY-MM-DD.{log,idx}` pairs whose
+date is *strictly before* `todayUtc - retentionDays`. The currently
+open day is never pruned, the per-channel watermark sidecar is never
+pruned, and unrelated / malformed filenames are ignored. The method
+is safe to call from any thread (it shares the `_checkpointLock`
+that serializes `Checkpoint`/`Dispose`). Operators wire it on a
+daily timer or invoke it ad-hoc from a maintenance job; the writer
+itself never schedules deletion automatically.
+
+```csharp
+// Daily prune from a maintenance job (5-year retention horizon).
+writer.PruneOldDays(DateOnly.FromDateTime(DateTime.UtcNow), retentionDays: 5 * 365);
+```
+
+**Recovery procedure (post-crash).**
+
+1. Start the host. The dispatcher loads the latest snapshot, then
+   replays the WAL through the matching engine — but emits *only*
+   the audit log (UMDF and ER outbound are stubbed during replay).
+2. For each replayed command, the audit gate compares the command's
+   `commandSeq` against `_bootAuditDurableSeq`:
+   - `commandSeq <= watermark` → trade was already on disk pre-crash,
+     the duplicate emission is suppressed and the
+     `exch_audit_replay_skipped_total` counter is bumped.
+   - `commandSeq > watermark` → the audit log has a hole; the gate
+     lets the trade through so the on-disk log is repaired.
+3. After replay finishes, the dispatcher transitions to live mode and
+   the WAL truncation gate proceeds normally (truncating up to the
+   newly-advanced audit watermark on the next snapshot save).
+4. Operator confirmation: `exch_audit_replay_skipped_total` should
+   be > 0 on any boot that found a non-empty WAL; a 0 reading
+   combined with replayed records means either no trades happened in
+   the recovered window OR the sidecar was missing/torn (also
+   surfaced by `exch_wal_replays_total > 0` with the sidecar
+   absent on disk). The second case is safe — duplicates within the
+   replay window are tolerated — but it is worth investigating the
+   underlying fsync / I/O failure that destroyed the sidecar.
+
+**Audit log vs WAL — quick comparison:**
+
+| Property | WAL (`channel-N.wal`) | Audit log (`fills-YYYY-MM-DD.log`) |
+| --- | --- | --- |
+| Lifetime | Transient — truncated on every successful snapshot, gated by the audit watermark. | Long-lived — kept until `PruneOldDays` deletes the day. |
+| Recovery role | Rebuilds engine state alongside the snapshot. | Reconstructs the trade history; not used to rebuild the engine. |
+| Schema versioning | Bumped via `SnapshotMigrations` chain. | Forward-compatible file header version field. |
+| Failure mode | A halted WAL stops the channel (`exch_wal_halt_rejects_total`). | A failed write makes the writer sticky-faulted; the watermark refuses to advance and the WAL stops truncating, surfacing the issue as backpressure rather than silent loss. |
+| Retention knob | `snapshotThrottle.everyN` + WAL truncation. | `PruneOldDays(today, retentionDays)`. |
+
+**Benchmarks.** Hot-path overhead is tracked by
+`PostTradeAuditBenchmarks` in `bench/B3.Exchange.Bench/`:
+
+```bash
+dotnet run -c Release --project bench/B3.Exchange.Bench -- \
+  --filter '*PostTradeAudit*'
+```
+
+Two scenarios: steady-state append (no fsync per record — the
+default operating mode) and pessimistic per-call `Checkpoint` (an
+upper bound on per-trade audit overhead). Compare numbers across PRs
+that touch the dispatcher hot path or the writer to catch
+regressions before they land.
+
+### 7.9 Common persistence headaches
 
 * **"Channel boots empty after restart."** Check
   `exch_snapshot_load_seconds` — `0` means `TryLoad` returned null.
@@ -999,6 +1098,7 @@ abandon the on-disk state.
 | Mass-cancel / CoD plumbing | `src/B3.Exchange.Gateway/OrderOwnershipMap.cs`, `FixpSession.cs` (CoD) |
 | Per-channel matching | `src/B3.Exchange.Core/ChannelDispatcher.cs`, `src/B3.Exchange.Matching/MatchingEngine.cs` |
 | State persistence | `src/B3.Exchange.Persistence/FileChannelStatePersister.cs`, `BinaryChannelStateSnapshotCodec.cs`, `FileChannelWriteAheadLog.cs`; migration framework in `src/B3.Exchange.Core/SnapshotMigrations.cs` |
+| Post-trade audit log | `src/B3.Exchange.PostTrade/FileAuditLogWriter.cs`, `AuditRecordCodec.cs`, `AuditIndexCodec.cs`, `AuditWatermarkCodec.cs` |
 | UMDF wire encoders | `src/B3.Umdf.WireEncoder/` |
 | Synthetic trader strategies | `src/B3.Exchange.SyntheticTrader/MarketMakerStrategy.cs`, `NoiseTakerStrategy.cs` |
 

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -395,6 +395,84 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         return DateOnly.FromDateTime(dt);
     }
 
+    /// <summary>
+    /// Issue #329 PR-6: delete on-disk audit files for UTC business
+    /// dates older than <c>todayUtc - retentionDays</c>. Files matching
+    /// the pattern <c>fills-YYYY-MM-DD.log</c> / <c>fills-YYYY-MM-DD.idx</c>
+    /// under the channel directory are removed in pairs; malformed or
+    /// non-date filenames are ignored. The currently-open day (i.e. the
+    /// one this writer is actively appending to) is never pruned even if
+    /// the calendar has rolled — operators must let the writer rotate first.
+    /// The watermark sidecar (<c>audit-watermark.bin</c>) is per-channel,
+    /// not per-day, and is intentionally NOT pruned.
+    ///
+    /// <para><paramref name="retentionDays"/> must be &gt;= 1. Pass the
+    /// compliance-mandated horizon (e.g. 5 years for B3 fills) or a
+    /// shorter operator value during development. Returns the number of
+    /// (.log, .idx) pairs deleted; partial pairs (an orphan .log or
+    /// .idx) are still counted toward the deletion total per file.</para>
+    ///
+    /// <para>Safe to call from any thread: the method acquires the same
+    /// <c>_checkpointLock</c> as <see cref="Checkpoint"/> / <see cref="Dispose"/>
+    /// so it never races the active stream. The active day is identified
+    /// by <c>_currentDate</c> under the lock to avoid a TOCTOU window.</para>
+    /// </summary>
+    public int PruneOldDays(DateOnly todayUtc, int retentionDays)
+    {
+        if (retentionDays < 1)
+            throw new ArgumentOutOfRangeException(nameof(retentionDays), "retentionDays must be >= 1");
+        var channelDir = Path.Combine(_rootDir, _channelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        if (!Directory.Exists(channelDir)) return 0;
+        var cutoff = todayUtc.AddDays(-retentionDays);
+        int deleted = 0;
+        lock (_checkpointLock)
+        {
+            foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.*"))
+            {
+                var name = Path.GetFileName(path);
+                if (!TryParseFillsDate(name, out var date, out var ext)) continue;
+                if (ext != ".log" && ext != ".idx") continue;
+                // Never delete the currently-open day even if it falls
+                // before the cutoff (e.g. a clock skew or aggressive
+                // retentionDays=1 during development).
+                if (_stream is not null && date == _currentDate) continue;
+                if (date >= cutoff) continue;
+                try
+                {
+                    File.Delete(path);
+                    deleted++;
+                }
+                catch (IOException)
+                {
+                    // Best-effort: file in use or transient FS error;
+                    // the next prune pass will retry.
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // Permissions issue — leave for the operator.
+                }
+            }
+        }
+        return deleted;
+    }
+
+    private static bool TryParseFillsDate(string fileName, out DateOnly date, out string ext)
+    {
+        date = default;
+        ext = string.Empty;
+        // Expected: fills-YYYY-MM-DD.log | fills-YYYY-MM-DD.idx
+        const string prefix = "fills-";
+        if (!fileName.StartsWith(prefix, StringComparison.Ordinal)) return false;
+        int dot = fileName.LastIndexOf('.');
+        if (dot <= prefix.Length) return false;
+        var dateSpan = fileName.AsSpan(prefix.Length, dot - prefix.Length);
+        if (!DateOnly.TryParseExact(dateSpan, "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out date))
+            return false;
+        ext = fileName[dot..];
+        return true;
+    }
+
     public void Dispose()
     {
         lock (_checkpointLock)

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterRetentionTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterRetentionTests.cs
@@ -1,0 +1,180 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>
+/// Issue #329 PR-6: retention policy tests for
+/// <see cref="FileAuditLogWriter.PruneOldDays(DateOnly, int)"/>. The
+/// pruner must delete <c>fills-YYYY-MM-DD.log</c>/<c>.idx</c> pairs
+/// older than the cutoff, never touch the currently-open day, never
+/// touch the per-channel watermark sidecar, and ignore non-matching
+/// filenames.
+/// </summary>
+public class FileAuditLogWriterRetentionTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileAuditLogWriterRetentionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeRetention_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    [Fact]
+    public void Prune_DeletesFiles_OlderThanCutoff()
+    {
+        var channelDir = Path.Combine(_root, "9");
+        Directory.CreateDirectory(channelDir);
+        var oldDates = new[] { "2024-01-01", "2024-06-15", "2025-12-31" };
+        var freshDates = new[] { "2026-05-15", "2026-05-16", "2026-05-17" };
+        foreach (var d in oldDates.Concat(freshDates))
+        {
+            File.WriteAllText(Path.Combine(channelDir, $"fills-{d}.log"), "x");
+            File.WriteAllText(Path.Combine(channelDir, $"fills-{d}.idx"), "x");
+        }
+
+        using var w = new FileAuditLogWriter(_root, channelNumber: 9);
+        // Today = 2026-05-18, retention = 3 days → cutoff = 2026-05-15.
+        // Files with date < cutoff are deleted; date >= cutoff stays.
+        int deleted = w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: 3);
+
+        // 3 old dates × 2 files each = 6 deletions.
+        Assert.Equal(6, deleted);
+        foreach (var d in oldDates)
+        {
+            Assert.False(File.Exists(Path.Combine(channelDir, $"fills-{d}.log")));
+            Assert.False(File.Exists(Path.Combine(channelDir, $"fills-{d}.idx")));
+        }
+        foreach (var d in freshDates)
+        {
+            Assert.True(File.Exists(Path.Combine(channelDir, $"fills-{d}.log")));
+            Assert.True(File.Exists(Path.Combine(channelDir, $"fills-{d}.idx")));
+        }
+    }
+
+    [Fact]
+    public void Prune_NeverDeletes_CurrentlyOpenDay()
+    {
+        // The active day is whatever the writer last appended to. Even
+        // if today's UTC date is far in the future and retentionDays
+        // would otherwise sweep it, the open file must survive.
+        using var w = new FileAuditLogWriter(_root, channelNumber: 11);
+        // 2026-05-18: write a record so the writer opens fills-2026-05-18.{log,idx}.
+        w.OnTrade(MakeRecord(1, Day0Nanos));
+        var logPath = Path.Combine(_root, "11", "fills-2026-05-18.log");
+        var idxPath = Path.Combine(_root, "11", "fills-2026-05-18.idx");
+        Assert.True(File.Exists(logPath));
+
+        // todayUtc = far future, retention = 1 day → cutoff = far future - 1.
+        // Without the open-day guard this would delete the active file.
+        int deleted = w.PruneOldDays(new DateOnly(2030, 1, 1), retentionDays: 1);
+
+        Assert.Equal(0, deleted);
+        Assert.True(File.Exists(logPath));
+        Assert.True(File.Exists(idxPath));
+    }
+
+    [Fact]
+    public void Prune_NeverDeletes_WatermarkSidecar()
+    {
+        var channelDir = Path.Combine(_root, "12");
+        Directory.CreateDirectory(channelDir);
+        // Seed an audit-watermark.bin alongside an old day. The sidecar is
+        // per-channel and must outlive any daily prune (its name does not
+        // match the fills-YYYY-MM-DD.{log,idx} pattern).
+        var sidecarPath = Path.Combine(channelDir, "audit-watermark.bin");
+        File.WriteAllBytes(sidecarPath, new byte[AuditWatermarkCodec.FileSize]);
+        File.WriteAllText(Path.Combine(channelDir, "fills-2024-01-01.log"), "x");
+        File.WriteAllText(Path.Combine(channelDir, "fills-2024-01-01.idx"), "x");
+
+        using var w = new FileAuditLogWriter(_root, channelNumber: 12);
+        int deleted = w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: 7);
+
+        Assert.Equal(2, deleted);
+        Assert.True(File.Exists(sidecarPath),
+            "watermark sidecar must survive daily prune");
+    }
+
+    [Fact]
+    public void Prune_IgnoresMalformedAndUnrelatedFiles()
+    {
+        var channelDir = Path.Combine(_root, "13");
+        Directory.CreateDirectory(channelDir);
+        // Genuine old file that SHOULD be deleted.
+        File.WriteAllText(Path.Combine(channelDir, "fills-2024-01-01.log"), "x");
+        // Files that look-like but don't match the strict pattern.
+        File.WriteAllText(Path.Combine(channelDir, "fills-not-a-date.log"), "x");
+        File.WriteAllText(Path.Combine(channelDir, "fills-2024-13-40.log"), "x"); // invalid month/day
+        File.WriteAllText(Path.Combine(channelDir, "fills-2024-01-01.bak"), "x"); // wrong extension
+        File.WriteAllText(Path.Combine(channelDir, "random.log"), "x");           // wrong prefix
+
+        using var w = new FileAuditLogWriter(_root, channelNumber: 13);
+        int deleted = w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: 7);
+
+        Assert.Equal(1, deleted);
+        Assert.False(File.Exists(Path.Combine(channelDir, "fills-2024-01-01.log")));
+        Assert.True(File.Exists(Path.Combine(channelDir, "fills-not-a-date.log")));
+        Assert.True(File.Exists(Path.Combine(channelDir, "fills-2024-13-40.log")));
+        Assert.True(File.Exists(Path.Combine(channelDir, "fills-2024-01-01.bak")));
+        Assert.True(File.Exists(Path.Combine(channelDir, "random.log")));
+    }
+
+    [Fact]
+    public void Prune_NoChannelDir_ReturnsZero()
+    {
+        // PruneOldDays runs before any OnTrade → channel directory may
+        // not exist yet. Must not throw.
+        using var w = new FileAuditLogWriter(_root, channelNumber: 14);
+        int deleted = w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: 1);
+        Assert.Equal(0, deleted);
+    }
+
+    [Fact]
+    public void Prune_RetentionDaysLessThanOne_Throws()
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: 15);
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: 0));
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: -1));
+    }
+
+    [Fact]
+    public void Prune_BoundaryCutoffIsInclusive_KeepsCutoffDay()
+    {
+        // cutoff = todayUtc - retentionDays. Files dated >= cutoff are
+        // kept; only date < cutoff is deleted. This pins the boundary
+        // contract so a future refactor cannot silently shift it.
+        var channelDir = Path.Combine(_root, "16");
+        Directory.CreateDirectory(channelDir);
+        File.WriteAllText(Path.Combine(channelDir, "fills-2026-05-10.log"), "x"); // cutoff - 1 → DELETE
+        File.WriteAllText(Path.Combine(channelDir, "fills-2026-05-11.log"), "x"); // cutoff      → KEEP
+        File.WriteAllText(Path.Combine(channelDir, "fills-2026-05-12.log"), "x"); // cutoff + 1 → KEEP
+
+        using var w = new FileAuditLogWriter(_root, channelNumber: 16);
+        // today = 2026-05-18, retention = 7 → cutoff = 2026-05-11.
+        int deleted = w.PruneOldDays(new DateOnly(2026, 5, 18), retentionDays: 7);
+
+        Assert.Equal(1, deleted);
+        Assert.False(File.Exists(Path.Combine(channelDir, "fills-2026-05-10.log")));
+        Assert.True(File.Exists(Path.Combine(channelDir, "fills-2026-05-11.log")));
+        Assert.True(File.Exists(Path.Combine(channelDir, "fills-2026-05-12.log")));
+    }
+
+    // 2026-05-18 00:00:00 UTC (matches Day0 used elsewhere in the suite).
+    private static readonly ulong Day0Nanos =
+        (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+
+    private static PostTradeRecord MakeRecord(uint id, ulong ts) => new(
+        TradeId: id, TransactTimeNanos: ts, SecurityId: 900_000_000_001L,
+        AggressorSide: Side.Buy, Quantity: 100, PriceMantissa: 10_0000L,
+        BuyClOrdId: 1000UL, SellClOrdId: 2000UL,
+        BuyFirm: 7, SellFirm: 8,
+        BuyOrderId: 5001, SellOrderId: 6001);
+}


### PR DESCRIPTION
Closes the 6-PR plan for #329.

## What

- **`FileAuditLogWriter.PruneOldDays(todayUtc, retentionDays)`** — deletes `fills-YYYY-MM-DD.{log,idx}` pairs strictly before `todayUtc - retentionDays`. Currently-open day, watermark sidecar, and unrelated/malformed files are preserved. Shares `_checkpointLock`, safe from any thread.
- **`PostTradeAuditBenchmarks`** — BenchmarkDotNet MemoryDiagnoser with steady-state and per-call-checkpoint scenarios so we can spot hot-path regressions.
- **RUNBOOK §7.8** — on-disk layout, watermark contract vs WAL truncation, recovery procedure, retention API, bench recipe, audit-vs-WAL comparison. Updated the stale trade-bust note and the 'where to look in the code' map.

## Out of scope

Host wiring (config schema, ExchangeHost factory, retention timer) — tracked separately; the writer is callable today but not yet constructed by `ExchangeHost`.

## Test

- 7 new unit tests in `FileAuditLogWriterRetentionTests` pin the cutoff (inclusive of cutoff day), open-day protection, sidecar preservation, malformed-name handling, missing-dir, and arg validation.
- Full `dotnet build` + `dotnet test` + `dotnet format --verify-no-changes` (Release) all green locally.