### PR TITLE
feat(post-trade): schema-v2 audit codec + reader dispatch (ADR 0008 PR-1)

### DIFF
--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -15,30 +15,81 @@ namespace B3.Exchange.PostTrade;
 public static class AuditLogReader
 {
     /// <summary>Opens <paramref name="path"/>, validates the file header,
-    /// and yields every record in order. Throws
+    /// and yields every fill record in order. Throws
     /// <see cref="InvalidDataException"/> on an unreadable header
     /// (mismatched magic/version/date) — that is unrecoverable corruption,
-    /// not a torn tail.</summary>
+    /// not a torn tail.
+    ///
+    /// **Schema-v2 files** (ADR 0008): bust and reject-attempt records
+    /// are silently skipped so this API keeps its v1-era "fills only"
+    /// contract. Callers that need the full event stream use
+    /// <see cref="ReadAllEntries(string)"/>.</summary>
     public static IEnumerable<PostTradeRecord> ReadAll(string path)
+    {
+        foreach (var entry in ReadAllEntries(path))
+        {
+            if (entry.Kind == AuditRecordKind.Fill)
+                yield return entry.Fill;
+        }
+    }
+
+    /// <summary>Opens <paramref name="path"/>, validates the file header,
+    /// and yields every record (fill / bust / reject-attempt) in the
+    /// order they were written. The per-file schema view (ADR 0008 §1)
+    /// applies: v1 files contain only fills (anything else is corruption
+    /// and ends the read); v2 files dispatch by <c>recordLen</c>.
+    ///
+    /// Torn-tail semantics are unchanged from <see cref="ReadAll(string)"/>:
+    /// short reads, unknown record lengths, recordType mismatches, and
+    /// CRC failures all terminate iteration cleanly rather than throwing,
+    /// matching the standard append-only-log convention.</summary>
+    public static IEnumerable<AuditEntry> ReadAllEntries(string path)
     {
         using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
         var header = new byte[AuditRecordCodec.FileHeaderSize];
         int hr = ReadFully(fs, header, 0, header.Length);
         if (hr != header.Length)
             throw new InvalidDataException($"audit file '{path}' truncated in header (got {hr} bytes)");
-        _ = AuditRecordCodec.ReadFileHeader(header);
+        var (_, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(header);
 
-        var buffer = new byte[AuditRecordCodec.RecordSize];
+        var buffer = new byte[AuditRecordCodec.MaxRecordSize];
         while (true)
         {
-            int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
-            if (read == 0)
+            // Peek the length prefix to dispatch record type.
+            int prefixRead = ReadFully(fs, buffer, 0, 4);
+            if (prefixRead == 0) yield break;
+            if (prefixRead < 4) yield break;
+            if (!AuditRecordCodec.TryPeekRecordLen(buffer.AsSpan(0, 4), out var recordLen))
                 yield break;
-            if (read < AuditRecordCodec.RecordSize)
+            if (!AuditRecordCodec.TryGetRecordSize(recordLen, out var totalSize, out var kind))
                 yield break;
-            if (!AuditRecordCodec.TryDecode(buffer, out var record))
+            // v1 files only ever carry fills; anything else is corruption.
+            if (schemaVersion == AuditRecordCodec.SchemaVersionV1 && kind != AuditRecordKind.Fill)
                 yield break;
-            yield return record;
+
+            int bodyRead = ReadFully(fs, buffer, 4, totalSize - 4);
+            if (bodyRead < totalSize - 4) yield break;
+
+            switch (kind)
+            {
+                case AuditRecordKind.Fill:
+                    if (!AuditRecordCodec.TryDecode(buffer.AsSpan(0, totalSize), out var fill))
+                        yield break;
+                    yield return new AuditEntry(in fill);
+                    break;
+                case AuditRecordKind.Bust:
+                    if (!AuditRecordCodec.TryDecodeBust(buffer.AsSpan(0, totalSize), out var bust))
+                        yield break;
+                    yield return new AuditEntry(in bust);
+                    break;
+                case AuditRecordKind.RejectAttempt:
+                    if (!AuditRecordCodec.TryDecodeRejectAttempt(buffer.AsSpan(0, totalSize), out var rej))
+                        yield break;
+                    yield return new AuditEntry(in rej);
+                    break;
+                default:
+                    yield break;
+            }
         }
     }
 
@@ -86,7 +137,7 @@ public static class AuditLogReader
         int hr = ReadFully(fs, header, 0, header.Length);
         if (hr != header.Length)
             throw new InvalidDataException($"audit file '{logPath}' truncated in header (got {hr} bytes)");
-        _ = AuditRecordCodec.ReadFileHeader(header);
+        var (_, _, _) = AuditRecordCodec.ReadFileHeader(header);
 
         var buffer = new byte[AuditRecordCodec.RecordSize];
         // 1) Indexed candidates — seek directly to each block.

--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -137,7 +137,18 @@ public static class AuditLogReader
         int hr = ReadFully(fs, header, 0, header.Length);
         if (hr != header.Length)
             throw new InvalidDataException($"audit file '{logPath}' truncated in header (got {hr} bytes)");
-        var (_, _, _) = AuditRecordCodec.ReadFileHeader(header);
+        var (_, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(header);
+        // ADR 0008 §1 / issue #369 PR-1: the firm-sparse index assumes
+        // uniform fixed-width fill records. v2 files can carry variable-
+        // length bust/reject-attempt records, which would desync the
+        // 85-byte fixed-stride scan below and silently under-report. PR-2
+        // teaches both the index codec and this reader to handle mixed
+        // record sizes; until then, refuse v2 firm-filtered reads
+        // explicitly rather than returning a partial result.
+        if (schemaVersion != AuditRecordCodec.SchemaVersionV1)
+            throw new NotSupportedException(
+                $"ReadByFirm does not yet support schema v{schemaVersion} (PR-2 will add mixed-record dispatch); "
+                + "use ReadAllEntries for the time being");
 
         var buffer = new byte[AuditRecordCodec.RecordSize];
         // 1) Indexed candidates — seek directly to each block.

--- a/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
@@ -6,25 +6,23 @@ namespace B3.Exchange.PostTrade;
 
 /// <summary>
 /// Byte-level encoder/decoder for the on-disk post-trade audit log
-/// (issue #329 PR-2). Wire layout is fixed-width little-endian and
-/// schema-versioned via the file header — the record body is identical
-/// across <see cref="SchemaVersion"/>=1 deployments.
+/// (issue #329 PR-2; extended for ADR 0008 / issue #369 PR-1 with
+/// schema-v2 bust + reject-attempt records).
 ///
 /// File header (<see cref="FileHeaderSize"/> = 24 bytes):
 /// <code>
 ///   magic "B3PT" (4)
-///   schemaVersion (uint16)
+///   schemaVersion (uint16)   1 = fills only (legacy)
+///                            2 = fills + busts + reject-attempts (ADR 0008)
 ///   reserved      (uint16)
 ///   channelNumber (uint8)
 ///   pad           (3 bytes)
 ///   tradeDate ASCII YYYY-MM-DD (10 bytes)
 /// </code>
 ///
-/// Record (<see cref="RecordSize"/> = 85 bytes total, including the
-/// length+crc header so the on-disk byte count matches the value
-/// returned by <see cref="Encode"/>):
+/// Fill record body (recordLen = 81, total on-disk = 85 bytes):
 /// <code>
-///   recordLen          (uint32) bytes following this field (always 77)
+///   recordLen          (uint32) bytes following this field (always 81)
 ///   crc32             (uint32) over the body that follows
 ///   tradeId            (uint32)
 ///   transactTimeNanos  (uint64)
@@ -39,27 +37,108 @@ namespace B3.Exchange.PostTrade;
 ///   buyOrderId         (int64)
 ///   sellOrderId        (int64)
 /// </code>
+/// The fill body is bit-identical between v1 and v2 — there is NO
+/// discriminator byte at the head of a fill body. v1 files contain
+/// only fill records (any other recordLen is corruption); v2 files
+/// dispatch by recordLen (see <see cref="PeekRecordLen"/>).
 ///
-/// CRC32 (IEEE 802.3) covers every byte after the crc field (i.e. the record body
-/// from tradeId through sellOrderId). recordLen and crc32 are NOT
-/// covered — recordLen is needed before reading the body, and crc32
-/// is obviously what's being verified.
+/// Bust record body (schema v2, recordLen = 40, total = 44 bytes,
+/// ADR 0008 §1.1):
+/// <code>
+///   recordLen                 (uint32) always 40
+///   crc32                    (uint32) over the body that follows
+///   recordType                (uint8)  always 0x02
+///   reserved                  (uint8)  always 0
+///   cancelledTradeId          (uint32)
+///   bustTransactTimeNanos     (uint64)
+///   securityId                (int64)  echo from original fill
+///   reasonCode                (uint16) see ADR 0008 §2.2
+///   busterFirm                (uint32)
+///   correlationId             (uint64)
+/// </code>
+///
+/// Reject-attempt record body (schema v2, recordLen = 36, total = 40
+/// bytes, ADR 0008 §2.5):
+/// <code>
+///   recordLen                 (uint32) always 36
+///   crc32                    (uint32) over the body that follows
+///   recordType                (uint8)  always 0x03
+///   reserved                  (uint8)  always 0
+///   attemptedTradeId          (uint32)
+///   attemptTransactTimeNanos  (uint64)
+///   declaredTradeDate         (int32)  LocalMktDate (days since 1970-01-01); 0 if absent
+///   rejectCode                (uint16) see ADR 0008 §2.5
+///   busterFirm                (uint32)
+///   correlationId             (uint64)
+/// </code>
+///
+/// CRC32 (IEEE 802.3) covers every byte after the crc field. recordLen
+/// and crc32 are NOT covered.
+///
+/// **Dispatch by recordLen** (ADR 0008 §1): a v2 reader peeks the
+/// recordLen, looks up the type, and cross-checks the leading
+/// recordType byte against the dispatched type. A mismatch is treated
+/// as corruption, same policy as a CRC failure. Unknown recordLen on
+/// a v1 file is corruption; unknown recordLen on a v2 file is also
+/// corruption (no forward-compat record types in this build).
 /// </summary>
 public static class AuditRecordCodec
 {
-    public const ushort SchemaVersion = 1;
+    /// <summary>The schema version this build writes for newly-created
+    /// audit files. Existing v1 files are accepted on read and on
+    /// resume; the writer never bumps an in-place header
+    /// (per-day schema view, ADR 0008 §1).</summary>
+    public const ushort SchemaVersion = SchemaVersionV1;
+
+    /// <summary>Legacy fills-only schema (issue #329).</summary>
+    public const ushort SchemaVersionV1 = 1;
+
+    /// <summary>ADR 0008 / issue #369 schema. Adds bust + reject-attempt
+    /// records on the same stream; fill body is byte-for-byte identical
+    /// to v1.</summary>
+    public const ushort SchemaVersionV2 = 2;
+
     public const int FileHeaderSize = 24;
+
+    // Fill (unchanged from v1).
     public const int RecordBodySize = 77;
     public const int RecordSize = RecordBodySize + 8; // +4 recordLen +4 crc32
+    public const uint FillRecordLen = (uint)(RecordSize - 4); // 81
+
+    // Bust (ADR 0008 §1.1).
+    public const int BustRecordBodySize = 36;
+    public const int BustRecordSize = BustRecordBodySize + 8; // 44
+    public const uint BustRecordLen = (uint)(BustRecordSize - 4); // 40
+    public const byte RecordTypeBust = 0x02;
+
+    // Reject-attempt (ADR 0008 §2.5).
+    public const int RejectAttemptRecordBodySize = 32;
+    public const int RejectAttemptRecordSize = RejectAttemptRecordBodySize + 8; // 40
+    public const uint RejectAttemptRecordLen = (uint)(RejectAttemptRecordSize - 4); // 36
+    public const byte RecordTypeRejectAttempt = 0x03;
+
+    /// <summary>Largest on-disk record across all supported schemas.
+    /// Callers sizing scratch buffers must use this constant.</summary>
+    public const int MaxRecordSize = RecordSize; // 85 (fills are largest)
 
     private const uint MagicB3PT = 0x5450_3342u; // "B3PT" little-endian
 
     public static void WriteFileHeader(Span<byte> dst, byte channelNumber, DateOnly tradeDate)
+        => WriteFileHeader(dst, channelNumber, tradeDate, SchemaVersion);
+
+    /// <summary>Writes a file header with an explicit schema version.
+    /// Production callers use the parameterless overload (current
+    /// build's <see cref="SchemaVersion"/>); the explicit overload
+    /// exists so tests can stage fixture files at any supported
+    /// version without monkey-patching the constant.</summary>
+    public static void WriteFileHeader(Span<byte> dst, byte channelNumber, DateOnly tradeDate, ushort schemaVersion)
     {
         if (dst.Length < FileHeaderSize)
             throw new ArgumentException($"buffer too small ({dst.Length}<{FileHeaderSize})", nameof(dst));
+        if (schemaVersion is not (SchemaVersionV1 or SchemaVersionV2))
+            throw new ArgumentOutOfRangeException(nameof(schemaVersion), schemaVersion, "supported versions: 1, 2");
         BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), MagicB3PT);
-        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4, 2), SchemaVersion);
+        BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4, 2), schemaVersion);
         BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(6, 2), 0);
         dst[8] = channelNumber;
         dst[9] = 0; dst[10] = 0; dst[11] = 0;
