### PR TITLE
Make multi-session replay test deterministic (closes #326)

### DIFF
--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -100,18 +100,50 @@ public class MultiSessionReplayTests
         // firmA posts a resting bid; firmB hits it with a marketable IOC sell.
         // clOrdId reuse across sessions is allowed (issue note: the gateway
         // namespaces orders by (firm, clOrdId)).
-        // The 200ms script-time gap (=> 20ms wall-clock at speed=10) is
-        // deliberately wider than the original 2ms: under CI parallel
-        // contention, a 2ms gap let firmB's NewOrder reach the dispatch
-        // queue ahead of firmA's, turning the IOC sell into an
-        // unmatched cancel and starving the test of trade ERs.
-        var script = new[]
+        //
+        // #326: previous incarnations gated the two submits on a wall-clock
+        // gap (200ms script-time => 20ms wall). Under CI / parallel test
+        // contention this was unreliable — firmB's IOC could reach the
+        // dispatch queue ahead of firmA's resting bid, find no liquidity,
+        // and be silently dropped by the matching engine (an IOC with zero
+        // fills currently emits no ER back to the aggressor — tracked as a
+        // separate engine bug). To make the test deterministic we now gate
+        // firmB's submission on observing firmA's ER_New on the tape
+        // instead of guessing how long the round-trip takes.
+        var scriptA = new[]
         {
-            new ScriptEvent(0,   ScriptEventKind.New, 1, Petr, Side.Buy,  OrderType.Limit, Tif.Day, 100, 320000, 0, 1, "firmA"),
-            new ScriptEvent(200, ScriptEventKind.New, 1, Petr, Side.Sell, OrderType.Limit, Tif.IOC, 100, 320000, 0, 2, "firmB"),
+            new ScriptEvent(0, ScriptEventKind.New, 1, Petr, Side.Buy, OrderType.Limit, Tif.Day, 100, 320000, 0, 1, "firmA"),
+        };
+        var scriptB = new[]
+        {
+            new ScriptEvent(0, ScriptEventKind.New, 1, Petr, Side.Sell, OrderType.Limit, Tif.IOC, 100, 320000, 0, 2, "firmB"),
         };
 
-        await runner.RunAsync(script, cts.Token);
+        await runner.RunAsync(scriptA, cts.Token);
+
+        // Block until firmA's resting bid is acknowledged by the engine
+        // before unleashing firmB. Bounded by a generous wall-clock cap
+        // so a genuinely stuck dispatcher fails the test fast instead of
+        // hanging at the outer 90s cts.
+        var firmAGate = DateTime.UtcNow.AddSeconds(10);
+        while (DateTime.UtcNow < firmAGate)
+        {
+            var snap = sw.ToString();
+            if (snap.Contains("\"src\":\"er\"") &&
+                snap.Contains("\"session\":\"firmA\"") &&
+                snap.Contains("\"execType\":\"new\""))
+            {
+                break;
+            }
+            await Task.Delay(10, cts.Token);
+        }
+        Assert.True(
+            sw.ToString().Contains("\"session\":\"firmA\"") &&
+            sw.ToString().Contains("\"execType\":\"new\""),
+            $"firmA ER_New not observed within 10s; tape so far:\n  " +
+            string.Join("\n  ", sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries)));
+
+        await runner.RunAsync(scriptB, cts.Token);
 
         // Wait for ER_Trade on BOTH sessions. Poll until both sides have
         // observed their own trade ER, not just any trade ER (the previous

--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -126,22 +126,24 @@ public class MultiSessionReplayTests
         // so a genuinely stuck dispatcher fails the test fast instead of
         // hanging at the outer 90s cts.
         var firmAGate = DateTime.UtcNow.AddSeconds(10);
+        string firmAGateSnap = string.Empty;
         while (DateTime.UtcNow < firmAGate)
         {
-            var snap = sw.ToString();
-            if (snap.Contains("\"src\":\"er\"") &&
-                snap.Contains("\"session\":\"firmA\"") &&
-                snap.Contains("\"execType\":\"new\""))
+            firmAGateSnap = capture.Snapshot();
+            if (firmAGateSnap.Contains("\"src\":\"er\"") &&
+                firmAGateSnap.Contains("\"session\":\"firmA\"") &&
+                firmAGateSnap.Contains("\"execType\":\"new\""))
             {
                 break;
             }
             await Task.Delay(10, cts.Token);
         }
