### PR TITLE
fix(matching): close zero-fill IOC/FOK aggressor with terminal ER (#357)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -250,7 +250,7 @@ public sealed partial class ChannelDispatcher
                             _currentClOrdId = prioClOrd;
                             _crossSweepFilledQty = 0;
                             BeginAggressor(sweepLeg.Quantity);
-                            _engine.Submit(sweepLeg);
+                            _engine.SubmitCrossSweep(sweepLeg);
                             long swept = _crossSweepFilledQty.GetValueOrDefault();
                             _crossSweepFilledQty = null;
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -305,6 +305,24 @@ public sealed partial class ChannelDispatcher
     public void OnOrderCanceled(in OrderCanceledEvent e)
     {
         AssertOnLoopThread();
+
+        // Issue #357: an IOC/FOK aggressor that found zero crossing
+        // liquidity is cancelled by the engine to give the originating
+        // session a definitive terminal ER. The order never rested on
+        // the public book, so we skip the MBO DeleteOrder frame and
+        // route the ER directly via the active command context (the
+        // requester is the aggressor; no registry entry to evict).
+        if (e.Reason == CancelReason.IocUnmatched)
+        {
+            if (_hasCurrentSession)
+            {
+                _outbound.WriteExecutionReportPassiveCancel(_currentSession, _currentClOrdId, e.OrderId, e,
+                    _currentClOrdId, _currentReceivedTimeNanos, CurrentDurability);
+                _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);
+            }
+            return;
+        }
+
         var entryType = e.Side == Side.Buy
             ? B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeBid
             : B3.Umdf.WireEncoder.UmdfWireEncoder.MdEntryTypeOffer;

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -158,6 +158,12 @@ public enum CancelReason : byte
     /// in the uncross is removed when the auction phase resolves.
     /// Issue #232 / Onda M5.</summary>
     AuctionExpired,
+    /// <summary>IOC/FOK aggressor that found zero crossing liquidity on
+    /// submission (no fills, never rested on the book). Issue #357. The
+    /// integration layer emits only an <c>ExecutionReport_Cancel</c> back
+    /// to the originating session — no MBO frame, since the order was
+    /// never visible on the public book.</summary>
+    IocUnmatched,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -746,7 +746,22 @@ public sealed class MatchingEngine
         }
     }
 
-    public void Submit(NewOrderCommand cmd)
+    public void Submit(NewOrderCommand cmd) => SubmitImpl(cmd, emitUnmatchedIocClose: true);
+
+    /// <summary>
+    /// Internal entry point used by <c>ChannelDispatcher</c> for the
+    /// AgainstBook cross sweep leg (#218 / Onda L · L5). Semantically
+    /// identical to <see cref="Submit(NewOrderCommand)"/> except that a
+    /// zero-fill IOC outcome does NOT emit an
+    /// <see cref="CancelReason.IocUnmatched"/> closure event: the cross
+    /// workflow continues with phase-2 / phase-3 submissions reusing the
+    /// same per-leg ClOrdID and would observe a contradictory terminal
+    /// cancel for an order that is still active in the same cross.
+    /// Refs #357.
+    /// </summary>
+    public void SubmitCrossSweep(NewOrderCommand cmd) => SubmitImpl(cmd, emitUnmatchedIocClose: false);
+
+    private void SubmitImpl(NewOrderCommand cmd, bool emitUnmatchedIocClose)
     {
         EnterDispatch();
         try
@@ -920,7 +935,7 @@ public sealed class MatchingEngine
                 RestForAuction(cmd, book);
                 return;
             }
-            ExecuteAggressor(cmd, rules, book, emitUnmatchedIocClose: true);
+            ExecuteAggressor(cmd, rules, book, emitUnmatchedIocClose);
         }
         finally { ExitDispatch(); }
     }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -920,7 +920,7 @@ public sealed class MatchingEngine
                 RestForAuction(cmd, book);
                 return;
             }
-            ExecuteAggressor(cmd, rules, book);
+            ExecuteAggressor(cmd, rules, book, emitUnmatchedIocClose: true);
         }
         finally { ExitDispatch(); }
     }
@@ -1163,13 +1163,14 @@ public sealed class MatchingEngine
                 RestForAuction(replacement, book);
                 return;
             }
-            ExecuteAggressor(replacement, rules, book);
+            ExecuteAggressor(replacement, rules, book, emitUnmatchedIocClose: false);
         }
         finally { ExitDispatch(); }
     }
 
