### PR TITLE
feat(post-trade): bust endpoint + dedup + audit (ADR 0008 PR-2)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -89,6 +89,15 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.OperatorBustV2)
+        {
+            ProcessOperatorBustV2(item.BustV2!, item.BustCompletion);
+            // Persist after every accept so the consumed RptSeq + dedup
+            // index state mirror durability of the audit-log write.
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
         if (item.Kind == WorkKind.OperatorSetTradingPhase)
         {
             ProcessSetTradingPhase(item.TradingPhase!, item.PhaseCompletion);

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -10,6 +10,8 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
+    private static readonly DateOnly LocalMktDateEpoch = new(1970, 1, 1);
+
     private void ProcessBumpVersion()
     {
         // Atomic operator-initiated channel reset (issue #6). Order matters:
@@ -200,6 +202,22 @@ public sealed partial class ChannelDispatcher
         AssertOnLoopThread();
         try
         {
+            // UMDF TradeBust_57 carries tradeDate as LocalMktDate (uint16
+            // days since 1970-01-01); the reject-attempt record stores
+            // the same value as int32. DateOnly.DayNumber is days since
+            // 0001-01-01 so a normal date overflows ushort — convert
+            // relative to the Unix epoch and range-check BEFORE writing
+            // any audit/dedup state so we never persist a half-applied
+            // accept.
+            int tradeDateDaysSinceEpoch = op.TradeDate.DayNumber - LocalMktDateEpoch.DayNumber;
+            if (tradeDateDaysSinceEpoch < 0 || tradeDateDaysSinceEpoch > ushort.MaxValue)
+            {
+                completion?.TrySetException(new ArgumentOutOfRangeException(
+                    nameof(op.TradeDate),
+                    $"tradeDate {op.TradeDate:yyyy-MM-dd} outside LocalMktDate range (1970-01-01..{LocalMktDateEpoch.AddDays(ushort.MaxValue):yyyy-MM-dd})"));
+                return;
+            }
+
             var request = new B3.Exchange.PostTrade.BustRequest(
                 op.TradeId, op.TradeDate, op.CorrelationId, op.SecurityIdEcho,
                 op.ReasonCode, op.BusterFirm, op.AttemptTransactTimeNanos);
@@ -224,8 +242,7 @@ public sealed partial class ChannelDispatcher
                             + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
                             + B3.Umdf.WireEncoder.WireOffsets.TradeBustBlockLength;
                         var dst = ReserveOrFlush(frameSize);
-                        // TradeDate to ushort days-since-epoch.
-                        ushort tradeDateDays = checked((ushort)op.TradeDate.DayNumber);
+                        ushort tradeDateDays = (ushort)tradeDateDaysSinceEpoch;
                         int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
                             result.MatchedFill.SecurityId, result.MatchedFill.PriceMantissa,
                             result.MatchedFill.Quantity, op.TradeId, tradeDateDays,
@@ -253,7 +270,7 @@ public sealed partial class ChannelDispatcher
                         };
                         var reject = new B3.Exchange.PostTrade.RejectAttemptRecord(
                             op.TradeId, op.AttemptTransactTimeNanos,
-                            op.TradeDate.DayNumber, code, op.BusterFirm, op.CorrelationId);
+                            tradeDateDaysSinceEpoch, code, op.BusterFirm, op.CorrelationId);
                         _postTradeSink.OnRejectAttempt(reject);
                         break;
                     }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -153,6 +153,122 @@ public sealed partial class ChannelDispatcher
     }
 
     /// <summary>
+    /// ADR 0008 PR-2: schedules an operator bust through the post-trade
+    /// validator + audit-log path. The dispatch thread runs
+    /// <see cref="B3.Exchange.PostTrade.BustValidator"/> against the
+    /// (per-channel) audit files and the in-memory dedup index; on accept
+    /// it writes a bust record + emits TradeBust_57, on reject it writes
+    /// a reject-attempt record + returns the validator's verdict via the
+    /// supplied <paramref name="completion"/> source. Returns <c>false</c>
+    /// if the inbound queue is full or the channel is WAL-halted; in
+    /// both cases the completion source is faulted.
+    /// </summary>
+    public bool EnqueueOperatorBustV2(
+        uint tradeId, DateOnly tradeDate, ulong correlationId,
+        ushort reasonCode, uint busterFirm, long? securityIdEcho,
+        ulong attemptTransactTimeNanos,
+        TaskCompletionSource<OperatorBustV2Outcome> completion)
+    {
+        ArgumentNullException.ThrowIfNull(completion);
+        if (_auditRootDir is null || _bustDedup is null)
+        {
+            completion.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} bust-v2 endpoint requires audit-log configuration; not wired"));
+            return false;
+        }
+        if (RejectIfWalHalted(WorkKind.OperatorBustV2))
+        {
+            completion.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; OperatorBustV2 rejected"));
+            return false;
+        }
+        var payload = new OperatorBustV2(tradeId, tradeDate, correlationId, reasonCode,
+            busterFirm, securityIdEcho, attemptTransactTimeNanos);
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorBustV2, default, 0, false,
+            0, 0, null, null, null, null,
+            BustV2: payload, BustCompletion: completion)))
+        {
+            return true;
+        }
+        completion.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; OperatorBustV2 rejected"));
+        return false;
+    }
+
+    private void ProcessOperatorBustV2(OperatorBustV2 op, TaskCompletionSource<OperatorBustV2Outcome>? completion)
+    {
+        AssertOnLoopThread();
+        try
+        {
+            var request = new B3.Exchange.PostTrade.BustRequest(
+                op.TradeId, op.TradeDate, op.CorrelationId, op.SecurityIdEcho,
+                op.ReasonCode, op.BusterFirm, op.AttemptTransactTimeNanos);
+            var result = B3.Exchange.PostTrade.BustValidator.Validate(
+                _auditRootDir!, ChannelNumber, request, _bustDedup!);
+
+            switch (result.Kind)
+            {
+                case B3.Exchange.PostTrade.BustValidationKind.Accept:
+                    {
+                        var bust = new B3.Exchange.PostTrade.BustRecord(
+                            op.TradeId, op.AttemptTransactTimeNanos,
+                            result.MatchedFill.SecurityId, op.ReasonCode, op.BusterFirm, op.CorrelationId);
+                        _postTradeSink.OnBust(bust, op.TradeDate);
+                        _bustDedup!.Add(op.TradeId, op.CorrelationId, op.TradeDate);
+                        // Emit TradeBust_57 frame; price/size echo come from the
+                        // matched fill so consumers see the same data the
+                        // original Trade_53 carried.
+                        uint rptSeq = _engine.AllocateNextRptSeq();
+                        _packetWritten = 0;
+                        int frameSize = B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+                            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+                            + B3.Umdf.WireEncoder.WireOffsets.TradeBustBlockLength;
+                        var dst = ReserveOrFlush(frameSize);
+                        // TradeDate to ushort days-since-epoch.
+                        ushort tradeDateDays = checked((ushort)op.TradeDate.DayNumber);
+                        int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
+                            result.MatchedFill.SecurityId, result.MatchedFill.PriceMantissa,
+                            result.MatchedFill.Quantity, op.TradeId, tradeDateDays,
+                            _nowNanos(), rptSeq);
+                        Commit(written);
+                        FlushPacket();
+                        break;
+                    }
+                case B3.Exchange.PostTrade.BustValidationKind.IdempotentReplay:
+                    // No new write, no UMDF emit.
+                    break;
+                case B3.Exchange.PostTrade.BustValidationKind.MissingDay:
+                    // No audit-log write (ADR §2.3).
+                    break;
+                case B3.Exchange.PostTrade.BustValidationKind.UnknownTradeId:
+                case B3.Exchange.PostTrade.BustValidationKind.AlreadyBustedDifferentCorrelation:
+                case B3.Exchange.PostTrade.BustValidationKind.SecurityIdMismatch:
+                    {
+                        ushort code = result.Kind switch
+                        {
+                            B3.Exchange.PostTrade.BustValidationKind.UnknownTradeId => (ushort)1,
+                            B3.Exchange.PostTrade.BustValidationKind.AlreadyBustedDifferentCorrelation => (ushort)2,
+                            B3.Exchange.PostTrade.BustValidationKind.SecurityIdMismatch => (ushort)3,
+                            _ => (ushort)0,
+                        };
+                        var reject = new B3.Exchange.PostTrade.RejectAttemptRecord(
+                            op.TradeId, op.AttemptTransactTimeNanos,
+                            op.TradeDate.DayNumber, code, op.BusterFirm, op.CorrelationId);
+                        _postTradeSink.OnRejectAttempt(reject);
+                        break;
+                    }
+            }
+
+            completion?.TrySetResult(new OperatorBustV2Outcome(result.Kind, result.ExistingCorrelationId));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Operator command (gap-functional §5 / issue #201): transitions the
     /// supplied instrument to the requested <see cref="TradingPhase"/>. The
     /// transition is applied on the dispatch thread; if it changes the

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -10,7 +10,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2 }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -36,6 +36,7 @@ public sealed partial class ChannelDispatcher
         "OperatorUncrossAuction",
         "OperatorHaltInstrument",
         "OperatorResumeInstrument",
+        "OperatorBustV2",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -63,6 +64,8 @@ public sealed partial class ChannelDispatcher
         OperatorHalt? Halt = null,
         OperatorResume? Resume = null,
         TaskCompletionSource<HaltOutcome>? HaltCompletion = null,
+        OperatorBustV2? BustV2 = null,
+        TaskCompletionSource<OperatorBustV2Outcome>? BustCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -111,6 +114,31 @@ public sealed partial class ChannelDispatcher
     /// Issue #322: operator-triggered resume payload.
     /// </summary>
     internal sealed record OperatorResume(long SecurityId);
+
+    /// <summary>
+    /// ADR 0008 PR-2: operator bust request payload (post-trade audit
+    /// path). Distinct from <see cref="OperatorTradeBust"/> (which is the
+    /// legacy fire-and-forget replay path that does no validation and no
+    /// audit-log write): this one runs through the dedup/validator before
+    /// optionally emitting a TradeBust_57 frame and writing a bust or
+    /// reject-attempt record to the post-trade audit log.
+    /// </summary>
+    internal sealed record OperatorBustV2(
+        uint TradeId,
+        DateOnly TradeDate,
+        ulong CorrelationId,
+        ushort ReasonCode,
+        uint BusterFirm,
+        long? SecurityIdEcho,
+        ulong AttemptTransactTimeNanos);
+
+    /// <summary>ADR 0008 PR-2: surfaced back to the HTTP handler so the
+    /// 200/4xx/5xx mapping can happen at the edge. The validator-kind
+    /// field carries the validator's verdict 1:1; <see cref="ExistingCorrelationId"/>
+    /// is populated only for <see cref="BustValidationKind.AlreadyBustedDifferentCorrelation"/>.</summary>
+    public readonly record struct OperatorBustV2Outcome(
+        B3.Exchange.PostTrade.BustValidationKind Kind,
+        ulong ExistingCorrelationId);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -227,6 +227,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     // NullPostTradeSink.Instance so existing callers see no behaviour
     // change; subsequent PRs install a real append-only writer.
     private readonly B3.Exchange.PostTrade.IPostTradeSink _postTradeSink;
+    private readonly string? _auditRootDir;
+    private readonly B3.Exchange.PostTrade.BustDedupIndex? _bustDedup;
     // Throttle bookkeeping (issue #267). Mutated only on the dispatch
     // loop thread → no Interlocked needed.
     private long _commandsSincePersist;
@@ -347,7 +349,9 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         Func<string, bool>? sessionExists = null,
         OrphanSessionPolicy orphanPolicy = OrphanSessionPolicy.Drop,
         IReadOnlyList<long>? seedSecurityIds = null,
-        B3.Exchange.PostTrade.IPostTradeSink? postTradeSink = null)
+        B3.Exchange.PostTrade.IPostTradeSink? postTradeSink = null,
+        string? auditRootDir = null,
+        B3.Exchange.PostTrade.BustDedupIndex? bustDedup = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -368,6 +372,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _sessionExists = sessionExists;
         _orphanPolicy = orphanPolicy;
         _postTradeSink = postTradeSink ?? B3.Exchange.PostTrade.NullPostTradeSink.Instance;
