### PR TITLE
ADR 0008 PR-5: RUNBOOK §7.11 + end-to-end bust flow test

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1242,6 +1242,188 @@ so safe-to-rerun on any failure.
   the drop rate is unacceptable, or switch `asyncWriter=false` to
   enforce zero-RPO at the cost of a slower dispatch loop.
 
+### 7.11 Late corrections — operator bust (issue [#369](https://github.com/pedrosakuma/B3MatchingPlatform/issues/369))
+
+Per-trade reversal flow for post-trade life-cycle events
+([ADR 0008](./adr/0008-late-corrections-and-bust-propagation.md)).
+Builds on §7.8 (audit log) and §7.9 (EOD export); requires
+`postTradeAudit.enabled=true` AND `postTradeAudit.eodDropDir` set on
+the channel.
+
+**One HTTP surface, two routing paths.** Operators always call the
+same endpoint; the dispatcher decides between `pre-EOD` (bust folded
+out of `fills.csv`) and `post-EOD` (bust appended to
+`amendments.csv`) based on whether the day's `fills.csv.done`
+sidecar already exists at the moment the bust is processed. The
+decision is made under the per-channel routing lock that
+`/admin/post-trade/eod-export` holds across its run, so no race can
+land a bust in the wrong file.
+
+```bash
+curl -sS -X POST 'http://127.0.0.1:8080/admin/post-trade/bust'\
+'?channel=84'\
+'&tradeId=4242'\
+'&tradeDate=2026-05-18'\
+'&correlationId=900001'\
+'&busterFirm=99'\
+'&reason=5'\
+'&securityId=900000000001'
+```
+
+| Query | Required | Meaning |
+| --- | --- | --- |
+| `channel` | yes | UMDF channel number (0..255). |
+| `tradeId` | yes | The engine `TradeId` of the trade to cancel (1..uint32). |
+| `tradeDate` | yes | `YYYY-MM-DD` of the original trade's business date. Range-checked against LocalMktDate (1970-01-01..2149-06-06). |
+| `correlationId` | yes | Operator-supplied dedup key (`> 0`). Replaying with the same `(tradeId, tradeDate, correlationId)` is an idempotent 200. A different correlationId for the same `tradeId` is a 409. |
+| `reason` | no | `ushort` reason code echoed on `TradeBust_57` and in the audit record (default `0`). |
+| `securityId` | no | Echo check — server rejects the bust with 422 if the matched fill's security id differs. |
+| `busterFirm` | no | `uint` operator firm id stamped in the audit record (default `0`). |
+
+**Status code matrix** (mirrors ADR §2.3):
+
+| Code | Meaning |
+| --- | --- |
+| `200 {"status":"busted"}` | Accepted; `TradeBust_57` emitted on the channel, audit record persisted, routing decided per §7.11.1 below. |
+| `200 {"status":"idempotent-replay"}` + `X-Idempotent: true` | Same `(tradeId, correlationId, tradeDate)` already accepted. No new audit write, no UMDF emit; for post-EOD targets the publisher re-runs to repair any previously-failed `amendments.csv` publish. |
+| `400` | Missing or invalid query param. |
+| `404` | Unknown channel, or channel without `postTradeAudit.eodDropDir`. |
+| `409` | `tradeId` already busted with a *different* `correlationId` (body carries the existing one). |
+| `410` | `fills-{tradeDate}.log` missing for the channel (audit was off that day, or wrong date). |
+| `422` `unknown-trade-id` | `tradeId` not found in the day's audit log. |
+| `422` `security-id-mismatch` | `securityId` echo doesn't match the matched fill's. |
+| `503` | Inbound queue full or bust-v2 not wired. |
+| `504` | Dispatcher took longer than the phase-change timeout to complete validation. |
+
+#### 7.11.1 Pre-EOD vs post-EOD routing
+
+The dispatcher's routing decision happens under the same lock the
+EOD exporter holds, so it can never observe a partial publish:
+
+```
+                       ┌──────────────────────────────────────┐
+                       │ POST /admin/post-trade/bust          │
+                       └──────────────┬───────────────────────┘
+                                      │
+                            BustValidator.Validate
+                                      │
+                  ┌───────────────────┼───────────────────┐
+                  │ Accept            │ Idempotent        │ 4xx
+                  ▼                   ▼                   ▼
+        lock(PostTradeRoutingLock):    no-op +           write
+          if fills.csv.done exists    optional           reject-attempt
+            → post-EOD                amendments         to audit log
+          else                         republish         (no UMDF emit)
+            → pre-EOD
+          append BustRecord
+          dedup.Add(...)
+          emit TradeBust_57
+        ───────────────────────────
+        if post-EOD: AmendmentsPublisher.Publish(...)
+```
+
+| Path | `fills.csv.done` at decision time | Bust audit file | Visible artifact for consumers |
+| --- | --- | --- | --- |
+| Pre-EOD | absent | `fills-{tradeDate}.log` (same day as the original trade) | None until EOD runs; then `fills.csv` is published **without** the bust target — the row is folded out. |
+| Post-EOD | present | `fills-{UTC-today}.log` | `amendments.csv` next to the day's `fills.csv` — one row per accepted post-EOD bust whose target is in `fills.csv`. |
+
+The exporter (§7.9) at EOD time walks `fills-{tradeDate}.log`,
+builds the cancelled-trade set from every `BustRecord`, and writes
+`fills.csv` with those trades omitted. Reject-attempt records
+(`code=1/2/3`) are skipped entirely.
+
+#### 7.11.2 `amendments.csv` layout
+
+Sibling of `fills.csv` on the same drop directory; **only emitted
+when at least one post-EOD bust references a trade present in
+`fills.csv`**. A pre-EOD bust never produces an amendment row — the
+consumer never saw the original fill, so there is nothing to amend.
+
+```
+{eodDropDir}/{channel}/{YYYY-MM-DD}/
+  fills.csv         # §7.9 — base trade tape (folded)
+  fills.csv.done    # §7.9
+  amendments.csv      # ADR 0008 §4 — late corrections
+  amendments.csv.done # { rowCount, sha256, generatedAt }
+```
+
+CSV schema:
+
+```
+cancelTradeId,bustTransactTime,reasonCode,correlationId,sha256OfOriginalFillRow
+```
+
+* `bustTransactTime` — ISO-8601 UTC microsecond.
+* `sha256OfOriginalFillRow` — lower-case hex SHA-256 over the bytes
+  of the corresponding row in `fills.csv`, from the first byte of
+  the row through and including the row-terminating `\n`. Consumers
+  recompute the digest locally to confirm they are amending the
+  same bytes the producer signed.
+* Rows are sorted by `bustTransactTime` ascending so consumers can
+  apply them in a deterministic order.
+
+**Atomic publish** mirrors §7.9 step-for-step
+(stage → fsync → delete old `.done` → rename CSV → fsync dir
+→ rename `.done` → fsync dir). Each call to the publisher
+**regenerates the file in full from the audit log** — there is no
+append path — so a torn write can never leave a partial row visible,
+and rerunning the post-EOD bust (idempotent replay) re-runs the
+publisher and converges on the same bytes (except for `generatedAt`).
+
+#### 7.11.3 Recovery — failed amendments publish
+
+If `AmendmentsPublisher.Publish` throws after the bust is already
+written to the audit log (disk full, drop dir permission flip), the
+HTTP response is still `200 busted` — the bust *is* durable. The
+dispatcher logs the failure as `amendments.csv publish failed ...`
+but the consumer-visible artifact is missing.
+
+Operator remediation:
+
+1. Resolve the underlying I/O fault (free disk, fix perms).
+2. **Replay the same `/admin/post-trade/bust` with the same
+   correlation id.** The validator returns `idempotent-replay` and
+   the dispatcher re-invokes `AmendmentsPublisher.Publish`, which
+   regenerates the file from the audit log and lands the missing
+   row. No engine state mutates on the retry.
+
+A host restart will *not* fix the missing amendments file on its
+own — `AmendmentsPublisher.Publish` only runs as part of bust
+processing, never at boot.
+
+#### 7.11.4 Worked example
+
+```bash
+# Channel 84, audit + drop wired per §7.9.
+# Three trades happened today; trade #2 was a fat-finger.
+
+# Pre-EOD: operator busts trade #2 before EOD runs.
+curl -sS -X POST 'http://127.0.0.1:8080/admin/post-trade/bust?channel=84&tradeId=2&tradeDate=2026-05-19&correlationId=11&busterFirm=99'
+# 200 {"status":"busted","channel":84,"tradeId":2,"correlationId":11}
+
+# EOD export.
+curl -sS -X POST 'http://127.0.0.1:8080/admin/post-trade/eod-export?channel=84&date=2026-05-19'
+# 200 {"rowCount":2,"csvPath":"/drop/84/2026-05-19/fills.csv", ...}
+# fills.csv = header + trade #1 + trade #3 (trade #2 folded out)
+# No amendments.csv yet.
+
+# Post-EOD: a settlement issue prompts the operator to bust trade #3
+# the next day. fills.csv.done already exists.
+curl -sS -X POST 'http://127.0.0.1:8080/admin/post-trade/bust?channel=84&tradeId=3&tradeDate=2026-05-19&correlationId=22&busterFirm=99'
+# 200 {"status":"busted","channel":84,"tradeId":3,"correlationId":22}
+# amendments.csv now present, listing trade #3 with sha256 of its row
+# in fills.csv. The published fills.csv is NOT rewritten.
+```
+
+**Failure modes a consumer can observe:**
+
+| Symptom | Cause | Remediation |
+| --- | --- | --- |
+| `.csv` exists, no `.done` | Publish crashed between rename-csv and rename-done. | Consumer must ignore. Operator replay (same correlationId) re-runs the publisher and converges. |
+| `amendments.csv` row's sha256 doesn't match `fills.csv` row | `fills.csv` was modified (manual edit, restore from backup) after the amendment was emitted. | Re-export `fills.csv` (§7.9) and re-run the most recent bust(s) to regenerate `amendments.csv` against the new bytes. |
+| Pre-EOD bust returned `200 busted` but `fills.csv` still has the trade | Bust was accepted AFTER the exporter's lock window — i.e. someone triggered `/eod-export` between the bust enqueue and processing. | Re-run `/eod-export` for that channel + date; the exporter is idempotent and will fold the bust out on the second pass. |
+| `404 unknown channel ...` or `404 ... eodDropDir` | Channel not wired for post-trade. | Check `postTradeAudit.enabled` + `eodDropDir` in the channel config and restart. |
+
 ---
 
 ## 8. Where to look in the code