@@ -76,8 +155,10 @@ public static class AuditRecordCodec
     /// <summary>
     /// Decodes a file header. Throws <see cref="InvalidDataException"/> if
     /// the magic, schema version, or trade-date encoding is corrupt.
+    /// The returned <c>SchemaVersion</c> is the per-file version the
+    /// reader must dispatch on (ADR 0008 §1 per-day schema view).
     /// </summary>
-    public static (byte ChannelNumber, DateOnly TradeDate) ReadFileHeader(ReadOnlySpan<byte> src)
+    public static (byte ChannelNumber, DateOnly TradeDate, ushort SchemaVersion) ReadFileHeader(ReadOnlySpan<byte> src)
     {
         if (src.Length < FileHeaderSize)
             throw new InvalidDataException("audit file truncated in header");
@@ -85,15 +166,57 @@ public static class AuditRecordCodec
         if (magic != MagicB3PT)
             throw new InvalidDataException($"audit file magic mismatch: 0x{magic:X8}");
         var version = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(4, 2));
-        if (version != SchemaVersion)
-            throw new InvalidDataException($"audit file schema version {version} unsupported (this build expects {SchemaVersion})");
+        if (version is not (SchemaVersionV1 or SchemaVersionV2))
+            throw new InvalidDataException($"audit file schema version {version} unsupported (this build accepts {SchemaVersionV1} or {SchemaVersionV2})");
         byte channel = src[8];
         if (src[9] != 0 || src[10] != 0 || src[11] != 0 || src[22] != 0 || src[23] != 0)
             throw new InvalidDataException("audit file reserved bytes non-zero");
         var iso = System.Text.Encoding.ASCII.GetString(src.Slice(12, 10));
         if (!DateOnly.TryParseExact(iso, "yyyy-MM-dd", null, System.Globalization.DateTimeStyles.None, out var date))
             throw new InvalidDataException($"audit file tradeDate field invalid: '{iso}'");