+        _auditRootDir = auditRootDir;
+        _bustDedup = bustDedup;
         _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
         // Issue #268: opt-in async snapshot writer. Off by default so
         // pre-existing deployments keep the synchronous in-loop persist

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -279,6 +279,20 @@ public sealed class ExchangeHost : IAsyncDisposable
             // host-agnostic (it just gets a predicate + enum).
             var orphanPolicy = ParseOrphanPolicy(ch.Persistence?.OrphanSessionPolicy);
             Func<string, bool> sessionExists = sid => firmRegistry.FindSession(sid) is not null;
+            // ADR 0008 PR-2: rebuild the bust dedup index from on-disk
+            // audit files within the retention window so a restart picks
+            // up where the previous run left off. Only meaningful when
+            // the audit writer is wired (otherwise there are no files).
+            B3.Exchange.PostTrade.BustDedupIndex? bustDedup = null;
+            string? auditRootDir = null;
+            if (auditWriter != null && ch.PostTradeAudit?.DataDir is { } dataDir && !string.IsNullOrWhiteSpace(dataDir))
+            {
+                auditRootDir = dataDir;
+                int retention = ch.PostTradeAudit.RetentionDays;
+                bustDedup = B3.Exchange.PostTrade.BustDedupIndex.LoadFromAuditFiles(
+                    dataDir, ch.ChannelNumber, retention, DateOnly.FromDateTime(DateTime.UtcNow));
+            }
+
             var disp = new ChannelDispatcher(
                 channelNumber: ch.ChannelNumber,
                 engineFactory: s =>
@@ -301,7 +315,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                 sessionExists: sessionExists,
                 orphanPolicy: orphanPolicy,
                 seedSecurityIds: instruments.Select(i => i.SecurityId).ToArray(),
-                postTradeSink: auditWriter);
+                postTradeSink: auditWriter,
+                auditRootDir: auditRootDir,
+                bustDedup: bustDedup);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -41,6 +41,8 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly Action<string>? _log;
     private WebApplication? _app;
 
+    private static readonly DateOnly LocalMktDateEpoch = new(1970, 1, 1);
+
     public HttpServer(HttpConfig config, MetricsRegistry metrics,
         IReadOnlyList<IReadinessProbe> probes,
         IReadOnlyDictionary<byte, ChannelDispatcher> dispatchers,
@@ -514,6 +516,15 @@ public sealed class HttpServer : IAsyncDisposable
         {
             ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
             return Results.Text("missing or invalid 'tradeDate' (YYYY-MM-DD)\n", "text/plain");
+        }
+        // UMDF TradeBust_57 encodes tradeDate as LocalMktDate (uint16,
+        // days since 1970-01-01). Range-check up front so accepted
+        // requests never crash mid-dispatch after writing audit state.
+        int tradeDateDaysSinceEpoch = tradeDate.DayNumber - LocalMktDateEpoch.DayNumber;
+        if (tradeDateDaysSinceEpoch < 0 || tradeDateDaysSinceEpoch > ushort.MaxValue)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"'tradeDate' out of LocalMktDate range (1970-01-01..{LocalMktDateEpoch.AddDays(ushort.MaxValue):yyyy-MM-dd})\n", "text/plain");
         }
         if (!TryParseULong(q["correlationId"], out ulong correlationId) || correlationId == 0)
         {

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -205,6 +205,21 @@ public sealed class HttpServer : IAsyncDisposable
         app.MapPost("/admin/post-trade/eod-export", (HttpContext ctx) =>
             HandleEodExport(ctx));
 
+        // ADR 0008 PR-2: operator trade-bust endpoint with full
+        // validation surface. Distinct from the legacy
+        // /channel/{ch}/trade-bust/{tradeId} replay path (which does no
+        // validation and no audit write). Query parameters:
+        //   channel        - channel number (0-255)
+        //   tradeId        - the engine TradeId of the trade to bust
+        //   tradeDate      - YYYY-MM-DD of the busted trade's day
+        //   correlationId  - operator-supplied dedup key (ulong)
+        //   reason         - optional ushort reason code (default 0)
+        //   securityId     - optional long echo (server validates against the fill)
+        //   busterFirm     - optional uint operator firm id (default 0)
+        // Status codes mirror ADR §2.3.
+        app.MapPost("/admin/post-trade/bust", async (HttpContext ctx) =>
+            await HandlePostTradeBustAsync(ctx).ConfigureAwait(false));
+
         // Issue #271: admin endpoints for snapshot management.
         //
         // GET /admin/channels/{ch}/snapshot
@@ -463,6 +478,146 @@ public sealed class HttpServer : IAsyncDisposable
         var s = values.ToString();
         if (string.IsNullOrEmpty(s)) return allowMissing;
         return long.TryParse(s, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value);
+    }
+
+    private static bool TryParseULong(Microsoft.Extensions.Primitives.StringValues values, out ulong value, bool allowMissing = false)
+    {
+        value = 0;
+        var s = values.ToString();
+        if (string.IsNullOrEmpty(s)) return allowMissing;
+        return ulong.TryParse(s, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out value);
+    }
+
+    private async Task<IResult> HandlePostTradeBustAsync(HttpContext ctx)
+    {
+        var q = ctx.Request.Query;
+        if (!TryParseLong(q["channel"], out long chRaw) || chRaw < 0 || chRaw > 255)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("missing or invalid 'channel' (0..255)\n", "text/plain");
+        }
+        byte channel = (byte)chRaw;
+        if (!_dispatchers.TryGetValue(channel, out var disp))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return Results.Text($"unknown channel {channel}\n", "text/plain");
+        }
+        if (!TryParseLong(q["tradeId"], out long tidRaw) || tidRaw <= 0 || tidRaw > uint.MaxValue)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text($"missing or invalid 'tradeId' (1..{uint.MaxValue})\n", "text/plain");
+        }
+        uint tradeId = (uint)tidRaw;
+        string tradeDateStr = q["tradeDate"].ToString();
+        if (string.IsNullOrEmpty(tradeDateStr)
+            || !DateOnly.TryParseExact(tradeDateStr, "yyyy-MM-dd", out var tradeDate))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("missing or invalid 'tradeDate' (YYYY-MM-DD)\n", "text/plain");
+        }
+        if (!TryParseULong(q["correlationId"], out ulong correlationId) || correlationId == 0)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return Results.Text("missing or invalid 'correlationId' (> 0)\n", "text/plain");
+        }
+        ushort reason = 0;
+        if (q.ContainsKey("reason"))
+        {
+            if (!TryParseLong(q["reason"], out long r) || r < 0 || r > ushort.MaxValue)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return Results.Text($"invalid 'reason' (0..{ushort.MaxValue})\n", "text/plain");
+            }
+            reason = (ushort)r;
+        }
+        long? securityIdEcho = null;
+        if (q.ContainsKey("securityId"))
+        {
+            if (!TryParseLong(q["securityId"], out long s) || s <= 0)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return Results.Text("invalid 'securityId' echo (must be > 0 when supplied)\n", "text/plain");
+            }
+            securityIdEcho = s;
+        }
+        uint busterFirm = 0;
+        if (q.ContainsKey("busterFirm"))
+        {
+            if (!TryParseLong(q["busterFirm"], out long bf) || bf < 0 || bf > uint.MaxValue)
+            {
+                ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return Results.Text($"invalid 'busterFirm' (0..{uint.MaxValue})\n", "text/plain");
+            }
+            busterFirm = (uint)bf;
+        }
+
+        var tcs = new TaskCompletionSource<B3.Exchange.Core.ChannelDispatcher.OperatorBustV2Outcome>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        ulong nowNanos = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+        if (!disp.EnqueueOperatorBustV2(tradeId, tradeDate, correlationId, reason, busterFirm,
+                securityIdEcho, nowNanos, tcs))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"channel {channel} inbound queue full or not wired for bust-v2\n", "text/plain");
+        }
+
+        B3.Exchange.Core.ChannelDispatcher.OperatorBustV2Outcome outcome;
+        try
+        {
+            outcome = await tcs.Task.WaitAsync(PhaseChangeTimeout, ctx.RequestAborted).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status504GatewayTimeout;
+            return Results.Text("timed out waiting for bust validation\n", "text/plain");
+        }
+        catch (InvalidOperationException ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            return Results.Text($"unavailable: {ex.Message}\n", "text/plain");
+        }
+        catch (Exception ex)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            return Results.Text($"bust failed: {ex.Message}\n", "text/plain");
+        }
+
+        switch (outcome.Kind)
+        {
+            case B3.Exchange.PostTrade.BustValidationKind.Accept:
+                ctx.Response.StatusCode = StatusCodes.Status200OK;
+                return Results.Text(
+                    $"{{\"status\":\"busted\",\"channel\":{channel},\"tradeId\":{tradeId},\"correlationId\":{correlationId}}}",
+                    "application/json");
+            case B3.Exchange.PostTrade.BustValidationKind.IdempotentReplay:
+                ctx.Response.Headers["X-Idempotent"] = "true";
+                ctx.Response.StatusCode = StatusCodes.Status200OK;
+                return Results.Text(
+                    $"{{\"status\":\"idempotent-replay\",\"channel\":{channel},\"tradeId\":{tradeId},\"correlationId\":{correlationId}}}",
+                    "application/json");
+            case B3.Exchange.PostTrade.BustValidationKind.MissingDay:
+                ctx.Response.StatusCode = StatusCodes.Status410Gone;
+                return Results.Text(
+                    $"fills-{tradeDate:yyyy-MM-dd}.log missing for channel {channel}\n", "text/plain");
+            case B3.Exchange.PostTrade.BustValidationKind.UnknownTradeId:
+                ctx.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+                return Results.Text(
+                    $"{{\"status\":\"reject\",\"reason\":\"unknown-trade-id\",\"code\":1}}",
+                    "application/json");
+            case B3.Exchange.PostTrade.BustValidationKind.AlreadyBustedDifferentCorrelation:
+                ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+                return Results.Text(
+                    $"{{\"status\":\"reject\",\"reason\":\"already-busted\",\"code\":2,\"existingCorrelationId\":{outcome.ExistingCorrelationId}}}",
+                    "application/json");
+            case B3.Exchange.PostTrade.BustValidationKind.SecurityIdMismatch:
+                ctx.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+                return Results.Text(
+                    $"{{\"status\":\"reject\",\"reason\":\"security-id-mismatch\",\"code\":3}}",
+                    "application/json");
+            default:
+                ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+                return Results.Text($"unexpected outcome {outcome.Kind}\n", "text/plain");
+        }
     }
 
     private IResult HandleAdminGetSnapshot(HttpContext ctx, int channelNumber)