-    private void ExecuteAggressor(NewOrderCommand cmd, InstrumentTradingRules rules, LimitOrderBook book)
-        => ExecuteAggressorWithOrderId(cmd, rules, book, _nextOrderId++);
+    private void ExecuteAggressor(NewOrderCommand cmd, InstrumentTradingRules rules, LimitOrderBook book,
+        bool emitUnmatchedIocClose)
+        => ExecuteAggressorWithOrderId(cmd, rules, book, _nextOrderId++, emitUnmatchedIocClose);
 
     /// <summary>
     /// Issue #228 (Onda M · M1): rest the order on the book without any
@@ -1403,7 +1404,7 @@ public sealed class MatchingEngine
         => t == OrderType.Market || t == OrderType.MarketWithLeftover;
 
     private void ExecuteAggressorWithOrderId(NewOrderCommand cmd, InstrumentTradingRules rules,
-        LimitOrderBook book, long aggressorOrderIdForTrades)
+        LimitOrderBook book, long aggressorOrderIdForTrades, bool emitUnmatchedIocClose)
     {
         long aggressorRemaining = cmd.Quantity;
         bool isMarket = IsMarketLike(cmd.Type);
@@ -1605,8 +1606,28 @@ public sealed class MatchingEngine
             if (cmd.Tif == TimeInForce.IOC || cmd.Tif == TimeInForce.FOK)
             {
                 // FOK reaches here only via the pre-check (impossible for it to
-                // partially fill); IOC remainder is silently dropped from the book
-                // perspective — no MBO event needed for an order that never rested.
+                // partially fill); IOC remainder is silently dropped from the
+                // public-book perspective (no MBO event for an order that
+                // never rested). Issue #357: when this branch is reached on a
+                // *new* IOC/FOK submission (not via Replace or stop trigger)
+                // and STP did not pre-cancel the aggressor, emit a closure
+                // event so the originating session receives an
+                // ExecutionReport_Cancel acknowledging the terminal state.
+                // We only signal the zero-fills case here; partial-fill
+                // remainders are still implicitly closed by the last
+                // ER_Trade carrying LeavesQty=0 in cum/leaves accounting.
+                if (emitUnmatchedIocClose && !stpAggressorCanceled && !anyTrade)
+                {
+                    _sink.OnOrderCanceled(new OrderCanceledEvent(
+                        SecurityId: book.SecurityId,
+                        OrderId: aggressorOrderIdForTrades,
+                        Side: cmd.Side,
+                        PriceMantissa: cmd.PriceMantissa,
+                        RemainingQuantityAtCancel: aggressorRemaining,
+                        TransactTimeNanos: cmd.EnteredAtNanos,
+                        Reason: CancelReason.IocUnmatched,
+                        RptSeq: NextRptSeq()));
+                }
                 return;
             }
 
@@ -1868,7 +1889,7 @@ public sealed class MatchingEngine
         if (triggered.Type == OrderType.Market && book.BestLevel(LimitOrderBook.Opposite(triggered.Side)) is null)
             return;
 
-        ExecuteAggressorWithOrderId(triggered, rules, book, s.OrderId);
+        ExecuteAggressorWithOrderId(triggered, rules, book, s.OrderId, emitUnmatchedIocClose: false);
     }
 
     private void Reject(string clOrdId, long securityId, long orderId, RejectReason r, ulong txn)

--- a/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
+++ b/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
@@ -167,6 +167,12 @@ public class CrossOrderSemanticsTests
         // Residual sell leg is fully consumed by internal print → no
         // resting sell remains. The buy cross-residual rested first then
         // was filled by sell — final: book empty, no News for sell rests.
