### PR TITLE
Add POST /admin/post-trade/eod-export endpoint (#330 PR-2)

### DIFF
--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -37,6 +37,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly List<Timer> _snapshotTimers = new();
     private readonly List<B3.Exchange.PostTrade.FileAuditLogWriter> _auditWriters = new();
     private readonly List<Timer> _auditRetentionTimers = new();
+    private readonly Dictionary<byte, EodExportContext> _eodExportByChannel = new();
     private readonly MetricsRegistry _metrics = new();
     private readonly StartupReadinessProbe _startupProbe = new("startup");
     private readonly ShutdownReadinessProbe _shutdownProbe = new("shutdown");
@@ -221,6 +222,23 @@ public sealed class ExchangeHost : IAsyncDisposable
                 _logger.LogInformation(
                     "channel {ChannelNumber}: post-trade audit log enabled at {DataDir} (retentionDays={RetentionDays})",
                     ch.ChannelNumber, audit.DataDir, audit.RetentionDays);
+
+                if (!string.IsNullOrWhiteSpace(audit.EodDropDir))
+                {
+                    // Snapshot the symbol map at startup. InstrumentLoader
+                    // already de-duplicates symbols per channel so the
+                    // dictionary is unambiguous; unknown securityIds (e.g.
+                    // delisted between runs) fall back to the numeric id
+                    // inside EodFillsExporter.
+                    var symbols = instruments.ToDictionary(i => i.SecurityId, i => i.Symbol);
+                    var exporterLogger = _loggerFactory.CreateLogger<B3.Exchange.PostTrade.EodFillsExporter>();
+                    var exporter = new B3.Exchange.PostTrade.EodFillsExporter(exporterLogger);
+                    _eodExportByChannel[ch.ChannelNumber] = new EodExportContext(
+                        exporter, audit.DataDir, audit.EodDropDir, symbols);
+                    _logger.LogInformation(
+                        "channel {ChannelNumber}: EOD fills export enabled (dropDir={DropDir})",
+                        ch.ChannelNumber, audit.EodDropDir);
+                }
                 if (audit.RetentionDays > 0)
                 {
                     var capturedWriter = auditWriter;
@@ -422,7 +440,8 @@ public sealed class ExchangeHost : IAsyncDisposable
                 dailyResetTrigger: () => TriggerDailyReset("http-trigger"),
                 persisters: _persistersByChannel,
                 wals: _walsByChannel,
-                instrumentRouting: routing);
+                instrumentRouting: routing,
+                eodExportTrigger: TriggerEodExport);
             await _http.StartAsync().ConfigureAwait(false);
         }
 
@@ -671,6 +690,46 @@ public sealed class ExchangeHost : IAsyncDisposable
             audit.DataDir,
             ch.ChannelNumber);
     }
+
+    /// <summary>
+    /// Issue #330 PR-2: trigger the EOD fills CSV export for a channel
+    /// and UTC business date. Wired into
+    /// <c>POST /admin/post-trade/eod-export?channel=N&amp;date=YYYY-MM-DD</c>
+    /// and (PR-3) the daily-reset scheduler.
+    /// </summary>
+    /// <returns><see langword="null"/> when the channel has no EOD export
+    /// configured (operator should treat as 404); otherwise the export
+    /// result so the endpoint can surface row count / sha256 / path.</returns>
+    /// <remarks>
+    /// Exceptions thrown by <c>EodFillsExporter.Export</c> propagate to the
+    /// caller — the HTTP endpoint translates them into structured 4xx/5xx
+    /// responses. The exporter is stateless and safe to call concurrently
+    /// for distinct (channel, date) pairs; serialization for the same
+    /// (channel, date) is the operator's responsibility.
+    /// </remarks>
+    internal B3.Exchange.PostTrade.EodFillsExportResult? TriggerEodExport(byte channelNumber, DateOnly businessDate)
+    {
+        if (!_eodExportByChannel.TryGetValue(channelNumber, out var ctx)) return null;
+        return ctx.Exporter.Export(
+            ctx.AuditRootDir,
+            ctx.DropRootDir,
+            channelNumber,
+            businessDate,
+            secId => ctx.Symbols.TryGetValue(secId, out var sym) ? sym : null,
+            DateTime.UtcNow);
+    }
+
+    /// <summary>
+    /// Per-channel EOD export wiring captured at host startup. Held in
+    /// <c>_eodExportByChannel</c> so the HTTP endpoint and (PR-3) the
+    /// daily-reset auto-trigger can resolve it without rebuilding the
+    /// symbol map on every call.
+    /// </summary>
+    private sealed record EodExportContext(
+        B3.Exchange.PostTrade.EodFillsExporter Exporter,
+        string AuditRootDir,
+        string DropRootDir,
+        IReadOnlyDictionary<long, string> Symbols);
 
     /// <summary>
     /// Issue #270: parses the <c>persistence.orphanSessionPolicy</c>

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -38,6 +38,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly List<B3.Exchange.PostTrade.FileAuditLogWriter> _auditWriters = new();
     private readonly List<Timer> _auditRetentionTimers = new();
     private readonly Dictionary<byte, EodExportContext> _eodExportByChannel = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<(byte Channel, DateOnly Date), byte> _eodExportInFlight = new();
     private readonly MetricsRegistry _metrics = new();
     private readonly StartupReadinessProbe _startupProbe = new("startup");
     private readonly ShutdownReadinessProbe _shutdownProbe = new("shutdown");
