### PR TITLE
feat(host): chain EOD fills export into daily reset (#330 PR-3)

### DIFF
--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -81,8 +81,64 @@ public sealed class ExchangeHost : IAsyncDisposable
     public int TriggerDailyReset(string reason = "operator-trigger")
     {
         var listener = _listener;
-        if (listener is null) return -1;
-        return listener.TerminateAllSessions(reason);
+        int terminated = listener is null ? -1 : listener.TerminateAllSessions(reason);
+        // Issue #330 PR-3: chain the EOD fills export for every channel
+        // with eodDropDir configured (yesterday UTC). Failures are
+        // logged and swallowed so a CSV problem on one channel never
+        // hides the listener-termination count from the operator.
+        TriggerEodExportForAllChannels(reason);
+        return terminated;
+    }
+
+    /// <summary>
+    /// Issue #330 PR-3: iterate every channel with an EOD export
+    /// configured and project yesterday's UTC business day's audit log
+    /// into the CSV drop. Per-channel failures (e.g. missing audit log
+    /// for a quiet day) are logged at warn level and swallowed so a
+    /// single failing channel never aborts the daily rollover for the
+    /// rest. Called from both the scheduled timer and the
+    /// <c>/admin/daily-reset</c> HTTP endpoint via
+    /// <see cref="TriggerDailyReset"/>.
+    /// </summary>
+    private void TriggerEodExportForAllChannels(string reason)
+    {
+        if (_eodExportByChannel.Count == 0) return;
+        // Project the just-closed UTC business day. Using yesterday UTC
+        // matches the audit writer's day-boundary semantics — the
+        // currently-open day's audit file is still being written, so
+        // operators export the last sealed day.
+        var businessDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+        foreach (var channel in _eodExportByChannel.Keys.ToList())
+        {
+            try
+            {
+                var result = TriggerEodExport(channel, businessDate);
+                if (result is { } r)
+                {
+                    _logger.LogInformation(
+                        "daily-reset ({Reason}): channel={Channel} date={Date} EOD export rows={Rows} sha256={Sha}",
+                        reason, channel, businessDate, r.RowCount, r.Sha256Hex);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                _logger.LogWarning(
+                    "daily-reset ({Reason}): channel={Channel} date={Date} EOD export skipped — no audit log for that day",
+                    reason, channel, businessDate);
+            }
+            catch (EodExportInProgressException)
+            {
+                _logger.LogWarning(
+                    "daily-reset ({Reason}): channel={Channel} date={Date} EOD export skipped — already in progress",
+                    reason, channel, businessDate);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "daily-reset ({Reason}): channel={Channel} date={Date} EOD export FAILED",
+                    reason, channel, businessDate);
+            }
+        }
     }
 
     /// <summary>Firm + session credentials parsed from <c>HostConfig</c>.
@@ -455,7 +511,11 @@ public sealed class ExchangeHost : IAsyncDisposable
             _dailyReset = new DailyResetScheduler(
                 drCfg.Schedule,
                 drCfg.Timezone,
-                action: () => _listener?.TerminateAllSessions("daily-reset"),
+                // Both the scheduled timer and /admin/daily-reset go
+                // through TriggerDailyReset so the listener-terminate +
+                // EOD-export chaining (#330 PR-3) is identical for
+                // automated and manual rollovers.
+                action: () => TriggerDailyReset("daily-reset"),
                 logger: _loggerFactory.CreateLogger<DailyResetScheduler>());
             _dailyReset.Start();
         }

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -82,12 +82,52 @@ public sealed class ExchangeHost : IAsyncDisposable
     {
         var listener = _listener;
         int terminated = listener is null ? -1 : listener.TerminateAllSessions(reason);
+        // Issue #330 PR-3 (review BLOCKING): drain per-channel inbound
+        // queues before reading yesterday's audit log. TerminateAllSessions
+        // only closes live FIXP transports; commands already decoded and
+        // enqueued on the dispatcher Channel keep flowing through
+        // ProcessOne → _postTradeSink.OnTrade after this call returns. If
+        // a fill with TransactTime in yesterday's UTC window is still in
+        // flight when EodFillsExporter starts reading, we'd export an
+        // incomplete CSV. Mirror the graceful-shutdown phase-3 drain
+        // (ExchangeHost.StopAsync) but keep it synchronous so the
+        // /admin/daily-reset response stays simple.
+        DrainDispatcherInboundForRollover(reason);
         // Issue #330 PR-3: chain the EOD fills export for every channel
         // with eodDropDir configured (yesterday UTC). Failures are
         // logged and swallowed so a CSV problem on one channel never
         // hides the listener-termination count from the operator.
         TriggerEodExportForAllChannels(reason);
         return terminated;
+    }
+
+    private void DrainDispatcherInboundForRollover(string reason)
+    {
+        if (_dispatchers.Count == 0) return;
+        int graceMs = Math.Max(0, _config.Shutdown.DrainGraceMs);
+        int pollMs = Math.Max(1, _config.Shutdown.DrainPollMs);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int residual = 0;
+        while (true)
+        {
+            residual = 0;
+            foreach (var d in _dispatchers) residual += d.InboundQueueDepth;
+            if (residual == 0) break;
+            if (sw.ElapsedMilliseconds >= graceMs) break;
+            Thread.Sleep(pollMs);
+        }
+        if (residual == 0)
+        {
+            _logger.LogInformation(
+                "daily-reset ({Reason}): drain phase=ok duration={DurationMs}ms",
+                reason, sw.ElapsedMilliseconds);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "daily-reset ({Reason}): drain phase=grace-expired duration={DurationMs}ms residual={Residual} — EOD export may miss in-flight fills",
+                reason, sw.ElapsedMilliseconds, residual);
+        }
     }
 
     /// <summary>