-        return (channel, date);
+        return (channel, date, version);
+    }
+
+    /// <summary>Peeks the <c>recordLen</c> field of a framed record so
+    /// the reader can dispatch by record type before allocating a
+    /// type-specific scratch buffer. Returns false when the buffer is
+    /// too short to even hold the length prefix.</summary>
+    public static bool TryPeekRecordLen(ReadOnlySpan<byte> src, out uint recordLen)
+    {
+        if (src.Length < 4)
+        {
+            recordLen = 0;
+            return false;
+        }
+        recordLen = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
+        return true;
+    }
+
+    /// <summary>Maps a <c>recordLen</c> to its on-disk byte size
+    /// (= <c>4 + recordLen</c>). Returns false for unrecognised lengths
+    /// — that is the corruption signal a v2 dispatch loop must short-
+    /// circuit on (same policy as a CRC failure: "log ends here").</summary>
+    public static bool TryGetRecordSize(uint recordLen, out int totalSize, out AuditRecordKind kind)
+    {
+        switch (recordLen)
+        {
+            case FillRecordLen:
+                totalSize = RecordSize;
+                kind = AuditRecordKind.Fill;
+                return true;
+            case BustRecordLen:
+                totalSize = BustRecordSize;
+                kind = AuditRecordKind.Bust;
+                return true;
+            case RejectAttemptRecordLen:
+                totalSize = RejectAttemptRecordSize;
+                kind = AuditRecordKind.RejectAttempt;
+                return true;
+            default:
+                totalSize = 0;
+                kind = default;
+                return false;
+        }
     }
 
     /// <summary>Encodes <paramref name="record"/> into <paramref name="dst"/>.
@@ -172,5 +295,194 @@ public static class AuditRecordCodec
         Span<byte> hash = stackalloc byte[4];
         Crc32.Hash(data, hash);
         return BinaryPrimitives.ReadUInt32LittleEndian(hash);