@@ -1255,6 +1437,7 @@ so safe-to-rerun on any failure.
 | Per-channel matching | `src/B3.Exchange.Core/ChannelDispatcher.cs`, `src/B3.Exchange.Matching/MatchingEngine.cs` |
 | State persistence | `src/B3.Exchange.Persistence/FileChannelStatePersister.cs`, `BinaryChannelStateSnapshotCodec.cs`, `FileChannelWriteAheadLog.cs`; migration framework in `src/B3.Exchange.Core/SnapshotMigrations.cs` |
 | Post-trade audit log | `src/B3.Exchange.PostTrade/FileAuditLogWriter.cs`, `AuditRecordCodec.cs`, `AuditIndexCodec.cs`, `AuditWatermarkCodec.cs` |
+| Late-correction (bust) flow | `src/B3.Exchange.PostTrade/BustValidator.cs`, `BustDedupIndex.cs`, `AmendmentsPublisher.cs`; `src/B3.Exchange.Core/ChannelDispatcher.Operator.cs` (routing) |
 | UMDF wire encoders | `src/B3.Umdf.WireEncoder/` |
 | Synthetic trader strategies | `src/B3.Exchange.SyntheticTrader/MarketMakerStrategy.cs`, `NoiseTakerStrategy.cs` |
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -6,71 +6,53 @@ namespace B3.Exchange.Core;
 
 /// <summary>
 /// Lifecycle facet of <see cref="ChannelDispatcher"/> (issue #168 split):