+
+        // Issue #357 regression: the cross-sweep IOC leg must NOT emit
+        // an IocUnmatched cancel even when the opposing public book is
+        // empty — the prioritized leg is still active in phase-2/3 of
+        // the same cross workflow under the same ClOrdID.
+        Assert.DoesNotContain(s.Cancels, c => c.Reason == CancelReason.IocUnmatched);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/IocUnmatchedClosureTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/IocUnmatchedClosureTests.cs
@@ -1,0 +1,147 @@
+namespace B3.Exchange.Matching.Tests;
+
+/// <summary>
+/// Issue #357: a new Limit IOC / Market IOC / FOK aggressor that finds
+/// zero crossing liquidity on submission must emit a terminal
+/// <see cref="OrderCanceledEvent"/> with reason
+/// <see cref="CancelReason.IocUnmatched"/> so the originating session
+/// receives an <c>ExecutionReport_Cancel</c> instead of hanging
+/// indefinitely. The signal must NOT fire on the Replace path or on a
+/// stop-triggered execution (both of those preserve the prior
+/// silent-drop semantics).
+/// </summary>
+public class IocUnmatchedClosureTests
+{
+    private static NewOrderCommand Limit(string id, Side side, decimal price, long qty,
+        TimeInForce tif = TimeInForce.IOC, uint firm = 1)
+        => new(id, TestFactory.PetrSecId, side, OrderType.Limit, tif,
+               TestFactory.Px(price), qty, firm, 0);
+
+    private static NewOrderCommand Market(string id, Side side, long qty,
+        TimeInForce tif = TimeInForce.IOC, uint firm = 1)
+        => new(id, TestFactory.PetrSecId, side, OrderType.Market, tif,
+               0, qty, firm, 0);
+
+    [Fact]
+    public void Limit_IOC_with_empty_opposite_emits_iocUnmatched_cancel()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+
+        engine.Submit(Limit("A1", Side.Sell, 32m, 100, tif: TimeInForce.IOC));
+
+        Assert.Empty(sink.Accepted);
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Rejects);
+        var cancel = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.IocUnmatched, cancel.Reason);
+        Assert.Equal(Side.Sell, cancel.Side);
+        Assert.Equal(100, cancel.RemainingQuantityAtCancel);
+        Assert.Equal(TestFactory.Px(32m), cancel.PriceMantissa);
+    }
+
+    [Fact]
+    public void Limit_IOC_non_crossing_against_resting_emits_iocUnmatched_cancel()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        // Resting bid @ 31 — does not cross an IOC sell @ 32.
+        engine.Submit(new NewOrderCommand("M1", TestFactory.PetrSecId, Side.Buy,
+            OrderType.Limit, TimeInForce.Day, TestFactory.Px(31m), 100, EnteringFirm: 8, EnteredAtNanos: 0));
+        sink.Clear();
+
+        engine.Submit(Limit("A1", Side.Sell, 32m, 100, tif: TimeInForce.IOC));
+
+        Assert.Empty(sink.Trades);
+        Assert.Empty(sink.Accepted);
+        var cancel = Assert.Single(sink.Canceled);
+        Assert.Equal(CancelReason.IocUnmatched, cancel.Reason);
+    }
+
+    [Fact]
+    public void Limit_IOC_with_partial_fill_does_not_emit_iocUnmatched_cancel()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(new NewOrderCommand("M1", TestFactory.PetrSecId, Side.Buy,
+            OrderType.Limit, TimeInForce.Day, TestFactory.Px(32m), 400, EnteringFirm: 8, EnteredAtNanos: 0));
+        sink.Clear();
+
+        // IOC sell of 1000 @ 32 takes 400 from the resting bid; remaining 600
+        // is silently dropped without an iocUnmatched cancel (the trade
+        // event already terminates the aggressor for this issue's scope).
+        engine.Submit(Limit("A1", Side.Sell, 32m, 1000, tif: TimeInForce.IOC));
+
+        Assert.Single(sink.Trades);
+        Assert.DoesNotContain(sink.Canceled, c => c.Reason == CancelReason.IocUnmatched);
+    }
+
+    [Fact]
+    public void Market_IOC_with_empty_opposite_is_preRejected_not_iocUnmatched()
+    {
+        // Pre-existing behavior (MarketNoLiquidity reject) takes precedence
+        // over the new IocUnmatched closure for Market orders against empty.
+        var engine = TestFactory.NewEngine(out var sink);
+
+        engine.Submit(Market("A1", Side.Sell, 100, tif: TimeInForce.IOC));
+
+        var reject = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.MarketNoLiquidity, reject.Reason);
+        Assert.Empty(sink.Canceled);
+    }
+
+    [Fact]
+    public void FOK_with_empty_opposite_is_preRejected_not_iocUnmatched()
+    {
+        // FOK with no crossing liquidity is rejected upfront with
+        // FokUnfillable — preserves existing behavior.
+        var engine = TestFactory.NewEngine(out var sink);
+
+        engine.Submit(Limit("A1", Side.Sell, 32m, 100, tif: TimeInForce.FOK));
+
+        var reject = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.FokUnfillable, reject.Reason);
+        Assert.Empty(sink.Canceled);
+    }
+
+    [Fact]
+    public void Replace_to_IOC_with_empty_counter_side_does_not_emit_iocUnmatched()
+    {
+        // Issue #357 must NOT change the Replace-to-IOC silent-drop semantics
+        // covered by ReplaceTypeAndTifTests — the original order's DEL is the
+        // closure signal there; the re-entered IOC remainder stays silent.
+        var engine = TestFactory.NewEngine(out var sink);
+        engine.Submit(new NewOrderCommand("M1", TestFactory.PetrSecId, Side.Buy,
+            OrderType.Limit, TimeInForce.Day, TestFactory.Px(10m), 100, EnteringFirm: 1, EnteredAtNanos: 0));
+        var original = sink.Accepted.Single();
+        sink.Clear();
+
+        // Replace to a worse price with TIF=IOC against empty counter side.
+        engine.Replace(new ReplaceOrderCommand("R1", TestFactory.PetrSecId,
+            original.OrderId, TestFactory.Px(11m), 100, 0)
+        { NewTif = TimeInForce.IOC });
+
+        // Original is canceled via ReplaceLostPriority; the re-entered IOC
+        // finds no crossing liquidity and is silently dropped — no
+        // IocUnmatched cancel from the Replace path.
+        Assert.DoesNotContain(sink.Canceled, c => c.Reason == CancelReason.IocUnmatched);
+    }
+
+    [Fact]
+    public void Stp_cancelAggressor_does_not_double_emit_iocUnmatched()
+    {
+        // STP=CancelAggressor pre-cancels the IOC aggressor mid-walk before
+        // any trades print. The silent-drop branch is reached with
+        // stpAggressorCanceled=true and anyTrade=false; we must NOT emit a
+        // second cancel event (the STP path is already a terminal signal).
+        var sink = new RecordingSink();
+        var engine = new MatchingEngine(new[] { TestFactory.Petr4 }, sink,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<MatchingEngine>.Instance,
+            SelfTradePrevention.CancelAggressor);
+        engine.Submit(new NewOrderCommand("M1", TestFactory.PetrSecId, Side.Buy,
+            OrderType.Limit, TimeInForce.Day, TestFactory.Px(32m), 100, EnteringFirm: 7, EnteredAtNanos: 0));
+        sink.Clear();
+
+        engine.Submit(Limit("A1", Side.Sell, 32m, 100, tif: TimeInForce.IOC, firm: 7));
+
+        Assert.Empty(sink.Trades);
+        Assert.DoesNotContain(sink.Canceled, c => c.Reason == CancelReason.IocUnmatched);
+    }
+}