@@ -701,22 +702,55 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// configured (operator should treat as 404); otherwise the export
     /// result so the endpoint can surface row count / sha256 / path.</returns>
     /// <remarks>
-    /// Exceptions thrown by <c>EodFillsExporter.Export</c> propagate to the
-    /// caller — the HTTP endpoint translates them into structured 4xx/5xx
-    /// responses. The exporter is stateless and safe to call concurrently
-    /// for distinct (channel, date) pairs; serialization for the same
-    /// (channel, date) is the operator's responsibility.
+    /// Concurrent calls for the SAME <c>(channel, date)</c> are serialized
+    /// here — the second caller throws <see cref="EodExportInProgressException"/>
+    /// so the endpoint can surface a 409 Conflict without partially
+    /// publishing two interleaved CSV / .done pairs. Different
+    /// <c>(channel, date)</c> pairs run concurrently (the underlying
+    /// exporter is stateless). Other exceptions from
+    /// <c>EodFillsExporter.Export</c> propagate to the caller.
     /// </remarks>
     internal B3.Exchange.PostTrade.EodFillsExportResult? TriggerEodExport(byte channelNumber, DateOnly businessDate)
     {
         if (!_eodExportByChannel.TryGetValue(channelNumber, out var ctx)) return null;
-        return ctx.Exporter.Export(
-            ctx.AuditRootDir,
-            ctx.DropRootDir,
-            channelNumber,
-            businessDate,
-            secId => ctx.Symbols.TryGetValue(secId, out var sym) ? sym : null,
-            DateTime.UtcNow);
+        var key = (channelNumber, businessDate);
+        if (!_eodExportInFlight.TryAdd(key, 0))
+        {
+            throw new EodExportInProgressException(channelNumber, businessDate);
+        }
+        try
+        {
+            return ctx.Exporter.Export(
+                ctx.AuditRootDir,
+                ctx.DropRootDir,
+                channelNumber,
+                businessDate,
+                secId => ctx.Symbols.TryGetValue(secId, out var sym) ? sym : null,
+                DateTime.UtcNow);
+        }
+        finally
+        {
+            _eodExportInFlight.TryRemove(key, out _);
+        }
+    }
+
+    /// <summary>
+    /// Thrown by <see cref="TriggerEodExport"/> when another export for
+    /// the same <c>(channel, date)</c> is already in flight. The HTTP
+    /// endpoint translates this into a 409 Conflict so concurrent
+    /// operators never observe a CSV / .done pair whose bytes came from
+    /// different exporter runs.
+    /// </summary>
+    internal sealed class EodExportInProgressException : InvalidOperationException
+    {
+        public byte Channel { get; }
+        public DateOnly Date { get; }
+        public EodExportInProgressException(byte channel, DateOnly date)
+            : base($"EOD export already in progress for channel={channel} date={date:yyyy-MM-dd}")
+        {
+            Channel = channel;
+            Date = date;
+        }
     }
 
     /// <summary>

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -450,6 +450,17 @@ public sealed class PostTradeAuditConfig
     /// files for the currently-open day and the watermark sidecar
     /// are never pruned.</summary>
     [JsonPropertyName("retentionDays")] public int RetentionDays { get; set; }