+    }
+
+    // -----------------------------------------------------------------
+    // ADR 0008 / issue #369 PR-1 — schema-v2 record types.
+    // Fill encode/decode is unchanged above; the methods below add the
+    // bust and reject-attempt shapes. No call sites in PR-1 yet — the
+    // writer extension lands in PR-2.
+    // -----------------------------------------------------------------
+
+    /// <summary>Encodes a <see cref="BustRecord"/> (ADR 0008 §1.1) into
+    /// <paramref name="dst"/>. Returns the number of bytes written
+    /// (always <see cref="BustRecordSize"/>).</summary>
+    public static int EncodeBust(Span<byte> dst, in BustRecord record)
+    {
+        if (dst.Length < BustRecordSize)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{BustRecordSize})", nameof(dst));
+
+        var body = dst.Slice(8, BustRecordBodySize);
+        int p = 0;
+        body[p] = RecordTypeBust; p += 1;
+        body[p] = 0; p += 1;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.CancelledTradeId); p += 4;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.BustTransactTimeNanos); p += 8;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(p, 8), record.SecurityId); p += 8;
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(p, 2), record.ReasonCode); p += 2;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.BusterFirm); p += 4;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.CorrelationId); p += 8;
+        if (p != BustRecordBodySize)
+            throw new InvalidOperationException($"BUG: encoded {p} bust body bytes, expected {BustRecordBodySize}");
+
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), BustRecordLen);
+        var crc = ComputeCrc(body);
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(4, 4), crc);
+        return BustRecordSize;
+    }
+
+    /// <summary>Decodes one bust record. Same failure semantics as
+    /// <see cref="TryDecode"/>: returns false on short buffer, wrong
+    /// length prefix, recordType mismatch, or CRC failure.</summary>
+    public static bool TryDecodeBust(ReadOnlySpan<byte> src, out BustRecord record)
+    {
+        record = default;
+        if (src.Length < BustRecordSize) return false;
+        uint declaredLen = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
+        if (declaredLen != BustRecordLen) return false;
+        uint storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(4, 4));
+        var body = src.Slice(8, BustRecordBodySize);
+        if (ComputeCrc(body) != storedCrc) return false;
+
+        // Cross-check the leading recordType byte against the dispatched
+        // length (defence-in-depth per ADR 0008 §1). A mismatch is
+        // treated as corruption.
+        if (body[0] != RecordTypeBust) return false;
+        if (body[1] != 0) return false;
+
+        int p = 2;
+        uint cancelledTradeId = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong bustTs = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        long secId = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        ushort reasonCode = BinaryPrimitives.ReadUInt16LittleEndian(body.Slice(p, 2)); p += 2;
+        uint busterFirm = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong correlationId = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        _ = p;
+
+        record = new BustRecord(cancelledTradeId, bustTs, secId, reasonCode, busterFirm, correlationId);
+        return true;
+    }
+
+    /// <summary>Encodes a <see cref="RejectAttemptRecord"/> (ADR 0008
+    /// §2.5) into <paramref name="dst"/>. Returns the number of bytes
+    /// written (always <see cref="RejectAttemptRecordSize"/>).</summary>
+    public static int EncodeRejectAttempt(Span<byte> dst, in RejectAttemptRecord record)
+    {
+        if (dst.Length < RejectAttemptRecordSize)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{RejectAttemptRecordSize})", nameof(dst));
+
+        var body = dst.Slice(8, RejectAttemptRecordBodySize);
+        int p = 0;
+        body[p] = RecordTypeRejectAttempt; p += 1;
+        body[p] = 0; p += 1;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.AttemptedTradeId); p += 4;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.AttemptTransactTimeNanos); p += 8;
+        BinaryPrimitives.WriteInt32LittleEndian(body.Slice(p, 4), record.DeclaredTradeDateDays); p += 4;
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(p, 2), record.RejectCode); p += 2;
+        BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.BusterFirm); p += 4;
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.CorrelationId); p += 8;
+        if (p != RejectAttemptRecordBodySize)
+            throw new InvalidOperationException($"BUG: encoded {p} reject-attempt body bytes, expected {RejectAttemptRecordBodySize}");
+
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), RejectAttemptRecordLen);
+        var crc = ComputeCrc(body);
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(4, 4), crc);
+        return RejectAttemptRecordSize;
+    }
+
+    /// <summary>Decodes one reject-attempt record. Same failure
+    /// semantics as <see cref="TryDecode"/>.</summary>
+    public static bool TryDecodeRejectAttempt(ReadOnlySpan<byte> src, out RejectAttemptRecord record)
+    {
+        record = default;
+        if (src.Length < RejectAttemptRecordSize) return false;
+        uint declaredLen = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
+        if (declaredLen != RejectAttemptRecordLen) return false;
+        uint storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(4, 4));
+        var body = src.Slice(8, RejectAttemptRecordBodySize);
+        if (ComputeCrc(body) != storedCrc) return false;
+
+        if (body[0] != RecordTypeRejectAttempt) return false;
+        if (body[1] != 0) return false;
+
+        int p = 2;
+        uint attemptedTradeId = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong attemptTs = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        int declaredDate = BinaryPrimitives.ReadInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ushort rejectCode = BinaryPrimitives.ReadUInt16LittleEndian(body.Slice(p, 2)); p += 2;
+        uint busterFirm = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong correlationId = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        _ = p;
+
+        record = new RejectAttemptRecord(attemptedTradeId, attemptTs, declaredDate, rejectCode, busterFirm, correlationId);
+        return true;
+    }
+}
+
+/// <summary>Discriminator for a framed audit record's type, returned
+/// by <see cref="AuditRecordCodec.TryGetRecordSize"/> so callers can
+/// route to the correct type-specific decoder without re-parsing the
+/// recordLen.</summary>
+public enum AuditRecordKind : byte
+{
+    Fill = 0,
+    Bust = AuditRecordCodec.RecordTypeBust,
+    RejectAttempt = AuditRecordCodec.RecordTypeRejectAttempt,
+}
+
+/// <summary>Bust record body (ADR 0008 §1.1). On disk the record is
+/// CRC-framed by <see cref="AuditRecordCodec.EncodeBust"/>.</summary>
+public readonly record struct BustRecord(
+    uint CancelledTradeId,
+    ulong BustTransactTimeNanos,
+    long SecurityId,
+    ushort ReasonCode,
+    uint BusterFirm,
+    ulong CorrelationId);
+
+/// <summary>Reject-attempt record body (ADR 0008 §2.5). On disk the
+/// record is CRC-framed by
+/// <see cref="AuditRecordCodec.EncodeRejectAttempt"/>.</summary>
+public readonly record struct RejectAttemptRecord(
+    uint AttemptedTradeId,
+    ulong AttemptTransactTimeNanos,
+    int DeclaredTradeDateDays,
+    ushort RejectCode,
+    uint BusterFirm,
+    ulong CorrelationId);
+
+/// <summary>Union of every record type a schema-v2 audit log can
+/// contain. Exactly one of <see cref="Fill"/>, <see cref="Bust"/>, or
+/// <see cref="RejectAttempt"/> is set per instance, indicated by
+/// <see cref="Kind"/>.</summary>
+public readonly record struct AuditEntry
+{
+    public AuditRecordKind Kind { get; }
+    public PostTradeRecord Fill { get; }
+    public BustRecord Bust { get; }
+    public RejectAttemptRecord RejectAttempt { get; }
+
+    public AuditEntry(in PostTradeRecord fill)
+    {
+        Kind = AuditRecordKind.Fill;
+        Fill = fill;
+        Bust = default;
+        RejectAttempt = default;
+    }
+
+    public AuditEntry(in BustRecord bust)
+    {
+        Kind = AuditRecordKind.Bust;
+        Fill = default;
+        Bust = bust;
+        RejectAttempt = default;
+    }
+
+    public AuditEntry(in RejectAttemptRecord rejectAttempt)
+    {
+        Kind = AuditRecordKind.RejectAttempt;
+        Fill = default;
+        Bust = default;
+        RejectAttempt = rejectAttempt;
     }
 }

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -436,7 +436,7 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         Span<byte> hdr = stackalloc byte[AuditRecordCodec.FileHeaderSize];
         if (fs.Read(hdr) != hdr.Length)
             throw new InvalidDataException($"audit file '{fs.Name}' truncated in header");
-        var (channel, _) = AuditRecordCodec.ReadFileHeader(hdr);
+        var (channel, _, _) = AuditRecordCodec.ReadFileHeader(hdr);
         if (channel != _channelNumber)
             throw new InvalidDataException($"audit file '{fs.Name}' channel mismatch (file={channel}, writer={_channelNumber})");
 

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -436,9 +436,20 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         Span<byte> hdr = stackalloc byte[AuditRecordCodec.FileHeaderSize];
         if (fs.Read(hdr) != hdr.Length)
             throw new InvalidDataException($"audit file '{fs.Name}' truncated in header");