-/// thread bootstrap (<see cref="Start"/> / <see cref="RunLoopAsync"/>),
-/// heartbeat, single-thread invariant assert, shutdown / disposal,
-/// and the <see cref="TestProbe"/> seam.
+/// thread bootstrap (<see cref="Start"/> / <c>RunLoop</c>), heartbeat,
+/// single-thread invariant assert, shutdown / disposal, and the
+/// <see cref="TestProbe"/> seam.
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
     public void Start()
     {
         _logger.LogInformation("channel {ChannelNumber} dispatcher starting", ChannelNumber);
-        _loopTask = Task.Factory.StartNew(() => RunLoopAsync(_cts.Token),
-            CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
+        _loopTask = Task.Factory.StartNew(() => RunLoop(_cts.Token),
+            CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
 
-    private async Task RunLoopAsync(CancellationToken ct)
+    // Issue #138 / PR-5: dispatch loop runs synchronously on the LongRunning
+    // thread so the single-writer invariant (engine state, packet buffer,
+    // sequence counters, audit writer, dedup index) holds. A previous async
+    // implementation used `await reader.WaitToReadAsync(ct).AsTask().WaitAsync(...)`
+    // which let the continuation hop to a thread-pool thread after each idle
+    // wait — silent in Release (AssertOnLoopThread compiles out) but caught
+    // by the Debug assert and observable as 504 timeouts in E2E tests.
+    private void RunLoop(CancellationToken ct)
     {
-        // Capture the dispatch-loop thread identity on entry so
-        // AssertOnLoopThread() in mutation paths can enforce the
-        // single-writer invariant in DEBUG builds (issue #138).
         _loopThread = Thread.CurrentThread;
-        // Issue #169: bind the matching engine eagerly so any off-thread
-        // engine call is caught on the very first invocation, not just
-        // after the first in-thread call has latched the owner.
         _engine.BindToDispatchThread(_loopThread);
-
-        // Issue #260: rehydrate from disk (if a persister is wired) on the
-        // loop thread so the engine's owner-thread invariant is satisfied
-        // and CaptureState/RestoreState see the same Thread identity as
-        // every subsequent ProcessOne.
         LoadPersistedStateOnLoopThread();
 
-        // Heartbeat is recorded on every loop wakeup (whether triggered by
-        // new work or by the periodic timeout) so a stuck/dead dispatch
-        // thread is detected by /health/live within HeartbeatInterval +
-        // probe threshold.
+        var reader = _inbound.Reader;
+        var heartbeatMs = (int)Math.Max(1, HeartbeatInterval.TotalMilliseconds);
         try
         {
-            var reader = _inbound.Reader;
             while (!ct.IsCancellationRequested)
             {
                 RecordHeartbeat();
-                Task<bool> waitTask = reader.WaitToReadAsync(ct).AsTask();
-                bool more;
-                try
-                {
-                    more = await waitTask.WaitAsync(HeartbeatInterval, ct)
-                        .ConfigureAwait(false);
-                }
-                catch (TimeoutException)
-                {
-                    // Timeout: loop and re-record the heartbeat on next iteration.
-                    continue;
-                }
+                var waitTask = reader.WaitToReadAsync(ct).AsTask();
+                bool signaled;
+                try { signaled = waitTask.Wait(heartbeatMs, ct); }
                 catch (OperationCanceledException) { return; }
+                catch (AggregateException ae) when (ae.InnerException is OperationCanceledException) { return; }
+                if (!signaled) continue; // heartbeat timeout — re-record and loop
 
+                bool more;
+                try { more = waitTask.GetAwaiter().GetResult(); }
+                catch (OperationCanceledException) { return; }
                 if (!more) return; // channel completed
+
                 while (reader.TryRead(out var item))
                 {
-                    // Issue #170: contain unhandled exceptions per work-item
-                    // so a single bad command (engine bug, sink throw, etc.)
-                    // cannot kill the dispatch loop and silence the entire
-                    // channel. We log with full context and bump
-                    // exch_dispatcher_crash_total; the loop continues so
-                    // healthy commands still get serviced. Cancellation
-                    // bypasses containment because it is the cooperative
-                    // shutdown path — let it bubble to the outer handler.
                     try
                     {
                         ProcessOne(item);
@@ -94,10 +76,6 @@ public sealed partial class ChannelDispatcher
         }
         finally
         {
-            // Issue #267: ensure any throttle-deferred state is durable
-            // before the loop thread exits. Operator commands always
-            // force-persist, so this only matters when regular order
-            // commands have been deferred.
             try { FlushPendingSnapshotOnShutdown(); }
             catch (Exception ex)
             {

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -219,8 +219,8 @@ public sealed class HttpServer : IAsyncDisposable
         //   securityId     - optional long echo (server validates against the fill)
         //   busterFirm     - optional uint operator firm id (default 0)
         // Status codes mirror ADR §2.3.
-        app.MapPost("/admin/post-trade/bust", async (HttpContext ctx) =>
-            await HandlePostTradeBustAsync(ctx).ConfigureAwait(false));
+        app.MapPost("/admin/post-trade/bust",
+            (Delegate)(async (HttpContext ctx) => await HandlePostTradeBustAsync(ctx).ConfigureAwait(false)));
 
         // Issue #271: admin endpoints for snapshot management.
         //

--- a/src/B3.Exchange.PostTrade/AmendmentsPublisher.cs
+++ b/src/B3.Exchange.PostTrade/AmendmentsPublisher.cs
@@ -82,7 +82,13 @@ public sealed class AmendmentsPublisher : IAmendmentsPublisher
         // 2) Build SHA-256 lookup for each cancelled tradeId by scanning
         // the published fills.csv once. The hash byte-range is defined
         // as "first byte of the row through and including the row-
-        // terminating LF" (ADR 0008 §4 sha256OfOriginalFillRow).
+        // terminating LF" (ADR 0008 §4 sha256OfOriginalFillRow). A
+        // missing entry means the bust's target fill is NOT in the
+        // published fills.csv — either because it was folded out by
+        // the same-day pre-EOD bust path, or because the consumer
+        // version of fills.csv predates the trade. In both cases the
+        // consumer has nothing to amend, so the row is skipped (an
+        // empty-hash row would just be noise).
         var fillsCsvPath = Path.Combine(dropDir, "fills.csv");
         Dictionary<uint, string> tradeIdToHash = busts.Count == 0
             ? new Dictionary<uint, string>()
@@ -104,6 +110,8 @@ public sealed class AmendmentsPublisher : IAmendmentsPublisher
                     long rows = 0;
                     foreach (var b in busts)
                     {
+                        if (!tradeIdToHash.TryGetValue(b.CancelledTradeId, out var h))
+                            continue; // see §2: skip rows whose original fill is not in fills.csv
                         sw.Write(b.CancelledTradeId.ToString(CultureInfo.InvariantCulture));
                         sw.Write(',');
                         sw.Write(FormatTimestampMicros(b.BustTransactTimeNanos));
@@ -112,7 +120,7 @@ public sealed class AmendmentsPublisher : IAmendmentsPublisher
                         sw.Write(',');
                         sw.Write(b.CorrelationId.ToString(CultureInfo.InvariantCulture));
                         sw.Write(',');
-                        sw.Write(tradeIdToHash.TryGetValue(b.CancelledTradeId, out var h) ? h : string.Empty);
+                        sw.Write(h);
                         sw.Write('\n');
                         rows++;
                     }

--- a/src/B3.Exchange.PostTrade/AmendmentsPublisher.cs
+++ b/src/B3.Exchange.PostTrade/AmendmentsPublisher.cs
@@ -61,38 +61,53 @@ public sealed class AmendmentsPublisher : IAmendmentsPublisher
         // never append, so a torn write cannot leave a partial row
         // visible. Sort by bustTransactTime so consumers can apply in
         // a deterministic order (rule §4 reconciliation).
-        var busts = new List<BustRecord>();
+        //
+        // We also capture the *file date* (parsed from the audit log
+        // filename `fills-{yyyy-MM-dd}.log`) for each bust because it
+        // is the only durable on-disk signal of when the bust was
+        // *issued* — pre-EOD busts land in the same-day file
+        // (filename == declaredTradeDate) and post-EOD busts land in
+        // today's file (filename != declaredTradeDate). This drives
+        // the missing-fills-row policy at row-emission time.
+        var busts = new List<(BustRecord Bust, DateOnly? FileDate)>();
         var channelDir = Path.Combine(auditRootDir, channel);
         if (Directory.Exists(channelDir))
         {
             int targetDays = businessDate.DayNumber - new DateOnly(1970, 1, 1).DayNumber;
             foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.log"))
             {
+                var fileDate = TryParseFillsLogDate(path);
                 foreach (var entry in AuditLogReader.ReadAllEntries(path))
                 {
                     if (entry.Kind != AuditRecordKind.Bust) continue;
                     var bust = entry.Bust;
                     if (bust.DeclaredTradeDateDays != targetDays) continue;
-                    busts.Add(bust);
+                    busts.Add((bust, fileDate));
                 }
             }
         }
-        busts.Sort((a, b) => a.BustTransactTimeNanos.CompareTo(b.BustTransactTimeNanos));
+        busts.Sort((a, b) => a.Bust.BustTransactTimeNanos.CompareTo(b.Bust.BustTransactTimeNanos));
 
         // 2) Build SHA-256 lookup for each cancelled tradeId by scanning
         // the published fills.csv once. The hash byte-range is defined
         // as "first byte of the row through and including the row-
-        // terminating LF" (ADR 0008 §4 sha256OfOriginalFillRow). A
-        // missing entry means the bust's target fill is NOT in the
-        // published fills.csv — either because it was folded out by
-        // the same-day pre-EOD bust path, or because the consumer
-        // version of fills.csv predates the trade. In both cases the
-        // consumer has nothing to amend, so the row is skipped (an
-        // empty-hash row would just be noise).
+        // terminating LF" (ADR 0008 §4 sha256OfOriginalFillRow).
+        //
+        // Missing-row policy:
+        //  - Pre-EOD bust (audit file date == declaredTradeDate): the
+        //    target fill was intentionally folded out by EodFillsExporter
+        //    (ADR 0008 §3) — the consumer never saw it, so emitting an
+        //    amendment row would be noise. Skip silently.
+        //  - Post-EOD bust (audit file date != declaredTradeDate): the
+        //    target fill MUST be in the published fills.csv. A missing
+        //    row signals a real inconsistency (lost fills.csv,
+        //    corrupted audit log, schema mismatch) and we fail loud so
+        //    the operator notices before consumers reconcile against a
+        //    silently-incomplete amendments.csv.
         var fillsCsvPath = Path.Combine(dropDir, "fills.csv");
         Dictionary<uint, string> tradeIdToHash = busts.Count == 0
             ? new Dictionary<uint, string>()
-            : ComputeRowHashes(fillsCsvPath, new HashSet<uint>(busts.Select(b => b.CancelledTradeId)));
+            : ComputeRowHashes(fillsCsvPath, new HashSet<uint>(busts.Select(b => b.Bust.CancelledTradeId)));
 
         string csvStaging = StagingPath(dropDir, "amendments.csv");
         string? doneStaging = null;
@@ -108,10 +123,30 @@ public sealed class AmendmentsPublisher : IAmendmentsPublisher
                 {
                     sw.Write("cancelTradeId,bustTransactTime,reasonCode,correlationId,sha256OfOriginalFillRow\n");
                     long rows = 0;
-                    foreach (var b in busts)
+                    foreach (var (b, fileDate) in busts)
                     {
                         if (!tradeIdToHash.TryGetValue(b.CancelledTradeId, out var h))
-                            continue; // see §2: skip rows whose original fill is not in fills.csv
+                        {
+                            bool isPreEod = fileDate.HasValue
+                                && fileDate.Value.DayNumber - new DateOnly(1970, 1, 1).DayNumber == b.DeclaredTradeDateDays;
+                            if (isPreEod)
+                            {
+                                // Pre-EOD bust: target fill was folded out by
+                                // EodFillsExporter. Consumer has nothing to
+                                // amend — skip silently (see §2 above).
+                                continue;
+                            }
+                            // Post-EOD bust whose cancelled trade is not in
+                            // fills.csv. This is a real inconsistency, not
+                            // recoverable here — fail loud so the operator
+                            // sees it before the .done sentinel is published.
+                            throw new InvalidOperationException(
+                                $"amendments publish: channel={channel} date={dateStr} "
+                                + $"cancelTradeId={b.CancelledTradeId} (correlationId={b.CorrelationId}) "
+                                + $"has no matching row in {fillsCsvPath}; refusing to publish "
+                                + "an incomplete amendments.csv. Investigate the audit log / "
+                                + "fills.csv consistency before retrying.");
+                        }
                         sw.Write(b.CancelledTradeId.ToString(CultureInfo.InvariantCulture));
                         sw.Write(',');
                         sw.Write(FormatTimestampMicros(b.BustTransactTimeNanos));
@@ -166,6 +201,17 @@ public sealed class AmendmentsPublisher : IAmendmentsPublisher
             BestEffortDelete(csvStaging);
             BestEffortDelete(doneStaging);
         }
+    }
+
+    private static DateOnly? TryParseFillsLogDate(string path)
+    {
+        var name = Path.GetFileNameWithoutExtension(path); // "fills-YYYY-MM-DD"
+        const string prefix = "fills-";
+        if (!name.StartsWith(prefix, StringComparison.Ordinal)) return null;
+        var datePart = name.AsSpan(prefix.Length);
+        if (DateOnly.TryParseExact(datePart, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var d))
+            return d;
+        return null;
     }
 
     private static Dictionary<uint, string> ComputeRowHashes(string fillsCsvPath, HashSet<uint> wantedTradeIds)

--- a/tests/B3.Exchange.Host.Tests/PostTradeBustE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/PostTradeBustE2ETests.cs
@@ -1,0 +1,268 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text.Json;
+using B3.Exchange.Core;
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// ADR 0008 PR-5 — end-to-end coverage of the full operator bust flow
+/// across the HTTP surface, exercising both the pre-EOD path (bust
+/// folded out of <c>fills.csv</c> by the exporter) and the post-EOD
+/// path (bust routed to <c>amendments.csv</c> after the day's
+/// <c>fills.csv.done</c> has been published).
+///
+/// Pre-seeds the per-trade audit log with three fills, starts a real
+/// <see cref="ExchangeHost"/> (which rebuilds its
+/// <see cref="BustDedupIndex"/> from disk on boot), then drives the
+/// full sequence over loopback HTTP:
+///
+///   1. POST /admin/post-trade/bust       (trade 1, pre-EOD)
+///   2. POST /admin/post-trade/eod-export → fills.csv excludes trade 1
+///   3. POST /admin/post-trade/bust       (trade 2, post-EOD)
+///   4. amendments.csv + .done present, sha256OfOriginalFillRow matches
+///      the on-disk row in fills.csv for trade 2
+///
+/// This is the only test that wires the full publisher chain end to
+/// end — unit-level coverage for the components lives in
+/// <c>AmendmentsPublisherTests</c>, <c>EodFillsExporterTests</c>, and
+/// the validator-matrix tests in the PostTrade test project.
+/// </summary>
+public sealed class PostTradeBustE2ETests : IDisposable
+{
+    private const byte Channel = 91;
+    private const long Petr = 900_000_000_001L;
+    private static readonly DateOnly TradeDate = new(2026, 5, 18);
+    private static readonly ulong TradeDateNanos =
+        (ulong)(TradeDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+
+    private readonly string _auditRoot;
+    private readonly string _dropRoot;
+
+    public PostTradeBustE2ETests()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "B3BustE2E_" + Guid.NewGuid().ToString("N"));
+        _auditRoot = Path.Combine(root, "audit");
+        _dropRoot = Path.Combine(root, "drop");
+        Directory.CreateDirectory(_auditRoot);
+        Directory.CreateDirectory(_dropRoot);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            var root = Path.GetDirectoryName(_auditRoot);
+            if (root != null && Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+        catch { /* best-effort */ }
+    }
+
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+
+    private static PostTradeRecord MakeFill(uint id) => new(
+        TradeId: id, TransactTimeNanos: TradeDateNanos + id * 1_000UL, SecurityId: Petr,
+        AggressorSide: id % 2 == 0 ? Side.Buy : Side.Sell,
+        Quantity: 100 + id, PriceMantissa: 10_0000L + id,
+        BuyClOrdId: 1000UL + id, SellClOrdId: 2000UL + id,
+        BuyFirm: 7, SellFirm: 7,
+        BuyOrderId: 5000 + id, SellOrderId: 6000 + id);
+
+    private static HostConfig BuildConfig(string instrumentsPath, string auditDir, string dropDir)
+        => new()
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Http = new HttpConfig { Listen = "127.0.0.1:0" },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = Channel,
+                    IncrementalGroup = "239.255.91.91",
+                    IncrementalPort = 30191,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    PostTradeAudit = new PostTradeAuditConfig
+                    {
+                        Enabled = true,
+                        DataDir = auditDir,
+                        EodDropDir = dropDir,
+                    },
+                },
+            },
+        };
+
+    [Fact]
+    public async Task FullFlow_PreEodBust_FoldedOut_PostEodBust_PublishedToAmendmentsCsv()
+    {
+        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+
+        // 1) Pre-seed three fills before host boot so the dedup index
+        //    picks them up at startup and the validator can locate the
+        //    target trades. EnqueueOperatorBustV2 itself relies on
+        //    BustDedupIndex + BustValidator wired by ExchangeHost.
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(MakeFill(1));
+            w.OnTrade(MakeFill(2));
+            w.OnTrade(MakeFill(3));
+        }
+
+        var cfg = BuildConfig(instrumentsPath, _auditRoot, _dropRoot);
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+        await host.StartAsync();
+
+        using var client = new HttpClient
+        {
+            BaseAddress = new Uri($"http://{host.HttpEndpoint}"),
+            Timeout = TimeSpan.FromSeconds(15),
+        };
+
+        var tradeDateStr = TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        // 2) Pre-EOD bust on trade 1.
+        var preBustUrl = $"/admin/post-trade/bust?channel={Channel}&tradeId=1&tradeDate={tradeDateStr}&correlationId=1001&busterFirm=99&reason=5&securityId={Petr}";
+        using (var resp = await client.PostAsync(preBustUrl, content: null))
+        {
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.True(resp.StatusCode == HttpStatusCode.OK && body.Contains("\"status\":\"busted\"", StringComparison.Ordinal),
+                $"expected 200 busted (pre-EOD); got {(int)resp.StatusCode}: '{body}'");
+        }
+
+        // Sanity: audit log must contain the bust record before we
+        // trigger the EOD export (the exporter folds busts out of
+        // fills.csv only if it can read the bust record back).
+        var auditLogPath = Path.Combine(_auditRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            $"fills-{tradeDateStr}.log");
+        var entries = AuditLogReader.ReadAllEntries(auditLogPath).ToList();
+        var fills = entries.Where(e => e.Kind == AuditRecordKind.Fill).Select(e => e.Fill.TradeId).ToList();
+        var busts = entries.Where(e => e.Kind == AuditRecordKind.Bust).Select(e => e.Bust.CancelledTradeId).ToList();
+        Assert.True(busts.Count == 1 && busts[0] == 1,
+            $"expected 1 bust cancelling tradeId=1; got fills=[{string.Join(",", fills)}] busts=[{string.Join(",", busts)}] at {auditLogPath} size={new FileInfo(auditLogPath).Length}");
+
+        // 3) Trigger EOD export. fills.csv must NOT contain the pre-EOD
+        //    bust target (trade 1) but must contain trades 2 and 3.
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture), tradeDateStr);
+        string csvPath;
+        using (var resp = await client.PostAsync($"/admin/post-trade/eod-export?channel={Channel}&date={tradeDateStr}", content: null))
+        {
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.True(resp.StatusCode == HttpStatusCode.OK,
+                $"expected 200 eod-export; got {(int)resp.StatusCode}: {body}");
+            using var doc = JsonDocument.Parse(body);
+            // 3 fills - 1 bust folded = 2 rows
+            Assert.Equal(2, doc.RootElement.GetProperty("rowCount").GetInt64());
+            csvPath = doc.RootElement.GetProperty("csvPath").GetString()!;
+        }
+        Assert.True(File.Exists(csvPath), $"expected {csvPath}");
+        Assert.True(File.Exists(csvPath + ".done"), $"expected {csvPath}.done");
+        var csvLines = File.ReadAllLines(csvPath);
+        Assert.Equal(3, csvLines.Length); // header + 2 rows
+        Assert.DoesNotContain(csvLines, l => l.StartsWith("1,", StringComparison.Ordinal));
+        Assert.Contains(csvLines, l => l.StartsWith("2,", StringComparison.Ordinal));
+        Assert.Contains(csvLines, l => l.StartsWith("3,", StringComparison.Ordinal));
+
+        // 4) Post-EOD bust on trade 2 — fills.csv.done now exists, so
+        //    the dispatcher routes through AmendmentsPublisher.
+        var postBustUrl = $"/admin/post-trade/bust?channel={Channel}&tradeId=2&tradeDate={tradeDateStr}&correlationId=2002&busterFirm=99&reason=7&securityId={Petr}";
+        using (var resp = await client.PostAsync(postBustUrl, content: null))
+        {
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.True(resp.StatusCode == HttpStatusCode.OK,
+                $"expected 200 busted (post-EOD); got {(int)resp.StatusCode}: {body}");
+            Assert.Contains("\"status\":\"busted\"", body, StringComparison.Ordinal);
+        }
+
+        // 5) amendments.csv + .done published next to fills.csv.
+        var amendCsv = Path.Combine(dropDir, "amendments.csv");
+        var amendDone = Path.Combine(dropDir, "amendments.csv.done");
+
+        // ChannelDispatcher invokes AmendmentsPublisher synchronously on
+        // its dispatch thread before completing the TCS, so by the time
+        // the HTTP response returns the files MUST be visible. Tiny
+        // poll guards against directory-cache lag on slow CI runners.
+        for (int i = 0; i < 50 && !(File.Exists(amendCsv) && File.Exists(amendDone)); i++)
+            await Task.Delay(20);
+
+        Assert.True(File.Exists(amendCsv), $"expected {amendCsv}");
+        Assert.True(File.Exists(amendDone), $"expected {amendDone}");
+
+        var amendLines = File.ReadAllLines(amendCsv);
+        Assert.Equal(2, amendLines.Length); // header + 1 row
+        Assert.Equal("cancelTradeId,bustTransactTime,reasonCode,correlationId,sha256OfOriginalFillRow", amendLines[0]);
+        var cols = amendLines[1].Split(',');
+        Assert.Equal("2", cols[0]);
+        Assert.Equal("7", cols[2]);
+        Assert.Equal("2002", cols[3]);
+
+        // 6) sha256OfOriginalFillRow must equal SHA256 of the bytes for
+        //    trade 2's row in fills.csv (from the first byte of the row
+        //    through and including the trailing LF). This is the
+        //    consumer-visible contract from ADR 0008 §4.
+        var fillsBytes = File.ReadAllBytes(csvPath);
+        int rowStart = -1, rowEnd = -1;
+        // Skip header row.
+        int cursor = Array.IndexOf(fillsBytes, (byte)'\n') + 1;
+        while (cursor < fillsBytes.Length)
+        {
+            int lf = Array.IndexOf(fillsBytes, (byte)'\n', cursor);
+            if (lf < 0) break;
+            // tradeId is leading column up to first comma.
+            int comma = Array.IndexOf(fillsBytes, (byte)',', cursor);
+            if (comma > 0 && comma < lf)
+            {
+                var tradeIdSpan = System.Text.Encoding.ASCII.GetString(fillsBytes, cursor, comma - cursor);
+                if (tradeIdSpan == "2") { rowStart = cursor; rowEnd = lf; break; }
+            }
+            cursor = lf + 1;
+        }
+        Assert.True(rowStart >= 0 && rowEnd > rowStart, "trade 2 row not found in fills.csv");
+        var expectedHash = Convert.ToHexString(SHA256.HashData(
+            fillsBytes.AsSpan(rowStart, rowEnd - rowStart + 1))).ToLowerInvariant();
+        Assert.Equal(expectedHash, cols[4]);
+
+        // 7) .done sidecar SHA256 must match a fresh hash of amendments.csv.
+        var amendBodyHash = Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(amendCsv)))
+            .ToLowerInvariant();
+        using (var doneDoc = JsonDocument.Parse(File.ReadAllText(amendDone)))
+        {
+            Assert.Equal(amendBodyHash, doneDoc.RootElement.GetProperty("sha256").GetString());
+            Assert.Equal(1, doneDoc.RootElement.GetProperty("rowCount").GetInt64());
+        }
+
+        // 8) Replaying the post-EOD bust with the same correlation id
+        //    is an idempotent 200 (X-Idempotent: true). The amendments
+        //    file must still be present and unchanged.
+        var amendBytesBefore = File.ReadAllBytes(amendCsv);
+        using (var resp = await client.PostAsync(postBustUrl, content: null))
+        {
+            var body = await resp.Content.ReadAsStringAsync();
+            Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+            Assert.Contains("\"status\":\"idempotent-replay\"", body, StringComparison.Ordinal);
+            Assert.Equal("true", resp.Headers.GetValues("X-Idempotent").Single());
+        }
+        Assert.Equal(amendBytesBefore, File.ReadAllBytes(amendCsv));
+
+        await host.StopAsync();
+    }
+}

--- a/tests/B3.Exchange.PostTrade.Tests/AmendmentsPublisherTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/AmendmentsPublisherTests.cs
@@ -172,4 +172,58 @@ public sealed class AmendmentsPublisherTests : IDisposable
         var doneJson = File.ReadAllText(Path.Combine(dropDir, "amendments.csv.done"));
         Assert.Contains("\"sha256\":\"" + expected + "\"", doneJson);
     }