--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -138,20 +138,23 @@ public static class AuditLogReader
         if (hr != header.Length)
             throw new InvalidDataException($"audit file '{logPath}' truncated in header (got {hr} bytes)");
         var (_, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(header);
-        // ADR 0008 §1 / issue #369 PR-1: the firm-sparse index assumes
-        // uniform fixed-width fill records. v2 files can carry variable-
-        // length bust/reject-attempt records, which would desync the
-        // 85-byte fixed-stride scan below and silently under-report. PR-2
-        // teaches both the index codec and this reader to handle mixed
-        // record sizes; until then, refuse v2 firm-filtered reads
-        // explicitly rather than returning a partial result.
-        if (schemaVersion != AuditRecordCodec.SchemaVersionV1)
-            throw new NotSupportedException(
-                $"ReadByFirm does not yet support schema v{schemaVersion} (PR-2 will add mixed-record dispatch); "
-                + "use ReadAllEntries for the time being");
+        // ADR 0008 / issue #369 PR-2: schema-aware dispatch in both the
+        // indexed-block and unindexed-suffix paths. Bust and reject-
+        // attempt records sit on the same stream as fills (per ADR 0008
+        // §1) but have different sizes (44 / 40 bytes vs 85 for a fill);
+        // the v1-era fixed 85-byte stride would either CRC-fail on the
+        // first non-fill or read past it into the next record's body.
+        // The writer's invariant (firm-sparse .idx covers fill records
+        // only — non-fill records are written outside any open block)
+        // means recordCount in each .idx entry still counts fills only.
+        bool schemaIsV2 = schemaVersion == AuditRecordCodec.SchemaVersionV2;
 
-        var buffer = new byte[AuditRecordCodec.RecordSize];
-        // 1) Indexed candidates — seek directly to each block.
+        var buffer = new byte[AuditRecordCodec.MaxRecordSize];
+        // 1) Indexed candidates — seek directly to each block. Each entry
+        // in the .idx represents a contiguous run of fill records (the
+        // writer flushes any open fill block before writing a non-fill
+        // record, see ADR 0008 PR-2), so a fixed 85-byte stride is still
+        // correct here.
         foreach (var (offset, recordCount) in candidates)
         {
             fs.Seek((long)offset, SeekOrigin.Begin);
@@ -159,27 +162,50 @@ public static class AuditLogReader
             {
                 int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
                 if (read < AuditRecordCodec.RecordSize) break;
-                if (!AuditRecordCodec.TryDecode(buffer, out var record)) break;
+                if (!AuditRecordCodec.TryDecode(buffer.AsSpan(0, AuditRecordCodec.RecordSize), out var record)) break;
                 if (record.BuyFirm == firmId || record.SellFirm == firmId)
                     yield return record;
             }
         }
 
         // 2) Unindexed suffix — anything past the last byte the index claims
-        // to cover. Critical for correctness when (a) the index is stale by
-        // an in-progress block, (b) a malformed entry forced us to stop
-        // trusting the index mid-file, or (c) no index exists at all.
+        // to cover. On v2 files this stream is heterogeneous (fills + bust
+        // + reject-attempt records); peek the recordLen and dispatch.
         if (indexedEndOffset < fs.Length)
         {
             fs.Seek(indexedEndOffset, SeekOrigin.Begin);
             while (true)
             {
-                int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
-                if (read == 0) break;
-                if (read < AuditRecordCodec.RecordSize) break;
-                if (!AuditRecordCodec.TryDecode(buffer, out var record)) break;
-                if (record.BuyFirm == firmId || record.SellFirm == firmId)
-                    yield return record;
+                if (!schemaIsV2)
+                {
+                    int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
+                    if (read == 0) break;
+                    if (read < AuditRecordCodec.RecordSize) break;
+                    if (!AuditRecordCodec.TryDecode(buffer.AsSpan(0, AuditRecordCodec.RecordSize), out var record)) break;
+                    if (record.BuyFirm == firmId || record.SellFirm == firmId)
+                        yield return record;
+                    continue;
+                }
+
+                // v2: peek recordLen (4 bytes), read remaining body, dispatch.
+                int peeked = ReadFully(fs, buffer, 0, 4);
+                if (peeked == 0) break;
+                if (peeked < 4) break;
+                if (!AuditRecordCodec.TryPeekRecordLen(buffer.AsSpan(0, 4), out uint recordLen)) break;
+                if (!AuditRecordCodec.TryGetRecordSize(recordLen, out int onDiskSize, out var kind)) break;
+                int restRead = ReadFully(fs, buffer, 4, onDiskSize - 4);
+                if (restRead < onDiskSize - 4) break;
+                if (kind == AuditRecordKind.Fill)
+                {
+                    if (!AuditRecordCodec.TryDecode(buffer.AsSpan(0, onDiskSize), out var record)) break;
+                    if (record.BuyFirm == firmId || record.SellFirm == firmId)
+                        yield return record;
+                }
+                // bust / reject-attempt records: skip (fills-only API).
+                // CRC validation happens in the type-specific TryDecode in
+                // ReadAllEntries; here we trust the recordLen dispatch and
+                // continue. A bit-flip in a skipped record will most likely
+                // surface as a bad recordLen on the next iteration.
             }
         }
     }

