### PR TITLE
docs: ADR 0009 + CONTRIBUTING — single-writer threading model

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,9 +4,15 @@ Short, opinionated guide for humans and agents touching this codebase.
 
 ## Pre-PR checklist
 
-These commands mirror the required CI checks (`Build & Test`,
-`Build & Test (Debug)`, `Format check`). Run them locally before
-opening a PR — they are fast and they are exactly what CI runs:
+Run these locally before opening a PR. The Release `dotnet build` /
+`dotnet test` and `dotnet format` invocations match the required CI
+checks (`Build & Test` and `Format check`). The Debug build/test
+mirror the new `Build & Test (Debug)` lane — that job exists in CI
+but is not yet a *required* check (see the comment in
+`.github/workflows/ci.yml`); run it locally anyway so a Debug-only
+regression doesn't surface as a red lane on your PR. CI itself adds
+loggers, coverage, and `--blame-hang-timeout` on top of these — those
+flags don't change pass/fail, only artifact shape.
 
 ```bash
 dotnet restore SbeB3Exchange.slnx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing to B3MatchingPlatform
+
+Short, opinionated guide for humans and agents touching this codebase.
+
+## Pre-PR checklist
+
+These commands mirror the required CI checks (`Build & Test`,
+`Build & Test (Debug)`, `Format check`). Run them locally before
+opening a PR — they are fast and they are exactly what CI runs:
+
+```bash
+dotnet restore SbeB3Exchange.slnx
+dotnet build   SbeB3Exchange.slnx --no-restore -c Release
+dotnet test    SbeB3Exchange.slnx --no-build   -c Release
+dotnet build   SbeB3Exchange.slnx --no-restore -c Debug
+dotnet test    SbeB3Exchange.slnx --no-build   -c Debug
+dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
+```
+
+`TreatWarningsAsErrors=true` is on globally — a new warning fails the
+build. If `dotnet format` reports diffs, run it without
+`--verify-no-changes` to apply the fixes, then re-run the verification.
+
+## Threading model (read this before touching the dispatcher or engine)
+
+Per-channel state — `MatchingEngine`, `ChannelDispatcher` buffers and
+sequence counters, audit writer, dedup index, snapshot cadence — is
+**single-writer**. Exactly one thread (the dispatcher's `LongRunning`
+loop thread) is allowed to mutate it. There is no lock; the assumption
+is what makes the hot path lock-free.
+
+The invariant is documented and decided in
+[ADR 0009](docs/adr/0009-single-writer-threading-model.md). Two recent
+bugs (#374 dispatcher async-loop continuation hop, #375 test-thread hop
+after `await Task.Delay`) violated it; both compiled and ran green in
+Release but tripped the Debug assert on every run.
+
+Rules of thumb when working in this area:
+
+- **Never `await` inside the dispatch loop.** Use sync `Task.Wait(timeout, ct)`
+  or `.GetAwaiter().GetResult()` from the loop thread. An `await` lets
+  the continuation hop to a pool thread, and on a busy pool every
+  `await` is a coin flip.
+- **Do not `.Unwrap()` an async lambda passed to
+  `Task.Factory.StartNew(..., LongRunning)`.** That reintroduces the
+  same continuation-hop problem. Pass a synchronous `Action`.
+- **Cross-thread producers go through `ChannelDispatcher.EnqueueXxx`.**
+  TCP/FIXP sessions, the HTTP admin server, persistence callbacks, and
+  tests never call engine or dispatcher mutation methods directly. The
+  bounded `Channel<T>` is the only handoff.
+- **Add `AssertOnOwnerThread()` / `AssertOnLoopThread()` to any new
+  mutation entry point.** It is the first statement of the method.
+  These asserts are `[Conditional("DEBUG")]` so they have zero
+  Release-mode cost; the Debug CI lane runs them on every PR.
+- **Tests must respect the invariant too.** If a test calls
+  `TestProbe.DrainInbound` more than once, do not put `await Task.Delay`
+  or any other continuation point between drains — the engine has
+  latched to the test thread, and the second drain on a different pool
+  thread will trip the assert. Use the sync `WaitFor(Func<bool>, TimeSpan)`
+  helper to wait for background conditions between drains.
+
+The two CI lanes catch different things:
+
+- `Build & Test` (Release) — wire correctness, performance-sensitive
+  paths compiled the way production runs.
+- `Build & Test (Debug)` — `Debug.Assert` enforces single-writer
+  invariants that are compiled out in Release.
+
+Both must pass before merge.
+
+## PR flow
+
+- Branch naming: `fix/<issue>-<slug>`, `feat/<slug>`, `docs/<slug>`,
+  `ci/<slug>`, `refactor/<slug>`. Issue numbers in the branch name help
+  reviewers wire context fast.
+- Open PRs as **draft** while iterating. Mark ready only when the
+  pre-PR checklist passes locally.
+- Squash-merge by default (the repo's auto-merge rule uses squash).
+  Keep the squash commit message self-contained — the merged history is
+  what future readers will see.
+- A merged PR that closes an issue must link it via `Closes #N` in the
+  PR body, not just the commit message.
+
+## ADRs vs RFCs vs runbook vs code comments
+
+- **ADRs** (`docs/adr/`) record decisions that are expensive to reverse:
+  module boundaries, on-disk formats, protocol surfaces, threading
+  model. One ADR per file, numbered sequentially. See
+  [docs/adr/README.md](docs/adr/README.md) for the lifecycle.
+- **RFCs** (`docs/rfc/`) are umbrella architectural plans that may spawn
+  multiple ADRs. The post-trade architecture (RFC 0001) is the only one
+  so far.
+- **Runbook** (`docs/RUNBOOK.md`) is operational: how to halt a
+  channel, how to read metrics, how to recover from a crashed
+  dispatcher. Cite ADRs where they explain *why* a procedure exists.
+- **Code comments** cite the ADR or issue number (`// See ADR 0009`,
+  `// issue #374`) rather than repeating the rationale. The ADR is the
+  source of truth; the comment is a pointer.
+
+## Schemas are vendored
+
+Do not hand-edit files under `schemas/`. When upgrading B3 EntryPoint
+or UMDF, regenerate the SBE bindings in `B3.*.Sbe` and mirror the
+change in the companion `SbeB3UmdfConsumer` repo. The two repos must
+agree on the schema version.

