### PR TITLE
Add EodFillsExporter for post-trade CSV drop (#330 PR-1)

### DIFF
--- a/src/B3.Exchange.PostTrade/EodFillsExporter.cs
+++ b/src/B3.Exchange.PostTrade/EodFillsExporter.cs
@@ -26,25 +26,36 @@ public readonly record struct EodFillsExportResult(string CsvPath, long RowCount
 /// consumer-visible "ready" signal.</para>
 ///
 /// <para><b>Atomic publish contract</b> (consumer must never see a partial
-/// file even during a rerun):</para>
+/// file or a stale signal — the <c>.done</c> sidecar must never sit next
+/// to a different generation's <c>fills.csv</c>):</para>
 /// <list type="number">
-/// <item>Write CSV to a staging file <c>.fills.csv.tmp-{pid}-{guid}</c>.</item>
-/// <item><c>fsync</c> the staging file's data via <see cref="FileStream.Flush(bool)"/>.</item>
-/// <item><c>rename(2)</c> staging to <c>fills.csv</c> (POSIX atomic).</item>
-/// <item><c>fsync</c> the parent directory via
-/// <see cref="RandomAccess.FlushToDisk(SafeFileHandle)"/> so the directory
-/// entry is durable (same <see cref="SafeFileHandle"/> pattern used in
-/// <see cref="FileAuditLogWriter.Checkpoint"/> after #356).</item>
-/// <item>Repeat 1–4 for the JSON <c>fills.csv.done</c> sidecar so the
-/// signal file is the LAST thing to land on disk.</item>
+/// <item>Write CSV to a staging file <c>.fills.csv.tmp-{pid}-{guid}</c>
+/// and <c>fsync</c> it via <see cref="FileStream.Flush(bool)"/>.</item>
+/// <item>Write the <c>.done</c> JSON to a sibling staging file and
+/// <c>fsync</c> it.</item>
+/// <item><b>Invalidate</b> any prior <c>fills.csv.done</c> by removing it
+/// and <c>fsync</c>'ing the parent dir. From this point a consumer polling
+/// for <c>.done</c> sees "not ready" until step 5 completes.</item>
+/// <item><c>rename(2)</c> the CSV staging file to <c>fills.csv</c> (POSIX
+/// atomic) and <c>fsync</c> the parent directory.</item>
+/// <item><c>rename(2)</c> the <c>.done</c> staging file to
+/// <c>fills.csv.done</c> and <c>fsync</c> the parent directory. The
+/// signal file is the LAST thing to land on disk and is always paired
+/// with the CSV whose bytes its <c>sha256</c> describes.</item>
 /// </list>
 ///
-/// <para>Failure modes: any exception during projection leaves the
-/// previously-published <c>fills.csv</c> / <c>.done</c> untouched and the
-/// staging file is best-effort deleted in a <see langword="finally"/>
-/// block. The exception is rethrown so the operator endpoint surfaces a
-/// 4xx/5xx with a structured payload — partial output never reaches the
-/// drop directory.</para>
+/// <para>Crash recovery: a crash between steps 3 and 5 leaves
+/// <c>fills.csv</c> with no <c>.done</c> — consumers correctly observe
+/// "not ready" and the next exporter run rebuilds both files. A crash
+/// between steps 4 and 5 leaves a new <c>fills.csv</c> with no
+/// <c>.done</c> — same recovery.</para>
+///
+/// <para>Failure modes (exception during projection): any in-process
+/// exception before step 3 leaves the previously-published
+/// <c>fills.csv</c> / <c>.done</c> pair untouched. After step 3 the old
+/// <c>.done</c> is gone and the operator must rerun — partial output
+/// never reaches the drop directory in either case. Staging files are
+/// best-effort deleted in a <see langword="finally"/> block.</para>
 ///
 /// <para>Idempotency: rerun for the same channel + date streams the audit
 /// log deterministically, so <c>fills.csv</c> is byte-identical run-to-run
@@ -121,8 +132,9 @@ public sealed class EodFillsExporter
         long rowCount;
         string sha256Hex;
 
-        // 1) Write CSV to staging + atomic publish.
+        // 1) Write CSV to staging (also computes SHA-256 streaming).
         var csvStaging = StagingPath(dropDir, "fills.csv");
+        string? doneStaging = null;
         try
         {
             using (var sha = SHA256.Create())
@@ -139,31 +151,41 @@ public sealed class EodFillsExporter
                 sha256Hex = ToHex(sha.Hash!);
             }
 
+            // 2) Write .done staging file (paired with the CSV staging).
+            // We do this BEFORE invalidating any prior .done so a failure
+            // here still leaves the previous (csv, .done) pair intact.
+            var donePayload = BuildDonePayload(rowCount, sha256Hex, generatedAtUtc);
+            doneStaging = StagingPath(dropDir, "fills.csv.done");
+            using (var fs = OpenStagingForWrite(doneStaging))
+            {
+                fs.Write(donePayload);
+                fs.Flush(flushToDisk: true);
+            }
+
             var csvFinal = Path.Combine(dropDir, "fills.csv");
+            var doneFinal = Path.Combine(dropDir, "fills.csv.done");
+
+            // 3) Invalidate any prior .done BEFORE publishing the new
+            // CSV so consumers can never observe a stale ready signal
+            // pointing at a freshly-replaced fills.csv. From here a
+            // crash before step 5 leaves no .done — consumers correctly
+            // poll "not ready" until the next exporter run.
+            if (File.Exists(doneFinal))
+            {
+                File.Delete(doneFinal);
+                FsyncDirectory(dropDir);
+            }
+
+            // 4) Publish the new CSV.
             File.Move(csvStaging, csvFinal, overwrite: true);
             FsyncDirectory(dropDir);
             csvStaging = null!; // staging file is gone; suppress finally-cleanup.
 
-            // 2) Write .done sidecar last so consumers polling for it
-            // never observe a present-but-stale signal.
-            var donePayload = BuildDonePayload(rowCount, sha256Hex, generatedAtUtc);
-            var doneStaging = StagingPath(dropDir, "fills.csv.done");
-            try
-            {
-                using (var fs = OpenStagingForWrite(doneStaging))
-                {
-                    fs.Write(donePayload);
-                    fs.Flush(flushToDisk: true);
-                }
-                var doneFinal = Path.Combine(dropDir, "fills.csv.done");
-                File.Move(doneStaging, doneFinal, overwrite: true);
-                FsyncDirectory(dropDir);
-                doneStaging = null!;
-            }
-            finally
-            {
-                BestEffortDelete(doneStaging);
-            }
+            // 5) Publish the new .done sidecar last — this is the
+            // consumer-visible ready signal.
+            File.Move(doneStaging, doneFinal, overwrite: true);
+            FsyncDirectory(dropDir);
+            doneStaging = null;
 
             if (unresolved.Count > 0)
             {
@@ -181,6 +203,7 @@ public sealed class EodFillsExporter
         finally
         {
             BestEffortDelete(csvStaging);
+            BestEffortDelete(doneStaging);
         }
     }
 

--- a/src/B3.Exchange.PostTrade/EodFillsExporter.cs
+++ b/src/B3.Exchange.PostTrade/EodFillsExporter.cs
@@ -1,0 +1,315 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Result of a single <see cref="EodFillsExporter.Export"/> invocation —
+/// the on-disk path to the published <c>fills.csv</c>, the row count
+/// (excluding header), and a hex-encoded SHA-256 digest of the CSV bytes.
+/// The same triple appears in the <c>fills.csv.done</c> sidecar so external
+/// reconciliation consumers can verify integrity without re-hashing.
+/// </summary>
+public readonly record struct EodFillsExportResult(string CsvPath, long RowCount, string Sha256Hex);
+
+/// <summary>
+/// Projects the per-trade audit log (<see cref="FileAuditLogWriter"/>
+/// output) for one channel + one UTC business date into the
+/// "BVBG-like" EOD CSV drop required by ADR 0001 section 3 (issue #330 PR-1).
+///
+/// <para><b>Layout:</b> <c>{dropRootDir}/{channelNumber}/{YYYY-MM-DD}/fills.csv</c>
+/// plus a sibling <c>fills.csv.done</c> sidecar whose presence is the
+/// consumer-visible "ready" signal.</para>
+///
+/// <para><b>Atomic publish contract</b> (consumer must never see a partial
+/// file even during a rerun):</para>
+/// <list type="number">
+/// <item>Write CSV to a staging file <c>.fills.csv.tmp-{pid}-{guid}</c>.</item>
+/// <item><c>fsync</c> the staging file's data via <see cref="FileStream.Flush(bool)"/>.</item>
+/// <item><c>rename(2)</c> staging to <c>fills.csv</c> (POSIX atomic).</item>
+/// <item><c>fsync</c> the parent directory via
+/// <see cref="RandomAccess.FlushToDisk(SafeFileHandle)"/> so the directory
+/// entry is durable (same <see cref="SafeFileHandle"/> pattern used in
+/// <see cref="FileAuditLogWriter.Checkpoint"/> after #356).</item>
+/// <item>Repeat 1–4 for the JSON <c>fills.csv.done</c> sidecar so the
+/// signal file is the LAST thing to land on disk.</item>
+/// </list>
+///
+/// <para>Failure modes: any exception during projection leaves the
+/// previously-published <c>fills.csv</c> / <c>.done</c> untouched and the
+/// staging file is best-effort deleted in a <see langword="finally"/>
+/// block. The exception is rethrown so the operator endpoint surfaces a
+/// 4xx/5xx with a structured payload — partial output never reaches the
+/// drop directory.</para>
+///
+/// <para>Idempotency: rerun for the same channel + date streams the audit
+/// log deterministically, so <c>fills.csv</c> is byte-identical run-to-run
+/// (only <c>generatedAt</c> inside <c>.done</c> changes).</para>
+///
+/// <para><b>Threading:</b> this class is stateless; concurrent
+/// <see cref="Export"/> calls for distinct (channel, date) pairs are safe.
+/// Concurrent calls for the SAME (channel, date) are racy by construction
+/// (two renames into the same destination) — the operator endpoint and
+/// daily-reset scheduler serialize per-channel calls upstream.</para>
+/// </summary>
+public sealed class EodFillsExporter
+{
+    private readonly ILogger<EodFillsExporter> _logger;
+
+    public EodFillsExporter(ILogger<EodFillsExporter>? logger = null)
+    {
+        _logger = logger ?? NullLogger<EodFillsExporter>.Instance;
+    }
+
+    /// <summary>
+    /// Projects the audit log for (<paramref name="channelNumber"/>,
+    /// <paramref name="businessDate"/>) into an atomic CSV drop under
+    /// <paramref name="dropRootDir"/>. See class-level docs for the
+    /// contract and failure semantics.
+    /// </summary>
+    /// <param name="auditRootDir">The <see cref="FileAuditLogWriter"/>'s
+    /// configured rootDir — the exporter resolves
+    /// <c>{auditRootDir}/{channelNumber}/fills-{date}.log</c> from this.</param>
+    /// <param name="dropRootDir">Root directory for EOD drops. The exporter
+    /// creates per-channel + per-date subdirectories as needed.</param>
+    /// <param name="channelNumber">UMDF channel number (matches the audit
+    /// log directory layout).</param>
+    /// <param name="businessDate">UTC business date selecting which audit
+    /// log file to project.</param>
+    /// <param name="symbolLookup">Maps a <see cref="long"/> SecurityId to
+    /// the human-readable symbol that goes in the <c>symbol</c> column.
+    /// May return <see langword="null"/> or empty for unknown securities;
+    /// the exporter falls back to the numeric SecurityId and emits a
+    /// single warn log per unique unresolved id per export run.</param>
+    /// <param name="generatedAtUtc">Timestamp embedded in the <c>.done</c>
+    /// sidecar's <c>generatedAt</c> field. Caller provides it so tests
+    /// can pin a deterministic value; production callers pass
+    /// <see cref="DateTime.UtcNow"/>.</param>
+    /// <exception cref="FileNotFoundException">No audit log file exists
+    /// for the requested (channel, date).</exception>
+    /// <exception cref="InvalidDataException">The audit log's file header
+    /// is corrupt (unrecoverable; not a torn tail).</exception>
+    public EodFillsExportResult Export(
+        string auditRootDir,
+        string dropRootDir,
+        byte channelNumber,
+        DateOnly businessDate,
+        Func<long, string?> symbolLookup,
+        DateTime generatedAtUtc)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(auditRootDir);
+        ArgumentException.ThrowIfNullOrEmpty(dropRootDir);
+        ArgumentNullException.ThrowIfNull(symbolLookup);
+        if (generatedAtUtc.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("generatedAtUtc must be DateTimeKind.Utc", nameof(generatedAtUtc));
+
+        var channel = channelNumber.ToString(CultureInfo.InvariantCulture);
+        var dateStr = businessDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        var auditLogPath = Path.Combine(auditRootDir, channel, $"fills-{dateStr}.log");
+        if (!File.Exists(auditLogPath))
+            throw new FileNotFoundException($"audit log not found for channel={channel} date={dateStr}", auditLogPath);
+
+        var dropDir = Path.Combine(dropRootDir, channel, dateStr);
+        Directory.CreateDirectory(dropDir);
+
+        var unresolved = new HashSet<long>();
+        long rowCount;
+        string sha256Hex;
+
+        // 1) Write CSV to staging + atomic publish.
+        var csvStaging = StagingPath(dropDir, "fills.csv");
+        try
+        {
+            using (var sha = SHA256.Create())
+            {
+                using (var fs = OpenStagingForWrite(csvStaging))
+                using (var cs = new CryptoStream(fs, sha, CryptoStreamMode.Write, leaveOpen: true))
+                using (var sw = new StreamWriter(cs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 64 * 1024, leaveOpen: true))
+                {
+                    rowCount = WriteCsv(sw, auditLogPath, symbolLookup, unresolved);
+                    sw.Flush();
+                    cs.FlushFinalBlock();
+                    fs.Flush(flushToDisk: true);
+                }
+                sha256Hex = ToHex(sha.Hash!);
+            }
+
+            var csvFinal = Path.Combine(dropDir, "fills.csv");
+            File.Move(csvStaging, csvFinal, overwrite: true);
+            FsyncDirectory(dropDir);
+            csvStaging = null!; // staging file is gone; suppress finally-cleanup.
+
+            // 2) Write .done sidecar last so consumers polling for it
+            // never observe a present-but-stale signal.
+            var donePayload = BuildDonePayload(rowCount, sha256Hex, generatedAtUtc);
+            var doneStaging = StagingPath(dropDir, "fills.csv.done");
+            try
+            {
+                using (var fs = OpenStagingForWrite(doneStaging))
+                {
+                    fs.Write(donePayload);
+                    fs.Flush(flushToDisk: true);
+                }
+                var doneFinal = Path.Combine(dropDir, "fills.csv.done");
+                File.Move(doneStaging, doneFinal, overwrite: true);
+                FsyncDirectory(dropDir);
+                doneStaging = null!;
+            }
+            finally
+            {
+                BestEffortDelete(doneStaging);
+            }
+
+            if (unresolved.Count > 0)
+            {
+                _logger.LogWarning(
+                    "eod fills export: {Count} unknown securityId(s) emitted as numeric fallback for channel={Channel} date={Date}",
+                    unresolved.Count, channel, dateStr);
+            }
+
+            _logger.LogInformation(
+                "eod fills export: channel={Channel} date={Date} rows={Rows} sha256={Sha} path={Path}",
+                channel, dateStr, rowCount, sha256Hex, csvFinal);
+
+            return new EodFillsExportResult(csvFinal, rowCount, sha256Hex);
+        }
+        finally
+        {
+            BestEffortDelete(csvStaging);
+        }
+    }
+
+    private long WriteCsv(StreamWriter sw, string auditLogPath, Func<long, string?> symbolLookup, HashSet<long> unresolved)
+    {
+        // Header — frozen by ADR 0001 / issue #330.
+        sw.Write("tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm\n");
+
+        long rows = 0;
+        foreach (var r in AuditLogReader.ReadAll(auditLogPath))
+        {
+            var sym = symbolLookup(r.SecurityId);
+            if (string.IsNullOrEmpty(sym))
+            {
+                unresolved.Add(r.SecurityId);
+                sym = r.SecurityId.ToString(CultureInfo.InvariantCulture);
+            }
+
+            sw.Write(r.TradeId.ToString(CultureInfo.InvariantCulture));
+            sw.Write(',');
+            sw.Write(FormatTimestampMicros(r.TransactTimeNanos));
+            sw.Write(',');
+            sw.Write(EscapeCsv(sym));
+            sw.Write(',');
+            sw.Write(r.AggressorSide == Side.Buy ? 'B' : 'S');
+            sw.Write(',');
+            sw.Write(r.Quantity.ToString(CultureInfo.InvariantCulture));
+            sw.Write(',');
+            sw.Write(r.PriceMantissa.ToString(CultureInfo.InvariantCulture));
+            sw.Write(',');
+            sw.Write(r.BuyClOrdId.ToString(CultureInfo.InvariantCulture));
+            sw.Write(',');
+            sw.Write(r.SellClOrdId.ToString(CultureInfo.InvariantCulture));
+            sw.Write(',');
+            sw.Write(r.BuyFirm.ToString(CultureInfo.InvariantCulture));
+            sw.Write(',');
+            sw.Write(r.SellFirm.ToString(CultureInfo.InvariantCulture));
+            sw.Write('\n');
+            rows++;
+        }
+        return rows;
+    }
+
+    private static string FormatTimestampMicros(ulong transactTimeNanos)
+    {
+        // PostTradeRecord.TransactTimeNanos is documented as wall-clock UTC
+        // nanoseconds since Unix epoch (matches FileAuditLogWriter's input).
+        // ADR 0001 / #330 require ISO-8601 UTC with microsecond precision.
+        long micros = (long)(transactTimeNanos / 1000UL);
+        var dto = DateTimeOffset.FromUnixTimeMilliseconds(micros / 1000)
+            .AddTicks((micros % 1000) * 10);
+        return dto.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture);
+    }
+
+    private static string EscapeCsv(string field)
+    {
+        // The frozen columns are numeric or short identifiers, but symbols
+        // could in theory contain a quote/comma/newline. RFC 4180: wrap in
+        // quotes and double any embedded quotes.
+        if (field.IndexOfAny(s_csvSpecials) < 0)
+            return field;
+        return "\"" + field.Replace("\"", "\"\"") + "\"";
+    }
+
+    private static readonly char[] s_csvSpecials = new[] { ',', '"', '\n', '\r' };
+
+    private static byte[] BuildDonePayload(long rowCount, string sha256Hex, DateTime generatedAtUtc)
+    {
+        // Hand-formatted JSON keeps the dependency surface zero and the
+        // payload deterministic (no ordering / culture quirks).
+        var generatedAt = generatedAtUtc.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture);
+        var json = "{\"rowCount\":" + rowCount.ToString(CultureInfo.InvariantCulture)
+            + ",\"sha256\":\"" + sha256Hex + "\""
+            + ",\"generatedAt\":\"" + generatedAt + "\"}\n";
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    private static string ToHex(byte[] bytes)
+    {
+        // Lowercase hex; matches conventional sha256 sidecar formats.
+        var c = new char[bytes.Length * 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            byte b = bytes[i];
+            c[i * 2] = HexChar(b >> 4);
+            c[i * 2 + 1] = HexChar(b & 0xF);
+        }
+        return new string(c);
+    }
+
+    private static char HexChar(int nibble) => (char)(nibble < 10 ? '0' + nibble : 'a' + (nibble - 10));
+
+    private static string StagingPath(string dir, string finalName)
+    {
+        // Leading dot keeps the staging file hidden on POSIX so directory
+        // listeners don't react to it. {pid}-{guid} prevents collision
+        // between concurrent exporter instances on the same machine.
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        var nonce = Guid.NewGuid().ToString("N");
+        return Path.Combine(dir, $".{finalName}.tmp-{pid}-{nonce}");
+    }
+
+    private static FileStream OpenStagingForWrite(string path)
+        => new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None, bufferSize: 64 * 1024, FileOptions.None);
+
+    private static void FsyncDirectory(string dir)
+    {
+        // RandomAccess.FlushToDisk on a directory fd is the POSIX-correct
+        // way to make a rename(2) durable. On Windows it's a no-op (the
+        // rename itself is journaled). Some container/tmpfs configs reject
+        // a read-mode open on a directory with EACCES; treat dir fsync as
+        // best-effort (matches FileChannelStatePersister.FsyncDirectory) —
+        // the file rename itself is durable on every mainstream Linux FS.
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+        try
+        {
+            using var handle = File.OpenHandle(dir, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, FileOptions.None);
+            RandomAccess.FlushToDisk(handle);
+        }
+        catch
+        {
+            // Best-effort; some FSes reject directory fsync (EINVAL) or
+            // directory read-mode open (EACCES under restrictive mounts).
+        }
+    }
+
+    private static void BestEffortDelete(string? path)
+    {
+        if (path is null) return;
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* swallow */ }
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/EodFillsExporterTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/EodFillsExporterTests.cs
@@ -185,6 +185,33 @@ public class EodFillsExporterTests : IDisposable
     }
 
     [Fact]