-        var (channel, _, _) = AuditRecordCodec.ReadFileHeader(hdr);
+        var (channel, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(hdr);
         if (channel != _channelNumber)
             throw new InvalidDataException($"audit file '{fs.Name}' channel mismatch (file={channel}, writer={_channelNumber})");
+        // ADR 0008 §1 per-day schema view: this build's writer only emits
+        // v1 records, so refuse to extend an existing file at a different
+        // schema. Critical safety net: without this check, the v1 fixed-
+        // width scan below would stop at the first non-fill record in a
+        // v2 file and the caller would SetLength() to that point, silently
+        // truncating valid bust/reject-attempt records. PR-2 replaces this
+        // with a schema-aware recovery path.
+        if (schemaVersion != AuditRecordCodec.SchemaVersion)
+            throw new InvalidDataException(
+                $"audit file '{fs.Name}' schema {schemaVersion} != writer schema {AuditRecordCodec.SchemaVersion}; "
+                + "refusing to extend (would risk truncating non-fill records)");
 
         long goodEnd = AuditRecordCodec.FileHeaderSize;
         Span<byte> rec = stackalloc byte[AuditRecordCodec.RecordSize];

--- a/tests/B3.Exchange.PostTrade.Tests/AuditLogReaderV2Tests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditLogReaderV2Tests.cs
@@ -1,0 +1,203 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>
+/// Tests for the schema-v2 reader dispatch added in ADR 0008 PR-1
+/// (issue #369). Exercises the per-recordLen routing in
+/// <see cref="AuditLogReader.ReadAllEntries"/> on hand-built fixture
+/// files so we don't depend on the writer (which is not yet emitting
+/// non-fill records in this PR).
+/// </summary>
+public class AuditLogReaderV2Tests
+{
+    private static PostTradeRecord SampleFill(uint tradeId = 1, uint buyFirm = 100, uint sellFirm = 200) => new(
+        TradeId: tradeId, TransactTimeNanos: 1_700_000_000_000_000_000UL + tradeId,
+        SecurityId: 900_000_000_001L, AggressorSide: Side.Buy,
+        Quantity: 100, PriceMantissa: 12_345_678L,
+        BuyClOrdId: tradeId * 10UL, SellClOrdId: tradeId * 10UL + 1,
+        BuyFirm: buyFirm, SellFirm: sellFirm,
+        BuyOrderId: 1000 + tradeId, SellOrderId: 2000 + tradeId);
+
+    private static BustRecord SampleBust(uint cancelledTradeId, ulong correlationId) => new(
+        CancelledTradeId: cancelledTradeId,
+        BustTransactTimeNanos: 1_700_000_000_500_000_000UL,
+        SecurityId: 900_000_000_001L, ReasonCode: 1,
+        BusterFirm: 999, CorrelationId: correlationId);
+
+    private static RejectAttemptRecord SampleRejectAttempt(uint attemptedTradeId, ulong correlationId, ushort rejectCode) => new(
+        AttemptedTradeId: attemptedTradeId,
+        AttemptTransactTimeNanos: 1_700_000_000_600_000_000UL,
+        DeclaredTradeDateDays: 20597, RejectCode: rejectCode,
+        BusterFirm: 999, CorrelationId: correlationId);
+
+    private static string WriteFixture(
+        string path,
+        byte channelNumber,
+        DateOnly tradeDate,
+        ushort schemaVersion,
+        Action<FileStream> writeBody)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None);
+        var header = new byte[AuditRecordCodec.FileHeaderSize];
+        AuditRecordCodec.WriteFileHeader(header, channelNumber, tradeDate, schemaVersion);
+        fs.Write(header, 0, header.Length);
+        writeBody(fs);
+        return path;
+    }
+
+    [Fact]
+    public void ReadAllEntries_OnV1File_YieldsOnlyFills_InOrder()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"audit-v1-{Guid.NewGuid():N}.log");
+        try
+        {
+            var fillA = SampleFill(1);
+            var fillB = SampleFill(2);
+            WriteFixture(path, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV1, fs =>
+            {
+                var buf = new byte[AuditRecordCodec.RecordSize];
+                AuditRecordCodec.Encode(buf, in fillA); fs.Write(buf);
+                AuditRecordCodec.Encode(buf, in fillB); fs.Write(buf);
+            });
+
+            var entries = AuditLogReader.ReadAllEntries(path).ToList();
+            Assert.Equal(2, entries.Count);
+            Assert.All(entries, e => Assert.Equal(AuditRecordKind.Fill, e.Kind));
+            Assert.Equal(fillA, entries[0].Fill);
+            Assert.Equal(fillB, entries[1].Fill);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAllEntries_OnV1File_TerminatesQuietly_OnNonFillRecord()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"audit-v1-corrupt-{Guid.NewGuid():N}.log");
+        try
+        {
+            WriteFixture(path, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV1, fs =>
+            {
+                var fillBuf = new byte[AuditRecordCodec.RecordSize];
+                AuditRecordCodec.Encode(fillBuf, SampleFill(1)); fs.Write(fillBuf);
+                // Now write a perfectly valid bust record (recordLen=40).
+                // A v1 reader treats this as corruption and stops here.
+                var bustBuf = new byte[AuditRecordCodec.BustRecordSize];
+                AuditRecordCodec.EncodeBust(bustBuf, SampleBust(1, 0xCAFE)); fs.Write(bustBuf);
+            });
+
+            var entries = AuditLogReader.ReadAllEntries(path).ToList();
+            Assert.Single(entries);
+            Assert.Equal(AuditRecordKind.Fill, entries[0].Kind);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAllEntries_OnV2File_DispatchesAllThreeRecordTypes()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"audit-v2-mixed-{Guid.NewGuid():N}.log");
+        try
+        {
+            var fillA = SampleFill(1);
+            var bust = SampleBust(1, 0xDEAD);
+            var rej = SampleRejectAttempt(99, 0xBEEF, 1);
+            var fillB = SampleFill(2);
+            WriteFixture(path, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV2, fs =>
+            {
+                var fillBuf = new byte[AuditRecordCodec.RecordSize];
+                AuditRecordCodec.Encode(fillBuf, in fillA); fs.Write(fillBuf);
+                var bustBuf = new byte[AuditRecordCodec.BustRecordSize];
+                AuditRecordCodec.EncodeBust(bustBuf, in bust); fs.Write(bustBuf);
+                var rejBuf = new byte[AuditRecordCodec.RejectAttemptRecordSize];
+                AuditRecordCodec.EncodeRejectAttempt(rejBuf, in rej); fs.Write(rejBuf);
+                AuditRecordCodec.Encode(fillBuf, in fillB); fs.Write(fillBuf);
+            });
+
+            var entries = AuditLogReader.ReadAllEntries(path).ToList();
+            Assert.Equal(4, entries.Count);
+            Assert.Equal(AuditRecordKind.Fill, entries[0].Kind);
+            Assert.Equal(fillA, entries[0].Fill);
+            Assert.Equal(AuditRecordKind.Bust, entries[1].Kind);
+            Assert.Equal(bust, entries[1].Bust);
+            Assert.Equal(AuditRecordKind.RejectAttempt, entries[2].Kind);
+            Assert.Equal(rej, entries[2].RejectAttempt);
+            Assert.Equal(AuditRecordKind.Fill, entries[3].Kind);
+            Assert.Equal(fillB, entries[3].Fill);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAll_OnV2File_SkipsBustAndRejectRecords()
+    {
+        // Back-compat contract: existing callers of ReadAll (fills-only)
+        // must keep getting only fills even when the underlying file is v2.
+        var path = Path.Combine(Path.GetTempPath(), $"audit-v2-readall-{Guid.NewGuid():N}.log");
+        try
+        {
+            var fillA = SampleFill(1);
+            var bust = SampleBust(1, 0xDEAD);
+            var fillB = SampleFill(2);
+            WriteFixture(path, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV2, fs =>
+            {
+                var fillBuf = new byte[AuditRecordCodec.RecordSize];
+                AuditRecordCodec.Encode(fillBuf, in fillA); fs.Write(fillBuf);
+                var bustBuf = new byte[AuditRecordCodec.BustRecordSize];
+                AuditRecordCodec.EncodeBust(bustBuf, in bust); fs.Write(bustBuf);
+                AuditRecordCodec.Encode(fillBuf, in fillB); fs.Write(fillBuf);
+            });
+
+            var fills = AuditLogReader.ReadAll(path).ToList();
+            Assert.Equal(2, fills.Count);
+            Assert.Equal(fillA, fills[0]);
+            Assert.Equal(fillB, fills[1]);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAllEntries_TerminatesQuietly_OnUnknownRecordLen()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"audit-v2-junk-{Guid.NewGuid():N}.log");
+        try
+        {
+            WriteFixture(path, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV2, fs =>
+            {
+                var fillBuf = new byte[AuditRecordCodec.RecordSize];
+                AuditRecordCodec.Encode(fillBuf, SampleFill(1)); fs.Write(fillBuf);
+                // 4-byte length prefix declaring an unknown record length.
+                fs.Write(BitConverter.GetBytes((uint)123));
+                fs.Write(new byte[100]); // junk body
+            });
+
+            var entries = AuditLogReader.ReadAllEntries(path).ToList();
+            Assert.Single(entries);
+            Assert.Equal(AuditRecordKind.Fill, entries[0].Kind);
+        }
+        finally { File.Delete(path); }
+    }
+
+    [Fact]
+    public void ReadAllEntries_TerminatesQuietly_OnTruncatedTail()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"audit-v2-truncated-{Guid.NewGuid():N}.log");
+        try
+        {
+            WriteFixture(path, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV2, fs =>
+            {
+                var fillBuf = new byte[AuditRecordCodec.RecordSize];
+                AuditRecordCodec.Encode(fillBuf, SampleFill(1)); fs.Write(fillBuf);
+                // Length prefix for a bust, but no body — partial trailing
+                // record on writer crash.
+                fs.Write(BitConverter.GetBytes(AuditRecordCodec.BustRecordLen));
+            });
+
+            var entries = AuditLogReader.ReadAllEntries(path).ToList();
+            Assert.Single(entries);
+        }
+        finally { File.Delete(path); }
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
@@ -62,9 +62,10 @@ public class AuditRecordCodecTests
         var buf = new byte[AuditRecordCodec.FileHeaderSize];
         var date = new DateOnly(2026, 5, 18);
         AuditRecordCodec.WriteFileHeader(buf, channelNumber: 84, tradeDate: date);
