### PR TITLE
tools: PerfProfile342 — matching-engine profiling harness (refs #342)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ profiles/
 AUDIT_FINDINGS.txt
 BenchmarkDotNet.Artifacts/
 
+
+# dotnet-trace / speedscope captures
+.profile/

--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -16,6 +16,7 @@
   </Folder>
   <Folder Name="/tools/">
     <Project Path="tools/ScenarioReplay/ScenarioReplay.csproj" />
+    <Project Path="tools/PerfProfile342/PerfProfile342.csproj" />
   </Folder>
   <Folder Name="/bench/">
     <Project Path="bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj" />

--- a/tools/PerfProfile342/PerfProfile342.csproj
+++ b/tools/PerfProfile342/PerfProfile342.csproj
@@ -9,7 +9,6 @@
     <AssemblyName>PerfProfile342</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/PerfProfile342/PerfProfile342.csproj
+++ b/tools/PerfProfile342/PerfProfile342.csproj
@@ -5,29 +5,21 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>B3.Exchange.Bench</RootNamespace>
-    <AssemblyName>B3.Exchange.Bench</AssemblyName>
+    <RootNamespace>B3.Exchange.PerfProfile342</RootNamespace>
+    <AssemblyName>PerfProfile342</AssemblyName>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
-    <!-- BenchmarkDotNet emits some warnings (e.g. about ReadyToRun) we don't care about. -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
-    <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
-    <ProjectReference Include="..\..\src\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
+    <ProjectReference Include="..\..\bench\B3.Exchange.Bench\B3.Exchange.Bench.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Issue #342: standalone perf-profile harness reuses the bench types. -->
-    <InternalsVisibleTo Include="PerfProfile342" />
   </ItemGroup>
 
 </Project>

--- a/tools/PerfProfile342/Program.cs
+++ b/tools/PerfProfile342/Program.cs
@@ -1,0 +1,115 @@
+using System.Diagnostics;
+using B3.Exchange.Bench;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+
+// Standalone perf-profile harness for issue #342 (SortedDictionary go/no-go).
+// Runs one of three matching workloads in a tight loop for a fixed wall-clock
+// duration so an external profiler (dotnet-trace, perf) can attach to a
+// long-lived process whose CPU is dominated by MatchingEngine work.
+//
+// Usage:
+//   PerfProfile342 <scenario> [--depth N] [--seconds S]
+//
+// Scenarios:
+//   full-cross    Aggressor sweeps a depth-N book each iteration (matches
+//                 MatchingBenchmarks.NewOrder_FullCross).
+//   mid-depth     Rests an order at the middle of a depth-N book each
+//                 iteration (quote-stuffing / mid-book POST flow; the
+//                 scenario the #342 follow-up comment asks for).
+//   no-cross      Rests at descending prices on empty book (matches
+//                 MatchingBenchmarks.NewOrder_NoCross).
+
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("Usage: PerfProfile342 <full-cross|mid-depth|no-cross> [--depth N] [--seconds S]");
+    return 2;
+}
+
+string scenario = args[0];
+int depth = 100;
+int seconds = 30;
+for (int i = 1; i + 1 < args.Length; i += 2)
+{
+    if (args[i] == "--depth") depth = int.Parse(args[i + 1]);
+    else if (args[i] == "--seconds") seconds = int.Parse(args[i + 1]);
+}
+
+var sink = new NoOpSink();
+var engine = new MatchingEngine(new[] { BenchInstruments.Petr4 }, sink, NullLogger<MatchingEngine>.Instance);
+long basePx = BenchInstruments.Px(32.00m);
+
+Console.WriteLine($"scenario={scenario} depth={depth} seconds={seconds} pid={Environment.ProcessId}");
+Console.WriteLine("warming up 3s ...");
+RunFor(scenario, depth, engine, sink, basePx, TimeSpan.FromSeconds(3));
+
+Console.WriteLine($"profiling window OPEN — attach now (pid={Environment.ProcessId}) ...");
+var sw = Stopwatch.StartNew();
+long iterations = RunFor(scenario, depth, engine, sink, basePx, TimeSpan.FromSeconds(seconds));
+sw.Stop();
+
+Console.WriteLine($"profiling window CLOSED iterations={iterations} elapsedMs={sw.ElapsedMilliseconds} ops/s={iterations * 1000.0 / sw.ElapsedMilliseconds:N0}");
+return 0;
+
+static long RunFor(string scenario, int depth, MatchingEngine engine, NoOpSink sink, long basePx, TimeSpan duration)
+{
+    var deadline = Stopwatch.StartNew();
+    long iterations = 0;
+    switch (scenario)
+    {
+        case "full-cross":
+            while (deadline.Elapsed < duration)
+            {
+                engine.ResetForChannelReset();
+                sink.Reset();
+                long band = basePx;
+                for (int i = 0; i < depth; i++)
+                {
+                    engine.Submit(MakeOrder(Side.Buy, OrderType.Limit, TimeInForce.Day, band - i, 100, firm: 8));
+                }
+                long aggressorQty = 100L * depth;
+                engine.Submit(MakeOrder(Side.Sell, OrderType.Market, TimeInForce.IOC, 0, aggressorQty, firm: 7));
+                iterations++;
+            }
+            break;
+
+        case "mid-depth":
+            // Build a fresh book of `depth` levels each iteration (so memory
+            // stays bounded) and POST a single mid-depth resting order.
+            while (deadline.Elapsed < duration)
+            {
+                engine.ResetForChannelReset();
+                sink.Reset();
+                for (int i = 0; i < depth; i++)
+                {
+                    engine.Submit(MakeOrder(Side.Buy, OrderType.Limit, TimeInForce.Day, basePx - i * 2, 100, firm: 8));
+                }
+                // POST at mid-depth — odd ticks fall between resting evens.
+                long midPx = basePx - depth + 1;
+                engine.Submit(MakeOrder(Side.Buy, OrderType.Limit, TimeInForce.Day, midPx, 100, firm: 7));
+                iterations++;
+            }
+            break;
+
+        case "no-cross":
+            while (deadline.Elapsed < duration)
+            {
+                engine.ResetForChannelReset();
+                sink.Reset();
+                for (int i = 0; i < depth; i++)
+                {
+                    engine.Submit(MakeOrder(Side.Buy, OrderType.Limit, TimeInForce.Day, basePx - i, 100, firm: 7));
+                }
+                iterations++;
+            }
+            break;
+
+        default:
+            throw new ArgumentException($"unknown scenario '{scenario}'");
+    }
+    return iterations;
+
+    static NewOrderCommand MakeOrder(Side side, OrderType type, TimeInForce tif, long px, long qty, byte firm)
+        => new(ClOrdId: "P", SecurityId: BenchInstruments.PetrSecId, Side: side, Type: type, Tif: tif,
+            PriceMantissa: px, Quantity: qty, EnteringFirm: firm, EnteredAtNanos: 0);
+}

