### PR TITLE
feat(post-trade): pre-EOD bust folding in EodFillsExporter (ADR 0008 PR-3)

### DIFF
--- a/src/B3.Exchange.PostTrade/EodFillsExporter.cs
+++ b/src/B3.Exchange.PostTrade/EodFillsExporter.cs
@@ -212,9 +212,24 @@ public sealed class EodFillsExporter
         // Header — frozen by ADR 0001 / issue #330.
         sw.Write("tradeId,ts,symbol,aggressorSide,qty,price,buyClOrdId,sellClOrdId,buyFirm,sellFirm\n");
 
+        // ADR 0008 §3a — pre-EOD bust folding. The audit log for this
+        // business date may contain bust records (recordType=0x02) whose
+        // CancelledTradeId targets a fill that lives in this same file.
+        // The resulting fills.csv MUST NOT contain the busted fill at
+        // all (vs containing it then negating it), so first-pass walk
+        // builds the cancellation set, second-pass walk filters fills
+        // out of the projection. Reject-attempt records (type=0x03) are
+        // skipped entirely — they describe rejected operator commands
+        // and do not affect the published fills.
+        var cancelled = CollectCancelledTradeIds(auditLogPath);
+
         long rows = 0;
-        foreach (var r in AuditLogReader.ReadAll(auditLogPath))
+        foreach (var entry in AuditLogReader.ReadAllEntries(auditLogPath))
         {
+            if (entry.Kind != AuditRecordKind.Fill) continue;
+            var r = entry.Fill;
+            if (cancelled.Contains(r.TradeId)) continue;
+
             var sym = symbolLookup(r.SecurityId);
             if (string.IsNullOrEmpty(sym))
             {
@@ -245,6 +260,20 @@ public sealed class EodFillsExporter
             rows++;
         }
         return rows;
+    }
+
+    private static HashSet<uint> CollectCancelledTradeIds(string auditLogPath)
+    {
+        // Per-day memory: 4 bytes × #busts; bounded well under 1 MB for
+        // any realistic day (ADR 0008 §3a). Two-pass shape mirrors the
+        // existing exporter tests' streaming expectations.
+        var cancelled = new HashSet<uint>();
+        foreach (var entry in AuditLogReader.ReadAllEntries(auditLogPath))
+        {
+            if (entry.Kind == AuditRecordKind.Bust)
+                cancelled.Add(entry.Bust.CancelledTradeId);
+        }
+        return cancelled;
     }
 
     private static string FormatTimestampMicros(ulong transactTimeNanos)

--- a/tests/B3.Exchange.PostTrade.Tests/EodFillsExporterTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/EodFillsExporterTests.cs
@@ -261,4 +261,101 @@ public class EodFillsExporterTests : IDisposable
         // tradeId=1,ts,"WEIRD,""SYM""",...
         Assert.Contains(",\"WEIRD,\"\"SYM\"\"\",", line, StringComparison.Ordinal);
     }