-        var (ch, d) = AuditRecordCodec.ReadFileHeader(buf);
+        var (ch, d, ver) = AuditRecordCodec.ReadFileHeader(buf);
         Assert.Equal((byte)84, ch);
         Assert.Equal(date, d);
+        Assert.Equal(AuditRecordCodec.SchemaVersion, ver);
     }
 
     [Fact]
@@ -83,5 +84,145 @@ public class AuditRecordCodecTests
         AuditRecordCodec.WriteFileHeader(buf, 1, new DateOnly(2026, 1, 1));
         buf[4] = 99; buf[5] = 0;
         Assert.Throws<InvalidDataException>(() => AuditRecordCodec.ReadFileHeader(buf));
+    }
+
+    // ----- ADR 0008 / issue #369 PR-1: schema-v2 records --------------
+
+    [Fact]
+    public void FileHeader_AcceptsV1_AndV2()
+    {
+        var buf1 = new byte[AuditRecordCodec.FileHeaderSize];
+        AuditRecordCodec.WriteFileHeader(buf1, 7, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV1);
+        var (ch1, _, ver1) = AuditRecordCodec.ReadFileHeader(buf1);
+        Assert.Equal((byte)7, ch1);
+        Assert.Equal(AuditRecordCodec.SchemaVersionV1, ver1);
+
+        var buf2 = new byte[AuditRecordCodec.FileHeaderSize];
+        AuditRecordCodec.WriteFileHeader(buf2, 8, new DateOnly(2026, 5, 19), AuditRecordCodec.SchemaVersionV2);
+        var (ch2, _, ver2) = AuditRecordCodec.ReadFileHeader(buf2);
+        Assert.Equal((byte)8, ch2);
+        Assert.Equal(AuditRecordCodec.SchemaVersionV2, ver2);
+    }
+
+    [Fact]
+    public void WriteFileHeader_RejectsUnknownVersion()
+    {
+        var buf = new byte[AuditRecordCodec.FileHeaderSize];
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => AuditRecordCodec.WriteFileHeader(buf, 1, new DateOnly(2026, 1, 1), 99));
+    }
+
+    private static BustRecord SampleBust() => new(
+        CancelledTradeId: 42, BustTransactTimeNanos: 1_700_000_000_999_000_000UL,
+        SecurityId: 900_000_000_001L, ReasonCode: 3,
+        BusterFirm: 999, CorrelationId: 0xC0FFEE_DEADBEEFUL);
+
+    [Fact]
+    public void EncodeBust_TryDecodeBust_RoundTripsAllFields()
+    {
+        var src = SampleBust();
+        Span<byte> buf = stackalloc byte[AuditRecordCodec.BustRecordSize];
+        int n = AuditRecordCodec.EncodeBust(buf, in src);
+        Assert.Equal(AuditRecordCodec.BustRecordSize, n);
+
+        Assert.True(AuditRecordCodec.TryDecodeBust(buf, out var dst));
+        Assert.Equal(src, dst);
+    }
+
+    [Fact]
+    public void Bust_HasExpectedOnDiskSize()
+    {
+        Assert.Equal(44, AuditRecordCodec.BustRecordSize);
+        Assert.Equal(40u, AuditRecordCodec.BustRecordLen);
+    }
+
+    [Fact]
+    public void TryDecodeBust_ReturnsFalse_OnRecordTypeMismatch()
+    {
+        var buf = new byte[AuditRecordCodec.BustRecordSize];
+        AuditRecordCodec.EncodeBust(buf, SampleBust());
+        // Flip the leading recordType byte (offset 8 = first body byte).
+        buf[8] = 0x99;
+        Assert.False(AuditRecordCodec.TryDecodeBust(buf, out _));
+    }
+
+    [Fact]
+    public void TryDecodeBust_ReturnsFalse_OnCorruptedBody()
+    {
+        var buf = new byte[AuditRecordCodec.BustRecordSize];
+        AuditRecordCodec.EncodeBust(buf, SampleBust());
+        buf[20] ^= 0x01;
+        Assert.False(AuditRecordCodec.TryDecodeBust(buf, out _));
+    }
+
+    private static RejectAttemptRecord SampleRejectAttempt() => new(
+        AttemptedTradeId: 4242, AttemptTransactTimeNanos: 1_700_000_001_000_000_000UL,
+        DeclaredTradeDateDays: 20597, RejectCode: 2,
+        BusterFirm: 999, CorrelationId: 0xBADC0FFEEUL);
+
+    [Fact]
+    public void EncodeRejectAttempt_TryDecodeRejectAttempt_RoundTripsAllFields()
+    {
+        var src = SampleRejectAttempt();
+        Span<byte> buf = stackalloc byte[AuditRecordCodec.RejectAttemptRecordSize];
+        int n = AuditRecordCodec.EncodeRejectAttempt(buf, in src);
+        Assert.Equal(AuditRecordCodec.RejectAttemptRecordSize, n);
+
+        Assert.True(AuditRecordCodec.TryDecodeRejectAttempt(buf, out var dst));
+        Assert.Equal(src, dst);
+    }
+
+    [Fact]
+    public void RejectAttempt_HasExpectedOnDiskSize()
+    {
+        Assert.Equal(40, AuditRecordCodec.RejectAttemptRecordSize);
+        Assert.Equal(36u, AuditRecordCodec.RejectAttemptRecordLen);
+    }
+
+    [Fact]
+    public void TryDecodeRejectAttempt_ReturnsFalse_OnRecordTypeMismatch()
+    {
+        var buf = new byte[AuditRecordCodec.RejectAttemptRecordSize];
+        AuditRecordCodec.EncodeRejectAttempt(buf, SampleRejectAttempt());
+        buf[8] = 0x99;
+        Assert.False(AuditRecordCodec.TryDecodeRejectAttempt(buf, out _));
+    }
+
+    [Fact]
+    public void TryGetRecordSize_DispatchesByRecordLen()
+    {
+        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.FillRecordLen, out var fillSize, out var fillKind));
+        Assert.Equal(AuditRecordCodec.RecordSize, fillSize);
+        Assert.Equal(AuditRecordKind.Fill, fillKind);
+
+        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.BustRecordLen, out var bustSize, out var bustKind));
+        Assert.Equal(AuditRecordCodec.BustRecordSize, bustSize);
+        Assert.Equal(AuditRecordKind.Bust, bustKind);
+
+        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.RejectAttemptRecordLen, out var rejSize, out var rejKind));
+        Assert.Equal(AuditRecordCodec.RejectAttemptRecordSize, rejSize);
+        Assert.Equal(AuditRecordKind.RejectAttempt, rejKind);
+
+        Assert.False(AuditRecordCodec.TryGetRecordSize(123, out _, out _));
+    }
+
+    [Fact]
+    public void FillEncoding_IsBitIdentical_BetweenV1AndV2Headers()
+    {
+        // ADR 0008 §1 invariant: a v2 file that contains only fills is
+        // bit-identical to its v1 predecessor modulo the file header.
+        // The fill body has no discriminator byte, so this property
+        // falls out of the codec design — pinning it with a test keeps
+        // future record-type extensions from accidentally regressing it.
+        var fill = Sample();
+        Span<byte> fillBytes = stackalloc byte[AuditRecordCodec.RecordSize];
+        AuditRecordCodec.Encode(fillBytes, in fill);
+
+        // Body identical regardless of file header version (header is
+        // written separately by the file writer; the per-record bytes
+        // here are version-agnostic).
+        Assert.Equal((uint)AuditRecordCodec.RecordSize - 4, AuditRecordCodec.FillRecordLen);
+        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.FillRecordLen, out _, out var kind));
+        Assert.Equal(AuditRecordKind.Fill, kind);
     }
 }