--- a/docs/adr/0009-single-writer-threading-model.md
+++ b/docs/adr/0009-single-writer-threading-model.md
@@ -1,0 +1,176 @@
+# ADR 0009 — Single-writer threading model for per-channel state
+
+- **Status:** Accepted (retroactively documents the model in place since
+  issue #169 / #138 and reinforced by the #374 / #375 fixes and the
+  PR #377 Debug CI lane; written now so future work has a stable
+  reference instead of reverse-engineering the dispatcher and the
+  matching engine.)
+- **Date:** 2026-05-20
+- **Supersedes:** —
+- **Superseded by:** —
+- **Part of:** core infrastructure (not under RFC 0001 — applies to the
+  whole matching/dispatch stack, not just post-trade).
+- **Related ADRs:** [ADR 0002](0002-per-trade-audit-log-shape.md)
+  (audit writer is one of the single-writer-owned resources).
+- **Related issues:**
+  [#169](https://github.com/pedrosakuma/B3MatchingPlatform/issues/169)
+  (matching-engine single-thread invariant + per-call assert),
+  [#138](https://github.com/pedrosakuma/B3MatchingPlatform/issues/138)
+  (dispatcher single-writer invariant + `AssertOnLoopThread`),
+  [#374](https://github.com/pedrosakuma/B3MatchingPlatform/issues/374)
+  (sync `RunLoop` replaces async `RunLoopAsync` to keep the invariant),
+  [#375](https://github.com/pedrosakuma/B3MatchingPlatform/issues/375)
+  (test pattern that hopped pool threads between drains),
+  [#377](https://github.com/pedrosakuma/B3MatchingPlatform/pull/377)
+  (Debug CI lane that enforces the invariant on every PR).
+
+## Context
+
+Each UMDF channel owns a graph of mutable state:
+
+- the per-channel `MatchingEngine` (books, order/trade id allocators,
+  `RptSeq`),
+- the `ChannelDispatcher` packet buffer, sequence counters
+  (`SequenceNumber`, `SequenceVersion`), and per-session
+  `(EnteringFirm, ClOrdID) → OrderID` index,
+- the audit log writer, dedup index, and snapshot cadence state.
+
+All of it is `[NotThreadSafe]` by design: there are no locks on the hot
+path, the buffers are pooled and reused, and the audit/snapshot writers
+assume an append-only single producer. The performance and correctness
+arguments only hold while exactly one thread mutates this graph.
+
+That thread exists: `ChannelDispatcher` runs a dedicated loop thread
+(spawned via `Task.Factory.StartNew(..., TaskCreationOptions.LongRunning)`)
+that pumps the bounded inbound channel, calls into the engine, and
+flushes the packet buffer. Inbound producers (TCP/FIXP sessions, the
+HTTP admin server, persistence replay) marshal work onto it through
+`EnqueueXxx` methods backed by a `Channel<T>`.
+
+The invariant is **enforced**, not just documented:
+
+- `MatchingEngine.AssertOnOwnerThread` (`src/B3.Exchange.Matching/MatchingEngine.cs:1933-1960`)
+  lazy-latches the first calling thread and trips on every subsequent
+  cross-thread call. `BindToDispatchThread` lets the dispatcher latch
+  eagerly at startup.
+- `ChannelDispatcher.AssertOnLoopThread`
+  (`src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs:98-109`) is the
+  same guard for dispatcher-owned state.
+
+Both asserts are `[Conditional("DEBUG")]`, so they compile out in
+Release. Release CI was therefore blind to the whole class for months —
+two latent bugs landed even though they tripped these asserts on every
+Debug run:
+
+- #374 — `ChannelDispatcher.RunLoopAsync` used
+  `await reader.WaitToReadAsync(ct).AsTask().WaitAsync(timeout)`; after
+  every idle wait the continuation could resume on a pool thread. The
+  rest of the loop body (and any engine call it made) then ran on the
+  wrong thread.
+- #375 — Test pattern `DrainInbound → await Task.Delay → DrainInbound`:
+  the engine latched to the test thread on the first drain, the `await`
+  hopped to a pool thread, the second drain re-entered the engine and
+  tripped the assert.
+
+Both were caught only in retrospect. PR #377 added a parallel CI lane
+that builds and tests under `-c Debug` so this family of bug fails fast
+at PR time.
+
+## Decision
+
+1. **One owner thread per channel.** Per-channel mutable state
+   (matching engine, dispatcher buffers and counters, audit writer,
+   dedup index, snapshot cadence) is mutated only from the
+   `ChannelDispatcher` loop thread. There is no exception, including
+   "just a read", "just metrics", "just for tests".
+
+2. **The loop runs synchronously, not async.** `ChannelDispatcher.RunLoop`
+   blocks on `Task.Wait(timeout, ct)` to combine the inbound wait with
+   the heartbeat tick. We do **not** `await` inside the loop, and we do
+   **not** `.Unwrap()` an async lambda passed to
+   `Task.Factory.StartNew(..., LongRunning)` — both reintroduce the
+   continuation-hops-to-pool problem that #374 fixed. If a future
+   dependency only exposes an async API, the integration point must
+   call `.GetAwaiter().GetResult()` from the loop thread, not `await`.
+
+3. **The loop thread is `LongRunning`.** We spend the whole process
+   lifetime in this thread; the `LongRunning` hint tells the scheduler
+   to allocate a dedicated thread instead of borrowing a pool worker,
+   which keeps the latch stable and avoids pool starvation.
+
+4. **Cross-thread producers go through the channel.** TCP/FIXP
+   sessions, the HTTP admin server, persistence callbacks, and tests
+   all enqueue via `EnqueueXxx` on `ChannelDispatcher`. They never
+   call engine or dispatcher mutation methods directly. The bounded
+   `Channel<T>` is the only handoff.
+
+5. **The invariant is asserted in Debug, enforced by Debug CI.**
+   `AssertOnOwnerThread` / `AssertOnLoopThread` stay
+   `[Conditional("DEBUG")]` for hot-path cost reasons, and the
+   `build-test-debug` lane in `.github/workflows/ci.yml` runs the full
+   test suite under `-c Debug` on every PR so a regression cannot
+   merge silently.
+
+6. **Tests respect the invariant too.** `TestProbe.DrainInbound`
+   processes items on the caller's thread. Tests that call it must
+   stay on a single thread: no `await Task.Delay` (or any other
+   continuation point) between drains, no `Task.Run` wrapping engine
+   calls. If a test needs to wait for a background condition between
+   drains it uses the sync `WaitFor(Func<bool>, TimeSpan)` helper
+   (sleeps on the test thread) rather than the async `WaitForAsync`,
+   so the latch stays intact.
+
+## Consequences
+
+- The hot path stays lock-free: no `Monitor`, no `Interlocked`, no
+  `Volatile` on per-channel state. Throughput stays at the Release-mode
+  numbers RFC 0001 §3 budgets for.
+- Adding a new mutation entry point on the engine or dispatcher is a
+  three-line cost: place `AssertOnOwnerThread()` / `AssertOnLoopThread()`
+  as the first statement of the method. No new locking, no rework of
+  callers.
+- The Debug CI lane roughly doubles CI wall-clock on PRs (still under
+  the 20-minute job budget). We accept that cost in exchange for
+  catching the entire single-writer bug family at PR time instead of
+  in production-shaped E2E tests weeks later.
+- Cross-channel state (e.g. host-wide registries, metrics scraped by
+  the HTTP server, persistence-replay state machines) is **out of
+  scope** for this ADR — those use their own locks or
+  `Interlocked`/`Volatile` and are reviewed case by case. This ADR
+  governs the per-channel hot path only.
+- Inbound metrics read on the HTTP server thread are a known
+  exception: `SequenceNumber` / `SequenceVersion` are read without
+  synchronization. That gap is tracked as a separate concern (the
+  values are monotonic and the worst case is a stale-but-not-torn
+  read on x64; ARM/AOT would need `Volatile.Read`). It does not
+  invalidate the single-writer model — it acknowledges a known
+  read-only window outside it.
+
+## Alternatives considered
+
+- **Locks around engine/dispatcher state.** Rejected: the engine is on
+  the critical hot path (sub-microsecond per-order budget); per-call
+  `Monitor.Enter` would dominate latency. The whole architecture is
+  built on the single-writer assumption.
+- **Async dispatch loop with `ConfigureAwait(false)` discipline.**
+  Tried (the pre-#374 implementation). The thread the continuation
+  resumes on is a scheduler decision, not an `await` decision; on a
+  busy pool every `await` is a coin flip. Cannot satisfy the
+  invariant without effectively pinning back to a single thread, at
+  which point the sync loop is simpler.
+- **Remove the asserts, document the invariant in prose only.**
+  Rejected: every regression this ADR is reacting to was caught
+  *because* of the asserts. They are the load-bearing test
+  infrastructure; CONTRIBUTING.md just teaches new contributors how to
+  read them.
+
+## Open questions
+
+- The HTTP-thread read of `SequenceNumber` / `SequenceVersion`: should
+  we add `Volatile.Read` there or fold both counters into a single
+  `long` snapshot read on the loop thread? Currently neither — track
+  separately if ARM/AOT becomes a target.
+- Persistence replay currently runs on the loop thread inside
+  `LoadPersistedStateOnLoopThread`. If replay grows beyond what fits in
+  the startup window, we may need a second "replay thread" with a
+  formal handoff. Out of scope until measured.

--- a/docs/adr/0009-single-writer-threading-model.md
+++ b/docs/adr/0009-single-writer-threading-model.md
@@ -122,9 +122,9 @@ at PR time.
 
 ## Consequences
 
-- The hot path stays lock-free: no `Monitor`, no `Interlocked`, no
-  `Volatile` on per-channel state. Throughput stays at the Release-mode
-  numbers RFC 0001 §3 budgets for.
+- The hot path stays lock-free: no `Monitor` and no `Interlocked` on
+  per-channel state on the write side. Throughput stays at the
+  Release-mode numbers RFC 0001 §3 budgets for.
 - Adding a new mutation entry point on the engine or dispatcher is a
   three-line cost: place `AssertOnOwnerThread()` / `AssertOnLoopThread()`
   as the first statement of the method. No new locking, no rework of
@@ -138,13 +138,16 @@ at PR time.
   scope** for this ADR — those use their own locks or
   `Interlocked`/`Volatile` and are reviewed case by case. This ADR
   governs the per-channel hot path only.
-- Inbound metrics read on the HTTP server thread are a known
-  exception: `SequenceNumber` / `SequenceVersion` are read without
-  synchronization. That gap is tracked as a separate concern (the
-  values are monotonic and the worst case is a stale-but-not-torn
-  read on x64; ARM/AOT would need `Volatile.Read`). It does not
-  invalidate the single-writer model — it acknowledges a known
-  read-only window outside it.
+- One controlled exception lives inside the per-channel surface: the
+  HTTP-thread reads of `ChannelDispatcher.SequenceNumber` and
+  `SequenceVersion` (used by `HttpServer.RenderProm` and similar
+  scrapes). The loop thread is still the only writer, but external
+  readers are allowed; the writes use `Volatile.Write` and the public
+  getters use `Volatile.Read` against the backing fields so weak
+  memory models (ARM64, AOT) cannot hoist or tear. See
+  `ChannelDispatcher.cs:91-105` and the class-level XML doc. The
+  pattern is opt-in per-field: do not generalize it to other state
+  without an explicit ADR amendment.
 
 ## Alternatives considered
 
@@ -166,10 +169,6 @@ at PR time.
 
 ## Open questions
 
-- The HTTP-thread read of `SequenceNumber` / `SequenceVersion`: should
-  we add `Volatile.Read` there or fold both counters into a single
-  `long` snapshot read on the loop thread? Currently neither — track
-  separately if ARM/AOT becomes a target.
 - Persistence replay currently runs on the loop thread inside
   `LoadPersistedStateOnLoopThread`. If replay grows beyond what fits in
   the startup window, we may need a second "replay thread" with a

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,3 +51,4 @@ changes, a new ADR supersedes the old one.
 | 0006 | Surveillance feed: trade-only, no new artifact in v1           | Accepted |
 | 0007 | Position aggregate per firm (deferred)                         | Deferred |
 | 0008 | Late corrections and bust propagation                          | Accepted |
+| 0009 | Single-writer threading model for per-channel state            | Accepted |


### PR DESCRIPTION
## Why

Lock in the architectural learning from #374 (dispatcher async-loop continuation hop) and #375 (test-thread hop between `DrainInbound` calls). Both shipped to `main` despite tripping `AssertOnOwnerThread` / `AssertOnLoopThread` on every Debug run, because the asserts are `[Conditional("DEBUG")]` and Release CI was the only lane. PR #377 added the Debug CI lane that enforces the asserts; this PR documents the model the asserts are guarding so future contributors don't reverse-engineer it from the dispatcher.

## Changes

- **`docs/adr/0009-single-writer-threading-model.md`** (new). Status Accepted, retroactively documenting the model in place since #169 / #138. Decision: one owner thread per channel, sync `RunLoop` on a `LongRunning` thread, no `await` inside the loop, cross-thread producers via `EnqueueXxx`, invariant asserted in Debug and enforced by the Debug CI lane. Lists alternatives considered (locks; async loop with `ConfigureAwait(false)`; assert-less) and the known open question around HTTP-thread metrics reads of `SequenceNumber` / `SequenceVersion`.
- **`docs/adr/README.md`** — index row for 0009.
- **`CONTRIBUTING.md`** (new). Pre-PR checklist (now includes the Debug lane), threading rules of thumb, PR flow, ADR/RFC/runbook/comment hierarchy.

## Scope

Pure documentation — no code changes. No new tests; no behavior change.

## Validation

Markdown only; `dotnet format` doesn't touch `.md`. The pre-PR checklist's build/test steps are unaffected.