--- a/tests/B3.Exchange.Host.Tests/DailyResetEodExportChainingTests.cs
+++ b/tests/B3.Exchange.Host.Tests/DailyResetEodExportChainingTests.cs
@@ -1,0 +1,326 @@
+using System.Net;
+using System.Net.Http;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #330 PR-3: triggering the daily reset (scheduled or via
+/// <c>/admin/daily-reset</c>) must also chain the EOD fills CSV export
+/// for every channel whose <c>postTradeAudit.eodDropDir</c> is set,
+/// projecting yesterday UTC's audit log. Per-channel failures must
+/// not block other channels.
+/// </summary>
+public class DailyResetEodExportChainingTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    private static void TryDeleteDir(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    private static PostTradeRecord MakeFill(uint id, ulong nanos, long secId = 900000000001L)
+        => new(
+            TradeId: id, TransactTimeNanos: nanos, SecurityId: secId,
+            AggressorSide: Side.Buy,
+            Quantity: 100 + id, PriceMantissa: 10_0000L + id,
+            BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+            BuyFirm: 7, SellFirm: 7,
+            BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    private static ulong NanosForDate(DateOnly d)
+        => (ulong)(d.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+
+    [Fact]
+    public async Task TriggerDailyReset_ProjectsYesterdayAuditLogForAllConfiguredChannels()
+    {
+        var eqtPath = ResolveRepoFile("config/instruments-eqt.json");
+        var drvPath = ResolveRepoFile("config/instruments-drv.json");
+        var auditDirA = Path.Combine(Path.GetTempPath(), "b3-dr-audit-a-" + Guid.NewGuid().ToString("N"));
+        var dropDirA = Path.Combine(Path.GetTempPath(), "b3-dr-drop-a-" + Guid.NewGuid().ToString("N"));
+        var auditDirB = Path.Combine(Path.GetTempPath(), "b3-dr-audit-b-" + Guid.NewGuid().ToString("N"));
+        var dropDirB = Path.Combine(Path.GetTempPath(), "b3-dr-drop-b-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDirA);
+            Directory.CreateDirectory(auditDirB);
+            var yesterday = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+            var yesterdayNanos = NanosForDate(yesterday);
+
+            using (var w = new FileAuditLogWriter(auditDirA, channelNumber: 91))
+                w.OnTrade(MakeFill(1, yesterdayNanos));
+            using (var w = new FileAuditLogWriter(auditDirB, channelNumber: 92))
+            {
+                w.OnTrade(MakeFill(1, yesterdayNanos));
+                w.OnTrade(MakeFill(2, yesterdayNanos + 1_000UL));
+            }
+
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 91,
+                        IncrementalGroup = "239.255.91.91",
+                        IncrementalPort = 30191,
+                        Ttl = 0,
+                        InstrumentsFile = eqtPath,
+                        PostTradeAudit = new PostTradeAuditConfig
+                        {
+                            Enabled = true,
+                            DataDir = auditDirA,
+                            EodDropDir = dropDirA,
+                        },
+                    },
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 92,
+                        IncrementalGroup = "239.255.92.92",
+                        IncrementalPort = 30192,
+                        Ttl = 0,
+                        InstrumentsFile = drvPath,
+                        PostTradeAudit = new PostTradeAuditConfig
+                        {
+                            Enabled = true,
+                            DataDir = auditDirB,
+                            EodDropDir = dropDirB,
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            // Drives both listener termination AND the per-channel EOD
+            // CSV export chain (issue #330 PR-3).
+            host.TriggerDailyReset("test");
+
+            var date = yesterday.ToString("yyyy-MM-dd");
+            var csvA = Path.Combine(dropDirA, "91", date, "fills.csv");
+            var csvB = Path.Combine(dropDirB, "92", date, "fills.csv");
+            Assert.True(File.Exists(csvA), $"expected {csvA}");
+            Assert.True(File.Exists(csvA + ".done"));
+            Assert.True(File.Exists(csvB), $"expected {csvB}");
+            Assert.True(File.Exists(csvB + ".done"));
+
+            // 1 row + header / 2 rows + header.
+            Assert.Equal(2, File.ReadAllLines(csvA).Length);
+            Assert.Equal(3, File.ReadAllLines(csvB).Length);
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDirA);
+            TryDeleteDir(dropDirA);
+            TryDeleteDir(auditDirB);
+            TryDeleteDir(dropDirB);
+        }
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_SkipsChannelsWithoutEodDropConfigured()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-dr-audit-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDir);
+            var yesterday = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+            using (var w = new FileAuditLogWriter(auditDir, channelNumber: 93))
+                w.OnTrade(MakeFill(1, NanosForDate(yesterday)));
+
+            // Audit enabled, eodDropDir empty → no export trigger registered.
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 93,
+                        IncrementalGroup = "239.255.93.93",
+                        IncrementalPort = 30193,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                        PostTradeAudit = new PostTradeAuditConfig
+                        {
+                            Enabled = true,
+                            DataDir = auditDir,
+                            EodDropDir = "",
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            host.TriggerDailyReset("test"); // must not throw
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+        }
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_SwallowsMissingAuditLog_AndStillProcessesOtherChannels()
+    {
+        var eqtPath = ResolveRepoFile("config/instruments-eqt.json");
+        var drvPath = ResolveRepoFile("config/instruments-drv.json");
+        // Channel A has NO audit log written → export should swallow.
+        // Channel B has yesterday's audit log → export must still succeed.
+        var auditDirA = Path.Combine(Path.GetTempPath(), "b3-dr-audit-a-" + Guid.NewGuid().ToString("N"));
+        var dropDirA = Path.Combine(Path.GetTempPath(), "b3-dr-drop-a-" + Guid.NewGuid().ToString("N"));
+        var auditDirB = Path.Combine(Path.GetTempPath(), "b3-dr-audit-b-" + Guid.NewGuid().ToString("N"));
+        var dropDirB = Path.Combine(Path.GetTempPath(), "b3-dr-drop-b-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDirA);
+            Directory.CreateDirectory(auditDirB);
+            var yesterday = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+            using (var w = new FileAuditLogWriter(auditDirB, channelNumber: 95))
+                w.OnTrade(MakeFill(1, NanosForDate(yesterday)));
+
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 94,
+                        IncrementalGroup = "239.255.94.94",
+                        IncrementalPort = 30194,
+                        Ttl = 0,
+                        InstrumentsFile = eqtPath,
+                        PostTradeAudit = new PostTradeAuditConfig
+                        {
+                            Enabled = true,
+                            DataDir = auditDirA,
+                            EodDropDir = dropDirA,
+                        },
+                    },
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 95,
+                        IncrementalGroup = "239.255.95.95",
+                        IncrementalPort = 30195,
+                        Ttl = 0,
+                        InstrumentsFile = drvPath,
+                        PostTradeAudit = new PostTradeAuditConfig
+                        {
+                            Enabled = true,
+                            DataDir = auditDirB,
+                            EodDropDir = dropDirB,
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            host.TriggerDailyReset("test");
+
+            var date = yesterday.ToString("yyyy-MM-dd");
+            // Channel 94: no audit log → no CSV produced.
+            Assert.False(File.Exists(Path.Combine(dropDirA, "94", date, "fills.csv")));
+            // Channel 95: succeeded despite the sibling failure.
+            Assert.True(File.Exists(Path.Combine(dropDirB, "95", date, "fills.csv")));
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDirA);
+            TryDeleteDir(dropDirA);
+            TryDeleteDir(auditDirB);
+            TryDeleteDir(dropDirB);
+        }
+    }
+
+    [Fact]
+    public async Task AdminDailyReset_HttpEndpoint_AlsoTriggersEodExport()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var auditDir = Path.Combine(Path.GetTempPath(), "b3-dr-audit-" + Guid.NewGuid().ToString("N"));
+        var dropDir = Path.Combine(Path.GetTempPath(), "b3-dr-drop-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(auditDir);
+            var yesterday = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1);
+            using (var w = new FileAuditLogWriter(auditDir, channelNumber: 96))
+                w.OnTrade(MakeFill(1, NanosForDate(yesterday)));
+
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Http = new HttpConfig { Listen = "127.0.0.1:0" },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 96,
+                        IncrementalGroup = "239.255.96.96",
+                        IncrementalPort = 30196,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                        PostTradeAudit = new PostTradeAuditConfig
+                        {
+                            Enabled = true,
+                            DataDir = auditDir,
+                            EodDropDir = dropDir,
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var client = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint}") };
+            using var resp = await client.PostAsync("/admin/daily-reset", content: null);
+            Assert.Equal(HttpStatusCode.Accepted, resp.StatusCode);
+
+            var date = yesterday.ToString("yyyy-MM-dd");
+            Assert.True(File.Exists(Path.Combine(dropDir, "96", date, "fills.csv")));
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDeleteDir(auditDir);
+            TryDeleteDir(dropDir);
+        }
+    }
+}