--- a/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
@@ -85,10 +85,11 @@ namespace B3.Exchange.PostTrade;
 public static class AuditRecordCodec
 {
     /// <summary>The schema version this build writes for newly-created
-    /// audit files. Existing v1 files are accepted on read and on
-    /// resume; the writer never bumps an in-place header
-    /// (per-day schema view, ADR 0008 §1).</summary>
-    public const ushort SchemaVersion = SchemaVersionV1;
+    /// audit files. ADR 0008 / issue #369 PR-2 bumps the default to V2;
+    /// existing V1 files remain readable on resume (per-day schema view
+    /// per ADR 0008 §1) and the writer's recovery path dispatches on the
+    /// per-file header version.</summary>
+    public const ushort SchemaVersion = SchemaVersionV2;
 
     /// <summary>Legacy fills-only schema (issue #329).</summary>
     public const ushort SchemaVersionV1 = 1;

--- a/src/B3.Exchange.PostTrade/BustDedupIndex.cs
+++ b/src/B3.Exchange.PostTrade/BustDedupIndex.cs
@@ -11,9 +11,9 @@ namespace B3.Exchange.PostTrade;
 /// <c>{rootDir}/{channel}/</c> via
 /// <see cref="AuditLogReader.ReadAllEntries(string)"/> and filtering for
 /// <see cref="AuditRecordKind.Bust"/> records. Only files whose date
-/// falls within <c>[today - retentionDays + 1, today]</c> are inspected;
-/// older files are eligible for deletion by <c>PruneOldDays</c> and are
-/// therefore not authoritative.</para>
+/// falls within <c>[today - retentionDays, today]</c> are inspected;
+/// this window must match <see cref="FileAuditLogWriter.PruneOldDays"/>
+/// so every still-retained bust is reflected here on restart.</para>
 /// </summary>
 public sealed class BustDedupIndex
 {
@@ -34,7 +34,8 @@ public sealed class BustDedupIndex
     /// <summary>
     /// Rebuilds the index by scanning <c>{rootDir}/{channel}/fills-*.log</c>
     /// files whose embedded business date falls within
-    /// <c>[todayUtc - retentionDays + 1, todayUtc]</c>. When
+    /// <c>[todayUtc - retentionDays, todayUtc]</c> — the same window
+    /// <see cref="FileAuditLogWriter.PruneOldDays"/> preserves. When
     /// <paramref name="retentionDays"/> is 0 (= unlimited retention) every
     /// file under the channel directory is scanned.
     ///
@@ -52,7 +53,7 @@ public sealed class BustDedupIndex
         if (!Directory.Exists(channelDir)) return index;
 
         DateOnly? minDate = retentionDays > 0
-            ? todayUtc.AddDays(-(retentionDays - 1))
+            ? todayUtc.AddDays(-retentionDays)
             : null;
 
         foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.log"))

--- a/src/B3.Exchange.PostTrade/BustDedupIndex.cs
+++ b/src/B3.Exchange.PostTrade/BustDedupIndex.cs
@@ -1,0 +1,82 @@
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Per-channel idempotency index for operator trade-bust requests
+/// (ADR 0008 §2.1). Maps <c>tradeId → (correlationId, tradeDate)</c> for
+/// every accepted bust visible within the rolling retention window. The
+/// index lives on the dispatch thread and is mutated only by the
+/// bust-processing code path.
+///
+/// <para>Rebuilt at startup by scanning audit files in
+/// <c>{rootDir}/{channel}/</c> via
+/// <see cref="AuditLogReader.ReadAllEntries(string)"/> and filtering for
+/// <see cref="AuditRecordKind.Bust"/> records. Only files whose date
+/// falls within <c>[today - retentionDays + 1, today]</c> are inspected;
+/// older files are eligible for deletion by <c>PruneOldDays</c> and are
+/// therefore not authoritative.</para>
+/// </summary>
+public sealed class BustDedupIndex
+{
+    private readonly Dictionary<uint, Entry> _byTradeId = new();
+
+    public readonly record struct Entry(ulong CorrelationId, DateOnly TradeDate);
+
+    public int Count => _byTradeId.Count;
+
+    public bool TryGet(uint tradeId, out Entry entry) => _byTradeId.TryGetValue(tradeId, out entry);
+
+    /// <summary>Records an accepted bust. Last write wins so a replay that
+    /// re-applies the same record is idempotent. The caller is responsible
+    /// for routing replays through <see cref="TryGet"/> first.</summary>
+    public void Add(uint tradeId, ulong correlationId, DateOnly tradeDate)
+        => _byTradeId[tradeId] = new Entry(correlationId, tradeDate);
+
+    /// <summary>
+    /// Rebuilds the index by scanning <c>{rootDir}/{channel}/fills-*.log</c>
+    /// files whose embedded business date falls within
+    /// <c>[todayUtc - retentionDays + 1, todayUtc]</c>. When
+    /// <paramref name="retentionDays"/> is 0 (= unlimited retention) every
+    /// file under the channel directory is scanned.
+    ///
+    /// <para>Bust records carry the day they reference in the on-disk
+    /// record (the file name carries the day they were WRITTEN, which is
+    /// the validator's "today" at the time of the operator request) —
+    /// the validator's idempotency check needs the referenced day, so it
+    /// is the <see cref="BustRecord"/> body that wins. The file-name day
+    /// is only used to skip files outside the retention window.</para>
+    /// </summary>
+    public static BustDedupIndex LoadFromAuditFiles(string rootDir, byte channel, int retentionDays, DateOnly todayUtc)
+    {
+        var index = new BustDedupIndex();
+        var channelDir = Path.Combine(rootDir, channel.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        if (!Directory.Exists(channelDir)) return index;
+
+        DateOnly? minDate = retentionDays > 0
+            ? todayUtc.AddDays(-(retentionDays - 1))
+            : null;
+
+        foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.log"))
+        {
+            var fileDate = TryParseDateFromFileName(path);
+            if (fileDate is null) continue;
+            if (minDate is { } floor && fileDate.Value < floor) continue;
+            foreach (var entry in AuditLogReader.ReadAllEntries(path))
+            {
+                if (entry.Kind != AuditRecordKind.Bust) continue;
+                var bust = entry.Bust;
+                // The file-name day IS the busted trade's day (writer
+                // contract: OnBust appends to fills-<tradeDate>.log).
+                index._byTradeId[bust.CancelledTradeId] = new Entry(bust.CorrelationId, fileDate.Value);
+            }
+        }
+        return index;
+    }
+
+    private static DateOnly? TryParseDateFromFileName(string path)
+    {
+        var name = Path.GetFileNameWithoutExtension(path);
+        if (name.Length != "fills-YYYY-MM-DD".Length) return null;
+        if (!name.StartsWith("fills-", StringComparison.Ordinal)) return null;
+        return DateOnly.TryParseExact(name.AsSpan("fills-".Length), "yyyy-MM-dd", out var d) ? d : null;
+    }
+}

--- a/src/B3.Exchange.PostTrade/BustValidator.cs
+++ b/src/B3.Exchange.PostTrade/BustValidator.cs
@@ -1,0 +1,99 @@
+namespace B3.Exchange.PostTrade;
+
+/// <summary>Validation outcome for a single operator bust request
+/// (ADR 0008 §2.3). Each case maps to a specific HTTP status code in
+/// the host's <c>POST /admin/post-trade/bust</c> handler.</summary>
+public enum BustValidationKind : byte
+{
+    /// <summary>First-time accept — write bust record + emit UMDF
+    /// TradeBust_57 frame. HTTP 200 "busted".</summary>
+    Accept = 0,
+    /// <summary>Same (tradeId, correlationId, tradeDate) already
+    /// recorded — no write, no UMDF emit. HTTP 200 with
+    /// <c>X-Idempotent: true</c>.</summary>
+    IdempotentReplay = 1,
+    /// <summary><c>fills-&lt;tradeDate&gt;.log</c> does not exist.
+    /// HTTP 410. NO audit-log write (ADR §2.3).</summary>
+    MissingDay = 2,
+    /// <summary>tradeId not present in <c>fills-&lt;tradeDate&gt;.log</c>.
+    /// HTTP 422, reject-attempt code 1.</summary>
+    UnknownTradeId = 3,
+    /// <summary>tradeId already busted with a different correlationId.
+    /// HTTP 409, reject-attempt code 2.</summary>
+    AlreadyBustedDifferentCorrelation = 4,
+    /// <summary>Caller-supplied securityId echo doesn't match the fill.
+    /// HTTP 422, reject-attempt code 3.</summary>
+    SecurityIdMismatch = 5,
+}
+
+/// <summary>Caller-supplied request shape for the bust validator. Held
+/// flat (no nesting) so it can be assembled directly from HTTP query
+/// parameters at the dispatcher boundary.</summary>
+public readonly record struct BustRequest(
+    uint TradeId,
+    DateOnly TradeDate,
+    ulong CorrelationId,
+    long? SecurityIdEcho,
+    ushort ReasonCode,
+    uint BusterFirm,
+    ulong AttemptTransactTimeNanos);
+
+/// <summary>Result of a single validation pass.
+/// <see cref="MatchedFill"/> is populated on <see cref="BustValidationKind.Accept"/>
+/// so callers can craft the UMDF frame without re-scanning the log.</summary>
+public readonly record struct BustValidationResult(
+    BustValidationKind Kind,
+    PostTradeRecord MatchedFill,
+    ulong ExistingCorrelationId);
+
+/// <summary>Stateless validator for operator bust requests
+/// (ADR 0008 §2.3). All disk access funnels through
+/// <see cref="AuditLogReader"/>; the dedup index is owned by the
+/// caller so the validator stays purely functional.</summary>
+public static class BustValidator
+{
+    public static BustValidationResult Validate(
+        string rootDir,
+        byte channel,
+        in BustRequest request,
+        BustDedupIndex dedup)
+    {
+        // 1) Idempotency check first — replaying the exact same (tradeId,
+        // correlationId, tradeDate) is a 200 even if the file no longer
+        // exists.
+        if (dedup.TryGet(request.TradeId, out var prior))
+        {
+            if (prior.CorrelationId == request.CorrelationId && prior.TradeDate == request.TradeDate)
+                return new BustValidationResult(BustValidationKind.IdempotentReplay, default, prior.CorrelationId);
+            return new BustValidationResult(BustValidationKind.AlreadyBustedDifferentCorrelation, default, prior.CorrelationId);
+        }
+
+        // 2) File-existence check (HTTP 410).
+        var logPath = Path.Combine(
+            rootDir,
+            channel.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            $"fills-{request.TradeDate:yyyy-MM-dd}.log");
+        if (!File.Exists(logPath))
+            return new BustValidationResult(BustValidationKind.MissingDay, default, 0);
+
+        // 3) Locate the fill by tradeId.
+        PostTradeRecord? matched = null;
+        foreach (var entry in AuditLogReader.ReadAllEntries(logPath))
+        {
+            if (entry.Kind != AuditRecordKind.Fill) continue;
+            if (entry.Fill.TradeId == request.TradeId)
+            {
+                matched = entry.Fill;
+                break;
+            }
+        }
+        if (matched is null)
+            return new BustValidationResult(BustValidationKind.UnknownTradeId, default, 0);
+
+        // 4) Optional securityId echo check.
+        if (request.SecurityIdEcho is { } echo && echo != matched.Value.SecurityId)
+            return new BustValidationResult(BustValidationKind.SecurityIdMismatch, matched.Value, 0);
+
+        return new BustValidationResult(BustValidationKind.Accept, matched.Value, 0);
+    }
+}

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -201,6 +201,99 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         }
     }
 
+    /// <summary>ADR 0008 PR-2: appends a bust audit record. When
+    /// <paramref name="tradeDate"/> matches the currently-open log day the
+    /// write is inline against <c>_stream</c>; otherwise a transient handle
+    /// is opened to that day's <c>fills-YYYY-MM-DD.log</c>, the record is
+    /// appended, fsynced, and the handle disposed. The .idx sidecar is
+    /// NOT updated (only fill records contribute to the firm-sparse index;
+    /// busts are queried via the v2 ReadAllEntries path).</summary>
+    public void OnBust(in BustRecord record, DateOnly tradeDate)
+    {
+        lock (_stateLock)
+        {
+            if (_writeFault) return;
+            try
+            {
+                Span<byte> buf = stackalloc byte[AuditRecordCodec.BustRecordSize];
+                int n = AuditRecordCodec.EncodeBust(buf, in record);
+                if (_stream is not null && tradeDate == _currentDate)
+                {
+                    // Same-day inline: end any open fill block first so the
+                    // .idx invariant ("entries cover contiguous fill runs")
+                    // is preserved across the non-fill insertion.
+                    FlushCurrentBlock();
+                    _stream.Write(buf.Slice(0, n));
+                    _stream.Flush(flushToDisk: false);
+                    return;
+                }
+                // Cross-day write: open/create, fsync, close.
+                AppendNonFillToOtherDay(tradeDate, buf.Slice(0, n));
+            }
+            catch
+            {
+                _writeFault = true;
+                throw;
+            }
+        }
+    }
+
+    /// <summary>ADR 0008 PR-2 / §2.5: appends a reject-attempt audit
+    /// record to TODAY's log (the day of <c>AttemptTransactTimeNanos</c>)
+    /// so the audit trail explains the corresponding 4xx HTTP reply.
+    /// </summary>
+    public void OnRejectAttempt(in RejectAttemptRecord record)
+    {
+        lock (_stateLock)
+        {
+            if (_writeFault) return;
+            try
+            {
+                var recordDate = ToUtcDate(record.AttemptTransactTimeNanos);
+                Span<byte> buf = stackalloc byte[AuditRecordCodec.RejectAttemptRecordSize];
+                int n = AuditRecordCodec.EncodeRejectAttempt(buf, in record);
+                if (_stream is null || recordDate != _currentDate)
+                {
+                    // OnRejectAttempt is dispatched on the dispatch thread,
+                    // so a rotation to today's log is the natural action:
+                    // future fills land on the same day. Mirrors OnTrade's
+                    // RotateTo path.
+                    RotateTo(recordDate);
+                }
+                FlushCurrentBlock();
+                _stream!.Write(buf.Slice(0, n));
+                _stream.Flush(flushToDisk: false);
+            }
+            catch
+            {
+                _writeFault = true;
+                throw;
+            }
+        }
+    }
+
+    private void AppendNonFillToOtherDay(DateOnly tradeDate, ReadOnlySpan<byte> recordBytes)
+    {
+        var channelDir = Path.Combine(_rootDir, _channelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(channelDir);
+        var logPath = Path.Combine(channelDir, $"fills-{tradeDate:yyyy-MM-dd}.log");
+        using var fs = new FileStream(logPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+        if (fs.Length == 0)
+        {
+            Span<byte> header = stackalloc byte[AuditRecordCodec.FileHeaderSize];
+            AuditRecordCodec.WriteFileHeader(header, _channelNumber, tradeDate);
+            fs.Write(header);
+        }
+        else
+        {
+            long goodEnd = ScanLastGoodEndOffset(fs);
+            if (goodEnd != fs.Length) fs.SetLength(goodEnd);
+        }
+        fs.Seek(0, SeekOrigin.End);
+        fs.Write(recordBytes);
+        fs.Flush(flushToDisk: true);
+    }
+
     /// <summary>Flushes OS buffers, forces <c>fsync</c> on both files, and
     /// advances <see cref="DurableThroughCommandSeq"/> to the most recent
     /// <see cref="OnCommandBoundary"/> value. Safe to call from any thread
@@ -387,41 +480,92 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         ix.Flush(flushToDisk: false);
         if (logStream.Length <= AuditRecordCodec.FileHeaderSize) return;
 
+        // Schema-aware rebuild (ADR 0008 PR-2): on v2 files the stream is
+        // heterogeneous (fills + bust + reject-attempt records); only fills
+        // contribute to the firm-sparse index. A non-fill record at any
+        // position simply terminates the current fill block (writer
+        // invariant: non-fill records are written outside any open block).
         long savedPos = logStream.Position;
         try
         {
-            logStream.Seek(AuditRecordCodec.FileHeaderSize, SeekOrigin.Begin);
-            Span<byte> rec = stackalloc byte[AuditRecordCodec.RecordSize];
+            logStream.Seek(0, SeekOrigin.Begin);
+            Span<byte> hdr = stackalloc byte[AuditRecordCodec.FileHeaderSize];
+            if (logStream.Read(hdr) != hdr.Length) return;
+            var (_, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(hdr);
+            bool schemaIsV2 = schemaVersion == AuditRecordCodec.SchemaVersionV2;
+
+            Span<byte> buffer = stackalloc byte[AuditRecordCodec.MaxRecordSize];
+            Span<byte> lenPrefix = stackalloc byte[4];
             long blockStart = logStream.Position;
             int recsInBlock = 0;
             var firmsInBlock = new List<uint>();
-            while (true)
+
+            void FlushBlock()
             {
-                if (recsInBlock == 0) blockStart = logStream.Position;
-                int read = logStream.Read(rec);
-                if (read != rec.Length) break;
-                if (!AuditRecordCodec.TryDecode(rec, out var decoded)) break;
-                int idx;
-                idx = firmsInBlock.BinarySearch(decoded.BuyFirm);
-                if (idx < 0) firmsInBlock.Insert(~idx, decoded.BuyFirm);
-                idx = firmsInBlock.BinarySearch(decoded.SellFirm);
-                if (idx < 0) firmsInBlock.Insert(~idx, decoded.SellFirm);
-                recsInBlock++;
-                if (recsInBlock >= _indexBlockRecords)
-                {
-                    var span = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(firmsInBlock);
-                    int n = AuditIndexCodec.EncodeBlockEntry(_indexScratch, (ulong)blockStart, (ushort)recsInBlock, span);
-                    ix.Write(_indexScratch, 0, n);
-                    recsInBlock = 0;
-                    firmsInBlock.Clear();
-                }
-            }
-            if (recsInBlock > 0)
-            {
+                if (recsInBlock == 0) return;
                 var span = System.Runtime.InteropServices.CollectionsMarshal.AsSpan(firmsInBlock);
                 int n = AuditIndexCodec.EncodeBlockEntry(_indexScratch, (ulong)blockStart, (ushort)recsInBlock, span);
                 ix.Write(_indexScratch, 0, n);
+                recsInBlock = 0;
+                firmsInBlock.Clear();
             }
+
+            while (true)
+            {
+                long recordStart = logStream.Position;
+                int recordSize;
+                bool isFill;
+                if (!schemaIsV2)
+                {
+                    int read = logStream.Read(buffer.Slice(0, AuditRecordCodec.RecordSize));
+                    if (read != AuditRecordCodec.RecordSize) break;
+                    if (!AuditRecordCodec.TryDecode(buffer.Slice(0, AuditRecordCodec.RecordSize), out var decodedV1)) break;
+                    if (recsInBlock == 0) blockStart = recordStart;
+                    int idx;
+                    idx = firmsInBlock.BinarySearch(decodedV1.BuyFirm);
+                    if (idx < 0) firmsInBlock.Insert(~idx, decodedV1.BuyFirm);
+                    idx = firmsInBlock.BinarySearch(decodedV1.SellFirm);
+                    if (idx < 0) firmsInBlock.Insert(~idx, decodedV1.SellFirm);
+                    recsInBlock++;
+                    if (recsInBlock >= _indexBlockRecords) FlushBlock();
+                    continue;
+                }
+                // v2 dispatch
+                int peeked = logStream.Read(lenPrefix);
+                if (peeked == 0) break;
+                if (peeked < 4) break;
+                if (!AuditRecordCodec.TryPeekRecordLen(lenPrefix, out uint recordLen)) break;
+                if (!AuditRecordCodec.TryGetRecordSize(recordLen, out recordSize, out var kind)) break;
+                lenPrefix.CopyTo(buffer);
+                int bodyRead = logStream.Read(buffer.Slice(4, recordSize - 4));
+                if (bodyRead != recordSize - 4) break;
+                isFill = kind == AuditRecordKind.Fill;
+                if (!isFill)
+                {
+                    bool ok = kind switch
+                    {
+                        AuditRecordKind.Bust => AuditRecordCodec.TryDecodeBust(buffer.Slice(0, recordSize), out _),
+                        AuditRecordKind.RejectAttempt => AuditRecordCodec.TryDecodeRejectAttempt(buffer.Slice(0, recordSize), out _),
+                        _ => false,
+                    };
+                    if (!ok) break;
+                    // Non-fill record ends any open block (writer invariant
+                    // guarantees this didn't happen mid-block, but flush
+                    // defensively to keep rebuild idempotent).
+                    FlushBlock();
+                    continue;
+                }
+                if (!AuditRecordCodec.TryDecode(buffer.Slice(0, recordSize), out var decoded)) break;
+                if (recsInBlock == 0) blockStart = recordStart;
+                int idxV2;
+                idxV2 = firmsInBlock.BinarySearch(decoded.BuyFirm);
+                if (idxV2 < 0) firmsInBlock.Insert(~idxV2, decoded.BuyFirm);
+                idxV2 = firmsInBlock.BinarySearch(decoded.SellFirm);
+                if (idxV2 < 0) firmsInBlock.Insert(~idxV2, decoded.SellFirm);
+                recsInBlock++;
+                if (recsInBlock >= _indexBlockRecords) FlushBlock();
+            }
+            FlushBlock();
             ix.Flush(flushToDisk: false);
         }
         finally
@@ -439,26 +583,49 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         var (channel, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(hdr);
         if (channel != _channelNumber)
             throw new InvalidDataException($"audit file '{fs.Name}' channel mismatch (file={channel}, writer={_channelNumber})");
-        // ADR 0008 §1 per-day schema view: this build's writer only emits
-        // v1 records, so refuse to extend an existing file at a different
-        // schema. Critical safety net: without this check, the v1 fixed-
-        // width scan below would stop at the first non-fill record in a
-        // v2 file and the caller would SetLength() to that point, silently
-        // truncating valid bust/reject-attempt records. PR-2 replaces this
-        // with a schema-aware recovery path.
-        if (schemaVersion != AuditRecordCodec.SchemaVersion)
+        // ADR 0008 §1 per-day schema view: writer accepts files of any
+        // schema it understands (V1 from pre-PR-2 days, V2 from PR-2
+        // onward). The recovery scan dispatches by recordLen so v2 files
+        // with mixed fill/bust/reject-attempt records are scanned
+        // correctly. Refuse anything we don't recognise.
+        if (schemaVersion != AuditRecordCodec.SchemaVersionV1
+            && schemaVersion != AuditRecordCodec.SchemaVersionV2)
             throw new InvalidDataException(
-                $"audit file '{fs.Name}' schema {schemaVersion} != writer schema {AuditRecordCodec.SchemaVersion}; "
-                + "refusing to extend (would risk truncating non-fill records)");
+                $"audit file '{fs.Name}' unsupported schema v{schemaVersion} "
+                + $"(writer understands v{AuditRecordCodec.SchemaVersionV1} and v{AuditRecordCodec.SchemaVersionV2})");
 
         long goodEnd = AuditRecordCodec.FileHeaderSize;
-        Span<byte> rec = stackalloc byte[AuditRecordCodec.RecordSize];
+        Span<byte> buffer = stackalloc byte[AuditRecordCodec.MaxRecordSize];
+        Span<byte> lenPrefix = stackalloc byte[4];
         while (true)
         {
-            int read = fs.Read(rec);
-            if (read != rec.Length) break;
-            if (!AuditRecordCodec.TryDecode(rec, out _)) break;
-            goodEnd += rec.Length;
+            if (schemaVersion == AuditRecordCodec.SchemaVersionV1)
+            {
+                int read = fs.Read(buffer.Slice(0, AuditRecordCodec.RecordSize));
+                if (read != AuditRecordCodec.RecordSize) break;
+                if (!AuditRecordCodec.TryDecode(buffer.Slice(0, AuditRecordCodec.RecordSize), out _)) break;
+                goodEnd += AuditRecordCodec.RecordSize;
+                continue;
+            }
+            // v2: peek 4-byte recordLen, dispatch by kind, validate via
+            // type-specific TryDecode so a corrupt entry stops the scan.
+            int peeked = fs.Read(lenPrefix);
+            if (peeked == 0) break;
+            if (peeked < 4) break;
+            if (!AuditRecordCodec.TryPeekRecordLen(lenPrefix, out uint recordLen)) break;
+            if (!AuditRecordCodec.TryGetRecordSize(recordLen, out int onDiskSize, out var kind)) break;
+            lenPrefix.CopyTo(buffer);
+            int bodyRead = fs.Read(buffer.Slice(4, onDiskSize - 4));
+            if (bodyRead != onDiskSize - 4) break;
+            bool ok = kind switch
+            {
+                AuditRecordKind.Fill => AuditRecordCodec.TryDecode(buffer.Slice(0, onDiskSize), out _),
+                AuditRecordKind.Bust => AuditRecordCodec.TryDecodeBust(buffer.Slice(0, onDiskSize), out _),
+                AuditRecordKind.RejectAttempt => AuditRecordCodec.TryDecodeRejectAttempt(buffer.Slice(0, onDiskSize), out _),
+                _ => false,
+            };
+            if (!ok) break;
+            goodEnd += onDiskSize;
         }
         return goodEnd;
     }

--- a/src/B3.Exchange.PostTrade/IPostTradeSink.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeSink.cs
@@ -94,6 +94,25 @@ public interface IPostTradeSink
     /// pre-#329 truncate-everything behaviour is preserved exactly.</para>
     /// </summary>
     long DurableThroughCommandSeq { get; }
+
+    /// <summary>
+    /// Appends an operator-issued trade-bust audit record to the audit log
+    /// for <paramref name="tradeDate"/> (ADR 0008 §1, §3). Unlike
+    /// <see cref="OnTrade"/>, busts are not tied to the current dispatch
+    /// day — they reference a historical fill — so implementations MUST
+    /// be capable of writing to a day other than the currently-open log
+    /// (cross-day write). Called on the <c>ChannelDispatcher</c> dispatch
+    /// thread after the operator-bust validator has accepted the request.
+    /// </summary>
+    void OnBust(in BustRecord record, DateOnly tradeDate);
+
+    /// <summary>
+    /// Appends a reject-attempt audit record to TODAY's audit log
+    /// (ADR 0008 §2.5). Records every accepted-but-rejected operator
+    /// bust attempt so the audit trail explains 4xx HTTP responses.
+    /// Called on the dispatch thread.
+    /// </summary>
+    void OnRejectAttempt(in RejectAttemptRecord record);
 }
 
 /// <summary>
@@ -109,5 +128,7 @@ public sealed class NullPostTradeSink : IPostTradeSink
     public void OnTrade(in PostTradeRecord record) { }
     public void OnCommandBoundary(long commandSeq) { }
     public void Checkpoint() { }
+    public void OnBust(in BustRecord record, DateOnly tradeDate) { }
+    public void OnRejectAttempt(in RejectAttemptRecord record) { }
     public long DurableThroughCommandSeq => long.MaxValue;
 }

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
@@ -26,6 +26,8 @@ public partial class ChannelDispatcherTests
             CheckpointCount++;
             _durable = _pending;
         }
