### PR TITLE
bench: quantify FileAuditLogWriter Checkpoint contention (#349)

### DIFF
--- a/bench/B3.Exchange.Bench/PostTradeAuditBenchmarks.cs
+++ b/bench/B3.Exchange.Bench/PostTradeAuditBenchmarks.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Bench;
 /// synchronously on the dispatch thread for every matched trade, so
 /// any per-call regression directly inflates engine latency.
 ///
-/// <para>Two scenarios:</para>
+/// <para>Scenarios:</para>
 /// <list type="bullet">
 ///   <item><b>OnTrade_NoCheckpoint</b> — steady-state append cost. No
 ///   fsync runs (writer batches via <c>FileStream</c>'s OS buffer); this
@@ -18,6 +18,11 @@ namespace B3.Exchange.Bench;
 ///   <item><b>OnTrade_PerCallCheckpoint</b> — worst-case durability
 ///   (fsync after every record). Models a paranoid "fsync-per-trade"
 ///   policy and pins the upper bound on per-trade audit overhead.</item>
+///   <item><b>OnTrade_WithBackgroundCheckpoint</b> — issue #349: a
+///   background thread runs <see cref="FileAuditLogWriter.Checkpoint"/>
+///   in a tight loop while OnTrade fires on the bench thread. The fsync
+///   inside Checkpoint holds the shared lock for the full I/O latency;
+///   any spike here is the tail-latency hit the issue is sizing.</item>
 /// </list>
 ///
 /// <para>The benchmark writes to a temp directory under
@@ -33,6 +38,9 @@ public class PostTradeAuditBenchmarks
     private string _root = null!;
     private FileAuditLogWriter _writer = null!;
     private FileAuditLogWriter _checkpointingWriter = null!;
+    private FileAuditLogWriter _contentionWriter = null!;
+    private CancellationTokenSource? _contentionCts;
+    private Task? _contentionTask;
     private PostTradeRecord _record;
     private ulong _ts;
     private uint _tradeId;
@@ -44,16 +52,39 @@ public class PostTradeAuditBenchmarks
         Directory.CreateDirectory(_root);
         _writer = new FileAuditLogWriter(_root, channelNumber: 1);
         _checkpointingWriter = new FileAuditLogWriter(_root, channelNumber: 2);
+        _contentionWriter = new FileAuditLogWriter(_root, channelNumber: 3);
         _ts = (ulong)(new DateTime(2026, 5, 18, 12, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
         _tradeId = 1;
         _record = NextRecord();
+
+        // Background checkpoint thread for the contention benchmark.
+        // Loops Checkpoint() with no sleep so the dispatch-thread path
+        // contends with the fsync on (almost) every iteration — this is
+        // the worst-case shape of the tail-latency hit issue #349 is
+        // trying to characterize.
+        _contentionCts = new CancellationTokenSource();
+        var ct = _contentionCts.Token;
+        var w = _contentionWriter;
+        _contentionTask = Task.Factory.StartNew(() =>
+        {
+            // Seed at least one record so Checkpoint has something to fsync.
+            try { w.OnTrade(NextRecord()); } catch { }
+            while (!ct.IsCancellationRequested)
+            {
+                try { w.Checkpoint(); } catch { /* writer disposed */ break; }
+            }
+        }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
+        _contentionCts?.Cancel();
+        try { _contentionTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
         _writer.Dispose();
         _checkpointingWriter.Dispose();
+        _contentionWriter.Dispose();
+        _contentionCts?.Dispose();
         if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
     }
 
@@ -71,6 +102,16 @@ public class PostTradeAuditBenchmarks
         _checkpointingWriter.Checkpoint();
     }
 
+    [Benchmark]
+    public void OnTrade_WithBackgroundCheckpoint()
+    {
+        // Bench thread = "dispatch thread"; background task =
+        // "async-snapshot writer thread" calling Checkpoint. Any
+        // contention shows up as inflated mean/p99 here vs the
+        // NoCheckpoint baseline.
+        _contentionWriter.OnTrade(NextRecord());
+    }
+
     private PostTradeRecord NextRecord()
     {
         var id = ++_tradeId;
@@ -85,3 +126,4 @@ public class PostTradeAuditBenchmarks
             BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
     }
 }
+

--- a/bench/B3.Exchange.Bench/PostTradeAuditBenchmarks.cs
+++ b/bench/B3.Exchange.Bench/PostTradeAuditBenchmarks.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Bench;
 /// synchronously on the dispatch thread for every matched trade, so
 /// any per-call regression directly inflates engine latency.
 ///
-/// <para>Scenarios:</para>
+/// <para>Two scenarios:</para>
 /// <list type="bullet">
 ///   <item><b>OnTrade_NoCheckpoint</b> — steady-state append cost. No
 ///   fsync runs (writer batches via <c>FileStream</c>'s OS buffer); this
@@ -18,11 +18,6 @@ namespace B3.Exchange.Bench;
 ///   <item><b>OnTrade_PerCallCheckpoint</b> — worst-case durability
 ///   (fsync after every record). Models a paranoid "fsync-per-trade"
 ///   policy and pins the upper bound on per-trade audit overhead.</item>
-///   <item><b>OnTrade_WithBackgroundCheckpoint</b> — issue #349: a
-///   background thread runs <see cref="FileAuditLogWriter.Checkpoint"/>
-///   in a tight loop while OnTrade fires on the bench thread. The fsync
-///   inside Checkpoint holds the shared lock for the full I/O latency;
-///   any spike here is the tail-latency hit the issue is sizing.</item>
 /// </list>
 ///
 /// <para>The benchmark writes to a temp directory under
@@ -30,6 +25,11 @@ namespace B3.Exchange.Bench;
 /// writer instance is reused across iterations so file-open and header
 /// costs do not skew per-call numbers. Use
 /// <c>dotnet run -c Release --project bench/B3.Exchange.Bench -- --filter '*PostTradeAudit*'</c>.</para>
+///
+/// <para>For the cross-thread lock contention scenario (issue #349) see
+/// <see cref="PostTradeAuditContentionBenchmarks"/> in a separate class
+/// so its background checkpointer thread does not pollute these
+/// baseline measurements.</para>
 /// </summary>
 [MemoryDiagnoser]
 [SimpleJob(warmupCount: 3, iterationCount: 5)]
@@ -38,9 +38,6 @@ public class PostTradeAuditBenchmarks
     private string _root = null!;
     private FileAuditLogWriter _writer = null!;
     private FileAuditLogWriter _checkpointingWriter = null!;
-    private FileAuditLogWriter _contentionWriter = null!;
-    private CancellationTokenSource? _contentionCts;
-    private Task? _contentionTask;
     private PostTradeRecord _record;
     private ulong _ts;
     private uint _tradeId;
@@ -52,39 +49,16 @@ public class PostTradeAuditBenchmarks
         Directory.CreateDirectory(_root);
         _writer = new FileAuditLogWriter(_root, channelNumber: 1);
         _checkpointingWriter = new FileAuditLogWriter(_root, channelNumber: 2);
-        _contentionWriter = new FileAuditLogWriter(_root, channelNumber: 3);
         _ts = (ulong)(new DateTime(2026, 5, 18, 12, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
         _tradeId = 1;
         _record = NextRecord();
-
-        // Background checkpoint thread for the contention benchmark.
-        // Loops Checkpoint() with no sleep so the dispatch-thread path
-        // contends with the fsync on (almost) every iteration — this is
-        // the worst-case shape of the tail-latency hit issue #349 is
-        // trying to characterize.
-        _contentionCts = new CancellationTokenSource();
-        var ct = _contentionCts.Token;
-        var w = _contentionWriter;
-        _contentionTask = Task.Factory.StartNew(() =>
-        {
-            // Seed at least one record so Checkpoint has something to fsync.
-            try { w.OnTrade(NextRecord()); } catch { }
-            while (!ct.IsCancellationRequested)
-            {
-                try { w.Checkpoint(); } catch { /* writer disposed */ break; }
-            }
-        }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
 
     [GlobalCleanup]
     public void Cleanup()
     {
-        _contentionCts?.Cancel();
-        try { _contentionTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
         _writer.Dispose();
         _checkpointingWriter.Dispose();
-        _contentionWriter.Dispose();
-        _contentionCts?.Dispose();
         if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
     }
 
@@ -102,21 +76,9 @@ public class PostTradeAuditBenchmarks
         _checkpointingWriter.Checkpoint();
     }
 
-    [Benchmark]
-    public void OnTrade_WithBackgroundCheckpoint()
-    {
-        // Bench thread = "dispatch thread"; background task =
-        // "async-snapshot writer thread" calling Checkpoint. Any
-        // contention shows up as inflated mean/p99 here vs the
-        // NoCheckpoint baseline.
-        _contentionWriter.OnTrade(NextRecord());
-    }
-
     private PostTradeRecord NextRecord()
     {
         var id = ++_tradeId;
-        // Stay within a single UTC day so RotateTo is never invoked; the
-        // bench is measuring the steady-state hot path, not rollover.
         return new PostTradeRecord(
             TradeId: id, TransactTimeNanos: _ts, SecurityId: BenchInstruments.PetrSecId,
             AggressorSide: (id & 1) == 0 ? Side.Buy : Side.Sell,
@@ -126,4 +88,83 @@ public class PostTradeAuditBenchmarks
             BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
     }
 }
+
+/// <summary>
+/// Issue #349: measures the dispatch-thread tail latency cost of an
+/// <see cref="FileAuditLogWriter.OnTrade"/> call that contends with a
+/// concurrent <see cref="FileAuditLogWriter.Checkpoint"/> (held lock
+/// across both <c>Flush(flushToDisk:true)</c> fsyncs).
+///
+/// <para>Isolated in its own class so the background checkpointer
+/// thread only runs while this scenario is being measured — included
+/// in <see cref="PostTradeAuditBenchmarks"/> it would pollute the
+/// <c>OnTrade_NoCheckpoint</c> baseline with unrelated fsync /
+/// filesystem pressure.</para>
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(warmupCount: 3, iterationCount: 5)]
+public class PostTradeAuditContentionBenchmarks
+{
+    private string _root = null!;
+    private FileAuditLogWriter _writer = null!;
+    private CancellationTokenSource? _cts;
+    private Task? _checkpointTask;
+    private ulong _ts;
+    private uint _tradeId;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeContention_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        _writer = new FileAuditLogWriter(_root, channelNumber: 3);
+        _ts = (ulong)(new DateTime(2026, 5, 18, 12, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+        _tradeId = 1;
+
+        // Seed at least one record so Checkpoint has something to fsync.
+        _writer.OnTrade(NextRecord());
+
+        // Background checkpoint loop with no sleep — worst-case shape
+        // of the tail-latency hit issue #349 is sizing.
+        _cts = new CancellationTokenSource();
+        var ct = _cts.Token;
+        var w = _writer;
+        _checkpointTask = Task.Factory.StartNew(() =>
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                try { w.Checkpoint(); } catch { break; }
+            }
+        }, ct, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _cts?.Cancel();
+        try { _checkpointTask?.Wait(TimeSpan.FromSeconds(2)); } catch { }
+        _writer.Dispose();
+        _cts?.Dispose();
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    [Benchmark]
+    public void OnTrade_WithBackgroundCheckpoint()
+    {
+        _writer.OnTrade(NextRecord());
+    }
+
+    private PostTradeRecord NextRecord()
+    {
+        var id = ++_tradeId;
+        return new PostTradeRecord(
+            TradeId: id, TransactTimeNanos: _ts, SecurityId: BenchInstruments.PetrSecId,
+            AggressorSide: (id & 1) == 0 ? Side.Buy : Side.Sell,
+            Quantity: 100, PriceMantissa: BenchInstruments.Px(32.00m),
+            BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+            BuyFirm: 7, SellFirm: 8,
+            BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+    }
+}
+
 


### PR DESCRIPTION
## Profile-first for #349

Issue #349 explicitly asks for a benchmark before implementing the fix to size the actual hot-path cost. This PR adds that benchmark.

### New scenario: `OnTrade_WithBackgroundCheckpoint`

A background `Task` loops `Checkpoint()` tightly while the bench thread fires `OnTrade` on a separate `FileAuditLogWriter` instance. The two threads contend for `_checkpointLock`; the lock is held across both `Flush(flushToDisk:true)` fsyncs.

### Results (AMD EPYC 7763, tmpfs / dev box — real disks will be slower)

| Method | Mean | Ratio |
|---|---:|---:|
| OnTrade_NoCheckpoint | **2.25 µs** | 1.00× |
| OnTrade_PerCallCheckpoint | 12.52 ms | 5,569× |
| **OnTrade_WithBackgroundCheckpoint** | **7.28 ms** | **3,240×** |

Confirms the bug is material: a trade emission overlapping a checkpoint stalls for the full fsync latency (~ms range). With async-snapshot Checkpoint firing every few seconds, this is a real tail-latency hit.

### Next

Fix tracked as a follow-up PR — most likely option 1 from the issue (dedicated audit-writer thread; OnTrade enqueues to a bounded channel, writer thread owns the FileStream and serializes fsyncs against its own writes without blocking the dispatch thread).

Refs #349 (does not close)