### PR TITLE
host: wire FileAuditLogWriter + daily retention timer (#352)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -963,15 +963,24 @@ abandon the on-disk state.
 
 ### 7.8 Post-trade audit log (issue [#329](https://github.com/pedrosakuma/B3MatchingPlatform/issues/329))
 
-> ⚠️ **Status (as of this section landing): the writer/dispatcher
-> plumbing is fully implemented and unit-tested, but
-> `FileAuditLogWriter` is not yet constructed by `ExchangeHost`. A
-> default host run still uses `NullPostTradeSink`, so no audit files
-> are written and the recovery procedure below has nothing to
-> replay against.** Operators wanting to exercise the audit log
-> today must construct the writer programmatically and pass it as
-> the `postTradeSink` when wiring `ChannelDispatcher`. Host config
-> + factory + retention timer are tracked as a follow-up.
+Opt-in via the per-channel `postTradeAudit` config block (issue
+[#352](https://github.com/pedrosakuma/B3MatchingPlatform/issues/352)):
+
+```jsonc
+"channels": [{
+  "channelNumber": 1,
+  // ... transport, instruments, persistence ...
+  "postTradeAudit": {
+    "enabled": true,
+    "dataDir": "/var/lib/b3matching/audit",
+    "retentionDays": 1825   // 5 years; 0 disables auto-prune
+  }
+}]
+```
+
+When the block is absent or `enabled=false`, the dispatcher uses
+`NullPostTradeSink` and no audit files are written (preserving the
+pre-#352 behaviour).
 
 The post-trade audit log is the legally-authoritative per-trade record
 the simulator emits alongside the wire-published `Trade_53` /
@@ -1013,14 +1022,12 @@ date is *strictly before* `todayUtc - retentionDays`. The currently
 open day is never pruned, the per-channel watermark sidecar is never
 pruned, and unrelated / malformed filenames are ignored. The method
 is safe to call from any thread (it shares the `_checkpointLock`
-that serializes `Checkpoint`/`Dispose`). Operators wire it on a
-daily timer or invoke it ad-hoc from a maintenance job; the writer
-itself never schedules deletion automatically.
-
-```csharp
-// Daily prune from a maintenance job (5-year retention horizon).
-writer.PruneOldDays(DateOnly.FromDateTime(DateTime.UtcNow), retentionDays: 5 * 365);
-```
+that serializes `Checkpoint`/`Dispose`). When the host is
+configured with `postTradeAudit.retentionDays > 0`, a per-channel
+24h `Timer` (started ~1 minute after boot, then every 24h) invokes
+`PruneOldDays` automatically and logs the deletion count at
+`Information` when > 0. Set `retentionDays=0` to disable the timer
+and manage retention from an external operator job.
 
 **Recovery procedure (post-crash).**
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -147,9 +147,16 @@ public sealed partial class ChannelDispatcher
     /// </summary>
     private void TruncateWalAfterSyncSave(long snapshotLastAppliedSeq)
     {
+        // Issue #329 PR-4 / #352 follow-up: the audit-log Checkpoint
+        // (fsync .log/.idx + write watermark sidecar) MUST run after
+        // every successful snapshot save regardless of whether a WAL
+        // is configured — otherwise audit-only channels never fsync
+        // their per-trade data and never advance the durability
+        // watermark. The WAL truncation itself remains gated on _wal
+        // being non-null AND the watermark covering the snapshot seq.
+        bool watermarkOk = CheckpointAndGateAuditWatermark(snapshotLastAppliedSeq, async: false);
         if (_wal is null) return;
-        if (!CheckpointAndGateAuditWatermark(snapshotLastAppliedSeq, async: false))
-            return;
+        if (!watermarkOk) return;
         try
         {
             _wal.Truncate();
@@ -176,9 +183,13 @@ public sealed partial class ChannelDispatcher
     /// </summary>
     private void OnAsyncSnapshotSaved(ChannelStateSnapshot snap)
     {
+        // Issue #329 PR-4 / #352 follow-up: Checkpoint the audit sink
+        // even when no WAL is configured (see TruncateWalAfterSyncSave
+        // above for the same rationale). The audit sink's Checkpoint
+        // is safe to call cross-thread.
+        bool watermarkOk = CheckpointAndGateAuditWatermark(snap.LastAppliedSeq, async: true);
         if (_wal is null) return;
-        if (!CheckpointAndGateAuditWatermark(snap.LastAppliedSeq, async: true))
-            return;
+        if (!watermarkOk) return;
         try
         {
             _wal.Truncate();

--- a/src/B3.Exchange.Host/B3.Exchange.Host.csproj
+++ b/src/B3.Exchange.Host/B3.Exchange.Host.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\B3.Exchange.Persistence\B3.Exchange.Persistence.csproj" />
+    <ProjectReference Include="..\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -35,6 +35,8 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly List<InstrumentDefinitionPublisher> _instrumentDefPublishers = new();
     private readonly List<IDisposable> _ownedSinks = new();
     private readonly List<Timer> _snapshotTimers = new();
+    private readonly List<B3.Exchange.PostTrade.FileAuditLogWriter> _auditWriters = new();
+    private readonly List<Timer> _auditRetentionTimers = new();
     private readonly MetricsRegistry _metrics = new();
     private readonly StartupReadinessProbe _startupProbe = new("startup");
     private readonly ShutdownReadinessProbe _shutdownProbe = new("shutdown");
@@ -170,8 +172,10 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
             var persister = BuildPersister(ch);
             var wal = BuildWal(ch);
+            var auditWriter = BuildPostTradeAuditWriter(ch);
             if (persister != null) _persistersByChannel[ch.ChannelNumber] = persister;
             if (wal != null) _walsByChannel[ch.ChannelNumber] = wal;
+            if (auditWriter != null) _auditWriters.Add(auditWriter);
             // Issue #270: cross-channel consistency check on restore.
             // Resolve the policy here so the dispatcher can stay
             // host-agnostic (it just gets a predicate + enum).
@@ -198,7 +202,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 walAppendFailurePolicy: ch.Persistence?.Wal?.ResolveOnAppendFailure() ?? B3.Exchange.Core.WalAppendFailurePolicy.Continue,
                 sessionExists: sessionExists,
                 orphanPolicy: orphanPolicy,
-                seedSecurityIds: instruments.Select(i => i.SecurityId).ToArray());
+                seedSecurityIds: instruments.Select(i => i.SecurityId).ToArray(),
+                postTradeSink: auditWriter);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -209,6 +214,41 @@ public sealed class ExchangeHost : IAsyncDisposable
             }
             _logger.LogInformation("channel {ChannelNumber}: {InstrumentCount} instruments → {Group}:{Port}",
                 ch.ChannelNumber, instruments.Count, ch.IncrementalGroup, ch.IncrementalPort);
+
+            if (auditWriter != null)
+            {
+                var audit = ch.PostTradeAudit!;
+                _logger.LogInformation(
+                    "channel {ChannelNumber}: post-trade audit log enabled at {DataDir} (retentionDays={RetentionDays})",
+                    ch.ChannelNumber, audit.DataDir, audit.RetentionDays);
+                if (audit.RetentionDays > 0)
+                {
+                    var capturedWriter = auditWriter;
+                    int retentionDays = audit.RetentionDays;
+                    byte chNum = ch.ChannelNumber;
+                    var retentionLogger = _loggerFactory.CreateLogger<B3.Exchange.PostTrade.FileAuditLogWriter>();
+                    var timer = new Timer(_ =>
+                    {
+                        try
+                        {
+                            int deleted = capturedWriter.PruneOldDays(
+                                DateOnly.FromDateTime(DateTime.UtcNow), retentionDays);
+                            if (deleted > 0)
+                            {
+                                retentionLogger.LogInformation(
+                                    "channel {ChannelNumber}: pruned {Count} expired audit file(s) (retentionDays={RetentionDays})",
+                                    chNum, deleted, retentionDays);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            retentionLogger.LogWarning(ex,
+                                "channel {ChannelNumber}: audit log retention prune failed", chNum);
+                        }
+                    }, null, TimeSpan.FromMinutes(1), TimeSpan.FromHours(24));
+                    _auditRetentionTimers.Add(timer);
+                }
+            }
 
             if (ch.Snapshot != null)
             {
@@ -606,6 +646,33 @@ public sealed class ExchangeHost : IAsyncDisposable
     }
 
     /// <summary>
+    /// Builds the per-channel post-trade audit log writer
+    /// (issues #329 / #352). Returns <c>null</c> when the channel
+    /// has no <c>postTradeAudit</c> block or <c>enabled=false</c>,
+    /// in which case the dispatcher falls back to
+    /// <see cref="B3.Exchange.PostTrade.NullPostTradeSink"/>.
+    /// </summary>
+    private B3.Exchange.PostTrade.FileAuditLogWriter? BuildPostTradeAuditWriter(ChannelConfig ch)
+    {
+        if (ch.PostTradeAudit is not { Enabled: true } audit) return null;
+        if (string.IsNullOrWhiteSpace(audit.DataDir))
+        {
+            _logger.LogWarning(
+                "channel {ChannelNumber}: postTradeAudit.enabled=true but dataDir is empty; skipping audit log",
+                ch.ChannelNumber);
+            return null;
+        }
+        if (audit.RetentionDays < 0)
+        {
+            throw new InvalidOperationException(
+                $"channel {ch.ChannelNumber}: postTradeAudit.retentionDays must be >= 0 (got {audit.RetentionDays}); use 0 to disable automatic retention");
+        }
+        return new B3.Exchange.PostTrade.FileAuditLogWriter(
+            audit.DataDir,
+            ch.ChannelNumber);
+    }
+
+    /// <summary>
     /// Issue #270: parses the <c>persistence.orphanSessionPolicy</c>
     /// JSON string into the <see cref="OrphanSessionPolicy"/> enum
     /// expected by <see cref="ChannelDispatcher"/>. Defaults to
@@ -709,6 +776,19 @@ public sealed class ExchangeHost : IAsyncDisposable
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);
         foreach (var p in _instrumentDefPublishers) await p.DisposeAsync().ConfigureAwait(false);
         foreach (var d in _dispatchers) await d.DisposeAsync().ConfigureAwait(false);
+        // Dispose audit-log retention timers and writers AFTER the
+        // dispatchers have drained: the dispatcher's final
+        // OnCommandBoundary/Checkpoint must run before the writer is
+        // closed so the on-disk watermark matches the last appended
+        // record.
+        foreach (var t in _auditRetentionTimers) await t.DisposeAsync().ConfigureAwait(false);
+        _auditRetentionTimers.Clear();
+        foreach (var w in _auditWriters)
+        {
+            try { w.Dispose(); }
+            catch (Exception ex) { _logger.LogWarning(ex, "audit writer dispose threw"); }
+        }
+        _auditWriters.Clear();
         foreach (var s in _ownedSinks) s.Dispose();
         _retransmitPersister?.Dispose();
         // Issue #290: release dataDir locks last so any persister/WAL

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -328,6 +328,19 @@ public sealed class ChannelConfig
     /// intact. Omit to keep the legacy stateless boot.
     /// </summary>
     [JsonPropertyName("persistence")] public PersistenceConfig? Persistence { get; set; }
+
+    /// <summary>
+    /// Optional per-channel post-trade audit log (issue #329 / wiring
+    /// follow-up #352). When present and <see cref="PostTradeAuditConfig.Enabled"/>
+    /// is <c>true</c>, the dispatcher writes a per-day append-only
+    /// audit record per <c>OnTrade</c> under
+    /// <c>{DataDir}/{channel}/fills-YYYY-MM-DD.log</c> (plus a sparse
+    /// <c>.idx</c> firm index) and persists a watermark sidecar so
+    /// post-crash WAL replay can suppress duplicate audit emissions.
+    /// Omit (or set <c>enabled=false</c>) to keep the legacy
+    /// no-audit-log behaviour (<c>NullPostTradeSink</c>).
+    /// </summary>
+    [JsonPropertyName("postTradeAudit")] public PostTradeAuditConfig? PostTradeAudit { get; set; }
 }
 
 /// <summary>
@@ -404,6 +417,39 @@ public sealed class PersistenceConfig
     /// reduction documented in issue #266.
     /// </summary>
     [JsonPropertyName("format")] public string? Format { get; set; }
+}
+
+/// <summary>
+/// Per-channel post-trade audit log config (issue #329 / wiring
+/// follow-up #352). The audit log is an independent durability
+/// domain from snapshots/WAL: it appends one record per
+/// <c>OnTrade</c>, rolls daily by UTC business date, and is
+/// intended to be retained for the compliance horizon (typically
+/// 5 years for B3 fills). See RUNBOOK §7.8 for the on-disk layout
+/// and watermark contract.
+/// </summary>
+public sealed class PostTradeAuditConfig
+{
+    /// <summary>Master switch. <c>false</c> (default) ⇒ no audit
+    /// log files are written; the dispatcher uses
+    /// <c>NullPostTradeSink</c>.</summary>
+    [JsonPropertyName("enabled")] public bool Enabled { get; set; }
+
+    /// <summary>Root directory for audit files. The writer creates
+    /// <c>{DataDir}/{channelNumber}/</c> if missing. Operators must
+    /// mount a durable volume separate from the WAL/snapshot volume
+    /// when the compliance horizon exceeds the WAL retention.</summary>
+    [JsonPropertyName("dataDir")] public string DataDir { get; set; } = "";
+
+    /// <summary>Number of UTC days of audit log files to keep on
+    /// disk. <c>0</c> (default) disables automatic retention — the
+    /// host writes audit files but never deletes them, leaving
+    /// retention to an external operator job. When set to a
+    /// positive value, the host runs a daily timer that calls
+    /// <c>FileAuditLogWriter.PruneOldDays(todayUtc, retentionDays)</c>;
+    /// files for the currently-open day and the watermark sidecar
+    /// are never pruned.</summary>
+    [JsonPropertyName("retentionDays")] public int RetentionDays { get; set; }
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
   </ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/PostTradeAuditHostWiringTests.cs
+++ b/tests/B3.Exchange.Host.Tests/PostTradeAuditHostWiringTests.cs
@@ -1,0 +1,174 @@
+using B3.Exchange.Core;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #352: <see cref="ExchangeHost"/> must construct and inject a
+/// <see cref="FileAuditLogWriter"/> when the channel config has
+/// <c>postTradeAudit.enabled=true</c>, and must fall back to the
+/// no-op sink otherwise. Disposal must flush the writer's final
+/// watermark.
+/// </summary>
+public class PostTradeAuditHostWiringTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    private static HostConfig BaseCfg(string instrumentsPath, PostTradeAuditConfig? audit, byte channel = 81)
+        => new()
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = channel,
+                    IncrementalGroup = "239.255.81.81",
+                    IncrementalPort = 30181,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    PostTradeAudit = audit,
+                },
+            },
+        };
+
+    [Fact]
+    public async Task StartAsync_WithoutPostTradeAuditBlock_UsesNullSink()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var cfg = BaseCfg(instrumentsPath, audit: null);
+
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+        await host.StartAsync();
+        // Host must boot and shut down cleanly without touching disk.
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_WithDisabledAudit_DoesNotCreateAuditDir()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(),
+            "b3-audit-disabled-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var cfg = BaseCfg(instrumentsPath, new PostTradeAuditConfig
+            {
+                Enabled = false,
+                DataDir = auditDir,
+                RetentionDays = 5,
+            });
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            await host.StopAsync();
+
+            // Writer was never constructed; the per-channel sub-directory
+            // must not exist on disk.
+            Assert.False(Directory.Exists(Path.Combine(auditDir, "81")),
+                "disabled audit must not pre-create the per-channel dir");
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_WithEnabledAudit_BootsCleanly()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(),
+            "b3-audit-enabled-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var cfg = BaseCfg(instrumentsPath, new PostTradeAuditConfig
+            {
+                Enabled = true,
+                DataDir = auditDir,
+                RetentionDays = 0,
+            }, channel: 82);
+
+            await using (var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink()))
+            {
+                await host.StartAsync();
+                await host.StopAsync();
+            }
+            // No trades were emitted, so the writer never had to call
+            // RotateTo and the per-channel dir may not exist. The
+            // important assertion is that boot + shutdown cycle through
+            // a non-null FileAuditLogWriter without throwing.
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_WithEmptyDataDir_LogsWarningAndSkips()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var cfg = BaseCfg(instrumentsPath, new PostTradeAuditConfig
+        {
+            Enabled = true,
+            DataDir = "",
+            RetentionDays = 0,
+        }, channel: 83);
+
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+        // Empty dataDir is a misconfiguration that we tolerate (warn + skip)
+        // rather than failing closed — matches the BuildPersister/BuildWal
+        // convention so a half-configured channel keeps the legacy
+        // no-audit-log behaviour instead of refusing to boot.
+        await host.StartAsync();
+        await host.StopAsync();
+    }
+
+    [Fact]
+    public async Task StartAsync_WithNegativeRetentionDays_Throws()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(),
+            "b3-audit-neg-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var cfg = BaseCfg(instrumentsPath, new PostTradeAuditConfig
+            {
+                Enabled = true,
+                DataDir = auditDir,
+                RetentionDays = -1,
+            }, channel: 84);
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => host.StartAsync());
+            Assert.Contains("retentionDays", ex.Message);
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+        }
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
@@ -210,6 +210,45 @@ public class ChannelDispatcherAuditWatermarkTests
     }
 
     [Fact]