+        public void OnBust(in BustRecord record, DateOnly tradeDate) { }
+        public void OnRejectAttempt(in RejectAttemptRecord record) { }
         public long DurableThroughCommandSeq => _durable;
     }
 

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
@@ -83,6 +83,8 @@ public class ChannelDispatcherAuditWatermarkTests
             if (commandSeq > _pending) _pending = commandSeq;
         }
         public void Checkpoint() => CheckpointCount++;
+        public void OnBust(in BustRecord record, DateOnly tradeDate) { }
+        public void OnRejectAttempt(in RejectAttemptRecord record) { }
         // When DurableOverride >= 0 the test pins the watermark; otherwise we
         // honour OnCommandBoundary as the durable seq (i.e. Checkpoint trivially
         // promotes pending → durable).

--- a/tests/B3.Exchange.PostTrade.Tests/BustDedupIndexTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/BustDedupIndexTests.cs
@@ -1,0 +1,77 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>ADR 0008 PR-2 tests for <see cref="BustDedupIndex"/> rebuild
+/// from on-disk audit files.</summary>
+public class BustDedupIndexTests : IDisposable
+{
+    private readonly string _root;
+    public BustDedupIndexTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "BustDedupTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private static readonly DateOnly Day0 = new(2026, 5, 18);
+    private const ulong OneDayNanos = 86_400UL * 1_000_000_000UL;
+
+    private static PostTradeRecord Fill(uint id, ulong ts) => new(
+        TradeId: id, TransactTimeNanos: ts, SecurityId: 1L, AggressorSide: Side.Buy,
+        Quantity: 1, PriceMantissa: 1, BuyClOrdId: 1, SellClOrdId: 1,
+        BuyFirm: 1, SellFirm: 2, BuyOrderId: 1, SellOrderId: 2);
+
+    private static BustRecord Bust(uint tradeId, ulong correlationId) =>
+        new(tradeId, Day0Nanos + 1, 1L, 0, 99, correlationId);
+
+    [Fact]
+    public void LoadFromAuditFiles_PicksUpBustsAcrossDaysWithinWindow()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 3))
+        {
+            w.OnTrade(Fill(1, Day0Nanos));
+            w.OnBust(Bust(1, correlationId: 42UL), Day0);
+            w.OnTrade(Fill(2, Day0Nanos + OneDayNanos));
+            w.OnBust(Bust(2, correlationId: 43UL), Day0.AddDays(1));
+        }
+
+        var index = BustDedupIndex.LoadFromAuditFiles(_root, channel: 3, retentionDays: 0, todayUtc: Day0.AddDays(1));
+        Assert.Equal(2, index.Count);
+        Assert.True(index.TryGet(1, out var e1));
+        Assert.Equal(42UL, e1.CorrelationId);
+        Assert.Equal(Day0, e1.TradeDate);
+        Assert.True(index.TryGet(2, out var e2));
+        Assert.Equal(43UL, e2.CorrelationId);
+        Assert.Equal(Day0.AddDays(1), e2.TradeDate);
+    }
+
+    [Fact]
+    public void LoadFromAuditFiles_SkipsFilesOlderThanRetentionWindow()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 4))
+        {
+            w.OnTrade(Fill(1, Day0Nanos));
+            w.OnBust(Bust(1, 100UL), Day0);
+            w.OnTrade(Fill(2, Day0Nanos + OneDayNanos));
+            w.OnBust(Bust(2, 200UL), Day0.AddDays(1));
+        }
+        // retentionDays = 1 + today = Day0+1 → window = [Day0+1, Day0+1]
+        var index = BustDedupIndex.LoadFromAuditFiles(_root, channel: 4, retentionDays: 1, todayUtc: Day0.AddDays(1));
+        Assert.Equal(1, index.Count);
+        Assert.False(index.TryGet(1, out _));
+        Assert.True(index.TryGet(2, out _));
+    }
+
+    [Fact]
+    public void LoadFromAuditFiles_EmptyDirReturnsEmptyIndex()
+    {
+        var index = BustDedupIndex.LoadFromAuditFiles(_root, channel: 99, retentionDays: 0, todayUtc: Day0);
+        Assert.Equal(0, index.Count);
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/BustDedupIndexTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/BustDedupIndexTests.cs
@@ -61,8 +61,9 @@ public class BustDedupIndexTests : IDisposable
             w.OnTrade(Fill(2, Day0Nanos + OneDayNanos));
             w.OnBust(Bust(2, 200UL), Day0.AddDays(1));
         }