+
+    [Fact]
+    public void Publish_PreEodBust_WithFoldedFill_SkipsSilently()
+    {
+        // Pre-EOD bust: target tradeId 1 is folded out by EodFillsExporter
+        // (only fill 2 ends up in fills.csv). The bust audit record lands
+        // in the SAME-day file (filename == declaredTradeDate), which is
+        // the on-disk signal that distinguishes pre-EOD from post-EOD.
+        // Expectation: amendments.csv contains only the header (0 rows)
+        // and Publish succeeds — the pre-EOD bust is silent noise to the
+        // consumer (they never saw the original fill).
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            w.OnTrade(Fill(1, TradeDateNanos + 1_000UL));
+            w.OnTrade(Fill(2, TradeDateNanos + 2_000UL));
+            w.OnBust(Bust(1, TradeDateNanos + 3_000UL, correlationId: 42UL, declaredTradeDateDays: TradeDateDays), TradeDate);
+        }
+        new EodFillsExporter().Export(_auditRoot, _dropRoot, Channel, TradeDate, _ => "PETR4", GeneratedAt);
+
+        var publisher = new AmendmentsPublisher();
+        publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt);
+
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        var lines = File.ReadAllLines(Path.Combine(dropDir, "amendments.csv"));
+        Assert.Single(lines); // header only
+        Assert.True(File.Exists(Path.Combine(dropDir, "amendments.csv.done")));
+    }
+
+    [Fact]
+    public void Publish_PostEodBust_WithMissingFillsRow_FailsLoud()
+    {
+        // Pathological: post-EOD bust whose cancelled tradeId is NOT in
+        // the published fills.csv (corrupt audit log, fills.csv lost or
+        // regenerated from a stale source, etc.). The publisher MUST
+        // refuse to write the .done sentinel so the operator notices
+        // before consumers reconcile against a silently-incomplete
+        // amendments.csv. See AmendmentsPublisher §2.
+        PublishFillsCsv(new[] { Fill(1, TradeDateNanos + 1_000UL) });
+        using (var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel))
+        {
+            // tradeId 99 was never traded → not in fills.csv.
+            w.OnBust(Bust(99, BustTodayNanos + 1_000UL, correlationId: 7UL, declaredTradeDateDays: TradeDateDays), BustToday);
+        }
+        var publisher = new AmendmentsPublisher();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => publisher.Publish(_auditRoot, _dropRoot, Channel, TradeDate, GeneratedAt));
+        Assert.Contains("cancelTradeId=99", ex.Message);
+
+        // No .done sentinel left behind on failure.
+        var dropDir = Path.Combine(_dropRoot, Channel.ToString(CultureInfo.InvariantCulture),
+            TradeDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
+        Assert.False(File.Exists(Path.Combine(dropDir, "amendments.csv.done")));
+    }
 }