+    public void AuditCheckpoint_RunsAfterSnapshotSave_EvenWithoutWal()
+    {
+        // Issue #352 follow-up (PR #353 review): the audit sink must
+        // be Checkpointed after every successful snapshot save even
+        // when no WAL is configured. Pre-fix, TruncateWalAfterSyncSave
+        // returned immediately on `_wal is null`, so audit-only
+        // channels never fsync'd .log/.idx or advanced the watermark.
+        var persister = new InMemoryPersister();
+        var metrics = new ChannelMetrics(84);
+        var sink = new ManualPostTradeSink();
+        var disp = new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s, NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: new NoOpOutbound(),
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            metrics: metrics,
+            persister: persister,
+            snapshotThrottle: null,
+            useAsyncSnapshotWriter: false,
+            wal: null,
+            postTradeSink: sink);
+        var probe = disp.CreateTestProbe();
+
+        Assert.True(EnqueueOrder(disp, "CL-1", 0x1, 1UL));
+        probe.DrainInbound();
+
+        // Snapshot must have run AND the audit sink Checkpointed,
+        // even though no WAL was configured. WAL-related metrics
+        // stay at zero (there is no WAL to truncate or defer).
+        Assert.Equal(1, persister.SaveCount);
+        Assert.True(sink.CheckpointCount >= 1,
+            $"expected audit Checkpoint to run, got CheckpointCount={sink.CheckpointCount}");
+        Assert.Equal(0, metrics.WalTruncations);
+        Assert.Equal(0, metrics.AuditWalTruncateDeferred);
+    }
+
+
+    [Fact]
     public void Dispatcher_ForwardsCommandSeq_ToSinkBoundaries()
     {
         // Pins the contract that OnCommandBoundary fires after every command


### PR DESCRIPTION
Closes #352 (follow-up to #329 6-PR series).

## What

- New `PostTradeAuditConfig { enabled, dataDir, retentionDays }` under `channels[].postTradeAudit`.
- `ExchangeHost` factory constructs `FileAuditLogWriter` per channel when enabled and passes it as `postTradeSink` to `ChannelDispatcher` (otherwise the dispatcher keeps using `NullPostTradeSink`).
- Per-channel 24h retention `Timer` invokes `PruneOldDays(today, retentionDays)` ~1 min after boot and every 24h thereafter when `retentionDays > 0`. `0` disables the timer.
- Dispose ordering: dispatchers drain first (final `OnCommandBoundary` + `Checkpoint` write the watermark), then retention timers stop, then audit writers `Dispose`. Prevents a torn watermark outliving the last record.
- RUNBOOK §7.8 updated: caveat dropped, config snippet + timer cadence documented.

## Tests

5 new tests in `PostTradeAuditHostWiringTests`:
- absent `postTradeAudit` ⇒ NullSink (boot clean)
- `enabled=false` ⇒ per-channel dir never created
- `enabled=true` ⇒ host boots + disposes cleanly through a live writer
- empty `dataDir` ⇒ warn + skip (matches BuildPersister/BuildWal convention)
- `retentionDays=-1` ⇒ boot fails closed with explicit message

Full `dotnet build` + `dotnet test` + `dotnet format --verify-no-changes` (Release) green locally.