+    public void Export_OnRerun_StaleDoneIsRemovedBeforeNewCsvIsPublished()
+    {
+        // Publish a first version.
+        WriteAudit(Make(1, Day0Nanos, secId: 1));
+        var v1 = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "A", FixedGeneratedAt);
+        var v1Sha = v1.Sha256Hex;
+
+        // Append more records (changes the audit log content) then rerun.
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(Make(2, Day0Nanos + 1_000UL, secId: 1));
+        }
+        var v2 = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "A", FixedGeneratedAt.AddMinutes(5));
+
+        // Different content → different SHA.
+        Assert.NotEqual(v1Sha, v2.Sha256Hex);
+
+        // The published .done must describe the CURRENT csv (no stale signal).
+        var donePath = v2.CsvPath + ".done";
+        using var doc = JsonDocument.Parse(File.ReadAllText(donePath));
+        Assert.Equal(v2.Sha256Hex, doc.RootElement.GetProperty("sha256").GetString());
+        Assert.Equal(2, doc.RootElement.GetProperty("rowCount").GetInt64());
+    }
+
+    [Fact]
     public void Export_FailureMidWrite_LeavesPreviousOutputUntouchedAndCleansStaging()
     {
         // First, publish a "good" prior export so we can verify it survives.

--- a/tests/B3.Exchange.PostTrade.Tests/EodFillsExporterTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/EodFillsExporterTests.cs
@@ -1,0 +1,237 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+public class EodFillsExporterTests : IDisposable
+{
+    private readonly string _auditRoot;
+    private readonly string _dropRoot;
+    private const byte Channel = 7;
+    private static readonly DateOnly BusinessDate = new(2026, 5, 18);
+    // 2026-05-18 00:00:00 UTC, in nanoseconds since Unix epoch.
+    private static readonly ulong Day0Nanos =
+        (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+
+    public EodFillsExporterTests()
+    {
+        _auditRoot = Path.Combine(Path.GetTempPath(), "B3EodAudit_" + Guid.NewGuid().ToString("N"));
+        _dropRoot = Path.Combine(Path.GetTempPath(), "B3EodDrop_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_auditRoot);
+        Directory.CreateDirectory(_dropRoot);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_auditRoot)) Directory.Delete(_auditRoot, recursive: true);
+        if (Directory.Exists(_dropRoot)) Directory.Delete(_dropRoot, recursive: true);
+    }
+
+    private static PostTradeRecord Make(uint id, ulong ts, long secId = 900_000_000_001L, uint buyFirm = 7, uint sellFirm = 8)
+        => new(
+            TradeId: id, TransactTimeNanos: ts, SecurityId: secId,
+            AggressorSide: id % 2 == 0 ? Side.Buy : Side.Sell,
+            Quantity: 100 + id, PriceMantissa: 10_0000L + id,
+            BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+            BuyFirm: buyFirm, SellFirm: sellFirm,
+            BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    private void WriteAudit(params PostTradeRecord[] records)
+    {
+        using var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel);
+        foreach (var r in records) w.OnTrade(r);
+    }
+
+    private static EodFillsExporter NewExporter() => new EodFillsExporter();
+
+    private static readonly DateTime FixedGeneratedAt = new(2026, 5, 19, 3, 42, 11, 123, DateTimeKind.Utc);
+
+    [Fact]
+    public void Export_RoundTrips_RecordsToCsv()
+    {
+        var a = Make(1, Day0Nanos, secId: 100, buyFirm: 11, sellFirm: 22);
+        var b = Make(2, Day0Nanos + 1_500_000UL, secId: 100); // +1.5ms
+
+        WriteAudit(a, b);
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            secId => secId == 100 ? "PETR4" : null,
+            FixedGeneratedAt);
+
+        Assert.Equal(2, result.RowCount);
+        Assert.True(File.Exists(result.CsvPath));
+
+        var lines = File.ReadAllLines(result.CsvPath);
+        Assert.Equal(3, lines.Length); // header + 2 rows
+        Assert.Equal("tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm", lines[0]);
+
+        // Row 1: tradeId=1, side=S (odd), qty=101, price=100001
+        var cols1 = lines[1].Split(',');
+        Assert.Equal("1", cols1[0]);
+        Assert.Equal("2026-05-18T00:00:00.000000Z", cols1[1]);
+        Assert.Equal("PETR4", cols1[2]);
+        Assert.Equal("S", cols1[3]);
+        Assert.Equal("101", cols1[4]);
+        Assert.Equal("100001", cols1[5]);
+        Assert.Equal("1001", cols1[6]);
+        Assert.Equal("2001", cols1[7]);
+        Assert.Equal("11", cols1[8]);
+        Assert.Equal("22", cols1[9]);
+
+        // Row 2: tradeId=2, ts +1.5ms → .001500Z, side=B
+        var cols2 = lines[2].Split(',');
+        Assert.Equal("2", cols2[0]);
+        Assert.Equal("2026-05-18T00:00:00.001500Z", cols2[1]);
+        Assert.Equal("B", cols2[3]);
+    }
+
+    [Fact]
+    public void Export_EmptyAuditLog_EmitsHeaderOnly()
+    {
+        // Create a log with one record, then truncate back to just the file
+        // header so the reader yields zero records.
+        WriteAudit(Make(1, Day0Nanos));
+        var path = Path.Combine(_auditRoot, "7", "fills-2026-05-18.log");
+        using (var fs = new FileStream(path, FileMode.Open, FileAccess.Write))
+            fs.SetLength(AuditRecordCodec.FileHeaderSize);
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => "X", FixedGeneratedAt);
+
+        Assert.Equal(0, result.RowCount);
+        var text = File.ReadAllText(result.CsvPath);
+        Assert.Equal("tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm\n", text);
+    }
+
+    [Fact]
+    public void Export_MissingAuditFile_ThrowsFileNotFound()
+    {
+        Assert.Throws<FileNotFoundException>(() =>
+            NewExporter().Export(_auditRoot, _dropRoot, Channel, BusinessDate, _ => "X", FixedGeneratedAt));
+    }
+
+    [Fact]
+    public void Export_InternalCross_EmitsSameFirmInBothColumns()
+    {
+        WriteAudit(Make(1, Day0Nanos, buyFirm: 42, sellFirm: 42));
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "ABC", FixedGeneratedAt);
+
+        var cols = File.ReadAllLines(result.CsvPath)[1].Split(',');
+        Assert.Equal("42", cols[8]);
+        Assert.Equal("42", cols[9]);
+    }
+
+    [Fact]
+    public void Export_UnknownSymbol_FallsBackToNumericSecurityId()
+    {
+        WriteAudit(Make(1, Day0Nanos, secId: 555_000_111L));
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => null, // lookup never resolves
+            FixedGeneratedAt);
+
+        var cols = File.ReadAllLines(result.CsvPath)[1].Split(',');
+        Assert.Equal("555000111", cols[2]);
+    }
+
+    [Fact]
+    public void Export_IsIdempotent_AcrossReruns()
+    {
+        WriteAudit(Make(1, Day0Nanos), Make(2, Day0Nanos + 1_000UL), Make(3, Day0Nanos + 2_000UL));
+
+        var r1 = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "SYM", FixedGeneratedAt);
+        var bytes1 = File.ReadAllBytes(r1.CsvPath);
+
+        var r2 = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "SYM",
+            FixedGeneratedAt.AddHours(1)); // different generatedAt
+        var bytes2 = File.ReadAllBytes(r2.CsvPath);
+
+        Assert.Equal(r1.Sha256Hex, r2.Sha256Hex);
+        Assert.Equal(bytes1, bytes2);
+
+        // .done sidecar must differ on generatedAt across the two runs.
+        var donePath = r1.CsvPath + ".done";
+        Assert.True(File.Exists(donePath));
+    }
+
+    [Fact]
+    public void Export_DoneSidecar_HasExpectedJsonPayload()
+    {
+        WriteAudit(Make(1, Day0Nanos), Make(2, Day0Nanos));
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "SYM", FixedGeneratedAt);
+
+        var donePath = result.CsvPath + ".done";
+        Assert.True(File.Exists(donePath));
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(donePath));
+        var root = doc.RootElement;
+        Assert.Equal(2, root.GetProperty("rowCount").GetInt64());
+        Assert.Equal(result.Sha256Hex, root.GetProperty("sha256").GetString());
+        // generatedAt should round-trip to FixedGeneratedAt.
+        var gen = root.GetProperty("generatedAt").GetString();
+        Assert.Equal("2026-05-19T03:42:11.123000Z", gen);
+    }
+
+    [Fact]
+    public void Export_FailureMidWrite_LeavesPreviousOutputUntouchedAndCleansStaging()
+    {
+        // First, publish a "good" prior export so we can verify it survives.
+        WriteAudit(Make(1, Day0Nanos));
+        var prior = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "OK", FixedGeneratedAt);
+        var priorCsvBytes = File.ReadAllBytes(prior.CsvPath);
+        var priorDoneBytes = File.ReadAllBytes(prior.CsvPath + ".done");
+
+        // Now induce a failure mid-write by throwing from symbolLookup.
+        var boom = new InvalidOperationException("boom");
+        var thrown = Assert.ThrowsAny<Exception>(() => NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => throw boom, FixedGeneratedAt));
+        // CryptoStream may wrap the user exception; verify the original is reachable.
+        Assert.True(ReferenceEquals(boom, thrown) || ReferenceEquals(boom, thrown.InnerException));
+
+        // Prior output must be byte-identical (untouched).
+        Assert.Equal(priorCsvBytes, File.ReadAllBytes(prior.CsvPath));
+        Assert.Equal(priorDoneBytes, File.ReadAllBytes(prior.CsvPath + ".done"));
+
+        // No leftover staging files (hidden .fills.csv.tmp-*) in the drop dir.
+        var dropDir = Path.GetDirectoryName(prior.CsvPath)!;
+        var leftovers = Directory.GetFiles(dropDir, ".fills.csv*tmp-*");
+        Assert.Empty(leftovers);
+    }
+
+    [Fact]
+    public void Export_RejectsNonUtcGeneratedAt()
+    {
+        WriteAudit(Make(1, Day0Nanos));
+        var local = new DateTime(2026, 5, 19, 0, 0, 0, DateTimeKind.Local);
+        Assert.Throws<ArgumentException>(() => NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate, _ => "X", local));
+    }
+
+    [Fact]
+    public void Export_EscapesSymbolWithCsvSpecialChars()
+    {
+        WriteAudit(Make(1, Day0Nanos, secId: 1));
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => "WEIRD,\"SYM\"", FixedGeneratedAt);
+
+        var line = File.ReadAllLines(result.CsvPath)[1];
+        // tradeId=1,ts,"WEIRD,""SYM""",...
+        Assert.Contains(",\"WEIRD,\"\"SYM\"\"\",", line, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
First of four PRs implementing issue #330 (post-trade B: EOD fills file export — BVBG-like CSV drop). Pure infra in `B3.Exchange.PostTrade`; no HTTP / scheduler wiring yet.

## What

`EodFillsExporter.Export(auditRootDir, dropRootDir, channelNumber, businessDate, symbolLookup, generatedAtUtc)` projects the per-trade audit log (#329) for one channel + one UTC business date into:

```
{dropRootDir}/{channelNumber}/{YYYY-MM-DD}/fills.csv
{dropRootDir}/{channelNumber}/{YYYY-MM-DD}/fills.csv.done
```

Frozen CSV header (per ADR 0001 / #330):

```
tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm
```

## Atomic publish contract

1. Write CSV to hidden staging `.fills.csv.tmp-{pid}-{guid}`.
2. `fsync` data via `FileStream.Flush(true)`.
3. `rename(2)` staging → `fills.csv` (atomic on POSIX).
4. Best-effort directory `fsync` via `File.OpenHandle` + `RandomAccess.FlushToDisk` (same pattern as `FileChannelStatePersister.FsyncDirectory`).
5. Repeat 1–4 for the JSON `.done` sidecar so the consumer-visible signal lands LAST.
6. On any exception in steps 1–5: previously-published files are untouched and the staging file is best-effort deleted in a `finally`.

## SHA-256 + .done sidecar

SHA-256 is computed streaming via `CryptoStream` over the CSV bytes (single pass). It appears in both `EodFillsExportResult` and the `.done` JSON:

```json
{"rowCount":1234,"sha256":"…","generatedAt":"2026-05-19T03:42:11.123000Z"}
```

Reruns for the same (channel, date) produce byte-identical `fills.csv` (only `generatedAt` in `.done` differs).

## Symbol resolution decision

`PostTradeRecord` carries `SecurityId`; the CSV column is `symbol`. The exporter takes a `Func<long, string?>` from the caller; null/empty resolves to the numeric SecurityId and emits a single warn log per unique unresolved id per run. Host wiring (channel `InstrumentsFile`) lands in PR-2.

## Tests (10, all green)

Round-trip, empty audit log (header only), missing audit file → `FileNotFoundException`, internal cross (same firm both sides), unknown symbol fallback, idempotent reruns (byte-identical bytes + identical SHA across runs), `.done` JSON shape, induced failure mid-write leaves prior files intact and cleans staging, non-UTC `generatedAt` rejected, CSV escaping for symbols with quotes/commas.

## Out of scope (follow-up PRs)

- PR-2: `POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD` in HttpServer + ExchangeHost wiring.
- PR-3: `DailyResetScheduler` / `/admin/daily-reset` per-channel auto-trigger.
- PR-4: RUNBOOK "Post-trade" subsection + ADR 0001 cross-link.

Refs #330