### PR TITLE
ADR 0008 PR-4: post-EOD bust routing + amendments.csv publish (#369)

### DIFF
--- a/docs/adr/0008-late-corrections-and-bust-propagation.md
+++ b/docs/adr/0008-late-corrections-and-bust-propagation.md
@@ -98,7 +98,8 @@ This ADR therefore owns:
     records; no upgrade tool is needed and a v2 file that
     contains only fills compares equal to its v1 predecessor
     modulo the file header.
-  - `recordLen == 40` → Bust body (§1.1).
+  - `recordLen == 40` → Bust body, schema v2 (§1.1, pre-PR-4).
+  - `recordLen == 44` → Bust body, schema v3 (§1.1, PR-4 onward).
   - `recordLen == 36` → Reject-attempt body (§2.5).
   - any other value → reader treats the file as corrupt and
     surfaces the offset, same policy as a CRC failure.
@@ -109,15 +110,16 @@ This ADR therefore owns:
   dispatch; a mismatch is treated as corruption. The leading
   byte is inside the CRC-covered body.
 - Existing v1 files (any day that was opened before the v2
-  upgrade) are read by the v2 reader using a **per-day schema
+  upgrade) are read by the v2/v3 reader using a **per-day schema
   view**: if the file header says `schemaVersion=1`, the reader
   decodes only fill records (`recordLen == 81`) and refuses any
-  other value as corruption. New files (opened after the upgrade)
-  carry `schemaVersion=2` and the full dispatch table. This
-  mirrors the "old days are read with their original schema"
-  guarantee in ADR 0001 §2.
+  other value as corruption. New files (opened after the
+  PR-4 schema bump) carry `schemaVersion=3`; PR-2-era files carry
+  `schemaVersion=2` and continue to be read with their original
+  schema. This mirrors the "old days are read with their
+  original schema" guarantee in ADR 0001 §2.
 
-#### 1.1 Bust record body (schema v2, type=0x02, `recordLen` = 40)
+#### 1.1 Bust record body (schema v3, type=0x02, `recordLen` = 44)
 
 Fixed-width, little-endian, exactly as for fills:
 
@@ -135,12 +137,29 @@ busterFirm            (uint32)  — operator identity (always the host's
                                   operator firm constant for simulator;
                                   reserved for a future per-operator surface)
 correlationId         (uint64)  — operator-supplied idempotency key (see §2.1)