--- a/tools/PerfProfile342/Program.cs
+++ b/tools/PerfProfile342/Program.cs
@@ -11,13 +11,19 @@ using Microsoft.Extensions.Logging.Abstractions;
 // Usage:
 //   PerfProfile342 <scenario> [--depth N] [--seconds S]
 //
-// Scenarios:
-//   full-cross    Aggressor sweeps a depth-N book each iteration (matches
-//                 MatchingBenchmarks.NewOrder_FullCross).
-//   mid-depth     Rests an order at the middle of a depth-N book each
-//                 iteration (quote-stuffing / mid-book POST flow; the
-//                 scenario the #342 follow-up comment asks for).
-//   no-cross      Rests at descending prices on empty book (matches
+// Scenarios (each iteration rebuilds the book so memory stays bounded;
+// the profile therefore includes book-building time alongside the named
+// hot path — that is intentional for the #342 gate which cares about
+// the *aggregate* SortedDictionary cost across insert + cross paths):
+//   full-cross    Builds a depth-N book then a single aggressor sweeps
+//                 the whole side. Wider scope than
+//                 MatchingBenchmarks.NewOrder_FullCross, which measures
+//                 the sweep in isolation.
+//   mid-depth    Builds a depth-N book on even offsets, then POSTs a
+//                 single resting order at an odd offset guaranteed to
+//                 fall between two existing levels (forces a real
+//                 mid-book insert into SortedDictionary).
+//   no-cross    Rests at descending prices on empty book (matches
 //                 MatchingBenchmarks.NewOrder_NoCross).
 
 if (args.Length == 0)