-        // retentionDays = 1 + today = Day0+1 → window = [Day0+1, Day0+1]
-        var index = BustDedupIndex.LoadFromAuditFiles(_root, channel: 4, retentionDays: 1, todayUtc: Day0.AddDays(1));
+        // PruneOldDays-aligned window: retentionDays=1 + today=Day0+2 →
+        // [Day0+1, Day0+2], so Day0's bust is outside and skipped.
+        var index = BustDedupIndex.LoadFromAuditFiles(_root, channel: 4, retentionDays: 1, todayUtc: Day0.AddDays(2));
         Assert.Equal(1, index.Count);
         Assert.False(index.TryGet(1, out _));
         Assert.True(index.TryGet(2, out _));

--- a/tests/B3.Exchange.PostTrade.Tests/BustValidatorTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/BustValidatorTests.cs
@@ -1,0 +1,104 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>ADR 0008 PR-2: validator decision matrix.</summary>
+public class BustValidatorTests : IDisposable
+{
+    private readonly string _root;
+    public BustValidatorTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "BustValidatorTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private static readonly DateOnly Day0 = new(2026, 5, 18);
+    private const long SecId = 900_000_000_777L;
+
+    private static PostTradeRecord Fill(uint id) => new(
+        TradeId: id, TransactTimeNanos: Day0Nanos, SecurityId: SecId, AggressorSide: Side.Buy,
+        Quantity: 100, PriceMantissa: 10_0000L,
+        BuyClOrdId: 1, SellClOrdId: 2, BuyFirm: 10, SellFirm: 20, BuyOrderId: 5, SellOrderId: 6);
+
+    private void Seed(byte channel, params uint[] tradeIds)
+    {
+        using var w = new FileAuditLogWriter(_root, channelNumber: channel);
+        foreach (var id in tradeIds) w.OnTrade(Fill(id));
+    }
+
+    private static BustRequest Req(uint tradeId, ulong corr, long? echo = null) =>
+        new(tradeId, Day0, corr, echo, ReasonCode: 1, BusterFirm: 99, AttemptTransactTimeNanos: Day0Nanos + 1);
+
+    [Fact]
+    public void Accept_WhenTradeIdExistsAndNoPriorBust()
+    {
+        Seed(channel: 1, 100u);
+        var dedup = new BustDedupIndex();
+        var result = BustValidator.Validate(_root, 1, Req(100u, corr: 5UL, echo: SecId), dedup);
+        Assert.Equal(BustValidationKind.Accept, result.Kind);
+        Assert.Equal(100u, result.MatchedFill.TradeId);
+        Assert.Equal(SecId, result.MatchedFill.SecurityId);
+    }
+
+    [Fact]
+    public void IdempotentReplay_WhenSameTripleSeenBefore()
+    {
+        Seed(channel: 2, 100u);
+        var dedup = new BustDedupIndex();
+        dedup.Add(100u, correlationId: 5UL, tradeDate: Day0);
+        var result = BustValidator.Validate(_root, 2, Req(100u, corr: 5UL), dedup);
+        Assert.Equal(BustValidationKind.IdempotentReplay, result.Kind);
+    }
+
+    [Fact]
+    public void AlreadyBustedDifferentCorrelation_WhenCorrIdDiffers()
+    {
+        Seed(channel: 3, 100u);
+        var dedup = new BustDedupIndex();
+        dedup.Add(100u, correlationId: 5UL, tradeDate: Day0);
+        var result = BustValidator.Validate(_root, 3, Req(100u, corr: 999UL), dedup);
+        Assert.Equal(BustValidationKind.AlreadyBustedDifferentCorrelation, result.Kind);
+        Assert.Equal(5UL, result.ExistingCorrelationId);
+    }
+
+    [Fact]
+    public void MissingDay_WhenLogFileNotPresent()
+    {
+        var dedup = new BustDedupIndex();
+        var result = BustValidator.Validate(_root, 4, Req(100u, corr: 5UL), dedup);
+        Assert.Equal(BustValidationKind.MissingDay, result.Kind);
+    }
+
+    [Fact]
+    public void UnknownTradeId_WhenLogExistsButTradeIdMissing()
+    {
+        Seed(channel: 5, 1u, 2u, 3u);
+        var dedup = new BustDedupIndex();
+        var result = BustValidator.Validate(_root, 5, Req(99u, corr: 5UL), dedup);
+        Assert.Equal(BustValidationKind.UnknownTradeId, result.Kind);
+    }
+
+    [Fact]
+    public void SecurityIdMismatch_WhenEchoDoesNotMatchFill()
+    {
+        Seed(channel: 6, 100u);
+        var dedup = new BustDedupIndex();
+        var result = BustValidator.Validate(_root, 6, Req(100u, corr: 5UL, echo: SecId + 1), dedup);
+        Assert.Equal(BustValidationKind.SecurityIdMismatch, result.Kind);
+    }
+
+    [Fact]
+    public void SecurityIdEcho_Optional_AcceptedWhenAbsent()
+    {
+        Seed(channel: 7, 100u);
+        var dedup = new BustDedupIndex();
+        var result = BustValidator.Validate(_root, 7, Req(100u, corr: 5UL, echo: null), dedup);
+        Assert.Equal(BustValidationKind.Accept, result.Kind);
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterBustTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterBustTests.cs
@@ -1,0 +1,147 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>ADR 0008 PR-2 tests for the bust + reject-attempt
+/// extensions of <see cref="FileAuditLogWriter"/>.</summary>
+public class FileAuditLogWriterBustTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileAuditLogWriterBustTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "B3PostTradeBustTests_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private static readonly DateOnly Day0 = new(2026, 5, 18);
+    private const ulong OneDayNanos = 86_400UL * 1_000_000_000UL;
+
+    private static PostTradeRecord MakeFill(uint id, ulong ts, long secId = 900_000_000_001L) => new(
+        TradeId: id, TransactTimeNanos: ts, SecurityId: secId, AggressorSide: Side.Buy,
+        Quantity: 100, PriceMantissa: 10_0000L,
+        BuyClOrdId: 1000UL, SellClOrdId: 2000UL,
+        BuyFirm: 7, SellFirm: 8,
+        BuyOrderId: 5000, SellOrderId: 6000);
+
+    private static BustRecord MakeBust(uint tradeId, ulong correlationId) =>
+        new(CancelledTradeId: tradeId, BustTransactTimeNanos: Day0Nanos + 5UL * 60UL * 1_000_000_000UL,
+            SecurityId: 900_000_000_001L, ReasonCode: 1, BusterFirm: 99, CorrelationId: correlationId);
+
+    private static RejectAttemptRecord MakeReject(uint tradeId, ushort code) =>
+        new(AttemptedTradeId: tradeId, AttemptTransactTimeNanos: Day0Nanos + 10UL * 60UL * 1_000_000_000UL,
+            DeclaredTradeDateDays: Day0.DayNumber, RejectCode: code, BusterFirm: 99, CorrelationId: 555UL);
+
+    [Fact]
+    public void OnBust_SameDayInline_AppendsAndIsReadableViaReadAllEntries()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 7))
+        {
+            w.OnTrade(MakeFill(1, Day0Nanos));
+            w.OnBust(MakeBust(1, correlationId: 42UL), Day0);
+        }
+        var path = Path.Combine(_root, "7", "fills-2026-05-18.log");
+        var entries = AuditLogReader.ReadAllEntries(path).ToList();
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(AuditRecordKind.Fill, entries[0].Kind);
+        Assert.Equal(AuditRecordKind.Bust, entries[1].Kind);
+        Assert.Equal(1u, entries[1].Bust.CancelledTradeId);
+        Assert.Equal(42UL, entries[1].Bust.CorrelationId);
+    }
+
+    [Fact]
+    public void OnBust_CrossDay_OpensTransientFileAndAppends()
+    {
+        // Writer is "today" = day+1; bust references day 0.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 8))
+        {
+            w.OnTrade(MakeFill(1, Day0Nanos));         // creates day-0 file
+            w.OnTrade(MakeFill(2, Day0Nanos + OneDayNanos)); // rotates to day-1
+            w.OnBust(MakeBust(1, correlationId: 7UL), Day0);
+        }
+        var day0Path = Path.Combine(_root, "8", "fills-2026-05-18.log");
+        var day1Path = Path.Combine(_root, "8", "fills-2026-05-19.log");
+
+        var day0Entries = AuditLogReader.ReadAllEntries(day0Path).ToList();
+        Assert.Equal(2, day0Entries.Count);
+        Assert.Equal(AuditRecordKind.Fill, day0Entries[0].Kind);
+        Assert.Equal(AuditRecordKind.Bust, day0Entries[1].Kind);
+        Assert.Equal(7UL, day0Entries[1].Bust.CorrelationId);
+
+        var day1Entries = AuditLogReader.ReadAllEntries(day1Path).ToList();
+        var only = Assert.Single(day1Entries);
+        Assert.Equal(AuditRecordKind.Fill, only.Kind);
+        Assert.Equal(2u, only.Fill.TradeId);
+    }
+
+    [Fact]
+    public void OnBust_CrossDay_NewFileGetsValidHeader()
+    {
+        // Bust day has no fills at all -> writer must create the file +
+        // write the v2 header before appending.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 9))
+        {
+            // Open writer with a today-record to make _currentDate != bust day.
+            w.OnTrade(MakeFill(1, Day0Nanos + OneDayNanos));
+            w.OnBust(MakeBust(99, correlationId: 1UL), Day0); // creates day-0 file from scratch
+        }
+        var day0Path = Path.Combine(_root, "9", "fills-2026-05-18.log");
+        Assert.True(File.Exists(day0Path));
+        var entries = AuditLogReader.ReadAllEntries(day0Path).ToList();
+        var only = Assert.Single(entries);
+        Assert.Equal(AuditRecordKind.Bust, only.Kind);
+        Assert.Equal(99u, only.Bust.CancelledTradeId);
+    }
+
+    [Fact]
+    public void OnRejectAttempt_WritesToTodayFile()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 10))
+        {
+            w.OnTrade(MakeFill(1, Day0Nanos));
+            w.OnRejectAttempt(MakeReject(42, code: 1));
+        }
+        var path = Path.Combine(_root, "10", "fills-2026-05-18.log");
+        var entries = AuditLogReader.ReadAllEntries(path).ToList();
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(AuditRecordKind.Fill, entries[0].Kind);
+        Assert.Equal(AuditRecordKind.RejectAttempt, entries[1].Kind);
+        Assert.Equal(42u, entries[1].RejectAttempt.AttemptedTradeId);
+        Assert.Equal((ushort)1, entries[1].RejectAttempt.RejectCode);
+    }
+
+    [Fact]
+    public void NewFilesUseSchemaV2_AndAreReadableAfterReopen()
+    {
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 11))
+        {
+            w.OnTrade(MakeFill(1, Day0Nanos));
+            w.OnBust(MakeBust(1, correlationId: 99UL), Day0);
+        }
+        var path = Path.Combine(_root, "11", "fills-2026-05-18.log");
+        // Spot-check the header byte for the schema-v2 marker.
+        var bytes = File.ReadAllBytes(path);
+        Assert.True(bytes.Length > AuditRecordCodec.FileHeaderSize);
+        // schemaVersion lives at the start of the header (per codec layout).
+        var (_, _, sv) = AuditRecordCodec.ReadFileHeader(bytes.AsSpan(0, AuditRecordCodec.FileHeaderSize));
+        Assert.Equal(AuditRecordCodec.SchemaVersionV2, sv);
+
+        // Reopen and append more — should not truncate anything.
+        using (var w = new FileAuditLogWriter(_root, channelNumber: 11))
+        {
+            w.OnTrade(MakeFill(2, Day0Nanos));
+        }
+        var entries = AuditLogReader.ReadAllEntries(path).ToList();
+        Assert.Equal(3, entries.Count);
+        Assert.Equal(AuditRecordKind.Fill, entries[0].Kind);
+        Assert.Equal(AuditRecordKind.Bust, entries[1].Kind);
+        Assert.Equal(AuditRecordKind.Fill, entries[2].Kind);
+    }
+}


