### PR TITLE
docs(post-trade): RUNBOOK §7.9 EOD CSV drop + ADR 0001 acceptance (#330 PR-4)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -81,9 +81,12 @@ See §4 for tuning recipes.
 > (audit log, EOD fills export, future clearing files) live on a
 > separate boundary and are **file-based**, not REST — see
 > [ADR 0001](./adr/0001-post-trade-boundary-and-eod-file-export.md).
-> If you are looking for "where do I download yesterday's fills",
-> the answer is "a configured drop directory once the post-trade
-> module ships", not an endpoint on this surface.
+> The one exception is the **trigger** for the EOD export
+> (`POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD`,
+> documented in §7.9 below): it lives under `/admin/*` because it is
+> an operator-only action against the running host. The **artifact
+> it produces** is a CSV in a configured drop directory, not a REST
+> body.
 
 ### 2.1 Liveness & readiness
 
@@ -167,9 +170,19 @@ Per-spec daily rollover (#GAP-09 / #47):
 * Every live FIXP session is sent `Terminate(FINISHED)`.
 * Clients reconnect with `Negotiate` + `Establish(nextSeqNo=1)`.
 * Sequence numbers reset; retransmission buffers are cleared.
+* **Post-trade rollover (issue [#330](https://github.com/pedrosakuma/B3MatchingPlatform/issues/330)).**
+  After session termination, the handler waits for the per-channel
+  dispatcher inbound queues to drain (bounded by
+  `shutdown.drainGraceMs`, same knob the graceful-shutdown path
+  uses), then chains the EOD CSV export for **yesterday UTC** on
+  every channel that has `postTradeAudit.eodDropDir` configured.
+  See §7.9 for the file layout, atomic publish contract, and
+  failure modes.
 
 The same code path is wired to the optional scheduled trigger (set
-`hostConfig.dailyReset` to enable; absent ⇒ admin-trigger only).
+`hostConfig.dailyReset` to enable; absent ⇒ admin-trigger only), so
+both the cron-style scheduler and the operator `curl` produce
+identical artifacts.
 
 ---
 
@@ -1077,7 +1090,133 @@ upper bound on per-trade audit overhead). Compare numbers across PRs
 that touch the dispatcher hot path or the writer to catch
 regressions before they land.
 
-### 7.9 Common persistence headaches
+### 7.9 EOD fills export — CSV drop (issue [#330](https://github.com/pedrosakuma/B3MatchingPlatform/issues/330))
+
+Projects the per-trade audit log (§7.8) for a given business date
+into a CSV "drop" file that downstream recon tools poll. This is
+the **post-trade boundary** described by
+[ADR 0001](./adr/0001-post-trade-boundary-and-eod-file-export.md) —
+file-based, not REST. The `/admin/post-trade/eod-export` trigger is
+operator-only and lives on the admin surface for ergonomics; the
+artifact it produces is on disk.
+
+**Opt-in per channel** via the `postTradeAudit.eodDropDir` field
+(added by issue #330 PR-2). The channel must also have
+`postTradeAudit.enabled=true` (§7.8) — without an audit log there
+is nothing to project:
+
+```jsonc
+"channels": [{
+  "channelNumber": 1,
+  // ... transport, instruments, persistence ...
+  "postTradeAudit": {
+    "enabled": true,
+    "dataDir": "/var/lib/b3matching/audit",
+    "eodDropDir": "/var/lib/b3matching/drop",
+    "retentionDays": 1825
+  }
+}]
+```
+
+If `eodDropDir` is empty, the channel has no export configured and
+the trigger returns `404` for that channel (other channels still
+run).
+
+**On-disk layout** (one set per channel per business date):
+
+```
+{eodDropDir}/{channel}/{YYYY-MM-DD}/
+  fills.csv        # data
+  fills.csv.done   # sidecar with { rowCount, sha256, generatedAt }
+```
+
+The CSV columns are frozen at the ADR 0001 v1 shape:
+
+```
+tradeId, ts, symbol, aggressorSide, qty, price, buyClOrdId, sellClOrdId, buyFirm, sellFirm
+```
+
+`ts` is ISO-8601 UTC with microsecond precision. `aggressorSide`
+is taker-relative (`B`/`S`, matching UMDF `Trade_53` semantics).
+Internal crosses (same firm on both sides) emit one row with
+`buyFirm == sellFirm`. `symbol` is resolved from each channel's
+instrument map; trades on unknown securityIds fall back to the
+numeric `securityId` as the symbol so the row is never lost.
+
+**Atomic publish contract** (every consumer must rely on these
+invariants):
+
+1. The exporter stages `fills.csv` and `fills.csv.done` to
+   `.tmp-<pid>-<nonce>` paths in the same directory.
+2. The previous `.done` (if any) is deleted, then the directory
+   is fsync'd — this is what guarantees a polling consumer never
+   sees a stale `.done` next to a fresh CSV.
+3. The CSV is renamed into place and fsync'd.
+4. The `.done` sidecar is renamed last and fsync'd.
+
+**Consumers MUST wait for `fills.csv.done` before reading
+`fills.csv`.** A `.csv` without a matching `.done` is either
+still being written or a leftover from a crashed export run.
+
+**Idempotency.** Rerunning the export for the same `(channel,
+date)` produces a byte-identical CSV (same input → deterministic
+output). Only the `generatedAt` field inside `.done` differs.
+This is the intended recovery / re-issue path for operators.
+
+**Operator trigger — `POST /admin/post-trade/eod-export`.**
+Synchronous: blocks until the staging + fsync + rename cycle
+completes (typical CSV is small — a few MB at most for a busy
+channel — so wall-clock is sub-second on local SSD, low single
+digits on networked drops).
+
+```bash
+# Re-issue yesterday's drop for channel 1.
+curl -sS -X POST \
+  "http://127.0.0.1:8080/admin/post-trade/eod-export?channel=1&date=2026-05-18"
+# {"csvPath":"/var/lib/b3matching/drop/1/2026-05-18/fills.csv","rowCount":12345,"sha256":"…"}
+```
+
+| Status | Meaning |
+| --- | --- |
+| `200 OK` | Export succeeded. Body is a JSON object with `csvPath`, `rowCount`, `sha256` (matches the value in `.done`). |
+| `400 Bad Request` | Missing or malformed `channel` / `date` query parameter. `date` must be `YYYY-MM-DD` (UTC business date). |
+| `404 Not Found` | Either the channel has no `eodDropDir` configured, or no `fills-YYYY-MM-DD.log` exists for that channel and date (the response body distinguishes the two). |
+| `409 Conflict` | Another export for the same `(channel, date)` is already in progress. The in-flight guard is per-tuple, so different `(channel, date)` pairs can run in parallel. |
+| `500 Internal Server Error` | Unhandled exception during projection (disk full, audit-log CRC failure, permission flip). The body carries the exception type and message; no partial file is published. |
+| `503 Service Unavailable` | Host has not finished `StartAsync` (the trigger is not yet wired). |
+
+**Scheduled trigger — `POST /admin/daily-reset` and
+`DailyResetScheduler`.** Both go through the same code path (see
+§2.5): terminate sessions → drain dispatcher inbound queues →
+chain the per-channel EOD export for **yesterday UTC**. Per-channel
+failures (missing audit log for a quiet day → warning; race with an
+operator manual rerun → warning; other exceptions → error) are
+isolated so one channel never blocks siblings. Yesterday-UTC is
+chosen because the currently-open day's audit file is still being
+written by the dispatcher — operators always export the last
+**sealed** day at rollover.
+
+**Auth model.** Same as every other `/admin/*` endpoint: there is
+no application-level auth. Operators must network-gate the HTTP
+listener (bind to loopback, route through a reverse proxy, restrict
+by k8s NetworkPolicy, etc.). See §1.1 / §2 for the listener bind
+address.
+
+**Failure modes a consumer can observe:**
+
+| Symptom | Cause | Remediation |
+| --- | --- | --- |
+| `.csv` exists, no `.done` | Export run crashed mid-publish, or the host was killed between steps 3 and 4 above. | The consumer must ignore the file. Rerun the trigger; the rename is idempotent and the `.done` will appear once the rerun completes. |
+| `.done` lists a `sha256` that doesn't match `sha256sum fills.csv` | The CSV was modified after publish (manual edit, restore from backup). | Re-run the export to overwrite both files from the authoritative audit log. |
+| Trigger returns `404` "audit log not found" but the operator expected trades | Either the date is wrong (UTC vs local), or `postTradeAudit.enabled` was off on that day, or `dataDir` was different. | Check `{dataDir}/{channel}/fills-{date}.log` directly; verify the config in effect at the relevant historical moment. |
+| Trigger returns `409` and never clears | A scheduler tick is mid-flight (typically sub-second). If it persists for minutes, the dispatcher is stuck. | Check host logs for `daily-reset (...): drain phase=grace-expired` and `eod-export ... failed` lines; investigate the audit writer's sticky-fault state (§7.8). |
+
+**Failure-mode invariant:** a consumer that respects the
+`.done` gate never observes a partial, torn, or stale CSV. The
+exporter holds no state — every run reads the audit log fresh —
+so safe-to-rerun on any failure.
+
+### 7.10 Common persistence headaches
 
 * **"Channel boots empty after restart."** Check
   `exch_snapshot_load_seconds` — `0` means `TryLoad` returned null.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1180,7 +1180,7 @@ curl -sS -X POST \
 | --- | --- |
 | `200 OK` | Export succeeded. Body is a JSON object with `csvPath`, `rowCount`, `sha256` (matches the value in `.done`). |
 | `400 Bad Request` | Missing or malformed `channel` / `date` query parameter. `date` must be `YYYY-MM-DD` (UTC business date). |
-| `404 Not Found` | Either the channel has no `eodDropDir` configured, or no `fills-YYYY-MM-DD.log` exists for that channel and date (the response body distinguishes the two). |
+| `404 Not Found` | The channel has no EOD export wired (either `postTradeAudit.enabled=false`, `postTradeAudit.dataDir` empty, or `postTradeAudit.eodDropDir` empty), or no `fills-YYYY-MM-DD.log` exists for that channel and date. The response body distinguishes the cases. |
 | `409 Conflict` | Another export for the same `(channel, date)` is already in progress. The in-flight guard is per-tuple, so different `(channel, date)` pairs can run in parallel. |
 | `500 Internal Server Error` | Unhandled exception during projection (disk full, audit-log CRC failure, permission flip). The body carries the exception type and message; no partial file is published. |
 | `503 Service Unavailable` | Host has not finished `StartAsync` (the trigger is not yet wired). |

--- a/docs/adr/0001-post-trade-boundary-and-eod-file-export.md
+++ b/docs/adr/0001-post-trade-boundary-and-eod-file-export.md
@@ -166,12 +166,14 @@ We adopt **three concentric decisions**:
 
 ### 3. EOD file drop, BVBG-like
 
-- Once a trading session closes (operator-triggered via a new
-  `/admin/post-trade/eod-export?date=YYYY-MM-DD` endpoint, or
-  scheduler-driven via the phase scheduler from #321 when the
-  configured close phase fires), the per-trade log for that date is
-  projected into one or more **drop files** in a configured
-  directory `config.postTrade.dropDir`.
+- Once a trading session closes (operator-triggered via the
+  `POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD`
+  endpoint, or chained from the existing
+  `DailyResetScheduler` / `POST /admin/daily-reset` rollover —
+  see *D+0 vs D+1 cycle* below for the as-shipped wiring), the
+  per-trade log for that date is projected into one or more
+  **drop files** in the per-channel directory configured by
+  `channels[].postTradeAudit.eodDropDir`.
 - **Format v1 is CSV.** Header + rows, columns frozen at:
   ```
   tradeId, ts, symbol, aggressorSide, qty, price, buyClOrdId, sellClOrdId, buyFirm, sellFirm
@@ -200,8 +202,8 @@ We adopt **three concentric decisions**:
   sequence, hash) so downstream consumers that ingest real BVBG can
   reuse their parser. Not built until a consumer demands it; the
   file-name convention reserves the path
-  `<dropDir>/<YYYYMMDD>/fills.csv` so adding `fills.xml` later is
-  non-breaking.
+  `<eodDropDir>/<channel>/<YYYY-MM-DD>/fills.csv` so adding
+  `fills.xml` later is non-breaking.
 - **No REST query endpoint.** Downstream tools poll the drop
   directory (or subscribe to a filesystem notification). The
   matching simulator is not on the live recon path; it produces
@@ -234,37 +236,49 @@ We adopt **three concentric decisions**:
   callback; wiring it as an *additional* automatic trigger
   (separate from `DailyResetScheduler`) is future integration
   work, not blocking the post-trade module.
-- The file lands in `<dropDir>/<YYYYMMDD>/`.
+- The file lands in `<eodDropDir>/<channel>/<YYYY-MM-DD>/`.
 - **D+1 (next morning):** trading-host's recon tool reads
   matching's D+0 drop and diffs against its own statement. Match =
   same trade count, same notional sum to the cent, no orphan
   `tradeId`s. Mismatch surfaces immediately, before the day's
   trading reopens.
 - **Reprocessing:** the export is idempotent — pointing the operator
-  endpoint at a past date rewrites the drop file deterministically
-  from the audit log. **Atomic publish semantics — hard
-  requirement.** A consumer that polls the drop directory must
-  never observe a partial or truncated file. Therefore:
-  - The export writes to a staging path
-    `<dropDir>/<YYYYMMDD>/.fills.csv.tmp-<pid>-<nonce>`.
-  - On success: `fsync` the staging file, `rename(2)` to
-    `fills.csv`, `fsync` the directory.
+  endpoint at a past `(channel, date)` rewrites the drop file
+  deterministically from the audit log. **Atomic publish semantics
+  — hard requirement.** A consumer that polls the drop directory
+  must never observe a partial or torn file, nor a stale `.done`
+  paired with a fresh CSV. Therefore (as shipped by #330 PR-1,
+  ordering fixed in review):
+  - The export stages both files to `.tmp-<pid>-<nonce>` paths in
+    the target `<eodDropDir>/<channel>/<YYYY-MM-DD>/` directory.
+  - On success the publish sequence is:
+    1. Delete any prior `fills.csv.done`, then `fsync` the
+       directory — this is what guarantees a polling consumer never
+       sees a stale `.done` next to a fresh CSV.
+    2. `rename(2)` the staged CSV to `fills.csv`, then `fsync` the
+       directory.
+    3. `rename(2)` the staged sidecar to `fills.csv.done`, then
+       `fsync` the directory.
+  - **Consumer contract:** `fills.csv.done` is the gate — its
+    presence (carrying `{ rowCount, sha256, generatedAt }`) is the
+    only signal that `fills.csv` is final. A `.csv` without a
+    matching `.done` is either still being written or a leftover
+    from a crashed run; consumers must ignore it.
   - On any failure mid-write (disk full, audit-log CRC failure
     detected during projection, process crash): the staging file
-    is removed on next operator-triggered rerun or on host
-    startup; the previously successful `fills.csv` from a prior
-    run remains untouched and consumable.
-  - A sidecar `fills.csv.done` is written **last**, after the
-    rename, carrying `{ rowCount, sha256, generatedAt }`. Its
-    presence is the consumer-visible signal that the file is
-    final; consumers wait for `.done` before reading. Rerunning
-    overwrites both `fills.csv` and `fills.csv.done` atomically
-    (rename ordering: data file first, then `.done`).
+    is removed on the next operator-triggered rerun or on host
+    startup. There is **no rollback** of step 1 — once the prior
+    `.done` is gone, no `.csv` is published until the rerun
+    completes successfully. This is intentional: the alternative
+    (keep the prior pair and republish only on success) makes the
+    `.done` gate weaker because a successful CSV rename + failed
+    `.done` rename would leave a stale `.done` describing the
+    *previous* CSV.
   - Failed exports surface via the operator endpoint's HTTP
     response (and a structured log line) — never via a partial
     file on disk. Audit-log corruption discovered during
-    projection is a hard failure: the export aborts, no file is
-    overwritten, and the operator gets a clear error pointing at
+    projection is a hard failure: the export aborts, no `.done`
+    is published, and the operator gets a clear error pointing at
     the offending audit record offset.
 
 ## Consequences
@@ -274,7 +288,7 @@ We adopt **three concentric decisions**:
 - The architecture stops conflating operator admin with post-trade
   clearing. Adding more clearing artifacts later (instrument dumps,
   price files, position aggregates) is a matter of dropping more
-  files in `dropDir`, not adding more REST endpoints.
+  files in `eodDropDir`, not adding more REST endpoints.
 - Recon decouples from matching uptime: a recon tool can run the
   next morning while matching is down for maintenance, because the
   artifact is on disk.

--- a/docs/adr/0001-post-trade-boundary-and-eod-file-export.md
+++ b/docs/adr/0001-post-trade-boundary-and-eod-file-export.md
@@ -1,6 +1,8 @@
 # ADR 0001 — Post-trade boundary and EOD file export
 
-- **Status:** Proposed
+- **Status:** Accepted (implemented by #329 series for the audit log
+  and #330 series for the EOD CSV drop; see *Implementation status*
+  below).
 - **Date:** 2026-05-16
 - **Supersedes:** —
 - **Superseded by:** —
@@ -208,20 +210,30 @@ We adopt **three concentric decisions**:
 ### D+0 vs D+1 cycle
 
 - **D+0 (intraday close):** EOD export runs after a session-close
-  trigger. **In v1 the trigger is one of**:
-  - a new operator endpoint
-    `/admin/post-trade/eod-export?date=YYYY-MM-DD`, or
+  trigger. **As of issue [#330](https://github.com/pedrosakuma/B3MatchingPlatform/issues/330)
+  the trigger is either**:
+  - the operator endpoint
+    `POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD`
+    (re-issue / backfill path), or
   - the existing `DailyResetScheduler` /
-    `/admin/daily-reset` flow (see `docs/RUNBOOK.md` section 2),
-    which is the closest thing to a "session is over" hook the
-    host has today.
+    `POST /admin/daily-reset` flow, which chains the per-channel
+    export for **yesterday UTC** after terminating sessions and
+    draining dispatcher inbound queues.
 
-  The `PhaseScheduler` from #321 / PR #324 currently only enqueues
+  Both paths share the same `EodFillsExporter` codepath and the
+  same `ExchangeHost.TriggerEodExport` in-flight guard, so a
+  scheduled tick and a manual rerun for the same `(channel, date)`
+  can't race into a torn publish.
+
+  See `docs/RUNBOOK.md` §2.5 (daily-reset) and §7.9 (EOD CSV drop)
+  for the operator-facing surface, status-code matrix, file
+  layout, and consumer contract.
+
+  The `PhaseScheduler` from #321 / PR #324 still only enqueues
   phase / `Uncross` actions and has **no** generic post-close
-  callback (see `src/B3.Exchange.Host/PhaseScheduler.cs`); wiring
-  it as the automatic export trigger is **future integration
-  work** for issue B (or a follow-up issue), not a current
-  capability this ADR can assume.
+  callback; wiring it as an *additional* automatic trigger
+  (separate from `DailyResetScheduler`) is future integration
+  work, not blocking the post-trade module.
 - The file lands in `<dropDir>/<YYYYMMDD>/`.
 - **D+1 (next morning):** trading-host's recon tool reads
   matching's D+0 drop and diffs against its own statement. Match =
@@ -288,10 +300,38 @@ We adopt **three concentric decisions**:
 - **Close #327** as `not planned` — wrong shape. Link this ADR.
 - **Open A — per-trade audit log:** infra-only, no HTTP, no export.
   Implements section 2 above. Blocks B.
+  → **Shipped** as issue [#329](https://github.com/pedrosakuma/B3MatchingPlatform/issues/329)
+  (PR series #329 PR-1..PR-6). Operational surface in
+  `docs/RUNBOOK.md` §7.8.
 - **Open B — EOD fills file export (BVBG-like):** projects A into
   `dropDir`. Implements section 3 above. Closes
   B3TradingPlatform#274 via the file drop.
+  → **Shipped** as issue [#330](https://github.com/pedrosakuma/B3MatchingPlatform/issues/330)
+  (PR series #359 exporter, #360 operator endpoint, #361 daily-reset
+  chaining, this PR docs). Operational surface in
+  `docs/RUNBOOK.md` §7.9.
 - Both labelled `area:post-trade` so the new boundary is visible.
+
+### Implementation status (as of 2026-05)
+
+Acceptance criteria from sections 2 and 3 above are met:
+
+| Criterion | Status | Where |
+| --- | --- | --- |
+| Per-trade audit log written on the dispatch thread, daily-rolled by UTC, CRC-protected | ✅ #329 PR-1..PR-3 | `src/B3.Exchange.PostTrade/FileAuditLogWriter.cs` |
+| Independent retention from WAL (configurable `retentionDays`) | ✅ #329 PR-6 | `FileAuditLogWriter.PruneOldDays`, RUNBOOK §7.8 |
+| Durability watermark coupling audit checkpoint to WAL truncation gate | ✅ #329 PR-5 (sidecar) + PR-6 | `audit-watermark.bin`, RUNBOOK §7.8 |
+| EOD CSV drop with frozen v1 column shape | ✅ #330 PR-1 | `src/B3.Exchange.PostTrade/EodFillsExporter.cs`, RUNBOOK §7.9 |
+| Atomic publish (stage → fsync → rename CSV → rename `.done`) with no torn-file consumer visibility | ✅ #330 PR-1 (ordering fixed in review) | `EodFillsExporter.Export`, RUNBOOK §7.9 |
+| Operator trigger `POST /admin/post-trade/eod-export?channel=N&date=YYYY-MM-DD` with in-flight guard | ✅ #330 PR-2 | `src/B3.Exchange.Host/HttpServer.HandleEodExport`, RUNBOOK §7.9 |
+| `DailyResetScheduler` + `/admin/daily-reset` chain the EOD export for yesterday UTC | ✅ #330 PR-3 | `ExchangeHost.TriggerDailyReset`, RUNBOOK §2.5 + §7.9 |
+| Idempotent rerun (same inputs → byte-identical CSV) | ✅ #330 PR-1 + test | `EodFillsExporterTests`, RUNBOOK §7.9 |
+
+The deferred items in *Open questions* (signing, XML envelope,
+multi-firm split, compression, schema registry, exact retention
+defaults, session-time business-date boundary) remain explicit
+non-decisions and are not blocked by anything in the current
+shipped surface.
 
 ## Alternatives considered
 
@@ -353,7 +393,11 @@ the decision:
 ## References
 
 - `docs/RUNBOOK.md` — current operator endpoints; the `/admin/*`
-  surface this ADR draws a line around.
+  surface this ADR draws a line around. §7.8 documents the audit
+  log shipped by #329; §7.9 documents the EOD CSV drop shipped by
+  #330 (operator endpoint, file layout, atomic publish contract,
+  consumer rules); §2.5 documents the `DailyResetScheduler` /
+  `/admin/daily-reset` chaining.
 - `docs/EXCHANGE-SIMULATOR.md` — `wal` config block; this ADR keeps
   it untouched.
 - `src/B3.Exchange.Core/ChannelDispatcher.Operator.cs` — comment

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,4 +35,4 @@ changes, a new ADR supersedes the old one.
 
 | #    | Title                                                          | Status   |
 |------|----------------------------------------------------------------|----------|
-| 0001 | Post-trade boundary and EOD file export                        | Proposed |
+| 0001 | Post-trade boundary and EOD file export                        | Accepted |


### PR DESCRIPTION
PR-4 (final) of issue #330. Documentation-only.

## RUNBOOK changes (`docs/RUNBOOK.md`)

- **§2 scope-note** — clarifies that the post-trade trigger lives on `/admin/*` for operator ergonomics, while the artifact it produces is on disk.
- **§2.5 daily-reset** — documents the chained EOD export step (drain barrier reusing `shutdown.drainGraceMs`, yesterday-UTC rationale, per-channel error isolation).
- **new §7.9 'EOD fills export — CSV drop'** — operator endpoint reference, full HTTP status matrix (200/400/404/409/500/503), file layout, atomic publish invariant (`.done` gate), CSV column shape, idempotency, failure-mode table, auth model.
- prior §7.9 renumbered to §7.10.

## ADR changes (`docs/adr/0001-post-trade-boundary-and-eod-file-export.md`)

- **Status: Proposed → Accepted.**
- **D+0 vs D+1 cycle** rewritten to reflect what shipped (operator endpoint + `DailyResetScheduler` chaining via #330) and cross-link the new RUNBOOK sections.
- **Issue housekeeping** marks Open A (#329) and Open B (#330) as shipped, with the PR series listed.
- **New 'Implementation status' table** maps every acceptance criterion from sections 2 and 3 to the shipping code path + RUNBOOK section.
- **References** expanded to call out §7.8 / §7.9 / §2.5 explicitly.

## Pipeline

Per repo convention (custom_instruction `linting_building_testing`), documentation-only PRs skip build/test/format. No code paths touched.

Refs #330. Closes the #330 PR-1..PR-4 series.