+        firmAGateSnap = capture.Snapshot();
         Assert.True(
-            sw.ToString().Contains("\"session\":\"firmA\"") &&
-            sw.ToString().Contains("\"execType\":\"new\""),
+            firmAGateSnap.Contains("\"session\":\"firmA\"") &&
+            firmAGateSnap.Contains("\"execType\":\"new\""),
             $"firmA ER_New not observed within 10s; tape so far:\n  " +
-            string.Join("\n  ", sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries)));
+            string.Join("\n  ", firmAGateSnap.Split('\n', StringSplitOptions.RemoveEmptyEntries)));
 
         await runner.RunAsync(scriptB, cts.Token);
 
@@ -158,7 +160,7 @@ public class MultiSessionReplayTests
         var deadline = DateTime.UtcNow.AddSeconds(60);
         while (DateTime.UtcNow < deadline)
         {
-            var snapLines = sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            var snapLines = capture.Snapshot().Split('\n', StringSplitOptions.RemoveEmptyEntries);
             bool aNew = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"new\""));
             bool aTrade = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmA\"") && l.Contains("\"execType\":\"trade\""));
             bool bTrade = snapLines.Any(l => l.Contains("\"src\":\"er\"") && l.Contains("\"session\":\"firmB\"") && l.Contains("\"execType\":\"trade\""));
@@ -167,8 +169,9 @@ public class MultiSessionReplayTests
             await Task.Delay(50, cts.Token);
         }
 
+        var finalSnap = capture.Snapshot();
         capture.Dispose();
-        var lines = sw.ToString().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var lines = finalSnap.Split('\n', StringSplitOptions.RemoveEmptyEntries);
 
         // Dump captured tape on failure to make this test self-diagnosing
         // (the previous incarnations of #146 left no clue what was missing).
@@ -233,13 +236,13 @@ public class MultiSessionReplayTests
         var deadline = DateTime.UtcNow.AddSeconds(3);
         while (DateTime.UtcNow < deadline)
         {
-            if (sw.ToString().Contains("\"execType\":\"new\""))
+            if (capture.Snapshot().Contains("\"execType\":\"new\""))
                 break;
             await Task.Delay(50, cts.Token);
         }
 
+        var snapshot = capture.Snapshot();
         capture.Dispose();
-        var snapshot = sw.ToString();
         Assert.Contains("\"session\":\"only\"", snapshot);
         Assert.Contains("\"execType\":\"new\"", snapshot);
     }

--- a/tools/ScenarioReplay/CaptureWriter.cs
+++ b/tools/ScenarioReplay/CaptureWriter.cs
@@ -106,4 +106,20 @@ public sealed class CaptureWriter : IDisposable
             if (_ownsWriter) { try { _writer.Dispose(); } catch { } }
         }
     }
+
+    /// <summary>
+    /// Thread-safe snapshot of the underlying writer's accumulated text.
+    /// Tests poll the captured tape concurrently with receive-loop callbacks
+    /// writing new lines; reading <see cref="StringWriter.ToString"/> /
+    /// <see cref="System.Text.StringBuilder"/> directly is not safe under
+    /// concurrent writes. Takes the same gate <see cref="WriteLine{T}"/>
+    /// uses so readers always observe a consistent snapshot.
+    /// </summary>
+    public string Snapshot()
+    {
+        lock (_gate)
+        {
+            return _writer.ToString() ?? string.Empty;
+        }
+    }
 }


### PR DESCRIPTION
Closes #326. Follow-up engine bug filed as #357.

## Root cause

`TwoSessions_CrossingScript_LandsErTradesOnBothSides` gated the two submits on a wall-clock gap (200 ms script-time at `speed=10` → 20 ms wall). Under CI / parallel contention firmB's IOC could reach the dispatch queue ahead of firmA's resting bid, find no liquidity, and be silently dropped by the matching engine. firmB then never sees any ER and the test times out.

**Reproduction (this PR's baseline = main):**
- Local back-to-back: 20/50 fail (40%), peaking at 20/20 on cold start.
- Even on `4498dc8` (pre-post-trade work) the flake reproduces 5/10. The flake is genuine and not introduced by recent merges.

The deeper engine bug — IOC limit with zero fills emits no aggregator ER at all (`MatchingEngine.cs:1605-1611`) — is real and is now tracked as #357. Fixing it touches engine semantics + existing tests that assert the current silent-drop behaviour, so it's out of scope for this PR. Test-side gating is the correct surgical fix for the #326 flake symptom.

## Fix

Split the script into two ordered submits and gate firmB's submission on observing firmA's ER_New on the tape, instead of guessing how long the round-trip takes. The wait is bounded by a 10 s wall-clock cap so a genuinely stuck dispatcher fails fast instead of hanging at the outer 90 s deadline.

## Validation

- 40/40 green back-to-back locally on this branch.
- Full `dotnet test SbeB3Exchange.slnx -c Release` passes.
- `dotnet format --verify-no-changes` clean.