+
+    /// <summary>Root directory for EOD CSV drop files produced by
+    /// <c>EodFillsExporter</c> (issue #330). Layout:
+    /// <c>{EodDropDir}/{channelNumber}/{YYYY-MM-DD}/fills.csv</c> + sibling
+    /// <c>fills.csv.done</c>. Empty (default) ⇒ the
+    /// <c>POST /admin/post-trade/eod-export</c> endpoint returns 503 for
+    /// this channel and the daily-reset auto-trigger (PR-3) skips it.
+    /// Operators typically point this at a different mount than
+    /// <see cref="DataDir"/> so downstream reconciliation jobs can drain
+    /// the drop directory without racing the audit writer.</summary>
+    [JsonPropertyName("eodDropDir")] public string EodDropDir { get; set; } = "";
 }
 
 /// <summary>

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -455,7 +455,7 @@ public sealed class PostTradeAuditConfig
     /// <c>EodFillsExporter</c> (issue #330). Layout:
     /// <c>{EodDropDir}/{channelNumber}/{YYYY-MM-DD}/fills.csv</c> + sibling
     /// <c>fills.csv.done</c>. Empty (default) ⇒ the
-    /// <c>POST /admin/post-trade/eod-export</c> endpoint returns 503 for
+    /// <c>POST /admin/post-trade/eod-export</c> endpoint returns 404 for
     /// this channel and the daily-reset auto-trigger (PR-3) skips it.
     /// Operators typically point this at a different mount than
     /// <see cref="DataDir"/> so downstream reconciliation jobs can drain

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -35,6 +35,7 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly Func<IEnumerable<SessionDiagnostics>>? _sessionsProvider;
     private readonly IReadOnlyList<FirmInfo> _firms;
     private readonly Func<int>? _dailyResetTrigger;
+    private readonly Func<byte, DateOnly, B3.Exchange.PostTrade.EodFillsExportResult?>? _eodExportTrigger;
     private readonly IReadOnlyDictionary<byte, IChannelStatePersister> _persisters;
     private readonly IReadOnlyDictionary<byte, IChannelWriteAheadLog> _wals;
     private readonly Action<string>? _log;
@@ -49,7 +50,8 @@ public sealed class HttpServer : IAsyncDisposable
         Func<int>? dailyResetTrigger = null,
         IReadOnlyDictionary<byte, IChannelStatePersister>? persisters = null,
         IReadOnlyDictionary<byte, IChannelWriteAheadLog>? wals = null,
-        IReadOnlyDictionary<long, ChannelDispatcher>? instrumentRouting = null)
+        IReadOnlyDictionary<long, ChannelDispatcher>? instrumentRouting = null,
+        Func<byte, DateOnly, B3.Exchange.PostTrade.EodFillsExportResult?>? eodExportTrigger = null)
     {
         _config = config;
         _metrics = metrics;
@@ -61,6 +63,7 @@ public sealed class HttpServer : IAsyncDisposable
         _persisters = persisters ?? new Dictionary<byte, IChannelStatePersister>();
         _wals = wals ?? new Dictionary<byte, IChannelWriteAheadLog>();
         _instrumentRouting = instrumentRouting ?? new Dictionary<long, ChannelDispatcher>();
+        _eodExportTrigger = eodExportTrigger;
         _log = log;
     }
 
@@ -183,6 +186,24 @@ public sealed class HttpServer : IAsyncDisposable
             ctx.Response.StatusCode = StatusCodes.Status202Accepted;
             return Results.Text($"accepted daily-reset terminated={closed}\n", "text/plain");
         });
+
+        // Issue #330 PR-2: trigger the post-trade EOD fills CSV export
+        // for one channel + one UTC business date. The body of the request
+        // is ignored; query string carries the parameters so curl-shaped
+        // operator workflows match the rest of /admin/*.
+        //
+        //   POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD
+        //
+        // Returns 200 with a JSON body {csvPath, rowCount, sha256} on
+        // success; 400 on missing/invalid query params; 404 when the
+        // channel has no EOD export configured (postTradeAudit disabled
+        // or eodDropDir empty); 404 again (with a distinct reason) when
+        // the audit log for the requested date is missing; 500 with the
+        // exception type+message on any other failure. The endpoint is
+        // network-gated (no token auth) per the same convention as the
+        // rest of /admin/*; PR-3 wires the daily-reset auto-trigger.
+        app.MapPost("/admin/post-trade/eod-export", (HttpContext ctx) =>
+            HandleEodExport(ctx));
 
         // Issue #271: admin endpoints for snapshot management.
         //
