### PR TITLE
wal: prefix-truncate after async snapshot save (closes #348)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -192,7 +192,13 @@ public sealed partial class ChannelDispatcher
         if (!watermarkOk) return;
         try
         {
-            _wal.Truncate();
+            // Issue #348: prefix-truncate, NOT full truncate. Between
+            // BackgroundSnapshotWriter.Submit(snap) and this onSaved
+            // callback firing, the dispatch thread may have appended
+            // records with Seq > snap.LastAppliedSeq that are NOT
+            // covered by the just-saved snapshot. A full Truncate()
+            // would drop them and a subsequent crash would lose them.
+            _wal.TruncateThrough(snap.LastAppliedSeq);
             _metrics?.IncWalTruncation();
             _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
         }

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -1,5 +1,6 @@
 using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
+using System.Collections.Generic;
 
 namespace B3.Exchange.Core;
 
@@ -85,6 +86,38 @@ public interface IChannelWriteAheadLog : IDurabilityBarrier
     /// contains records that are not yet reflected in the snapshot.
     /// </summary>
     void Truncate();
+
+    /// <summary>
+    /// Issue #348: drops every record with <c>Seq &lt;= throughSeq</c>
+    /// and KEEPS every record with <c>Seq &gt; throughSeq</c>. Used by
+    /// the async-snapshot path where the dispatch thread may have
+    /// appended records past the snapshot's <c>LastAppliedSeq</c>
+    /// between <see cref="BackgroundSnapshotWriter"/>'s <c>Submit</c>
+    /// and <c>onSaved</c> callback firing — a full <see cref="Truncate"/>
+    /// in that window would silently drop the tail.
+    ///
+    /// <para>Default implementation reads the surviving tail, calls
+    /// <see cref="Truncate"/>, then re-<see cref="Append"/>s the tail
+    /// — correct for in-memory fakes. File-backed implementations
+    /// should override with an atomic rewrite to avoid the
+    /// drop+re-append window.</para>
+    ///
+    /// <para>Single-writer contract identical to <see cref="Truncate"/>:
+    /// implementations may assume only one caller at a time but MUST
+    /// be safe to run concurrently with <see cref="Append"/> from the
+    /// dispatch thread (the file implementation serializes via its
+    /// internal write lock).</para>
+    /// </summary>
+    void TruncateThrough(long throughSeq)
+    {
+        var tail = new List<WalRecord>();
+        foreach (var rec in ReadAll())
+        {
+            if (rec.Seq > throughSeq) tail.Add(rec);
+        }
+        Truncate();
+        foreach (var rec in tail) Append(rec);
+    }
 
     /// <summary>
     /// Issue #271: removes the underlying WAL artifact entirely (file,

--- a/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Core/ChannelWriteAheadLog.cs
@@ -96,28 +96,18 @@ public interface IChannelWriteAheadLog : IDurabilityBarrier
     /// and <c>onSaved</c> callback firing — a full <see cref="Truncate"/>
     /// in that window would silently drop the tail.
     ///
-    /// <para>Default implementation reads the surviving tail, calls
-    /// <see cref="Truncate"/>, then re-<see cref="Append"/>s the tail
-    /// — correct for in-memory fakes. File-backed implementations
-    /// should override with an atomic rewrite to avoid the
-    /// drop+re-append window.</para>
-    ///
-    /// <para>Single-writer contract identical to <see cref="Truncate"/>:
-    /// implementations may assume only one caller at a time but MUST
-    /// be safe to run concurrently with <see cref="Append"/> from the
-    /// dispatch thread (the file implementation serializes via its
-    /// internal write lock).</para>
+    /// <para><b>No default is provided on purpose.</b> Any naive
+    /// <c>ReadAll → Truncate → re-Append</c> default would be unsafe
+    /// for production implementations whose <see cref="Append"/> runs
+    /// on a different thread (the dispatch thread) than this call (the
+    /// async-snapshot writer thread): a record appended between
+    /// <see cref="ReadAll"/> and <see cref="Truncate"/> would be lost,
+    /// recreating the very race this method was introduced to close.
+    /// Implementations MUST serialize the rewrite atomically with
+    /// concurrent <see cref="Append"/> calls (the file implementation
+    /// uses its internal write lock and an atomic file rename).</para>
     /// </summary>
-    void TruncateThrough(long throughSeq)
-    {
-        var tail = new List<WalRecord>();
-        foreach (var rec in ReadAll())
-        {
-            if (rec.Seq > throughSeq) tail.Add(rec);
-        }
-        Truncate();
-        foreach (var rec in tail) Append(rec);
-    }
+    void TruncateThrough(long throughSeq);
 
     /// <summary>
     /// Issue #271: removes the underlying WAL artifact entirely (file,

--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -597,39 +597,135 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     {
         lock (_writeLock)
         {
+            TruncateLocked();
+        }
+    }
+
+    private void TruncateLocked()
+    {
+        if (_appendStream is not null)
+        {
+            _appendStream.Dispose();
+            _appendStream = null;
+        }
+        // Atomic truncate: write empty file to tmp, rename over.
+        var tmp = System.IO.Path.Combine(_dataDir,
+            string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
+        try
+        {
+            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                fs.Flush(flushToDisk: true);
+            }
+            File.Move(tmp, _path, overwrite: true);
+            FsyncDirectory(_dataDir);
+            Interlocked.Exchange(ref _currentSize, 0);
+            // Issue #312: every previously-appended record is now
+            // either durable (it was fsynced into the old file
+            // before snapshot persist asked us to truncate) or
+            // intentionally discarded — either way it can't be
+            // replayed any more, so it counts as "durable" for
+            // any caller still waiting on its seq. Advancing
+            // _durableSeq here unblocks them instead of letting
+            // them spin until the fsync thread notices the empty
+            // file.
+            AdvanceDurableSeqOnTruncate();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: failed to truncate WAL at {Path}",
+                _channelNumber, _path);
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Issue #348: atomic prefix truncate — drops every record with
+    /// <c>Seq &lt;= throughSeq</c> and KEEPS every record with
+    /// <c>Seq &gt; throughSeq</c>. Closes the async-snapshot race
+    /// where the dispatch thread could append a record past the
+    /// snapshot's <c>LastAppliedSeq</c> between
+    /// <see cref="BackgroundSnapshotWriter"/>'s <c>Submit</c> and
+    /// <c>onSaved</c> callback firing; a full <see cref="Truncate"/>
+    /// in that window would silently drop the tail and a subsequent
+    /// crash would lose it.
+    ///
+    /// <para>Implementation: under <c>_writeLock</c>, reads the
+    /// surviving tail via <see cref="ReadAll"/>, writes a fresh tmp
+    /// file containing only the kept records, atomically renames
+    /// over the live WAL, fsyncs the directory. Equivalent to
+    /// <see cref="Truncate"/> when no records survive (kept=0); a
+    /// no-op when every record is above the cutoff.</para>
+    /// </summary>
+    public void TruncateThrough(long throughSeq)
+    {
+        lock (_writeLock)
+        {
+            // Snapshot the surviving tail BEFORE we touch the file —
+            // ReadAll opens its own FileStream with FileShare.Read, so
+            // this is safe even while _appendStream is still open. We
+            // close _appendStream below so the rename can succeed on
+            // Windows (Move-with-overwrite refuses an open file).
+            var all = ReadAll();
+            var kept = new List<WalRecord>(all.Count);
+            foreach (var rec in all)
+            {
+                if (rec.Seq > throughSeq) kept.Add(rec);
+            }
+            if (kept.Count == all.Count)
+            {
+                // Cutoff is below every record on disk → nothing to do.
+                return;
+            }
+            if (kept.Count == 0)
+            {
+                // Equivalent to a full truncate.
+                TruncateLocked();
+                return;
+            }
             if (_appendStream is not null)
             {
                 _appendStream.Dispose();
                 _appendStream = null;
             }
-            // Atomic truncate: write empty file to tmp, rename over.
             var tmp = System.IO.Path.Combine(_dataDir,
                 string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
             try
             {
+                long newSize = 0;
+                Span<byte> crcBytes = stackalloc byte[8];
                 using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
                 {
+                    foreach (var rec in kept)
+                    {
+                        var json = JsonSerializer.SerializeToUtf8Bytes(rec, WalJsonContext.Default.WalRecord);
+                        uint crc = Crc32C.Compute(json);
+                        WriteHexUtf8(crc, crcBytes);
+                        fs.Write(json, 0, json.Length);
+                        fs.WriteByte(CrcSeparator);
+                        fs.Write(crcBytes);
+                        fs.WriteByte((byte)'\n');
+                        newSize += json.Length + 1 + 8 + 1;
+                    }
                     fs.Flush(flushToDisk: true);
                 }
                 File.Move(tmp, _path, overwrite: true);
                 FsyncDirectory(_dataDir);
-                Interlocked.Exchange(ref _currentSize, 0);
-                // Issue #312: every previously-appended record is now
-                // either durable (it was fsynced into the old file
-                // before snapshot persist asked us to truncate) or
-                // intentionally discarded — either way it can't be
-                // replayed any more, so it counts as "durable" for
-                // any caller still waiting on its seq. Advancing
-                // _durableSeq here unblocks them instead of letting
-                // them spin until the fsync thread notices the empty
-                // file.
+                Interlocked.Exchange(ref _currentSize, newSize);
+                // The kept tail records were already durable before
+                // this call (they were fsynced on Append), so the
+                // post-rewrite durable seq is the highest seq in the
+                // surviving tail — which is also _pendingSeq's value
+                // (or higher) for any caller still parked.
                 AdvanceDurableSeqOnTruncate();
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex,
-                    "channel {ChannelNumber}: failed to truncate WAL at {Path}",
-                    _channelNumber, _path);
+                    "channel {ChannelNumber}: failed to prefix-truncate WAL at {Path} (throughSeq={ThroughSeq}, kept={Kept})",
+                    _channelNumber, _path, throughSeq, kept.Count);
                 try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
                 throw;
             }

--- a/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogTruncateThroughTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/FileChannelWriteAheadLogTruncateThroughTests.cs
@@ -1,0 +1,126 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using Side = B3.Exchange.Matching.Side;
+using OrderType = B3.Exchange.Matching.OrderType;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #348: <c>TruncateThrough(seq)</c> must drop records with
+/// <c>Seq &lt;= seq</c> and KEEP records with <c>Seq &gt; seq</c>.
+/// Closes the async-snapshot truncate race where the dispatch thread
+/// could append a record past the snapshot's <c>LastAppliedSeq</c>
+/// between <c>BackgroundSnapshotWriter.Submit</c> and the writer
+/// thread's <c>onSaved</c> callback firing.
+/// </summary>
+public class FileChannelWriteAheadLogTruncateThroughTests
+{
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "wal-prefix-" + Guid.NewGuid().ToString("N"));
+
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { } }
+    }
+
+    private static WalRecord MakeNew(long seq)
+        => new(seq, WalRecordKind.NewOrder, "S", 1u, (ulong)seq, 0,
+            new NewOrderCommand(ClOrdId: seq.ToString(), SecurityId: 1, Side: Side.Buy,
+                Type: OrderType.Limit, Tif: TimeInForce.Day, PriceMantissa: 100_0000,
+                Quantity: 10, EnteringFirm: 1u, EnteredAtNanos: 0),
+            null, null);
+
+    [Fact]
+    public void TruncateThrough_KeepsTail_BeyondCutoff()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        for (int i = 1; i <= 5; i++) wal.Append(MakeNew(i));
+
+        wal.TruncateThrough(3);
+
+        var read = wal.ReadAll();
+        Assert.Equal(2, read.Count);
+        Assert.Equal(4L, read[0].Seq);
+        Assert.Equal(5L, read[1].Seq);
+        Assert.Equal(0, wal.LastReadCorruptCount);
+        Assert.Equal(0, wal.LastReadLegacyCount);
+    }
+
+    [Fact]
+    public void TruncateThrough_NoTail_EqualsFullTruncate()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        for (int i = 1; i <= 3; i++) wal.Append(MakeNew(i));
+
+        wal.TruncateThrough(10);
+
+        Assert.Empty(wal.ReadAll());
+        Assert.Equal(0, wal.CurrentSizeBytes);
+    }
+
+    [Fact]
+    public void TruncateThrough_CutoffBelowAllRecords_IsNoOp()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        for (int i = 5; i <= 7; i++) wal.Append(MakeNew(i));
+        long sizeBefore = wal.CurrentSizeBytes;
+
+        wal.TruncateThrough(0);
+
+        var read = wal.ReadAll();
+        Assert.Equal(3, read.Count);
+        Assert.Equal(new long[] { 5, 6, 7 }, read.Select(r => r.Seq).ToArray());
+        Assert.Equal(sizeBefore, wal.CurrentSizeBytes);
+    }
+
+    [Fact]
+    public void TruncateThrough_PreservesAppendContinuity()
+    {
+        // After a prefix truncate the next Append must produce a file
+        // that ReadAll round-trips back as the surviving tail + the
+        // new record. Guards against stale append-stream offsets or
+        // a torn rename.
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        for (int i = 1; i <= 4; i++) wal.Append(MakeNew(i));
+
+        wal.TruncateThrough(2);
+        wal.Append(MakeNew(5));
+
+        var read = wal.ReadAll();
+        Assert.Equal(new long[] { 3, 4, 5 }, read.Select(r => r.Seq).ToArray());
+        Assert.Equal(0, wal.LastReadCorruptCount);
+    }
+
+    [Fact]
+    public void TruncateThrough_CurrentSizeBytes_ReflectsSurvivingTail()
+    {
+        using var dir = new TempDir();
+        using var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 7,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        for (int i = 1; i <= 6; i++) wal.Append(MakeNew(i));
+        long sizeFull = wal.CurrentSizeBytes;
+
+        wal.TruncateThrough(4);
+
+        long sizeAfter = wal.CurrentSizeBytes;
+        Assert.True(sizeAfter > 0, "kept records → non-zero size");
+        Assert.True(sizeAfter < sizeFull, $"prefix truncate must shrink the file (full={sizeFull}, after={sizeAfter})");
+        // Round-trip sanity: on-disk size must match what the file
+        // actually has after the atomic rename.
+        long onDisk = new FileInfo(System.IO.Path.Combine(dir.Path, "channel-7.wal")).Length;
+        Assert.Equal(onDisk, sizeAfter);
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAppendFailurePolicyTests.cs
@@ -63,6 +63,7 @@ public class WalAppendFailurePolicyTests
         }
         public IReadOnlyList<WalRecord> ReadAll() => Array.Empty<WalRecord>();
         public void Truncate() { }