+
+    // ADR 0008 §3a — pre-EOD bust folding: bust records targeting fills
+    // in the same day's log cause those fills to disappear from the
+    // projection entirely (not be negated). Reject-attempt records are
+    // operator audit-only and must not affect the export.
+
+    private static BustRecord MakeBust(uint cancelledTradeId, ulong attemptTs, long secId = 900_000_000_001L, uint busterFirm = 99, ulong correlationId = 4242UL)
+        => new(cancelledTradeId, attemptTs, secId, ReasonCode: 1, busterFirm, correlationId);
+
+    private static RejectAttemptRecord MakeReject(uint attemptedTradeId, ulong attemptTs, int declaredDate = 20597, uint busterFirm = 99, ulong correlationId = 5555UL)
+        => new(attemptedTradeId, attemptTs, declaredDate, RejectCode: 1, busterFirm, correlationId);
+
+    [Fact]
+    public void Export_PreEodFolding_OmitsBustedFills()
+    {
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(Make(1, Day0Nanos, secId: 100));
+            w.OnTrade(Make(2, Day0Nanos + 1_000_000UL, secId: 100));
+            w.OnTrade(Make(3, Day0Nanos + 2_000_000UL, secId: 100));
+            // Cancel trade 2 in the same day's log (pre-EOD path).
+            w.OnBust(MakeBust(2, Day0Nanos + 3_000_000UL, secId: 100), BusinessDate);
+        }
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => "PETR4", FixedGeneratedAt);
+
+        Assert.Equal(2, result.RowCount);
+        var lines = File.ReadAllLines(result.CsvPath);
+        Assert.Equal(3, lines.Length); // header + 2 rows
+        Assert.Equal("1", lines[1].Split(',')[0]);
+        Assert.Equal("3", lines[2].Split(',')[0]); // tradeId=2 is gone entirely
+    }
+
+    [Fact]
+    public void Export_PreEodFolding_SkipsRejectAttempts()
+    {
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(Make(1, Day0Nanos, secId: 100));
+            // Reject-attempt records are operator audit; they must never
+            // appear in the projection, nor cancel anything.
+            w.OnRejectAttempt(MakeReject(1, Day0Nanos + 500_000UL));
+            w.OnTrade(Make(2, Day0Nanos + 1_000_000UL, secId: 100));
+        }
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => "PETR4", FixedGeneratedAt);
+
+        Assert.Equal(2, result.RowCount);
+        var lines = File.ReadAllLines(result.CsvPath);
+        Assert.Equal(3, lines.Length);
+        Assert.Equal("1", lines[1].Split(',')[0]);
+        Assert.Equal("2", lines[2].Split(',')[0]);
+    }
+
+    [Fact]
+    public void Export_PreEodFolding_AllFillsBusted_EmitsHeaderOnly()
+    {
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(Make(1, Day0Nanos, secId: 100));
+            w.OnTrade(Make(2, Day0Nanos + 1_000_000UL, secId: 100));
+            w.OnBust(MakeBust(1, Day0Nanos + 2_000_000UL, secId: 100), BusinessDate);
+            w.OnBust(MakeBust(2, Day0Nanos + 3_000_000UL, secId: 100), BusinessDate);
+        }
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => "PETR4", FixedGeneratedAt);
+
+        Assert.Equal(0, result.RowCount);
+        var lines = File.ReadAllLines(result.CsvPath);
+        Assert.Single(lines); // header only
+    }
+
+    [Fact]
+    public void Export_PreEodFolding_BustForUnknownTradeId_IsHarmless()
+    {
+        // The validator gates this in the dispatch path (UnknownTradeId
+        // never writes a Bust record), but defense-in-depth: a stray
+        // bust pointing at a tradeId that isn't in the day's fills
+        // simply has no effect.
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(Make(1, Day0Nanos, secId: 100));
+            w.OnBust(MakeBust(99, Day0Nanos + 1_000_000UL, secId: 100), BusinessDate);
+        }
+
+        var result = NewExporter().Export(
+            _auditRoot, _dropRoot, Channel, BusinessDate,
+            _ => "PETR4", FixedGeneratedAt);
+
+        Assert.Equal(1, result.RowCount);
+    }
 }


### PR DESCRIPTION
ADR 0008 implementation PR-3 of 5 (tracking #369). Builds on PR-1 (#370) and PR-2 (#371).

## What this PR does

Per ADR 0008 §3a, the EOD projection now folds same-day bust records into `fills.csv` so busted trades **disappear entirely** from the published file (vs. being negated). Consumer-side D+1 reconciliation becomes a single-pass match-and-tick exercise; no amendment file is needed for same-day busts.

### Implementation

- `EodFillsExporter.WriteCsv` switched from `AuditLogReader.ReadAll` to `AuditLogReader.ReadAllEntries` so it can see the full v2 record stream.
- New first pass collects `HashSet<uint>` of `CancelledTradeId`s from `Bust` records (per-day memory ≪ 1 MB for any realistic day; matches ADR estimate).
- Second pass emits a fill row only if its `TradeId` is not in the cancelled set.
- `RejectAttempt` records are skipped entirely (operator audit; no projection impact).

### Backwards compat

V1 logs (no `Bust` records) yield an empty cancelled set → projection is byte-identical to the previous behaviour. All existing tests continue to pass.

## Tests (+4)

- `PreEodFolding_OmitsBustedFills` — 3 fills + 1 bust → 2 rows; the busted `tradeId` is absent.
- `PreEodFolding_SkipsRejectAttempts` — reject-attempt records affect neither row count nor row identity.
- `PreEodFolding_AllFillsBusted_EmitsHeaderOnly` — every fill cancelled → header only.
- `PreEodFolding_BustForUnknownTradeId_IsHarmless` — defense-in-depth against a stray bust pointing at a non-existent `tradeId`.

All 110 PostTrade tests + full solution suite green. `dotnet format --verify-no-changes` clean.

## Deferrals (PR-4)

- Post-EOD routing (bust lands in `tradeDate`'s file vs. `bustToday`'s file based on `fills.csv.done` presence).
- `amendments.csv` publish (post-EOD consumer-visible artifact per ADR §4).

Refs #369