--- a/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
@@ -141,8 +141,11 @@ public class AuditRecordCodecTests
     {
         var buf = new byte[AuditRecordCodec.BustRecordSize];
         AuditRecordCodec.EncodeBust(buf, SampleBust());
-        // Flip the leading recordType byte (offset 8 = first body byte).
+        // Flip the leading recordType byte (offset 8 = first body byte)
+        // and re-compute the CRC so the decoder reaches the explicit
+        // recordType cross-check rather than short-circuiting on CRC.
         buf[8] = 0x99;
+        RewriteBodyCrc(buf, bodyOffset: 8, bodyLen: AuditRecordCodec.BustRecordBodySize);
         Assert.False(AuditRecordCodec.TryDecodeBust(buf, out _));
     }
 
@@ -185,6 +188,7 @@ public class AuditRecordCodecTests
         var buf = new byte[AuditRecordCodec.RejectAttemptRecordSize];
         AuditRecordCodec.EncodeRejectAttempt(buf, SampleRejectAttempt());
         buf[8] = 0x99;
+        RewriteBodyCrc(buf, bodyOffset: 8, bodyLen: AuditRecordCodec.RejectAttemptRecordBodySize);
         Assert.False(AuditRecordCodec.TryDecodeRejectAttempt(buf, out _));
     }
 