### PR DESCRIPTION
ADR 0008 implementation PR-2 of 5 (tracking #369). Builds on PR-1 (#370) which added the schema-v2 codec + reader dispatch.

## What this PR adds

**Schema-v2 writer** — `AuditRecordCodec.SchemaVersion` bumped to V2; new files are written with v2 headers. V1 files still readable on resume (per-day schema view, ADR §1). `FileAuditLogWriter.ScanLastGoodEndOffset` and `OpenAndRebuildIndex` now dispatch by `recordLen` so mixed fill/bust/reject logs scan correctly.

**IPostTradeSink extensions**
- `OnBust(in BustRecord, DateOnly tradeDate)` — cross-day capable (transient file handle when `tradeDate != _currentDate`); writes a v2 header to the target file if it's new.
- `OnRejectAttempt(in RejectAttemptRecord)` — always today.
- Write-fault sticky gate preserved.

**ReadByFirm v2 dispatch** — the unindexed-suffix path now dispatches by recordLen and skips non-fills (the firm-sparse `.idx` only covers fill blocks per writer invariant).

**Dedup + validator**
- `BustDedupIndex`: per-channel `tradeId → (correlationId, tradeDate)`; rebuilt at startup from rolling-window audit files via `AuditLogReader.ReadAllEntries`.
- `BustValidator` (stateless): 7-outcome decision per ADR §2.3 — Accept, IdempotentReplay, MissingDay, UnknownTradeId, AlreadyBustedDifferentCorrelation, SecurityIdMismatch.

**Dispatcher**
- `WorkKind.OperatorBustV2` + `EnqueueOperatorBustV2(...)` with `TaskCompletionSource<OperatorBustV2Outcome>` so HTTP can await.
- `ProcessOperatorBustV2` on the dispatch thread: validate → write bust or reject-attempt → emit `TradeBust_57` on accept → complete TCS.
- `RejectIfWalHalted` gated. Audit-root + dedup index passed through the constructor (defaults preserve existing call sites).

**HTTP** — `POST /admin/post-trade/bust?channel=N&tradeId=T&tradeDate=YYYY-MM-DD&correlationId=C[&reason=R][&securityId=S][&busterFirm=F]` with the full ADR §2.3 status matrix (200/400/404/409/410/422/503/504) and `X-Idempotent: true` on replays. Legacy `/channel/{ch}/trade-bust/{tradeId}` kept (replay-only).

**Host wiring** — `ExchangeHost` builds the dedup index from disk per channel at startup using the configured `postTradeAudit.retentionDays`.

## Deliberate deferrals (documented for next PRs)

- Pre/post-EOD routing keyed on `fills.csv.done` presence → **PR-4** (every accepted bust currently lands in tradeDate's `.log`, i.e. the pre-EOD path).
- `amendments.csv` publish → **PR-4**.

## Tests

- `FileAuditLogWriterBustTests` (5): same-day inline, cross-day transient file, new-file header, OnRejectAttempt, v2 schema marker + reopen round-trip.
- `BustDedupIndexTests` (3): rebuild across days, retention-window skip, empty dir.
- `BustValidatorTests` (7): every outcome in the matrix.
- All 106 PostTrade tests + full solution suite green (one known `FixpSessionRetransmitTests` flake passes on rerun).
- `dotnet format --verify-no-changes` clean.

Refs #369