@@ -472,6 +493,59 @@ public sealed class HttpServer : IAsyncDisposable
         _log?.Invoke($"admin: snapshot-get channel={channelNumber} returned snapshot version={snap.Version}");
         var json = System.Text.Json.JsonSerializer.Serialize(snap, AdminJsonOptions);
         return Results.Text(json, "application/json");
+    }
+
+    private IResult HandleEodExport(HttpContext ctx)
+    {
+        if (_eodExportTrigger is null)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text("eod-export not wired (host not started)\n", "text/plain");
+        }
+
+        var q = ctx.Request.Query;
+        if (!q.TryGetValue("channel", out var chRaw) || !byte.TryParse(chRaw.ToString(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var channel))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("missing or invalid 'channel' (expected byte 0..255)\n", "text/plain");
+        }
+        if (!q.TryGetValue("date", out var dateRaw) || !DateOnly.TryParseExact(dateRaw.ToString(), "yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out var date))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("missing or invalid 'date' (expected YYYY-MM-DD UTC)\n", "text/plain");
+        }
+
+        B3.Exchange.PostTrade.EodFillsExportResult? result;
+        try
+        {
+            result = _eodExportTrigger(channel, date);
+        }
+        catch (FileNotFoundException ex)
+        {
+            _log?.Invoke($"admin: eod-export channel={channel} date={date:yyyy-MM-dd} audit log missing: {ex.FileName}");
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"audit log not found for channel={channel} date={date:yyyy-MM-dd}\n", "text/plain");
+        }
+        catch (Exception ex)
+        {
+            _log?.Invoke($"admin: eod-export channel={channel} date={date:yyyy-MM-dd} failed: {ex.GetType().Name}: {ex.Message}");
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"eod-export failed: {ex.GetType().Name}: {ex.Message}\n", "text/plain");
+        }
+
+        if (result is null)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"channel {channel} has no EOD export configured (postTradeAudit.eodDropDir empty)\n", "text/plain");
+        }
+
+        _log?.Invoke($"admin: eod-export channel={channel} date={date:yyyy-MM-dd} rows={result.Value.RowCount} sha256={result.Value.Sha256Hex} path={result.Value.CsvPath}");
+        var payload = "{"
+            + "\"csvPath\":" + System.Text.Json.JsonSerializer.Serialize(result.Value.CsvPath)
+            + ",\"rowCount\":" + result.Value.RowCount.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            + ",\"sha256\":\"" + result.Value.Sha256Hex + "\""
+            + "}\n";
+        return Results.Text(payload, "application/json");
     }
 
     private IResult HandleAdminReset(HttpContext ctx, int channelNumber)

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -526,6 +526,12 @@ public sealed class HttpServer : IAsyncDisposable
             ctx.Response.StatusCode = StatusCodes.Status404NotFound;
             return Results.Text($"audit log not found for channel={channel} date={date:yyyy-MM-dd}\n", "text/plain");
         }
+        catch (ExchangeHost.EodExportInProgressException)
+        {
+            _log?.Invoke($"admin: eod-export channel={channel} date={date:yyyy-MM-dd} rejected: already in progress");
+            ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+            return Results.Text($"eod-export already in progress for channel={channel} date={date:yyyy-MM-dd}\n", "text/plain");
+        }
         catch (Exception ex)
         {
             _log?.Invoke($"admin: eod-export channel={channel} date={date:yyyy-MM-dd} failed: {ex.GetType().Name}: {ex.Message}");

--- a/tests/B3.Exchange.Host.Tests/HttpServerEodExportTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerEodExportTests.cs
@@ -220,4 +220,92 @@ public class HttpServerEodExportTests
             TryDeleteDir(dropDir);
         }
     }