+declaredTradeDate     (int32)   — LocalMktDate (days since 1970-01-01) of
+                                  the original fill being busted; PR-4
+                                  addition so post-EOD busts (which land
+                                  in fills-<bustToday>.log, not the
+                                  original day's file) still attribute
+                                  back to the original day for §4
+                                  amendments-file regeneration
 ```
 
-Total body length: 1 + 1 + 4 + 8 + 8 + 2 + 4 + 8 = **36 bytes**.
-On-disk record: 4 (`recordLen`) + 4 (`crc32`) + 36 = **44 bytes**;
-`recordLen` reads as **40** (= `crc(4) + body(36)`), matching the
+Total body length: 1 + 1 + 4 + 8 + 8 + 2 + 4 + 8 + 4 = **40 bytes**.
+On-disk record: 4 (`recordLen`) + 4 (`crc32`) + 40 = **48 bytes**;
+`recordLen` reads as **44** (= `crc(4) + body(40)`), matching the
 v1 framing convention.
+
+**v2 backwards compatibility** (per the per-day schema view above):
+PR-2-era v2 bust records on disk have `recordLen == 40`, omit the
+trailing `declaredTradeDate` field (body = 36 bytes, on-disk = 44
+bytes), and are decoded into in-memory `BustRecord`s with
+`DeclaredTradeDateDays = -1` (the `BustRecord.DeclaredTradeDateAbsent`
+sentinel). `BustDedupIndex.LoadFromAuditFiles` falls back to the
+file-name day in that case — for v2 records the writer contract
+(OnBust appends to `fills-<tradeDate>.log`) made the file-name day
+always equal to the trade's day.
 
 - `cancelledTradeId` is the **only** field the projection looks at;
   the other fields are for diagnostics and forward-compat with

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -292,8 +292,36 @@ public sealed partial class ChannelDispatcher
                         break;
                     }
                 case B3.Exchange.PostTrade.BustValidationKind.IdempotentReplay:
-                    // No new write, no UMDF emit.
-                    break;
+                    {
+                        // No new audit write, no UMDF emit. BUT: if the
+                        // original accept was a post-EOD bust whose
+                        // amendments.csv publish failed (logged-only
+                        // failure under §4), this is the operator's
+                        // retry — re-run the publish so the missing
+                        // row finally lands. AmendmentsPublisher
+                        // regenerates the file in full from the audit
+                        // log so this is naturally idempotent: if the
+                        // original publish succeeded the new file is
+                        // byte-identical except for `generatedAt`.
+                        if (_amendmentsPublisher != null && _auditRootDir != null && _dropRootDir != null
+                            && File.Exists(Path.Combine(_dropRootDir,
+                                ChannelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                                op.TradeDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
+                                "fills.csv.done")))
+                        {
+                            try
+                            {
+                                _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, ChannelNumber, op.TradeDate, DateTime.UtcNow);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex,
+                                    "amendments.csv republish on idempotent replay failed for channel={Channel} date={Date}; further retries required",
+                                    ChannelNumber, op.TradeDate);
+                            }
+                        }
+                        break;
+                    }
                 case B3.Exchange.PostTrade.BustValidationKind.MissingDay:
                     // No audit-log write (ADR §2.3).
                     break;

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -1,5 +1,7 @@
 namespace B3.Exchange.Core;
 
+using Microsoft.Extensions.Logging;
+
 /// <summary>
 /// Operator-command facet of <see cref="ChannelDispatcher"/> (issue #168
 /// split): the producer-side <c>EnqueueOperator*</c> APIs (channel-reset,
@@ -230,9 +232,31 @@ public sealed partial class ChannelDispatcher
                     {
                         var bust = new B3.Exchange.PostTrade.BustRecord(
                             op.TradeId, op.AttemptTransactTimeNanos,
-                            result.MatchedFill.SecurityId, op.ReasonCode, op.BusterFirm, op.CorrelationId);
-                        _postTradeSink.OnBust(bust, op.TradeDate);
-                        _bustDedup!.Add(op.TradeId, op.CorrelationId, op.TradeDate);
+                            result.MatchedFill.SecurityId, op.ReasonCode, op.BusterFirm, op.CorrelationId,
+                            DeclaredTradeDateDays: tradeDateDaysSinceEpoch);
+                        // ADR 0008 §3 routing: under the per-channel
+                        // post-trade lock, decide pre-EOD vs post-EOD
+                        // based on the existence of the target day's
+                        // fills.csv.done sidecar; this closes the race
+                        // with EodFillsExporter (which holds the same
+                        // lock between its cancelled-set scan and the
+                        // .done rename).
+                        DateOnly bustFileDate = op.TradeDate;
+                        bool isPostEod = false;
+                        lock (PostTradeRoutingLock)
+                        {
+                            if (_dropRootDir != null
+                                && File.Exists(Path.Combine(_dropRootDir,
+                                    ChannelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                                    op.TradeDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
+                                    "fills.csv.done")))
+                            {
+                                bustFileDate = DateOnly.FromDateTime(DateTime.UtcNow);
+                                isPostEod = true;
+                            }
+                            _postTradeSink.OnBust(bust, bustFileDate);
+                            _bustDedup!.Add(op.TradeId, op.CorrelationId, op.TradeDate);
+                        }
                         // Emit TradeBust_57 frame; price/size echo come from the
                         // matched fill so consumers see the same data the
                         // original Trade_53 carried.
@@ -249,6 +273,22 @@ public sealed partial class ChannelDispatcher
                             _nowNanos(), rptSeq);
                         Commit(written);
                         FlushPacket();
+                        // ADR 0008 §4: post-EOD busts publish/refresh
+                        // amendments.csv for the original trade's day so
+                        // external consumers see the late correction.
+                        if (isPostEod && _amendmentsPublisher != null && _auditRootDir != null && _dropRootDir != null)
+                        {
+                            try
+                            {
+                                _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, ChannelNumber, op.TradeDate, DateTime.UtcNow);
+                            }
+                            catch (Exception ex)
+                            {
+                                _logger.LogError(ex,
+                                    "amendments.csv publish failed for channel={Channel} date={Date}; bust persisted but downstream consumers will only see it on next operator retry or restart",
+                                    ChannelNumber, op.TradeDate);
+                            }
+                        }
                         break;
                     }
                 case B3.Exchange.PostTrade.BustValidationKind.IdempotentReplay:

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -229,6 +229,17 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly B3.Exchange.PostTrade.IPostTradeSink _postTradeSink;
     private readonly string? _auditRootDir;
     private readonly B3.Exchange.PostTrade.BustDedupIndex? _bustDedup;
+    private readonly string? _dropRootDir;
+    private readonly B3.Exchange.PostTrade.IAmendmentsPublisher? _amendmentsPublisher;
+    /// <summary>
+    /// ADR 0008 §3 routing race-window closure: shared lock between
+    /// the dispatch thread (which checks fills.csv.done existence and
+    /// writes the bust record) and the EOD exporter (which scans the
+    /// audit log for cancelled fills then renames its .done sidecar).
+    /// Exposed so <see cref="ExchangeHost.TriggerEodExport"/> can take
+    /// the same monitor across the scan→publish window.
+    /// </summary>
+    public object PostTradeRoutingLock { get; } = new();
     // Throttle bookkeeping (issue #267). Mutated only on the dispatch
     // loop thread → no Interlocked needed.
     private long _commandsSincePersist;
@@ -351,7 +362,9 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         IReadOnlyList<long>? seedSecurityIds = null,
         B3.Exchange.PostTrade.IPostTradeSink? postTradeSink = null,
         string? auditRootDir = null,
-        B3.Exchange.PostTrade.BustDedupIndex? bustDedup = null)
+        B3.Exchange.PostTrade.BustDedupIndex? bustDedup = null,
+        string? dropRootDir = null,
+        B3.Exchange.PostTrade.IAmendmentsPublisher? amendmentsPublisher = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -374,6 +387,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _postTradeSink = postTradeSink ?? B3.Exchange.PostTrade.NullPostTradeSink.Instance;
         _auditRootDir = auditRootDir;
         _bustDedup = bustDedup;
+        _dropRootDir = dropRootDir;
+        _amendmentsPublisher = amendmentsPublisher;
         _snapshotThrottle = snapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
         // Issue #268: opt-in async snapshot writer. Off by default so
         // pre-existing deployments keep the synchronous in-loop persist

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -285,12 +285,20 @@ public sealed class ExchangeHost : IAsyncDisposable
             // the audit writer is wired (otherwise there are no files).
             B3.Exchange.PostTrade.BustDedupIndex? bustDedup = null;
             string? auditRootDir = null;
+            string? dropRootDir = null;
+            B3.Exchange.PostTrade.IAmendmentsPublisher? amendmentsPublisher = null;
             if (auditWriter != null && ch.PostTradeAudit?.DataDir is { } dataDir && !string.IsNullOrWhiteSpace(dataDir))
             {
                 auditRootDir = dataDir;
                 int retention = ch.PostTradeAudit.RetentionDays;
                 bustDedup = B3.Exchange.PostTrade.BustDedupIndex.LoadFromAuditFiles(
                     dataDir, ch.ChannelNumber, retention, DateOnly.FromDateTime(DateTime.UtcNow));
+                if (!string.IsNullOrWhiteSpace(ch.PostTradeAudit.EodDropDir))
+                {
+                    dropRootDir = ch.PostTradeAudit.EodDropDir;
+                    amendmentsPublisher = new B3.Exchange.PostTrade.AmendmentsPublisher(
+                        _loggerFactory.CreateLogger<B3.Exchange.PostTrade.AmendmentsPublisher>());
+                }
             }
 
             var disp = new ChannelDispatcher(
@@ -317,7 +325,9 @@ public sealed class ExchangeHost : IAsyncDisposable
                 seedSecurityIds: instruments.Select(i => i.SecurityId).ToArray(),
                 postTradeSink: auditWriter,
                 auditRootDir: auditRootDir,
-                bustDedup: bustDedup);
+                bustDedup: bustDedup,
+                dropRootDir: dropRootDir,
+                amendmentsPublisher: amendmentsPublisher);
             disp.Start();
             _dispatchers.Add(disp);
             foreach (var inst in instruments)
@@ -347,7 +357,7 @@ public sealed class ExchangeHost : IAsyncDisposable
                     var exporterLogger = _loggerFactory.CreateLogger<B3.Exchange.PostTrade.EodFillsExporter>();
                     var exporter = new B3.Exchange.PostTrade.EodFillsExporter(exporterLogger);
                     _eodExportByChannel[ch.ChannelNumber] = new EodExportContext(
-                        exporter, audit.DataDir, audit.EodDropDir, symbols);
+                        exporter, audit.DataDir, audit.EodDropDir, symbols, disp.PostTradeRoutingLock);
                     _logger.LogInformation(
                         "channel {ChannelNumber}: EOD fills export enabled (dropDir={DropDir})",
                         ch.ChannelNumber, audit.EodDropDir);
@@ -836,13 +846,22 @@ public sealed class ExchangeHost : IAsyncDisposable
         }
         try
         {
-            return ctx.Exporter.Export(
-                ctx.AuditRootDir,
-                ctx.DropRootDir,
-                channelNumber,
-                businessDate,
-                secId => ctx.Symbols.TryGetValue(secId, out var sym) ? sym : null,
-                DateTime.UtcNow);
+            // ADR 0008 §3 race-window closure: hold the per-channel
+            // post-trade routing lock across the full export so any
+            // bust accepted concurrently either (a) lands in the
+            // pre-EOD file before the cancelled-set scan, or (b) is
+            // routed to the post-EOD path because it observes the
+            // new .done sidecar after we release the lock.
+            lock (ctx.RoutingLock)
+            {
+                return ctx.Exporter.Export(
+                    ctx.AuditRootDir,
+                    ctx.DropRootDir,
+                    channelNumber,
+                    businessDate,
+                    secId => ctx.Symbols.TryGetValue(secId, out var sym) ? sym : null,
+                    DateTime.UtcNow);
+            }
         }
         finally
         {
@@ -879,7 +898,8 @@ public sealed class ExchangeHost : IAsyncDisposable
         B3.Exchange.PostTrade.EodFillsExporter Exporter,
         string AuditRootDir,
         string DropRootDir,
-        IReadOnlyDictionary<long, string> Symbols);
+        IReadOnlyDictionary<long, string> Symbols,
+        object RoutingLock);
 
     /// <summary>
     /// Issue #270: parses the <c>persistence.orphanSessionPolicy</c>

--- a/src/B3.Exchange.PostTrade/AmendmentsPublisher.cs
+++ b/src/B3.Exchange.PostTrade/AmendmentsPublisher.cs
@@ -1,0 +1,266 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>Pluggable seam for the post-EOD amendments-file
+/// publisher; <see cref="ChannelDispatcher"/> invokes
+/// <see cref="Publish"/> immediately after writing the bust audit
+/// record on the post-EOD path (ADR 0008 §4). Tests can substitute
+/// fakes to assert that the dispatcher routes correctly without
+/// touching the file system.</summary>
+public interface IAmendmentsPublisher
+{
+    /// <summary>Regenerates
+    /// <c>{dropRootDir}/{channelNumber}/{businessDate}/amendments.csv</c>
+    /// from the audit log (every bust record whose
+    /// <see cref="BustRecord.DeclaredTradeDateDays"/> matches
+    /// <paramref name="businessDate"/>) and atomically swaps the
+    /// sibling <c>amendments.csv.done</c> sentinel per the protocol
+    /// in ADR 0008 §4 steps 1-6.</summary>
+    void Publish(string auditRootDir, string dropRootDir, byte channelNumber, DateOnly businessDate, DateTime generatedAtUtc);
+}
+
+/// <summary>
+/// Default <see cref="IAmendmentsPublisher"/> — projects every post-EOD
+/// <see cref="AuditRecordKind.Bust"/> record whose
+/// <see cref="BustRecord.DeclaredTradeDateDays"/> matches the requested
+/// business date into an <c>amendments.csv</c> drop next to the day's
+/// <c>fills.csv</c>. See ADR 0008 §4 for the column schema and the
+/// publish protocol — the implementation mirrors
+/// <see cref="EodFillsExporter"/>'s stage→fsync→delete-old-done→
+/// rename-csv→rename-done sequence so consumers never observe a body
+/// whose digest does not match the <c>.done</c> sidecar.
+/// </summary>
+public sealed class AmendmentsPublisher : IAmendmentsPublisher
+{
+    private readonly ILogger<AmendmentsPublisher> _logger;
+
+    public AmendmentsPublisher(ILogger<AmendmentsPublisher>? logger = null)
+    {
+        _logger = logger ?? NullLogger<AmendmentsPublisher>.Instance;
+    }
+
+    public void Publish(string auditRootDir, string dropRootDir, byte channelNumber, DateOnly businessDate, DateTime generatedAtUtc)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(auditRootDir);
+        ArgumentException.ThrowIfNullOrEmpty(dropRootDir);
+        if (generatedAtUtc.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("generatedAtUtc must be DateTimeKind.Utc", nameof(generatedAtUtc));
+
+        var channel = channelNumber.ToString(CultureInfo.InvariantCulture);
+        var dateStr = businessDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var dropDir = Path.Combine(dropRootDir, channel, dateStr);
+        Directory.CreateDirectory(dropDir);
+
+        // 1) Collect every bust whose declaredTradeDate matches the
+        // target. ADR 0008 §4 step 1: regenerate from the audit log,
+        // never append, so a torn write cannot leave a partial row
+        // visible. Sort by bustTransactTime so consumers can apply in
+        // a deterministic order (rule §4 reconciliation).
+        var busts = new List<BustRecord>();
+        var channelDir = Path.Combine(auditRootDir, channel);
+        if (Directory.Exists(channelDir))
+        {
+            int targetDays = businessDate.DayNumber - new DateOnly(1970, 1, 1).DayNumber;
+            foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.log"))
+            {
+                foreach (var entry in AuditLogReader.ReadAllEntries(path))
+                {
+                    if (entry.Kind != AuditRecordKind.Bust) continue;
+                    var bust = entry.Bust;
+                    if (bust.DeclaredTradeDateDays != targetDays) continue;
+                    busts.Add(bust);
+                }
+            }
+        }
+        busts.Sort((a, b) => a.BustTransactTimeNanos.CompareTo(b.BustTransactTimeNanos));
+
+        // 2) Build SHA-256 lookup for each cancelled tradeId by scanning
+        // the published fills.csv once. The hash byte-range is defined
+        // as "first byte of the row through and including the row-
+        // terminating LF" (ADR 0008 §4 sha256OfOriginalFillRow).
+        var fillsCsvPath = Path.Combine(dropDir, "fills.csv");
+        Dictionary<uint, string> tradeIdToHash = busts.Count == 0
+            ? new Dictionary<uint, string>()
+            : ComputeRowHashes(fillsCsvPath, new HashSet<uint>(busts.Select(b => b.CancelledTradeId)));
+
+        string csvStaging = StagingPath(dropDir, "amendments.csv");
+        string? doneStaging = null;
+        long rowCount;
+        string sha256Hex;
+        try
+        {
+            using (var sha = SHA256.Create())
+            {
+                using (var fs = OpenStagingForWrite(csvStaging))
+                using (var cs = new CryptoStream(fs, sha, CryptoStreamMode.Write, leaveOpen: true))
+                using (var sw = new StreamWriter(cs, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false), bufferSize: 64 * 1024, leaveOpen: true))
+                {
+                    sw.Write("cancelTradeId,bustTransactTime,reasonCode,correlationId,sha256OfOriginalFillRow\n");
+                    long rows = 0;
+                    foreach (var b in busts)
+                    {
+                        sw.Write(b.CancelledTradeId.ToString(CultureInfo.InvariantCulture));
+                        sw.Write(',');
+                        sw.Write(FormatTimestampMicros(b.BustTransactTimeNanos));
+                        sw.Write(',');
+                        sw.Write(b.ReasonCode.ToString(CultureInfo.InvariantCulture));
+                        sw.Write(',');
+                        sw.Write(b.CorrelationId.ToString(CultureInfo.InvariantCulture));
+                        sw.Write(',');
+                        sw.Write(tradeIdToHash.TryGetValue(b.CancelledTradeId, out var h) ? h : string.Empty);
+                        sw.Write('\n');
+                        rows++;
+                    }
+                    rowCount = rows;
+                    sw.Flush();
+                    cs.FlushFinalBlock();
+                    fs.Flush(flushToDisk: true);
+                }
+                sha256Hex = ToHex(sha.Hash!);
+            }
+
+            var donePayload = BuildDonePayload(rowCount, sha256Hex, generatedAtUtc);
+            doneStaging = StagingPath(dropDir, "amendments.csv.done");
+            using (var fs = OpenStagingForWrite(doneStaging))
+            {
+                fs.Write(donePayload);
+                fs.Flush(flushToDisk: true);
+            }
+
+            var csvFinal = Path.Combine(dropDir, "amendments.csv");
+            var doneFinal = Path.Combine(dropDir, "amendments.csv.done");
+
+            if (File.Exists(doneFinal))
+            {
+                File.Delete(doneFinal);
+                FsyncDirectory(dropDir);
+            }
+
+            File.Move(csvStaging, csvFinal, overwrite: true);
+            FsyncDirectory(dropDir);
+            csvStaging = null!;
+
+            File.Move(doneStaging, doneFinal, overwrite: true);
+            FsyncDirectory(dropDir);
+            doneStaging = null;
+
+            _logger.LogInformation(
+                "amendments publish: channel={Channel} date={Date} rows={Rows} sha256={Sha} path={Path}",
+                channel, dateStr, rowCount, sha256Hex, csvFinal);
+        }
+        finally
+        {
+            BestEffortDelete(csvStaging);
+            BestEffortDelete(doneStaging);
+        }
+    }
+
+    private static Dictionary<uint, string> ComputeRowHashes(string fillsCsvPath, HashSet<uint> wantedTradeIds)
+    {
+        var result = new Dictionary<uint, string>();
+        if (!File.Exists(fillsCsvPath) || wantedTradeIds.Count == 0) return result;
+
+        // Stream the file, identifying row boundaries on LF. The first
+        // row is the header (skipped); for every subsequent row, parse
+        // the leading tradeId up to the first comma, and if it matches
+        // a wanted id, compute SHA-256 of the row bytes (including the
+        // trailing LF).
+        using var fs = new FileStream(fillsCsvPath, FileMode.Open, FileAccess.Read, FileShare.Read, 64 * 1024);
+        using var ms = new MemoryStream(64 * 1024);
+        int b;
+        bool inHeader = true;
+        while ((b = fs.ReadByte()) >= 0)
+        {
+            ms.WriteByte((byte)b);
+            if (b == (byte)'\n')
+            {
+                if (inHeader)
+                {
+                    inHeader = false;
+                }
+                else
+                {
+                    var rowBytes = ms.GetBuffer().AsSpan(0, (int)ms.Length);
+                    int commaIdx = rowBytes.IndexOf((byte)',');
+                    if (commaIdx > 0
+                        && uint.TryParse(Encoding.UTF8.GetString(rowBytes[..commaIdx]), NumberStyles.Integer, CultureInfo.InvariantCulture, out uint tradeId)
+                        && wantedTradeIds.Contains(tradeId)
+                        && !result.ContainsKey(tradeId))
+                    {
+                        result[tradeId] = ToHex(SHA256.HashData(rowBytes));
+                    }
+                }
+                ms.SetLength(0);
+            }
+        }
+        return result;
+    }
+
+    private static string FormatTimestampMicros(ulong transactTimeNanos)
+    {
+        long micros = (long)(transactTimeNanos / 1000UL);
+        var dto = DateTimeOffset.FromUnixTimeMilliseconds(micros / 1000)
+            .AddTicks((micros % 1000) * 10);
+        return dto.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture);
+    }
+
+    private static byte[] BuildDonePayload(long rowCount, string sha256Hex, DateTime generatedAtUtc)
+    {
+        var generatedAt = generatedAtUtc.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ", CultureInfo.InvariantCulture);
+        var json = "{\"rowCount\":" + rowCount.ToString(CultureInfo.InvariantCulture)
+            + ",\"sha256\":\"" + sha256Hex + "\""
+            + ",\"generatedAt\":\"" + generatedAt + "\"}\n";
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    private static string ToHex(byte[] bytes) => ToHex((ReadOnlySpan<byte>)bytes);
+
+    private static string ToHex(ReadOnlySpan<byte> bytes)
+    {
+        var c = new char[bytes.Length * 2];
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            byte b = bytes[i];
+            c[i * 2] = HexChar(b >> 4);
+            c[i * 2 + 1] = HexChar(b & 0xF);
+        }
+        return new string(c);
+    }
+
+    private static char HexChar(int nibble) => (char)(nibble < 10 ? '0' + nibble : 'a' + (nibble - 10));
+
+    private static string StagingPath(string dir, string finalName)
+    {
+        var pid = Environment.ProcessId.ToString(CultureInfo.InvariantCulture);
+        var nonce = Guid.NewGuid().ToString("N");
+        return Path.Combine(dir, $".{finalName}.tmp-{pid}-{nonce}");
+    }
+
+    private static FileStream OpenStagingForWrite(string path)
+        => new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None, bufferSize: 64 * 1024, FileOptions.None);
+
+    private static void FsyncDirectory(string dir)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+        try
+        {
+            using var handle = File.OpenHandle(dir, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, FileOptions.None);
+            RandomAccess.FlushToDisk(handle);
+        }
+        catch
+        {
+            // Best-effort; some FSes reject directory fsync.
+        }
+    }
+
+    private static void BestEffortDelete(string? path)
+    {
+        if (path is null) return;
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* swallow */ }
+    }
+}

--- a/src/B3.Exchange.PostTrade/AuditLogReader.cs
+++ b/src/B3.Exchange.PostTrade/AuditLogReader.cs
@@ -147,7 +147,8 @@ public static class AuditLogReader
         // The writer's invariant (firm-sparse .idx covers fill records
         // only — non-fill records are written outside any open block)
         // means recordCount in each .idx entry still counts fills only.
-        bool schemaIsV2 = schemaVersion == AuditRecordCodec.SchemaVersionV2;
+        bool schemaIsHeterogeneous = schemaVersion == AuditRecordCodec.SchemaVersionV2
+            || schemaVersion == AuditRecordCodec.SchemaVersionV3;
 
         var buffer = new byte[AuditRecordCodec.MaxRecordSize];
         // 1) Indexed candidates — seek directly to each block. Each entry
@@ -176,7 +177,7 @@ public static class AuditLogReader
             fs.Seek(indexedEndOffset, SeekOrigin.Begin);
             while (true)
             {
-                if (!schemaIsV2)
+                if (!schemaIsHeterogeneous)
                 {
                     int read = ReadFully(fs, buffer, 0, AuditRecordCodec.RecordSize);
                     if (read == 0) break;
@@ -187,7 +188,7 @@ public static class AuditLogReader
                     continue;
                 }
 
-                // v2: peek recordLen (4 bytes), read remaining body, dispatch.
+                // v2/v3: peek recordLen (4 bytes), read remaining body, dispatch.
                 int peeked = ReadFully(fs, buffer, 0, 4);
                 if (peeked == 0) break;
                 if (peeked < 4) break;

--- a/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
+++ b/src/B3.Exchange.PostTrade/AuditRecordCodec.cs
@@ -13,7 +13,9 @@ namespace B3.Exchange.PostTrade;
 /// <code>
 ///   magic "B3PT" (4)
 ///   schemaVersion (uint16)   1 = fills only (legacy)
-///                            2 = fills + busts + reject-attempts (ADR 0008)
+///                            2 = fills + busts + reject-attempts (ADR 0008 PR-1/PR-2)
+///                            3 = bust extended with declaredTradeDate
+///                                (ADR 0008 PR-4, post-EOD routing)
 ///   reserved      (uint16)
 ///   channelNumber (uint8)
 ///   pad           (3 bytes)
@@ -37,9 +39,9 @@ namespace B3.Exchange.PostTrade;
 ///   buyOrderId         (int64)
 ///   sellOrderId        (int64)
 /// </code>
-/// The fill body is bit-identical between v1 and v2 — there is NO
+/// The fill body is bit-identical between v1, v2 and v3 — there is NO
 /// discriminator byte at the head of a fill body. v1 files contain
-/// only fill records (any other recordLen is corruption); v2 files
+/// only fill records (any other recordLen is corruption); v2/v3 files
 /// dispatch by recordLen (see <see cref="PeekRecordLen"/>).
 ///
 /// Bust record body (schema v2, recordLen = 40, total = 44 bytes,
@@ -55,6 +57,24 @@ namespace B3.Exchange.PostTrade;
 ///   reasonCode                (uint16) see ADR 0008 §2.2
 ///   busterFirm                (uint32)
 ///   correlationId             (uint64)
+/// </code>
+///
+/// Bust record body (schema v3, recordLen = 44, total = 48 bytes,
+/// ADR 0008 PR-4 — adds the declared trade date so post-EOD busts
+/// living in a different day's file can still be attributed back to
+/// the original fill's day):
+/// <code>
+///   recordLen                 (uint32) always 44
+///   crc32                    (uint32) over the body that follows
+///   recordType                (uint8)  always 0x02
+///   reserved                  (uint8)  always 0
+///   cancelledTradeId          (uint32)
+///   bustTransactTimeNanos     (uint64)
+///   securityId                (int64)  echo from original fill
+///   reasonCode                (uint16) see ADR 0008 §2.2
+///   busterFirm                (uint32)
+///   correlationId             (uint64)
+///   declaredTradeDate         (int32)  LocalMktDate (days since 1970-01-01)
 /// </code>
 ///
 /// Reject-attempt record body (schema v2, recordLen = 36, total = 40
@@ -85,19 +105,28 @@ namespace B3.Exchange.PostTrade;
 public static class AuditRecordCodec
 {
     /// <summary>The schema version this build writes for newly-created
-    /// audit files. ADR 0008 / issue #369 PR-2 bumps the default to V2;
-    /// existing V1 files remain readable on resume (per-day schema view
-    /// per ADR 0008 §1) and the writer's recovery path dispatches on the
-    /// per-file header version.</summary>
-    public const ushort SchemaVersion = SchemaVersionV2;
+    /// audit files. ADR 0008 / issue #369 PR-4 bumps the default to V3
+    /// (bust records gain a declaredTradeDate field). Existing V1 and V2
+    /// files remain readable on resume (per-day schema view per ADR
+    /// 0008 §1); the writer's recovery path dispatches on the per-file
+    /// header version.</summary>
+    public const ushort SchemaVersion = SchemaVersionV3;
 
     /// <summary>Legacy fills-only schema (issue #329).</summary>
     public const ushort SchemaVersionV1 = 1;
 
-    /// <summary>ADR 0008 / issue #369 schema. Adds bust + reject-attempt
-    /// records on the same stream; fill body is byte-for-byte identical
-    /// to v1.</summary>
+    /// <summary>ADR 0008 / issue #369 PR-1/PR-2 schema. Adds bust +
+    /// reject-attempt records on the same stream; fill body is
+    /// byte-for-byte identical to v1. Bust body is 36 bytes (no
+    /// declaredTradeDate).</summary>
     public const ushort SchemaVersionV2 = 2;
+
+    /// <summary>ADR 0008 / issue #369 PR-4 schema. Extends the bust
+    /// body with a declaredTradeDate (int32 LocalMktDate) so post-EOD
+    /// busts (which land in <c>fills-&lt;bustToday&gt;.log</c>, not the
+    /// original day's log) still carry the link back to the original
+    /// fill's day required by §4 amendments rebuild.</summary>
+    public const ushort SchemaVersionV3 = 3;
 
     public const int FileHeaderSize = 24;
 
@@ -106,11 +135,25 @@ public static class AuditRecordCodec
     public const int RecordSize = RecordBodySize + 8; // +4 recordLen +4 crc32
     public const uint FillRecordLen = (uint)(RecordSize - 4); // 81
 
-    // Bust (ADR 0008 §1.1).
-    public const int BustRecordBodySize = 36;
-    public const int BustRecordSize = BustRecordBodySize + 8; // 44
-    public const uint BustRecordLen = (uint)(BustRecordSize - 4); // 40
+    // Bust v2 (ADR 0008 §1.1) — legacy on-disk shape, still decoded for
+    // backwards compatibility with files written by PR-1/PR-2 builds.
+    public const int BustRecordV2BodySize = 36;
+    public const int BustRecordV2Size = BustRecordV2BodySize + 8; // 44
+    public const uint BustRecordV2Len = (uint)(BustRecordV2Size - 4); // 40
+
+    // Bust v3 (ADR 0008 PR-4) — adds declaredTradeDate (int32) at the tail.
+    public const int BustRecordV3BodySize = 40;
+    public const int BustRecordV3Size = BustRecordV3BodySize + 8; // 48
+    public const uint BustRecordV3Len = (uint)(BustRecordV3Size - 4); // 44
     public const byte RecordTypeBust = 0x02;
+
+    // Compatibility aliases — old code (and external callers) used the
+    // BustRecord* constants without a version suffix. They now point at
+    // the current default (V3) write layout; readers MUST use the
+    // versioned constants explicitly so they keep decoding V2 files.
+    public const int BustRecordBodySize = BustRecordV3BodySize;
+    public const int BustRecordSize = BustRecordV3Size;
+    public const uint BustRecordLen = BustRecordV3Len;
 
     // Reject-attempt (ADR 0008 §2.5).
     public const int RejectAttemptRecordBodySize = 32;
@@ -136,8 +179,8 @@ public static class AuditRecordCodec
     {
         if (dst.Length < FileHeaderSize)
             throw new ArgumentException($"buffer too small ({dst.Length}<{FileHeaderSize})", nameof(dst));
-        if (schemaVersion is not (SchemaVersionV1 or SchemaVersionV2))
-            throw new ArgumentOutOfRangeException(nameof(schemaVersion), schemaVersion, "supported versions: 1, 2");
+        if (schemaVersion is not (SchemaVersionV1 or SchemaVersionV2 or SchemaVersionV3))
+            throw new ArgumentOutOfRangeException(nameof(schemaVersion), schemaVersion, "supported versions: 1, 2, 3");
         BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), MagicB3PT);
         BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(4, 2), schemaVersion);
         BinaryPrimitives.WriteUInt16LittleEndian(dst.Slice(6, 2), 0);
@@ -167,8 +210,8 @@ public static class AuditRecordCodec
         if (magic != MagicB3PT)
             throw new InvalidDataException($"audit file magic mismatch: 0x{magic:X8}");
         var version = BinaryPrimitives.ReadUInt16LittleEndian(src.Slice(4, 2));
-        if (version is not (SchemaVersionV1 or SchemaVersionV2))
-            throw new InvalidDataException($"audit file schema version {version} unsupported (this build accepts {SchemaVersionV1} or {SchemaVersionV2})");
+        if (version is not (SchemaVersionV1 or SchemaVersionV2 or SchemaVersionV3))
+            throw new InvalidDataException($"audit file schema version {version} unsupported (this build accepts {SchemaVersionV1}, {SchemaVersionV2} or {SchemaVersionV3})");
         byte channel = src[8];
         if (src[9] != 0 || src[10] != 0 || src[11] != 0 || src[22] != 0 || src[23] != 0)
             throw new InvalidDataException("audit file reserved bytes non-zero");
@@ -205,8 +248,12 @@ public static class AuditRecordCodec
                 totalSize = RecordSize;
                 kind = AuditRecordKind.Fill;
                 return true;
-            case BustRecordLen:
-                totalSize = BustRecordSize;
+            case BustRecordV2Len:
+                totalSize = BustRecordV2Size;
+                kind = AuditRecordKind.Bust;
+                return true;
+            case BustRecordV3Len:
+                totalSize = BustRecordV3Size;
                 kind = AuditRecordKind.Bust;
                 return true;
             case RejectAttemptRecordLen:
@@ -305,15 +352,16 @@ public static class AuditRecordCodec
     // writer extension lands in PR-2.
     // -----------------------------------------------------------------
 
-    /// <summary>Encodes a <see cref="BustRecord"/> (ADR 0008 §1.1) into
-    /// <paramref name="dst"/>. Returns the number of bytes written
-    /// (always <see cref="BustRecordSize"/>).</summary>
+    /// <summary>Encodes a <see cref="BustRecord"/> (ADR 0008 §1.1 +
+    /// PR-4 extension) into <paramref name="dst"/> using the v3 layout
+    /// (recordLen=44, body carries declaredTradeDate). Returns the number
+    /// of bytes written (always <see cref="BustRecordV3Size"/>).</summary>
     public static int EncodeBust(Span<byte> dst, in BustRecord record)
     {
-        if (dst.Length < BustRecordSize)
-            throw new ArgumentException($"buffer too small ({dst.Length}<{BustRecordSize})", nameof(dst));
+        if (dst.Length < BustRecordV3Size)
+            throw new ArgumentException($"buffer too small ({dst.Length}<{BustRecordV3Size})", nameof(dst));
 
-        var body = dst.Slice(8, BustRecordBodySize);
+        var body = dst.Slice(8, BustRecordV3BodySize);
         int p = 0;
         body[p] = RecordTypeBust; p += 1;
         body[p] = 0; p += 1;
@@ -323,31 +371,68 @@ public static class AuditRecordCodec
         BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(p, 2), record.ReasonCode); p += 2;
         BinaryPrimitives.WriteUInt32LittleEndian(body.Slice(p, 4), record.BusterFirm); p += 4;
         BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(p, 8), record.CorrelationId); p += 8;
-        if (p != BustRecordBodySize)
-            throw new InvalidOperationException($"BUG: encoded {p} bust body bytes, expected {BustRecordBodySize}");
+        BinaryPrimitives.WriteInt32LittleEndian(body.Slice(p, 4), record.DeclaredTradeDateDays); p += 4;
+        if (p != BustRecordV3BodySize)
+            throw new InvalidOperationException($"BUG: encoded {p} bust body bytes, expected {BustRecordV3BodySize}");
 
-        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), BustRecordLen);
+        BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(0, 4), BustRecordV3Len);
         var crc = ComputeCrc(body);
         BinaryPrimitives.WriteUInt32LittleEndian(dst.Slice(4, 4), crc);
-        return BustRecordSize;
+        return BustRecordV3Size;
     }
 
-    /// <summary>Decodes one bust record. Same failure semantics as
-    /// <see cref="TryDecode"/>: returns false on short buffer, wrong
-    /// length prefix, recordType mismatch, or CRC failure.</summary>
+    /// <summary>Decodes one bust record. Dispatches by the leading
+    /// recordLen field between the v2 layout (36-byte body, no
+    /// declaredTradeDate — legacy files written by PR-1/PR-2) and the
+    /// v3 layout (40-byte body, includes declaredTradeDate — PR-4 and
+    /// later). v2-decoded records carry <c>DeclaredTradeDateDays =
+    /// <see cref="BustRecord.DeclaredTradeDateAbsent"/></c> so callers
+    /// can detect "field not on disk".
+    /// Same failure semantics as <see cref="TryDecode"/>: returns false
+    /// on short buffer, wrong length prefix, recordType mismatch, or
+    /// CRC failure.</summary>
     public static bool TryDecodeBust(ReadOnlySpan<byte> src, out BustRecord record)
     {
         record = default;
-        if (src.Length < BustRecordSize) return false;
+        if (src.Length < 8) return false;
         uint declaredLen = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(0, 4));
-        if (declaredLen != BustRecordLen) return false;
-        uint storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(4, 4));
-        var body = src.Slice(8, BustRecordBodySize);
-        if (ComputeCrc(body) != storedCrc) return false;
+        if (declaredLen == BustRecordV3Len) return TryDecodeBustV3(src, out record);
+        if (declaredLen == BustRecordV2Len) return TryDecodeBustV2(src, out record);
+        return false;
+    }
 
-        // Cross-check the leading recordType byte against the dispatched
-        // length (defence-in-depth per ADR 0008 §1). A mismatch is
-        // treated as corruption.
+    private static bool TryDecodeBustV3(ReadOnlySpan<byte> src, out BustRecord record)
+    {
+        record = default;
+        if (src.Length < BustRecordV3Size) return false;
+        uint storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(4, 4));
+        var body = src.Slice(8, BustRecordV3BodySize);
+        if (ComputeCrc(body) != storedCrc) return false;
+        if (body[0] != RecordTypeBust) return false;
+        if (body[1] != 0) return false;
+
+        int p = 2;
+        uint cancelledTradeId = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong bustTs = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        long secId = BinaryPrimitives.ReadInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        ushort reasonCode = BinaryPrimitives.ReadUInt16LittleEndian(body.Slice(p, 2)); p += 2;
+        uint busterFirm = BinaryPrimitives.ReadUInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        ulong correlationId = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
+        int declaredTradeDateDays = BinaryPrimitives.ReadInt32LittleEndian(body.Slice(p, 4)); p += 4;
+        _ = p;
+
+        record = new BustRecord(cancelledTradeId, bustTs, secId, reasonCode,
+            busterFirm, correlationId, declaredTradeDateDays);
+        return true;
+    }
+
+    private static bool TryDecodeBustV2(ReadOnlySpan<byte> src, out BustRecord record)
+    {
+        record = default;
+        if (src.Length < BustRecordV2Size) return false;
+        uint storedCrc = BinaryPrimitives.ReadUInt32LittleEndian(src.Slice(4, 4));
+        var body = src.Slice(8, BustRecordV2BodySize);
+        if (ComputeCrc(body) != storedCrc) return false;
         if (body[0] != RecordTypeBust) return false;
         if (body[1] != 0) return false;
 
@@ -360,7 +445,8 @@ public static class AuditRecordCodec
         ulong correlationId = BinaryPrimitives.ReadUInt64LittleEndian(body.Slice(p, 8)); p += 8;
         _ = p;
 
-        record = new BustRecord(cancelledTradeId, bustTs, secId, reasonCode, busterFirm, correlationId);
+        record = new BustRecord(cancelledTradeId, bustTs, secId, reasonCode,
+            busterFirm, correlationId, BustRecord.DeclaredTradeDateAbsent);
         return true;
     }
 
@@ -431,15 +517,28 @@ public enum AuditRecordKind : byte
     RejectAttempt = AuditRecordCodec.RecordTypeRejectAttempt,
 }
 
-/// <summary>Bust record body (ADR 0008 §1.1). On disk the record is
-/// CRC-framed by <see cref="AuditRecordCodec.EncodeBust"/>.</summary>
+/// <summary>Bust record body (ADR 0008 §1.1 + PR-4 extension). On disk
+/// the record is CRC-framed by <see cref="AuditRecordCodec.EncodeBust"/>
+/// using the v3 layout (recordLen=44). Legacy v2 records (recordLen=40,
+/// no declaredTradeDate on disk) decode into a <c>BustRecord</c> whose
+/// <see cref="DeclaredTradeDateDays"/> is
+/// <see cref="DeclaredTradeDateAbsent"/>.</summary>
 public readonly record struct BustRecord(
     uint CancelledTradeId,
     ulong BustTransactTimeNanos,
     long SecurityId,
     ushort ReasonCode,
     uint BusterFirm,
-    ulong CorrelationId);
+    ulong CorrelationId,
+    int DeclaredTradeDateDays = BustRecord.DeclaredTradeDateAbsent)
+{
+    /// <summary>Sentinel for "field not present on disk" — emitted by
+    /// the v2 decoder so callers can distinguish a legacy bust (no
+    /// declared trade date) from a v3 bust that happens to declare
+    /// 1970-01-01. Negative values are otherwise unused: LocalMktDate
+    /// is days since the Unix epoch and cannot be negative.</summary>
+    public const int DeclaredTradeDateAbsent = -1;
+}
 
 /// <summary>Reject-attempt record body (ADR 0008 §2.5). On disk the
 /// record is CRC-framed by

--- a/src/B3.Exchange.PostTrade/BustDedupIndex.cs
+++ b/src/B3.Exchange.PostTrade/BustDedupIndex.cs
@@ -65,9 +65,17 @@ public sealed class BustDedupIndex
             {
                 if (entry.Kind != AuditRecordKind.Bust) continue;
                 var bust = entry.Bust;
-                // The file-name day IS the busted trade's day (writer
-                // contract: OnBust appends to fills-<tradeDate>.log).
-                index._byTradeId[bust.CancelledTradeId] = new Entry(bust.CorrelationId, fileDate.Value);
+                // ADR 0008 v3 BustRecord carries the original trade's
+                // day (declaredTradeDate) so post-EOD busts — written
+                // to fills-<bustToday>.log, not fills-<tradeDate>.log —
+                // still attribute correctly. v2 records leave the field
+                // as Absent (-1); fall back to the file-name day, which
+                // for v2 always equals the trade's day per the PR-2
+                // writer contract.
+                var resolvedDate = bust.DeclaredTradeDateDays >= 0
+                    ? DateOnly.FromDayNumber(bust.DeclaredTradeDateDays + EpochUnixDayNumber)
+                    : fileDate.Value;
+                index._byTradeId[bust.CancelledTradeId] = new Entry(bust.CorrelationId, resolvedDate);
             }
         }
         return index;
@@ -80,4 +88,9 @@ public sealed class BustDedupIndex
         if (!name.StartsWith("fills-", StringComparison.Ordinal)) return null;
         return DateOnly.TryParseExact(name.AsSpan("fills-".Length), "yyyy-MM-dd", out var d) ? d : null;
     }
+
+    // Number of days between DateOnly.MinValue (0001-01-01) and the Unix
+    // epoch (1970-01-01). BustRecord.DeclaredTradeDateDays uses the
+    // SBE LocalMktDate convention (days since 1970-01-01).
+    private static readonly int EpochUnixDayNumber = new DateOnly(1970, 1, 1).DayNumber;
 }

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -492,7 +492,8 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
             Span<byte> hdr = stackalloc byte[AuditRecordCodec.FileHeaderSize];
             if (logStream.Read(hdr) != hdr.Length) return;
             var (_, _, schemaVersion) = AuditRecordCodec.ReadFileHeader(hdr);
-            bool schemaIsV2 = schemaVersion == AuditRecordCodec.SchemaVersionV2;
+            bool schemaIsHeterogeneous = schemaVersion == AuditRecordCodec.SchemaVersionV2
+                || schemaVersion == AuditRecordCodec.SchemaVersionV3;
 
             Span<byte> buffer = stackalloc byte[AuditRecordCodec.MaxRecordSize];
             Span<byte> lenPrefix = stackalloc byte[4];
@@ -515,7 +516,7 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
                 long recordStart = logStream.Position;
                 int recordSize;
                 bool isFill;
-                if (!schemaIsV2)
+                if (!schemaIsHeterogeneous)
                 {
                     int read = logStream.Read(buffer.Slice(0, AuditRecordCodec.RecordSize));
                     if (read != AuditRecordCodec.RecordSize) break;
@@ -530,7 +531,7 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
                     if (recsInBlock >= _indexBlockRecords) FlushBlock();
                     continue;
                 }
-                // v2 dispatch
+                // v2/v3 dispatch
                 int peeked = logStream.Read(lenPrefix);
                 if (peeked == 0) break;
                 if (peeked < 4) break;
@@ -584,15 +585,17 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         if (channel != _channelNumber)
             throw new InvalidDataException($"audit file '{fs.Name}' channel mismatch (file={channel}, writer={_channelNumber})");
         // ADR 0008 §1 per-day schema view: writer accepts files of any
-        // schema it understands (V1 from pre-PR-2 days, V2 from PR-2
-        // onward). The recovery scan dispatches by recordLen so v2 files
-        // with mixed fill/bust/reject-attempt records are scanned
-        // correctly. Refuse anything we don't recognise.
+        // schema it understands (V1 from pre-PR-2 days, V2 from PR-2,
+        // V3 from PR-4 onward). The recovery scan dispatches by
+        // recordLen so v2/v3 files with mixed fill/bust/reject-attempt
+        // records are scanned correctly. Refuse anything we don't
+        // recognise.
         if (schemaVersion != AuditRecordCodec.SchemaVersionV1
-            && schemaVersion != AuditRecordCodec.SchemaVersionV2)
+            && schemaVersion != AuditRecordCodec.SchemaVersionV2
+            && schemaVersion != AuditRecordCodec.SchemaVersionV3)
             throw new InvalidDataException(
                 $"audit file '{fs.Name}' unsupported schema v{schemaVersion} "
-                + $"(writer understands v{AuditRecordCodec.SchemaVersionV1} and v{AuditRecordCodec.SchemaVersionV2})");
+                + $"(writer understands v{AuditRecordCodec.SchemaVersionV1}, v{AuditRecordCodec.SchemaVersionV2}, v{AuditRecordCodec.SchemaVersionV3})");
 
         long goodEnd = AuditRecordCodec.FileHeaderSize;
         Span<byte> buffer = stackalloc byte[AuditRecordCodec.MaxRecordSize];

--- a/tests/B3.Exchange.PostTrade.Tests/AmendmentsPublisherTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AmendmentsPublisherTests.cs
@@ -1,0 +1,175 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>ADR 0008 PR-4 tests for <see cref="AmendmentsPublisher"/> —
+/// the post-EOD amendments-file producer.</summary>
+public sealed class AmendmentsPublisherTests : IDisposable
+{
+    private readonly string _auditRoot;
+    private readonly string _dropRoot;
+    private const byte Channel = 7;
+    private static readonly DateOnly TradeDate = new(2026, 5, 18);
+    private static readonly DateOnly BustToday = new(2026, 5, 20);
+    private static readonly DateTime GeneratedAt = new(2026, 5, 20, 18, 0, 0, DateTimeKind.Utc);
+    private static readonly ulong TradeDateNanos = (ulong)(TradeDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private static readonly ulong BustTodayNanos = (ulong)(BustToday.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private static readonly int TradeDateDays = TradeDate.DayNumber - new DateOnly(1970, 1, 1).DayNumber;
+
+    public AmendmentsPublisherTests()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "B3AmendPubTests_" + Guid.NewGuid().ToString("N"));
+        _auditRoot = Path.Combine(root, "audit");
+        _dropRoot = Path.Combine(root, "drop");
+        Directory.CreateDirectory(_auditRoot);
+        Directory.CreateDirectory(_dropRoot);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            var root = Path.GetDirectoryName(_auditRoot);
+            if (root != null && Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+        catch { /* swallow */ }
+    }
+
+    private static PostTradeRecord Fill(uint id, ulong ts) => new(
+        TradeId: id, TransactTimeNanos: ts, SecurityId: 900_000_000_001L,
+        AggressorSide: Side.Buy, Quantity: 100, PriceMantissa: 10_0000L,
+        BuyClOrdId: 1000UL, SellClOrdId: 2000UL, BuyFirm: 7, SellFirm: 8,
+        BuyOrderId: 5000, SellOrderId: 6000);
+
+    private static BustRecord Bust(uint tradeId, ulong ts, ulong correlationId, int declaredTradeDateDays) =>
+        new(CancelledTradeId: tradeId, BustTransactTimeNanos: ts,
+            SecurityId: 900_000_000_001L, ReasonCode: 5, BusterFirm: 99,
+            CorrelationId: correlationId, DeclaredTradeDateDays: declaredTradeDateDays);
+
+    private void PublishFillsCsv(IEnumerable<PostTradeRecord> fills)
+    {
+        // Use EodFillsExporter to publish a real fills.csv for the
+        // tradeDate, so amendments hashes match what a consumer would
+        // compute against the same file.
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            foreach (var f in fills) w.OnTrade(f);
+        }
+        var exporter = new EodFillsExporter();
+        exporter.Export(_auditRoot, _dropRoot, Channel, TradeDate,
+            _ => "PETR4", GeneratedAt);
+    }
+
+    [Fact]
+    public void Publish_EmitsAmendmentRow_WithSha256OfOriginalFillsRow()
+    {
+        PublishFillsCsv(new[] { Fill(1, TradeDateNanos + 1_000UL), Fill(2, TradeDateNanos + 2_000UL) });
+
+        // Post-EOD bust lands in fills-<bustToday>.log but carries
+        // declaredTradeDate = TradeDate.
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnBust(Bust(1, BustTodayNanos + 1_000UL, correlationId: 42UL, declaredTradeDateDays: TradeDateDays), BustToday);
+        }
+
+        var publisher = new AmendmentsPublisher();
+        publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt);
+
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var amendCsv = Path.Combine(dropDir, "amendments.csv");
+        var amendDone = Path.Combine(dropDir, "amendments.csv.done");
+        Assert.True(File.Exists(amendCsv));
+        Assert.True(File.Exists(amendDone));
+
+        var lines = File.ReadAllLines(amendCsv);
+        Assert.Equal(2, lines.Length); // header + 1 row
+        Assert.Equal("cancelTradeId,bustTransactTime,reasonCode,correlationId,sha256OfOriginalFillRow", lines[0]);
+        var cols = lines[1].Split(',');
+        Assert.Equal("1", cols[0]);
+        Assert.Equal("5", cols[2]);
+        Assert.Equal("42", cols[3]);
+
+        // Cross-check sha256 column against bytes 0..first '\n' AFTER
+        // the header row in fills.csv (the row whose tradeId == 1).
+        var fillsBytes = File.ReadAllBytes(Path.Combine(dropDir, "fills.csv"));
+        int firstLf = Array.IndexOf(fillsBytes, (byte)'\n');
+        int secondLf = Array.IndexOf(fillsBytes, (byte)'\n', firstLf + 1);
+        var rowBytes = fillsBytes.AsSpan(firstLf + 1, secondLf - firstLf).ToArray();
+        var expected = Convert.ToHexString(SHA256.HashData(rowBytes)).ToLowerInvariant();
+        Assert.Equal(expected, cols[4]);
+    }
+
+    [Fact]
+    public void Publish_RegeneratesFromAuditLog_OnRepeatedCalls()
+    {
+        PublishFillsCsv(new[] { Fill(1, TradeDateNanos + 1_000UL), Fill(2, TradeDateNanos + 2_000UL) });
+
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnBust(Bust(1, BustTodayNanos + 1_000UL, 42UL, TradeDateDays), BustToday);
+        }
+        var publisher = new AmendmentsPublisher();
+        publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt);
+
+        // Second bust appended; re-publish must reflect both rows
+        // (regenerated from audit log, not appended).
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnBust(Bust(2, BustTodayNanos + 2_000UL, 43UL, TradeDateDays), BustToday);
+        }
+        publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt.AddSeconds(1));
+
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var lines = File.ReadAllLines(Path.Combine(dropDir, "amendments.csv"));
+        Assert.Equal(3, lines.Length); // header + 2 rows
+        Assert.StartsWith("1,", lines[1]);
+        Assert.StartsWith("2,", lines[2]);
+    }
+
+    [Fact]
+    public void Publish_FiltersBustsByDeclaredTradeDate()
+    {
+        PublishFillsCsv(new[] { Fill(1, TradeDateNanos + 1_000UL) });
+
+        // Two busts: one targets TradeDate, the other targets a
+        // different day; only the former should appear.
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnBust(Bust(1, BustTodayNanos + 1_000UL, 42UL, TradeDateDays), BustToday);
+            w.OnBust(Bust(99, BustTodayNanos + 2_000UL, 43UL, TradeDateDays + 1), BustToday);
+        }
+        var publisher = new AmendmentsPublisher();
+        publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt);
+
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var lines = File.ReadAllLines(Path.Combine(dropDir, "amendments.csv"));
+        Assert.Equal(2, lines.Length); // header + only the TradeDate-targeting bust
+        Assert.StartsWith("1,", lines[1]);
+    }
+
+    [Fact]
+    public void Publish_DoneSidecar_HashesPublishedCsvBytes()
+    {
+        PublishFillsCsv(new[] { Fill(1, TradeDateNanos + 1_000UL) });
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnBust(Bust(1, BustTodayNanos + 1_000UL, 42UL, TradeDateDays), BustToday);
+        }
+        var publisher = new AmendmentsPublisher();
+        publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt);
+
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var csvBytes = File.ReadAllBytes(Path.Combine(dropDir, "amendments.csv"));
+        var expected = Convert.ToHexString(SHA256.HashData(csvBytes)).ToLowerInvariant();
+        var doneJson = File.ReadAllText(Path.Combine(dropDir, "amendments.csv.done"));
+        Assert.Contains("\"sha256\":\"" + expected + "\"", doneJson);
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AuditRecordCodecTests.cs
@@ -130,10 +130,39 @@ public class AuditRecordCodecTests
     }
 
     [Fact]
+    public void EncodeBust_V3_RoundTripsDeclaredTradeDate()
+    {
+        // ADR 0008 PR-4: declaredTradeDate (LocalMktDate days since
+        // 1970-01-01) survives a v3 encode/decode round-trip.
+        var src = SampleBust() with { DeclaredTradeDateDays = 20597 };
+        Span<byte> buf = stackalloc byte[AuditRecordCodec.BustRecordSize];
+        AuditRecordCodec.EncodeBust(buf, in src);
+        Assert.True(AuditRecordCodec.TryDecodeBust(buf, out var dst));
+        Assert.Equal(20597, dst.DeclaredTradeDateDays);
+        Assert.Equal(src, dst);
+    }
+
+    [Fact]
+    public void TryGetRecordSize_AcceptsBothV2AndV3BustLengths()
+    {
+        // ADR 0008 PR-4: schema bump V2→V3 added declaredTradeDate to
+        // BustRecord (recordLen 40→44). The dispatcher and the writer's
+        // recovery scan both call TryGetRecordSize per-record, so the
+        // size table must keep accepting v2-on-disk records to honour
+        // the per-file-header schema view.
+        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.BustRecordV2Len, out var v2Size, out var v2Kind));
+        Assert.Equal(AuditRecordCodec.BustRecordV2Size, v2Size);
+        Assert.Equal(AuditRecordKind.Bust, v2Kind);
+        Assert.True(AuditRecordCodec.TryGetRecordSize(AuditRecordCodec.BustRecordV3Len, out var v3Size, out var v3Kind));
+        Assert.Equal(AuditRecordCodec.BustRecordV3Size, v3Size);
+        Assert.Equal(AuditRecordKind.Bust, v3Kind);
+    }
+
+    [Fact]
     public void Bust_HasExpectedOnDiskSize()
     {
-        Assert.Equal(44, AuditRecordCodec.BustRecordSize);
-        Assert.Equal(40u, AuditRecordCodec.BustRecordLen);
+        Assert.Equal(48, AuditRecordCodec.BustRecordSize);
+        Assert.Equal(44u, AuditRecordCodec.BustRecordLen);
     }
 
     [Fact]

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterBustTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterBustTests.cs
@@ -118,7 +118,7 @@ public class FileAuditLogWriterBustTests : IDisposable
     }
 
     [Fact]
-    public void NewFilesUseSchemaV2_AndAreReadableAfterReopen()
+    public void NewFilesUseSchemaV3_AndAreReadableAfterReopen()
     {
         using (var w = new FileAuditLogWriter(_root, channelNumber: 11))
         {
@@ -126,12 +126,12 @@ public class FileAuditLogWriterBustTests : IDisposable
             w.OnBust(MakeBust(1, correlationId: 99UL), Day0);
         }
         var path = Path.Combine(_root, "11", "fills-2026-05-18.log");
-        // Spot-check the header byte for the schema-v2 marker.
+        // Spot-check the header byte for the schema-v3 marker.
         var bytes = File.ReadAllBytes(path);
         Assert.True(bytes.Length > AuditRecordCodec.FileHeaderSize);
         // schemaVersion lives at the start of the header (per codec layout).
         var (_, _, sv) = AuditRecordCodec.ReadFileHeader(bytes.AsSpan(0, AuditRecordCodec.FileHeaderSize));
-        Assert.Equal(AuditRecordCodec.SchemaVersionV2, sv);
+        Assert.Equal(AuditRecordCodec.SchemaVersionV3, sv);
 
         // Reopen and append more — should not truncate anything.
         using (var w = new FileAuditLogWriter(_root, channelNumber: 11))


### PR DESCRIPTION
Fourth PR in the ADR 0008 series (issue #369). Follows #370 (PR-1), #371 (PR-2), #372 (PR-3).

## What

Implements the post-EOD half of operator trade-bust handling: busts accepted **after** `fills.csv.done` has been published for the original trade date are routed to the late-corrections path, where they land in the current day's audit log but trigger an atomic publish of `amendments.csv` next to the original day's `fills.csv`.

## Why

ADR 0008 §3 splits operator busts into pre-EOD and post-EOD by the existence of `fills.csv.done`. Pre-EOD was finished in PR-3 (bust folding into `fills.csv`); this PR closes the post-EOD half so consumers that have already ingested `fills.csv` can apply late corrections without us silently mutating the published file.

## How

**Schema bump V2→V3** (`AuditRecordCodec`): `BustRecord` gains a trailing `declaredTradeDate` field (int32 LocalMktDate, +4 bytes). Required because a post-EOD bust is written to `fills-<bustToday>.log` (not the original day's file), so the file name no longer encodes the trade's day. PR-2-era v2 records remain decodable via the per-day schema view; the in-memory `BustRecord` carries a `DeclaredTradeDateAbsent = -1` sentinel for them and `BustDedupIndex.LoadFromAuditFiles` falls back to the file-name day (which the PR-2 writer contract guaranteed equals the trade's day for v2).

**Routing decision** (`ChannelDispatcher.ProcessOperatorBustV2`): under a new per-channel `PostTradeRoutingLock`, the dispatch thread checks `{dropRootDir}/{ch}/{tradeDate}/fills.csv.done` existence and routes the `OnBust` write to either `fills-<tradeDate>.log` (pre-EOD) or `fills-<bustToday>.log` (post-EOD). The lock closes the race with `EodFillsExporter` (which now holds the same lock between its cancelled-set scan and the `.done` rename) so no bust can be observed by both paths.

**`AmendmentsPublisher`** (new): on the post-EOD accept path, regenerates `amendments.csv` from every audit-log Bust record whose `declaredTradeDate` matches the target day. Columns per ADR §4: `cancelTradeId,bustTransactTime,reasonCode,correlationId,sha256OfOriginalFillRow`. The hash is computed against the contiguous bytes of the matching row in the published `fills.csv` (first byte through and including the trailing `\n`). Atomic publish mirrors `EodFillsExporter`'s stage→fsync→delete-old-`.done`→rename-csv→rename-`.done` sequence.

**ADR doc**: §1.1 updated for the v3 layout with a v2-compat note.

## Tests

+6 PostTrade tests (110 → 116 total, full suite 1248 green, format clean):
- `AuditRecordCodecTests.EncodeBust_V3_RoundTripsDeclaredTradeDate`
- `AuditRecordCodecTests.TryGetRecordSize_AcceptsBothV2AndV3BustLengths`
- `AmendmentsPublisherTests.Publish_EmitsAmendmentRow_WithSha256OfOriginalFillsRow`
- `AmendmentsPublisherTests.Publish_RegeneratesFromAuditLog_OnRepeatedCalls`
- `AmendmentsPublisherTests.Publish_FiltersBustsByDeclaredTradeDate`
- `AmendmentsPublisherTests.Publish_DoneSidecar_HashesPublishedCsvBytes`

Also updated pre-existing PR-2 assertions: `Bust_HasExpectedOnDiskSize` now expects 48/44 (was 44/40) and `NewFilesUseSchemaV3_AndAreReadableAfterReopen` checks the v3 header marker.

## Deferred to PR-5

- RUNBOOK + E2E tests that exercise the full pre→post-EOD flow end-to-end (operator bust HTTP → audit write → amendments file → consumer reconciliation against `sha256OfOriginalFillRow`).

Closes part of #369.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>