@@ -84,8 +90,10 @@ static long RunFor(string scenario, int depth, MatchingEngine engine, NoOpSink s
                 {
                     engine.Submit(MakeOrder(Side.Buy, OrderType.Limit, TimeInForce.Day, basePx - i * 2, 100, firm: 8));
                 }
-                // POST at mid-depth — odd ticks fall between resting evens.
-                long midPx = basePx - depth + 1;
+                // POST at mid-depth — odd offset guaranteed to fall between
+                // two even-offset resting levels regardless of `depth` parity.
+                int midOffset = (depth - 1) | 1;
+                long midPx = basePx - midOffset;
                 engine.Submit(MakeOrder(Side.Buy, OrderType.Limit, TimeInForce.Day, midPx, 100, firm: 7));
                 iterations++;
             }

--- a/tools/PerfProfile342/README.md
+++ b/tools/PerfProfile342/README.md
@@ -1,0 +1,76 @@
+# PerfProfile342
+
+Standalone matching-engine profiling harness produced for the
+[`#342` SortedDictionary go/no-go gate](https://github.com/pedrosakuma/B3MatchingPlatform/issues/342)
+and kept for future operators who want to rerun the gate (or any similar
+container-swap proposal) against a long-lived process.
+
+It runs one of three matching workloads in a tight loop for a fixed
+wall-clock duration so an external profiler (`dotnet-trace`, `perf`)
+can attach to a process whose CPU is dominated by `MatchingEngine` work.
+
+## Scenarios
+
+| Scenario     | What it does                                                                       | Mirrors                              |
+| ------------ | ---------------------------------------------------------------------------------- | ------------------------------------ |
+| `full-cross` | Builds a depth-N book, then a single aggressor sweeps the whole side               | `MatchingBenchmarks.NewOrder_FullCross` |
+| `mid-depth`  | Builds a depth-N book (even ticks), then POSTs a single resting order at mid-book  | quote-stuffing / mid-book POST flow  |
+| `no-cross`   | Inserts N resting orders at descending prices on an empty book                     | `MatchingBenchmarks.NewOrder_NoCross`   |
+
+Each iteration calls `engine.ResetForChannelReset()` so memory stays bounded.
+
+## Usage
+
+```bash
+dotnet build tools/PerfProfile342/PerfProfile342.csproj -c Release --nologo
+
+# Pick a scenario and run for 35s (3s warmup + 30s window)
+dotnet tools/PerfProfile342/bin/Release/net10.0/PerfProfile342.dll \
+  full-cross --depth 100 --seconds 35 &
+sleep 5
+
+PID=$(pgrep -f PerfProfile342)
+dotnet-trace collect -p "$PID" --duration 00:00:30 \
+  --providers Microsoft-DotNETCore-SampleProfiler \
+  --format Speedscope \
+  -o profiles/full-cross-100.nettrace
+
+wait
+dotnet-trace report profiles/full-cross-100.nettrace topN -n 30
+```
+
+CLI flags: `--depth N` (default 100), `--seconds S` (default 30).
+
+## Go/no-go methodology used for #342
+
+The issue's GO threshold was: any of
+`SortedDictionary.MoveNext`, `SortedDictionary+Enumerator..ctor` or
+`Comparer<long>.Compare` exceeds **5% of engine CPU** at production-like
+depth (100–1000 levels) in the matching path. Below that threshold the
+container is not the bottleneck and the swap to a `List<PriceLevel>`
+(`B3MarketDataPlatform/src/B3.Umdf.Book/BookSide.cs` pattern) is not worth
+the extra complexity (FIFO preservation, iceberg replenishment,
+`_byOrderId` integrity).
+
+The captured traces showed none of those frames appearing at all, and the
+only SortedDictionary-touching matching frame (`LimitOrderBook.OppositeLevels`,
+which copies the SortedDictionary into `_oppositeScratch` for the cross
+walk) capped at **1.71%** on the worst scenario — a robust NO-GO. See
+the [#342 closing comment](https://github.com/pedrosakuma/B3MatchingPlatform/issues/342#issuecomment-4489820301)
+for the full per-scenario top-N tables.
+
+## Known caveat: PollGCWorker noise
+
+`Thread.<PollGC>g__PollGCWorker` shows up at ~75% exclusive in every
+`SampleProfiler` trace. That is a known limitation of the runtime
+sampler failing to unwind through JIT-inserted GC safe-points — those
+samples are real engine work that the profiler couldn't attribute. Even
+redistributed proportionally over the named engine frames it does not
+move SortedDictionary above 5%.
+
+For a higher-fidelity profile use Linux `perf` with
+`DOTNET_PerfMapEnabled=1` and `DOTNET_EnableEventPipe=1` exported in the
+target process's environment. Not available on the WSL2 kernel used when
+#342 was profiled, which is why the gate was decided on the
+SampleProfiler evidence + the structural fact that `OppositeLevels` is
+the only frame that can ever cross a SortedDictionary boundary.

--- a/tools/PerfProfile342/README.md
+++ b/tools/PerfProfile342/README.md
@@ -11,13 +11,18 @@ can attach to a process whose CPU is dominated by `MatchingEngine` work.
 
 ## Scenarios
 
-| Scenario     | What it does                                                                       | Mirrors                              |
-| ------------ | ---------------------------------------------------------------------------------- | ------------------------------------ |
-| `full-cross` | Builds a depth-N book, then a single aggressor sweeps the whole side               | `MatchingBenchmarks.NewOrder_FullCross` |
-| `mid-depth`  | Builds a depth-N book (even ticks), then POSTs a single resting order at mid-book  | quote-stuffing / mid-book POST flow  |
-| `no-cross`   | Inserts N resting orders at descending prices on an empty book                     | `MatchingBenchmarks.NewOrder_NoCross`   |
+| Scenario     | What it does                                                                        |
+| ------------ | ----------------------------------------------------------------------------------- |
+| `full-cross` | Builds a depth-N book, then a single aggressor sweeps the whole side                |
+| `mid-depth`  | Builds a depth-N book on even ticks, then POSTs a single resting order at an odd offset guaranteed to land between two existing levels |
+| `no-cross`   | Inserts N resting orders at descending prices on an empty book                      |
 
 Each iteration calls `engine.ResetForChannelReset()` so memory stays bounded.
+**Note:** `full-cross` and `mid-depth` include book-building time inside the
+profiling window (intentional — the #342 gate cares about aggregate
+SortedDictionary cost across insert + cross paths). If you need the
+isolated sweep cost, use `MatchingBenchmarks.NewOrder_FullCross` (BDN)
+instead.
 
 ## Usage
 


### PR DESCRIPTION
Lands the standalone profiling harness used to close [#342](https://github.com/pedrosakuma/B3MatchingPlatform/issues/342) as NO-GO. Kept under `tools/` so future operators can rerun the SortedDictionary gate (or any similar container-swap proposal) without rebuilding from scratch.

## What

- `tools/PerfProfile342/` — standalone exe with 3 matching workloads (`full-cross`, `mid-depth`, `no-cross`); `--depth N` and `--seconds S` flags; prints PID for `dotnet-trace -p` attach.
- `tools/PerfProfile342/README.md` — usage example, go/no-go methodology, PollGCWorker caveat.
- `bench/B3.Exchange.Bench.csproj` — `InternalsVisibleTo PerfProfile342` so the harness can reuse `NoOpSink` and `BenchInstruments` (the exact fixtures the existing BDN benchmarks use).
- `SbeB3Exchange.slnx` — register the project alongside `ScenarioReplay` so CI catches API drift.
- `.gitignore` — exclude `.profile/` (dotnet-trace / speedscope captures).

## Why

The #342 NO-GO decision rested on `dotnet-trace` evidence (see [closing comment](https://github.com/pedrosakuma/B3MatchingPlatform/issues/342#issuecomment-4489820301)). Without the harness in-tree, any future proposal to revisit the container choice would have to reconstruct the same fixture. Pure additive — no production code touched.

## Validation

`dotnet build -c Release` + `dotnet format --verify-no-changes` clean. No new tests (harness is not on the matching path).