+
+    [Fact]
+    public async Task Post_EodExport_IsIdempotent_AcrossSequentialReruns()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
+        var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDir);
+            SeedAuditLog(auditDir, MakeFill(1, 900000000001L), MakeFill(2, 900000000001L));
+
+            var cfg = BuildConfig(instrumentsPath, auditDir, dropDir);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+            using var r1 = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026-05-18", content: null);
+            using var r2 = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026-05-18", content: null);
+
+            Assert.Equal(HttpStatusCode.OK, r1.StatusCode);
+            Assert.Equal(HttpStatusCode.OK, r2.StatusCode);
+
+            using var d1 = JsonDocument.Parse(await r1.Content.ReadAsStringAsync());
+            using var d2 = JsonDocument.Parse(await r2.Content.ReadAsStringAsync());
+            Assert.Equal(
+                d1.RootElement.GetProperty("sha256").GetString(),
+                d2.RootElement.GetProperty("sha256").GetString());
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+            TryDeleteDir(dropDir);
+        }
+    }
+
+    [Fact]
+    public async Task Post_EodExport_RejectsConcurrentSameChannelDateWith409()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
+        var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDir);
+            // Many records so the export takes long enough to race against.
+            var records = new PostTradeRecord[2000];
+            for (uint i = 0; i < records.Length; i++)
+                records[i] = MakeFill(i + 1, 900000000001L, nanosOffset: (ulong)i * 1000UL);
+            SeedAuditLog(auditDir, records);
+
+            var cfg = BuildConfig(instrumentsPath, auditDir, dropDir);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+            // Fire 8 parallel requests for the same (channel, date). Each
+            // must return either 200 (the one that grabbed the in-flight
+            // slot) or 409 (lost the race) — NEVER 500, never partial.
+            var tasks = Enumerable.Range(0, 8).Select(_ =>
+                client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026-05-18", content: null)).ToArray();
+            var responses = await Task.WhenAll(tasks);
+            try
+            {
+                int ok = responses.Count(r => r.StatusCode == HttpStatusCode.OK);
+                int conflict = responses.Count(r => r.StatusCode == HttpStatusCode.Conflict);
+                Assert.Equal(responses.Length, ok + conflict);
+                Assert.True(ok >= 1, "at least one request must succeed");
+                // 409 count is environment-dependent (zero is acceptable
+                // when requests serialize on the wire); the critical
+                // guarantee is no 500s and no partial publishes.
+            }
+            finally
+            {
+                foreach (var r in responses) r.Dispose();
+            }
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+            TryDeleteDir(dropDir);
+        }
+    }
 }