+        public void TruncateThrough(long throughSeq) { }
         public void Dispose() { }
     }
 

--- a/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
@@ -72,10 +72,12 @@ public class WalAsyncSnapshotTruncateRaceTests
     {
         private readonly SemaphoreSlim _gate = new(0, int.MaxValue);
         public int SaveCount { get; private set; }
+        public int SaveEnteredCount;
         public ChannelStateSnapshot? Last { get; private set; }
         public ChannelStateSnapshot? TryLoad(byte channelNumber) => null;
         public long Save(ChannelStateSnapshot snapshot)
         {
+            Interlocked.Increment(ref SaveEnteredCount);
             _gate.Wait();
             SaveCount++;
             Last = snapshot;
@@ -122,15 +124,24 @@ public class WalAsyncSnapshotTruncateRaceTests
         var probe = disp.CreateTestProbe();
         var session = new SessionId("80801");
 
-        // Cmd 1 → WAL seq=1 → submits snap@1 to the writer thread,
-        // which BLOCKS inside Save.
+        // Cmd 1 → WAL seq=1 → submits snap@1 to the writer thread.
+        // Wait until the writer thread observably entered Save (and is
+        // now parked on the gate) BEFORE enqueueing cmd 2. Without this
+        // sync the dispatch thread may finish cmd 2 first on slow CI
+        // runners, causing both snapshots to coalesce into snap@2 →
+        // TruncateThrough(2) → empty WAL → wrong race exercised.
         Assert.True(EnqueueOrder(disp, session, "CL-1", 0x1, 1UL));
         probe.DrainInbound();
         Assert.Single(wal.ReadAll());
+        Assert.True(await WaitForAsync(
+            () => Volatile.Read(ref blocking.SaveEnteredCount) >= 1,
+            TimeSpan.FromSeconds(5)),
+            "writer thread never entered Save(snap@1) — async writer may not be running");
 
-        // Cmd 2 → WAL seq=2 appended while the writer is parked.
-        // The dispatch thread's snapshot Submit is coalesced/dropped
-        // by the single-slot mailbox.
+        // Cmd 2 → WAL seq=2 appended while the writer is parked inside
+        // Save(snap@1). The dispatch thread's snapshot Submit lands in
+        // the single-slot mailbox; the writer will drain it after we
+        // release the first save.
         Assert.True(EnqueueOrder(disp, session, "CL-2", 0x2, 2UL));
         probe.DrainInbound();
         Assert.Equal(2, wal.ReadAll().Count);

--- a/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
@@ -1,0 +1,161 @@
+using B3.Exchange.Contracts;
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+using OrderType = B3.Exchange.Matching.OrderType;
+using Side = B3.Exchange.Matching.Side;
+using TimeInForce = B3.Exchange.Matching.TimeInForce;
+
+namespace B3.Exchange.Persistence.Tests;
+
+/// <summary>
+/// Issue #348: <see cref="ChannelDispatcher.OnAsyncSnapshotSaved"/>
+/// MUST prefix-truncate the WAL (keep records with
+/// <c>Seq &gt; snap.LastAppliedSeq</c>) so a record appended by the
+/// dispatch thread between <c>BackgroundSnapshotWriter.Submit</c> and
+/// the writer thread's <c>onSaved</c> callback firing is preserved.
+/// Pre-fix a full <see cref="IChannelWriteAheadLog.Truncate"/> would
+/// drop the tail and a subsequent crash would silently lose it.
+/// </summary>
+public class WalAsyncSnapshotTruncateRaceTests
+{
+    private const long Sec = 900_000_000_002L;
+
+    private static Instrument Petr4 => new()
+    {
+        Symbol = "PETR4",
+        SecurityId = Sec,
+        TickSize = 0.01m,
+        LotSize = 100,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = "BRPETRACNPR6",
+        SecurityType = "EQUITY",
+    };
+
+    private static long Px(decimal p) => (long)(p * 10_000m);
+
+    private sealed class NoOpPacketSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private sealed class NoOpOutbound : ICoreOutbound
+    {
+        public bool WriteExecutionReportNew(SessionId s, uint f, ulong c, in OrderAcceptedEvent e, ulong r = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportTrade(SessionId s, in TradeEvent e, bool a, long o, ulong c, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveTrade(SessionId s, ulong c, long o, in TradeEvent e, long l, long u, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportPassiveCancel(SessionId s, ulong c, long o, in OrderCanceledEvent e, ulong r, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportModify(SessionId s, long sec, long o, ulong c, ulong oc, Side side, long np, long nq, ulong tt, uint rpt, ulong rt = ulong.MaxValue, DurabilityHandle d = default) => true;
+        public bool WriteExecutionReportReject(SessionId s, in B3.Exchange.Matching.RejectEvent e, ulong c, DurabilityHandle d = default) => true;
+    }
+
+    private sealed class TempDir : IDisposable
+    {
+        public string Path { get; } = System.IO.Path.Combine(System.IO.Path.GetTempPath(),
+            "wal-race-" + Guid.NewGuid().ToString("N"));
+
+        public TempDir() { Directory.CreateDirectory(Path); }
+        public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { } }
+    }
+
+    /// <summary>
+    /// Persister whose <c>Save</c> blocks on a counting gate. The test
+    /// releases one save at a time so it can observe the post-fix WAL
+    /// state after the FIRST onSaved fires, before the writer thread
+    /// proceeds to drain the coalesced second snapshot.
+    /// </summary>
+    private sealed class BlockingPersister : IChannelStatePersister
+    {
+        private readonly SemaphoreSlim _gate = new(0, int.MaxValue);
+        public int SaveCount { get; private set; }
+        public ChannelStateSnapshot? Last { get; private set; }
+        public ChannelStateSnapshot? TryLoad(byte channelNumber) => null;
+        public long Save(ChannelStateSnapshot snapshot)
+        {
+            _gate.Wait();
+            SaveCount++;
+            Last = snapshot;
+            return 0;
+        }
+        public void ReleaseOne() => _gate.Release();
+    }
+
+    private static bool EnqueueOrder(ChannelDispatcher disp, SessionId session,
+        string clOrdId, ulong clOrdIdValue, ulong nanos)
+        => disp.EnqueueNewOrder(
+            new NewOrderCommand(clOrdId, Sec, Side.Buy, OrderType.Limit,
+                TimeInForce.Day, Px(10.00m), 100, 100, nanos),
+            session, enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+        return condition();
+    }
+
+    [Fact]
+    public async Task AsyncSnapshotSaved_PrefixTruncatesWal_KeepsRecordsBeyondSnapshotSeq()
+    {
+        using var dir = new TempDir();
+        var blocking = new BlockingPersister();
+        var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 84,
+            NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
+        var disp = new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s, NullLogger<MatchingEngine>.Instance),
+            packetSink: new NoOpPacketSink(),
+            outbound: new NoOpOutbound(),
+            logger: NullLogger<ChannelDispatcher>.Instance,
+            persister: blocking,
+            snapshotThrottle: null,
+            useAsyncSnapshotWriter: true,
+            wal: wal);
+        var probe = disp.CreateTestProbe();
+        var session = new SessionId("80801");
+
+        // Cmd 1 → WAL seq=1 → submits snap@1 to the writer thread,
+        // which BLOCKS inside Save.
+        Assert.True(EnqueueOrder(disp, session, "CL-1", 0x1, 1UL));
+        probe.DrainInbound();
+        Assert.Single(wal.ReadAll());
+
+        // Cmd 2 → WAL seq=2 appended while the writer is parked.
+        // The dispatch thread's snapshot Submit is coalesced/dropped
+        // by the single-slot mailbox.
+        Assert.True(EnqueueOrder(disp, session, "CL-2", 0x2, 2UL));
+        probe.DrainInbound();
+        Assert.Equal(2, wal.ReadAll().Count);
+
+        // Release ONLY the first blocked Save. The writer completes
+        // snap@1 → fires onSaved(snap@1) → TruncateThrough(1). The
+        // coalesced snap@2 is the next item in the mailbox; the writer
+        // will pick it up and block again on the gate (since we don't
+        // release a second time), giving us a stable window to assert
+        // the WAL state after the first prefix truncate.
+        blocking.ReleaseOne();
+
+        // Pre-fix (full Truncate): WAL ends up empty → seq=2 is lost.
+        // Post-fix (TruncateThrough): seq=2 survives.
+        Assert.True(await WaitForAsync(() => blocking.SaveCount >= 1, TimeSpan.FromSeconds(2)));
+        Assert.True(await WaitForAsync(() =>
+        {
+            var recs = wal.ReadAll();
+            return recs.Count == 1 && recs[0].Seq == 2;
+        }, TimeSpan.FromSeconds(2)),
+            $"expected WAL to contain only seq=2 after prefix truncate, got [{string.Join(",", wal.ReadAll().Select(r => r.Seq))}]");
+
+        // Drain the writer cleanly before disposing.
+        blocking.ReleaseOne();
+        await disp.DisposeAsync();
+        wal.Dispose();
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalSizeCapDispatcherTests.cs
@@ -79,6 +79,7 @@ public class WalSizeCapDispatcherTests
         }
         public IReadOnlyList<WalRecord> ReadAll() => Array.Empty<WalRecord>();
         public void Truncate() { }
+        public void TruncateThrough(long throughSeq) { }
         public void Dispose() { }
     }
 


### PR DESCRIPTION
## Bug

`OnAsyncSnapshotSaved` (writer thread) previously called the full `_wal.Truncate()`. Between `BackgroundSnapshotWriter.Submit(snap)` and the `onSaved` callback firing, the dispatch thread can `Append` records with `Seq > snap.LastAppliedSeq`. A full truncate in that window drops them silently → a subsequent crash loses the tail (snapshot replay restores up to `snap.LastAppliedSeq` only).

Pre-existing, surfaced by gpt-5.5 review of #347. The audit-watermark gate (#347) only checks `durable >= snapshotSeq` — it does NOT protect the WAL tail beyond the snapshot.

## Fix — Option 1 from #348 (prefix truncate)

- **`IChannelWriteAheadLog.TruncateThrough(long throughSeq)`** — keep records with `Seq > throughSeq`. Default impl reads tail, calls `Truncate`, re-Appends — correct for single-writer in-memory fakes.
- **`FileChannelWriteAheadLog`** override: under `_writeLock`, snapshot surviving tail via `ReadAll`, write tmp file with kept records only, atomic `File.Move(overwrite:true)` + `FsyncDirectory`. `Truncate` refactored to delegate to a private `TruncateLocked` helper so the `kept==0` edge case reuses the fast path.
- **`ChannelDispatcher.Wal.OnAsyncSnapshotSaved`** → `_wal.TruncateThrough(snap.LastAppliedSeq)`. Sync path `TruncateWalAfterSyncSave` left as `Truncate()` (dispatch-thread only, no race; avoids re-reading the file).

## Tests

- `FileChannelWriteAheadLogTruncateThroughTests` — 5 unit tests: keeps tail beyond cutoff, no-tail == full truncate, cutoff below all == no-op, append continuity, `CurrentSizeBytes` matches on-disk `FileInfo.Length`.
- `WalAsyncSnapshotTruncateRaceTests` — integration test using a `BlockingPersister` to deterministically reproduce the Submit→onSaved race window and assert the prefix truncate preserves the tail record. Verified to fail on the pre-fix code.

Closes #348