### PR DESCRIPTION
Closes #357.

## Problem

`MatchingEngine.ExecuteAggressorWithOrderId` silently dropped a Limit IOC / Limit FOK aggressor that walked the opposite book and found no crossing liquidity. The originating session was left waiting indefinitely for an ExecutionReport. Also the root cause of the intermittent flake masked test-side in #326.

## Fix

Engine emits `OnOrderCanceled(reason=IocUnmatched)` in the silent-drop branch when:
- the aggressor came in via `Submit` (NOT via `Replace` or stop trigger),
- no trades were emitted during the walk, AND
- self-trade prevention did not pre-cancel the aggressor.

Integration (`ChannelDispatcher.OnOrderCanceled`) detects the new reason and routes ER_Cancel via active session **without** emitting an MBO DeleteOrder frame (order never reached the public book).

## Scoping decisions

| Path | Behavior |
|---|---|
| `Submit` → IOC empty book | **New**: emits `IocUnmatched` cancel ER |
| `Submit` → Market IOC empty book | Unchanged: pre-rejected `MarketNoLiquidity` (takes precedence) |
| `Submit` → FOK no-fill | Unchanged: pre-rejected `FokUnfillable` (takes precedence) |
| `Submit` → IOC partial fill | Unchanged: closed by last ER_Trade |
| `Replace` → IOC silent drop | Unchanged: original is canceled via ReplaceLostPriority; IOC remainder stays silent |
| Stop trigger → empty book | Unchanged: stop expires silently per #214 comment |
| STP=CancelAggressor + zero fills | Unchanged: STP already terminal, no double-emit |

## Tests

7 new tests in `IocUnmatchedClosureTests.cs` covering each row above. Full suite green (1170+ tests).

## Files

- `src/B3.Exchange.Matching/Commands.cs` — add `CancelReason.IocUnmatched`.
- `src/B3.Exchange.Matching/MatchingEngine.cs` — emit closure event in silent-drop branch; plumb `emitUnmatchedIocClose` flag through `ExecuteAggressor` / `ExecuteAggressorWithOrderId`; Submit passes `true`, Replace / stop-trigger pass `false`.
- `src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs` — gate `OnOrderCanceled` MBO emit + registry eviction; for `IocUnmatched` route ER via `_currentSession` / `_currentClOrdId` with no MBO.
- `tests/B3.Exchange.Matching.Tests/IocUnmatchedClosureTests.cs` — new test file.