--- a/tests/B3.Exchange.Host.Tests/HttpServerEodExportTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerEodExportTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #330 PR-2: smoke tests for the
+/// <c>POST /admin/post-trade/eod-export</c> endpoint wired by
+/// <see cref="ExchangeHost"/>. Pre-writes an audit log on disk via
+/// <see cref="FileAuditLogWriter"/> at the location the exporter reads
+/// from, then drives the endpoint over loopback HTTP.
+/// </summary>
+public class HttpServerEodExportTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    private const byte Channel = 82;
+    private static readonly DateOnly TestDate = new(2026, 5, 18);
+    private static readonly ulong TestDateNanos =
+        (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+
+    private static HostConfig BuildConfig(string instrumentsPath, string auditDir, string? dropDir)
+        => new()
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Http = new HttpConfig { Listen = "127.0.0.1:0" },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = Channel,
+                    IncrementalGroup = "239.255.82.82",
+                    IncrementalPort = 30182,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    PostTradeAudit = new PostTradeAuditConfig
+                    {
+                        Enabled = true,
+                        DataDir = auditDir,
+                        EodDropDir = dropDir ?? "",
+                    },
+                },
+            },
+        };
+
+    private static void SeedAuditLog(string auditDir, params PostTradeRecord[] records)
+    {
+        using var w = new FileAuditLogWriter(auditDir, channelNumber: Channel);
+        foreach (var r in records) w.OnTrade(r);
+    }
+
+    private static PostTradeRecord MakeFill(uint id, long secId, ulong nanosOffset = 0)
+        => new(
+            TradeId: id, TransactTimeNanos: TestDateNanos + nanosOffset, SecurityId: secId,
+            AggressorSide: id % 2 == 0 ? Side.Buy : Side.Sell,
+            Quantity: 100 + id, PriceMantissa: 10_0000L + id,
+            BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+            BuyFirm: 7, SellFirm: 7,
+            BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    [Fact]
+    public async Task Post_EodExport_ProducesCsvAndDoneFilesAndReturnsJson()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
+        var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDir);
+            // PETR4 = 900000000001 (resolved by symbol lookup at startup).
+            SeedAuditLog(auditDir,
+                MakeFill(1, 900000000001L),
+                MakeFill(2, 900000000001L, nanosOffset: 1_000_000UL));
+
+            var cfg = BuildConfig(instrumentsPath, auditDir, dropDir);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+            using var resp = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026-05-18", content: null);
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+            var body = await resp.Content.ReadAsStringAsync();
+            using var doc = JsonDocument.Parse(body);
+            Assert.Equal(2, doc.RootElement.GetProperty("rowCount").GetInt64());
+            var csvPath = doc.RootElement.GetProperty("csvPath").GetString()!;
+            var sha = doc.RootElement.GetProperty("sha256").GetString()!;
+            Assert.True(File.Exists(csvPath));
+            Assert.True(File.Exists(csvPath + ".done"));
+
+            var lines = File.ReadAllLines(csvPath);
+            Assert.Equal(3, lines.Length); // header + 2 rows
+            Assert.Contains("PETR4", lines[1]);
+
+            // .done sidecar SHA matches response body.
+            using var doneDoc = JsonDocument.Parse(File.ReadAllText(csvPath + ".done"));
+            Assert.Equal(sha, doneDoc.RootElement.GetProperty("sha256").GetString());
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+            TryDeleteDir(dropDir);
+        }
+    }
+
+    [Fact]
+    public async Task Post_EodExport_Returns404_WhenChannelHasNoEodDropConfigured()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            // Audit enabled but EodDropDir empty → exporter not wired.
+            var cfg = BuildConfig(instrumentsPath, auditDir, dropDir: null);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+            using var resp = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026-05-18", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+            var text = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("eodDropDir", text, StringComparison.Ordinal);
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+        }
+    }
+
+    [Fact]
+    public async Task Post_EodExport_Returns404_WhenAuditLogForDateIsMissing()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
+        var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDir);
+            var cfg = BuildConfig(instrumentsPath, auditDir, dropDir);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+            // No audit log written → 404.
+            using var resp = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026-05-18", content: null);
+            Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+            var text = await resp.Content.ReadAsStringAsync();
+            Assert.Contains("audit log not found", text, StringComparison.Ordinal);
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+            TryDeleteDir(dropDir);
+        }
+    }
+
+    [Fact]
+    public async Task Post_EodExport_Returns400_OnMissingOrInvalidQueryParams()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
+        var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var cfg = BuildConfig(instrumentsPath, auditDir, dropDir);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+
+            using var noChannel = await client.PostAsync("/admin/post-trade/eod-export?date=2026-05-18", content: null);
+            Assert.Equal(HttpStatusCode.BadRequest, noChannel.StatusCode);
+
+            using var noDate = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}", content: null);
+            Assert.Equal(HttpStatusCode.BadRequest, noDate.StatusCode);
+
+            using var badDate = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date=2026/05/18", content: null);
+            Assert.Equal(HttpStatusCode.BadRequest, badDate.StatusCode);
+
+            using var badChannel = await client.PostAsync("/admin/post-trade/eod-export?channel=abc&date=2026-05-18", content: null);
+            Assert.Equal(HttpStatusCode.BadRequest, badChannel.StatusCode);
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+            TryDeleteDir(dropDir);
+        }
+    }
+}


### PR DESCRIPTION
PR-2 of 4 for issue #330. Wires the `EodFillsExporter` from #359 into `HttpServer` so operators can trigger the EOD fills CSV drop on demand.

## Endpoint

```
POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD
```

| Status | Meaning |
|---|---|
| 200 | JSON `{csvPath, rowCount, sha256}`; CSV + `.done` sidecar published |
| 400 | Missing/invalid `channel` or `date` query param |
| 404 | Channel has no EOD export configured (`eodDropDir` empty), OR audit log for the requested date does not exist |
| 500 | Any other failure (type+message in body) |
| 503 | Endpoint not yet wired (host not fully started) |

Network-gated like the rest of `/admin/*` (no token auth).

## Config

`PostTradeAuditConfig` gains an `eodDropDir` field (empty by default for backward compatibility). When set, `ExchangeHost` captures a per-channel `EodExportContext` at startup with the instrument symbol map — `SecurityId → symbol` resolution is in-memory, unknown ids fall back to numeric per the contract from #359.

## Tests (4, all green)

- Happy path: CSV + `.done` published, `sha256` in response matches sidecar JSON, symbol resolved from instrument map.
- 404 when `eodDropDir` empty.
- 404 when audit log file for date is missing.
- 400 across four bad-query variants (missing channel, missing date, malformed date, non-numeric channel).

## Out of scope (next PRs)

- PR-3: `DailyResetScheduler` auto-trigger for every channel with `eodDropDir` set (yesterday UTC).
- PR-4: RUNBOOK "Post-trade" subsection + ADR 0001 cross-link.

Refs #330