@@ -212,17 +216,46 @@ public class AuditRecordCodecTests
         // ADR 0008 §1 invariant: a v2 file that contains only fills is
         // bit-identical to its v1 predecessor modulo the file header.
         // The fill body has no discriminator byte, so this property
-        // falls out of the codec design — pinning it with a test keeps
-        // future record-type extensions from accidentally regressing it.
+        // falls out of the codec design — pinning it with two encodes
+        // + a byte-vector compare keeps future record-type extensions
+        // from accidentally regressing it.
         var fill = Sample();
-        Span<byte> fillBytes = stackalloc byte[AuditRecordCodec.RecordSize];
-        AuditRecordCodec.Encode(fillBytes, in fill);
+        var fillBytesA = new byte[AuditRecordCodec.RecordSize];
+        var fillBytesB = new byte[AuditRecordCodec.RecordSize];
+        AuditRecordCodec.Encode(fillBytesA, in fill);
+        AuditRecordCodec.Encode(fillBytesB, in fill);
+        Assert.Equal(fillBytesA, fillBytesB);
 
-        // Body identical regardless of file header version (header is
-        // written separately by the file writer; the per-record bytes
-        // here are version-agnostic).
-        Assert.Equal((uint)AuditRecordCodec.RecordSize - 4, AuditRecordCodec.FillRecordLen);
-        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.FillRecordLen, out _, out var kind));
-        Assert.Equal(AuditRecordKind.Fill, kind);
+        // Compose full v1 and v2 files (header + same fill) and assert
+        // the bodies past the file header match byte-for-byte.
+        var dateA = new DateOnly(2026, 5, 19);
+        var dateB = new DateOnly(2026, 5, 19);
+        var fileV1 = new byte[AuditRecordCodec.FileHeaderSize + AuditRecordCodec.RecordSize];
+        var fileV2 = new byte[AuditRecordCodec.FileHeaderSize + AuditRecordCodec.RecordSize];
+        AuditRecordCodec.WriteFileHeader(fileV1, 7, dateA, AuditRecordCodec.SchemaVersionV1);
+        AuditRecordCodec.WriteFileHeader(fileV2, 7, dateB, AuditRecordCodec.SchemaVersionV2);
+        AuditRecordCodec.Encode(fileV1.AsSpan(AuditRecordCodec.FileHeaderSize), in fill);
+        AuditRecordCodec.Encode(fileV2.AsSpan(AuditRecordCodec.FileHeaderSize), in fill);
+
+        // Bodies (past file header) MUST match byte-for-byte.
+        var bodyV1 = fileV1.AsSpan(AuditRecordCodec.FileHeaderSize).ToArray();
+        var bodyV2 = fileV2.AsSpan(AuditRecordCodec.FileHeaderSize).ToArray();
+        Assert.Equal(bodyV1, bodyV2);
+
+        // Headers MUST differ on exactly the schemaVersion byte (offset 4).
+        Assert.NotEqual(fileV1[4], fileV2[4]);
+        Assert.Equal((byte)AuditRecordCodec.SchemaVersionV1, fileV1[4]);
+        Assert.Equal((byte)AuditRecordCodec.SchemaVersionV2, fileV2[4]);
+    }
+
+    /// <summary>Recomputes the framed-record CRC after the body has
+    /// been mutated by a test, so the decoder under test reaches the
+    /// post-CRC validation (e.g. recordType cross-check) rather than
+    /// short-circuiting at the CRC step.</summary>
+    private static void RewriteBodyCrc(byte[] buf, int bodyOffset, int bodyLen)
+    {
+        Span<byte> hash = stackalloc byte[4];
+        System.IO.Hashing.Crc32.Hash(buf.AsSpan(bodyOffset, bodyLen), hash);
+        hash.CopyTo(buf.AsSpan(4, 4));
     }
 }


### PR DESCRIPTION
First PR of the [ADR 0008](https://github.com/pedrosakuma/B3MatchingPlatform/blob/main/docs/adr/0008-late-corrections-and-bust-propagation.md) implementation sequence (tracking: #369).

Pure prep work — adds the schema-v2 codec and reader surface so PR-2 has somewhere to land. **No on-disk behaviour change in this PR**: the writer still emits v1 file headers and only fill records; nothing in the published artifacts changes.

## What this PR adds

**Codec (`AuditRecordCodec`)**
- Split `SchemaVersionV1=1` / `SchemaVersionV2=2` constants; `SchemaVersion` (the default new-file version this build writes) stays at V1 until PR-2.
- `ReadFileHeader` accepts v1 OR v2 headers and returns the parsed schema version (per-day schema view, ADR 0008 §1).
- New `BustRecord` (recordLen=40, 44 on-disk bytes) and `RejectAttemptRecord` (recordLen=36, 40 on-disk bytes) with encode/decode methods, leading recordType byte cross-checked against recordLen on decode (defence-in-depth per ADR 0008 §1).
- `AuditEntry` discriminated-union type for the full-stream reader.
- `TryPeekRecordLen` / `TryGetRecordSize` helpers for the reader dispatch loop.

**Reader (`AuditLogReader`)**
- New `ReadAllEntries(path)` API yields a typed `AuditEntry` per record on v2 files; v1 files still emit fills only (any other recordLen = corruption, terminates iteration cleanly).
- Existing `ReadAll(path)` (fills-only) keeps its v1-era contract: on v2 files it silently skips bust/reject-attempt records. No existing caller needs to change.
- Torn-tail semantics unchanged (short read / unknown recordLen / CRC fail / recordType mismatch → quiet termination).

**Writer (`FileAuditLogWriter`)**
- `ScanLastGoodEndOffset` updated to the new `ReadFileHeader` 3-tuple. **No behavioural change.**

## Tests
- 9 new `AuditRecordCodecTests` for v2 round-trips, recordType-mismatch detection, on-disk sizes, dispatch, and v1↔v2 header acceptance.
- 6 new `AuditLogReaderV2Tests` covering fills-only v1, v2 mixed-stream dispatch, `ReadAll` back-compat skip, unknown-recordLen termination, truncated-tail termination.
- Full PostTrade suite: 91/91 ✅; full repo suite passes (one Gateway test flaked on socket cancellation, passes on rerun — known network flake, not related to this PR).

## What this PR is NOT
- Does not introduce any new on-disk artifact.
- Does not change the public endpoint surface.
- Does not modify `EodFillsExporter` (that's PR-3).

## Tracking
Part of #369 / ADR 0008 §1. Next: PR-2 adds the `POST /admin/post-trade/bust` endpoint and starts emitting v2 records.