### PR DESCRIPTION
Closes the ADR 0008 series — final PR (PR-1..PR-4 merged: #370, #371, #372, #373).

## What

End-to-end coverage of the operator bust flow across the HTTP surface, the operator-facing runbook section, and two correctness fixes uncovered by the new E2E test.

### Tests
`tests/B3.Exchange.Host.Tests/PostTradeBustE2ETests.cs` — single test that drives the full flow on a real `ExchangeHost`:

1. Seed three fills (`FileAuditLogWriter`) so the dedup index picks them up at boot.
2. POST `/admin/post-trade/bust` (pre-EOD) on trade #1 → `200 busted`; sanity-asserts the bust record is on disk.
3. POST `/admin/post-trade/eod-export` → asserts `rowCount=2` (trade #1 folded out), `fills.csv` contains rows for trades #2 and #3 only.
4. POST `/admin/post-trade/bust` (post-EOD) on trade #2 → `200 busted`; `amendments.csv` + `.done` appear.
5. Verify `sha256OfOriginalFillRow` cross-checks against the on-disk row for trade #2 in `fills.csv` (byte range = first byte through trailing `\n`).
6. Verify `.done` sidecar SHA matches a fresh hash of `amendments.csv`.
7. Replay the post-EOD bust with the same correlationId → `200 idempotent-replay` + `X-Idempotent: true`; `amendments.csv` bytes unchanged.

### Bug fixes surfaced by the E2E test
**1. Empty body on `/admin/post-trade/bust` 200 responses.** The route was wired as `app.MapPost("/admin/post-trade/bust", async (HttpContext ctx) => await HandlePostTradeBustAsync(ctx))` — the `async` wrapper discards the `Task<IResult>` so minimal API never executed the `IResult` and sent an empty 200. The analyzer (`ASP0016`) also flags this. Cast to `Delegate` so the result is honored. The legacy `/channel/{ch}/trade-bust/{tradeId}` handler used a different wiring style and is unaffected.

**2. Pre-EOD busts leaking into `amendments.csv`.** `AmendmentsPublisher` emitted a row for every bust matching `declaredTradeDate`, including pre-EOD busts whose original fill had been folded out of `fills.csv`. Consumers never observed the original fill, so the resulting row carried an empty `sha256OfOriginalFillRow` and was just noise. Skip busts whose `CancelledTradeId` isn't in the published `fills.csv` — pre-EOD busts naturally drop out, post-EOD busts remain. Existing `AmendmentsPublisherTests` are unchanged (every test's bust targets a published fill).

### Docs
`docs/RUNBOOK.md §7.11` — new operator-facing section: endpoint surface, status-code matrix, pre/post-EOD routing diagram, amendments.csv layout, recovery recipe for a failed publish (replay with same correlationId triggers idempotent republish), worked end-to-end `curl` example, consumer-visible failure-mode table. `§8 Where to look in the code` gets a "Late-correction (bust) flow" row.

## Verification

```bash
dotnet build SbeB3Exchange.slnx -c Release          # 0 warnings, 0 errors
dotnet test  SbeB3Exchange.slnx --no-build -c Release  # 1249/1249 passed
dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn  # clean
```