### PR TITLE
Fix #375: stop AsyncWriter_ThrowingPersister_DoesNotCrashWriter flake

### DIFF
--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -699,6 +699,21 @@ public class ChannelDispatcherPersistenceTests
         return condition();
     }
 
+    // Issue #375: synchronous variant for tests that interact with the
+    // engine before AND after the wait. Using `await Task.Delay` between
+    // two engine calls lets the second call resume on a thread-pool
+    // thread, violating MatchingEngine's single-owner invariant in Debug.
+    private static bool WaitFor(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            Thread.Sleep(10);
+        }
+        return condition();
+    }
+
     [Fact]
     public async Task AsyncWriter_Submits_PersistAfterFlush()
     {
@@ -778,6 +793,14 @@ public class ChannelDispatcherPersistenceTests
     [Fact]
     public async Task AsyncWriter_ThrowingPersister_DoesNotCrashWriter()
     {
+        // Issue #375: this test must NOT cross an `await` between the two
+        // DrainInbound calls. After `await Task.Delay(...)` resumes on a
+        // thread-pool thread, the second DrainInbound would run on a
+        // different thread than the first — violating the engine's
+        // single-owner invariant and tripping MatchingEngine.AssertOnOwnerThread
+        // in Debug. Use the synchronous WaitFor helper for inter-drain
+        // polling; await only at the end (DisposeAsync) where no further
+        // engine call follows.
         var throwing = new ThrowingPersister();
         var metrics = new ChannelMetrics(channelNumber: 84);
         var disp = BuildDispatcher(throwing, out _, metrics, useAsyncSnapshotWriter: true);
@@ -787,13 +810,13 @@ public class ChannelDispatcherPersistenceTests
         Assert.True(EnqueueOrder(disp, session, "CL-1", 0xD0, 8000UL));
         probe.DrainInbound();
 
-        Assert.True(await WaitForAsync(() => metrics.SnapshotSaveFailures >= 1,
+        Assert.True(WaitFor(() => metrics.SnapshotSaveFailures >= 1,
             TimeSpan.FromSeconds(2)));
 
         // Subsequent submissions still flow — writer survived the throw.
         Assert.True(EnqueueOrder(disp, session, "CL-2", 0xD1, 8001UL));
         probe.DrainInbound();
-        Assert.True(await WaitForAsync(() => metrics.SnapshotSaveFailures >= 2,
+        Assert.True(WaitFor(() => metrics.SnapshotSaveFailures >= 2,
             TimeSpan.FromSeconds(2)));
 
         await disp.DisposeAsync();


### PR DESCRIPTION
Closes #375.

## Root cause

The test called `probe.DrainInbound()` twice with an `await Task.Delay(...)` (via `WaitForAsync`) between the two calls. After `await`, the continuation can resume on any thread-pool thread; the second `DrainInbound` then runs `ProcessOne` on a different thread than the first. `MatchingEngine.AssertOnOwnerThread` (Debug-only) latches the owner on the first call and throws on the second, failing ~4/5 Debug runs locally. Release is silent because the assert compiles out — so CI never noticed.

This is the same family of bugs as the async-loop continuation hop fixed in #374.

## Fix

Add a synchronous `WaitFor(condition, timeout)` (`Thread.Sleep` instead of `Task.Delay`) and use it between the two `DrainInbound` calls. Keep `WaitForAsync` for the genuinely-async tests; the only `await` left in the failing test is the final `DisposeAsync` — no engine call follows it.

## Validation

- Debug: **10/10 passes** for the targeted test (was ~1/5 on `main`).
- Release: full 1257-test suite green.
- `dotnet format --verify-no-changes`: clean.