### PR DESCRIPTION
PR-3 of #330 (post-trade B EOD CSV drop).

DailyResetScheduler and `POST /admin/daily-reset` now invoke `EodFillsExporter` for every channel with `PostTradeAudit` + `EodDropDir` configured, projecting yesterday's UTC audit log into the operator drop directory as part of rollover.

## Scope

- Single code path: scheduled timer + HTTP `/admin/daily-reset` both go through `ExchangeHost.TriggerDailyReset(reason)`, which terminates sessions then chains the per-channel export. Avoids drift between automated and manual rollover.
- Yesterday-UTC business date: the currently-open day's audit file is still being written; operators export the last sealed day at rollover.
- Per-channel error isolation:
  - `FileNotFoundException` → warn (common on quiet days)
  - `EodExportInProgressException` → warn (race with operator manual trigger via PR-2)
  - other exceptions → error, sibling channels still run

## Tests

`DailyResetEodExportChainingTests` (4 tests, all green):
- Multi-channel happy path (yesterday log on 2 channels → 2 CSVs published)
- Skip channels without `eodDropDir` configured (no-op, no throw)
- Swallow missing audit log on one channel, sibling still gets CSV
- `POST /admin/daily-reset` HTTP path also triggers EOD export

## Pipeline

- `dotnet build -c Release` ✅
- `dotnet test -c Release` ✅ (one known flake `FixpSessionPassiveErBufferingTests.PassiveTrade_WhileSuspended_AppendsToRetransmitRing`; passes on rerun)
- `dotnet format --verify-no-changes` ✅

Refs #330. Sequenced after #359 (PR-1 exporter) and #360 (PR-2 HTTP endpoint). PR-4 (RUNBOOK + ADR cross-link) to follow.