### PR TITLE
ci: add parallel Debug build & test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,60 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  build-test-debug:
+    name: Build & Test (Debug)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Debug builds enforce single-thread invariants (MatchingEngine /
+    # ChannelDispatcher) via Debug.Assert, which compiles out in
+    # Release. Two latent bugs (#374 dispatcher async-loop continuation
+    # hop; #375 test-thread hop) were silently green in Release CI
+    # for months. This lane catches that whole family on every PR.
+    # Kept as a SEPARATE job (not a matrix) so the existing required
+    # check "Build & Test" name remains stable for branch protection /
+    # auto-merge until this lane is promoted to required.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up .NET SDK (pinned by global.json)
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/*.slnx', 'Directory.Build.props', 'Directory.Packages.props', 'global.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Restore
+        run: dotnet restore SbeB3Exchange.slnx
+
+      - name: Build (Debug, warnings-as-errors)
+        run: dotnet build SbeB3Exchange.slnx --no-restore -c Debug
+
+      - name: Test (Debug)
+        run: >
+          dotnet test SbeB3Exchange.slnx
+          --no-build -c Debug
+          --logger "trx;LogFileName=test-results-debug.trx"
+          --logger "console;verbosity=normal"
+          --blame-hang-timeout 60000
+          --results-directory ./TestResults
+
+      - name: Upload test results (Debug)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-results-debug
+          path: TestResults/**/*
+          if-no-files-found: ignore
+          retention-days: 14
+
   format:
     name: Format check
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Debug builds enforce single-thread invariants (`MatchingEngine.AssertOnOwnerThread`, `ChannelDispatcher.AssertOnLoopThread`) via `Debug.Assert`, which is `[Conditional("DEBUG")]` and compiles out in Release.

Two latent bugs landed in main this month even though they tripped those asserts on every Debug run:

- #374 — `ChannelDispatcher.RunLoopAsync` continuation hopped to a pool thread after `await reader.WaitToReadAsync().AsTask().WaitAsync(timeout)`, so any subsequent engine call ran on the wrong thread.
- #375 — Test pattern: `DrainInbound → await Task.Delay → DrainInbound` where the second drain ran on a different pool thread than the first owner-latched one.

Both were invisible to Release CI for months. This adds a parallel CI lane that builds and runs the full suite under `-c Debug` so this whole family of bugs is caught at PR time.

## Shape

- New job `build-test-debug` in `.github/workflows/ci.yml`, runs in parallel with the existing `build-test` (Release) lane.
- Kept as a **separate job** (not a matrix variant of the existing one) so the required check name `Build & Test` stays stable for branch protection / auto-merge. Once this lane proves stable across a handful of PRs it can be promoted to required.
- Adds `--blame-hang-timeout 60000` to surface hangs instead of timing out the whole job silently.
- Uploads results to a distinct artifact `test-results-debug`.

## Validation

Full Debug suite locally:
```
dotnet test SbeB3Exchange.slnx --no-build -c Debug
```
1257 tests, all green (no flake repro in this run).