### PR TITLE
refactor(#386): extract shared B3.Exchange.TestSupport helpers

### DIFF
--- a/SbeB3Exchange.slnx
+++ b/SbeB3Exchange.slnx
@@ -22,6 +22,7 @@
     <Project Path="bench/B3.Exchange.Bench/B3.Exchange.Bench.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/B3.Exchange.TestSupport/B3.Exchange.TestSupport.csproj" />
     <Project Path="tests/B3.Umdf.WireEncoder.Tests/B3.Umdf.WireEncoder.Tests.csproj" />
     <Project Path="tests/B3.EntryPoint.Wire.Tests/B3.EntryPoint.Wire.Tests.csproj" />
     <Project Path="tests/B3.Exchange.Instruments.Tests/B3.Exchange.Instruments.Tests.csproj" />

--- a/tests/B3.Exchange.Host.Tests/AdminSnapshotEndpointsTests.cs
+++ b/tests/B3.Exchange.Host.Tests/AdminSnapshotEndpointsTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -14,7 +15,7 @@ public class AdminSnapshotEndpointsTests
 {
     private static (HostConfig cfg, string dataDir) BuildConfig(string testName)
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var dataDir = Path.Combine(Path.GetTempPath(), "b3-admin-tests-" + testName + "-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dataDir);
         var cfg = new HostConfig
@@ -47,17 +48,6 @@ public class AdminSnapshotEndpointsTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task GetSnapshot_WhenNoneExists_Returns204()
@@ -72,7 +62,7 @@ public class AdminSnapshotEndpointsTests
             using var resp = await client.GetAsync("/admin/channels/91/snapshot");
             Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 
     [Fact]
@@ -109,7 +99,7 @@ public class AdminSnapshotEndpointsTests
             var body = await validate.Content.ReadAsStringAsync();
             Assert.StartsWith("ok ", body);
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 
     [Fact]
@@ -125,7 +115,7 @@ public class AdminSnapshotEndpointsTests
             using var resp = await client.PostAsync("/admin/channels/91/snapshot/reset", content: null);
             Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 
     [Fact]
@@ -158,7 +148,7 @@ public class AdminSnapshotEndpointsTests
                 Assert.Empty(Directory.GetFiles(dataDir, "channel-91.snapshot*"));
             }
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 
     [Fact]
@@ -174,7 +164,7 @@ public class AdminSnapshotEndpointsTests
             using var resp = await client.PostAsync("/admin/channels/91/snapshot/validate", content: null);
             Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 
     [Fact]
@@ -196,11 +186,7 @@ public class AdminSnapshotEndpointsTests
             using var reset = await client.PostAsync("/admin/channels/200/snapshot/reset?force=true", content: null);
             Assert.Equal(HttpStatusCode.NotFound, reset.StatusCode);
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 
-    private static void TryDeleteDir(string dir)
-    {
-        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); } catch { }
-    }
 }

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />

--- a/tests/B3.Exchange.Host.Tests/BundledConfigMultiGroupTests.cs
+++ b/tests/B3.Exchange.Host.Tests/BundledConfigMultiGroupTests.cs
@@ -1,4 +1,5 @@
 using B3.Exchange.Host;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -10,17 +11,6 @@ namespace B3.Exchange.Host.Tests;
 /// </summary>
 public class BundledConfigMultiGroupTests
 {
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Theory]
     [InlineData("config/exchange-simulator.json")]
@@ -28,7 +18,7 @@ public class BundledConfigMultiGroupTests
     [InlineData("config/exchange-simulator.soak.json")]
     public void BundledConfig_DeclaresBothEqtAndDrvChannels(string relPath)
     {
-        var cfg = HostConfigLoader.Load(ResolveRepoFile(relPath));
+        var cfg = HostConfigLoader.Load(TestPaths.ResolveRepoFile(relPath));
 
         var channelNumbers = cfg.Channels.Select(c => c.ChannelNumber).ToHashSet();
         Assert.Contains((byte)84, channelNumbers);

--- a/tests/B3.Exchange.Host.Tests/DailyResetEodExportChainingTests.cs
+++ b/tests/B3.Exchange.Host.Tests/DailyResetEodExportChainingTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Exchange.PostTrade;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -20,23 +21,7 @@ public class DailyResetEodExportChainingTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
-    private static void TryDeleteDir(string dir)
-    {
-        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
-        catch { /* best-effort */ }
-    }
 
     private static PostTradeRecord MakeFill(uint id, ulong nanos, long secId = 900000000001L)
         => new(
@@ -53,8 +38,8 @@ public class DailyResetEodExportChainingTests
     [Fact]
     public async Task TriggerDailyReset_ProjectsYesterdayAuditLogForAllConfiguredChannels()
     {
-        var eqtPath = ResolveRepoFile("config/instruments-eqt.json");
-        var drvPath = ResolveRepoFile("config/instruments-drv.json");
+        var eqtPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+        var drvPath = TestPaths.ResolveRepoFile("config/instruments-drv.json");
         var auditDirA = Path.Combine(Path.GetTempPath(), "b3-dr-audit-a-" + Guid.NewGuid().ToString("N"));
         var dropDirA = Path.Combine(Path.GetTempPath(), "b3-dr-drop-a-" + Guid.NewGuid().ToString("N"));
         var auditDirB = Path.Combine(Path.GetTempPath(), "b3-dr-audit-b-" + Guid.NewGuid().ToString("N"));
@@ -134,17 +119,17 @@ public class DailyResetEodExportChainingTests
         }
         finally
         {
-            TryDeleteDir(auditDirA);
-            TryDeleteDir(dropDirA);
-            TryDeleteDir(auditDirB);
-            TryDeleteDir(dropDirB);
+            TempDirs.TryDelete(auditDirA);
+            TempDirs.TryDelete(dropDirA);
+            TempDirs.TryDelete(auditDirB);
+            TempDirs.TryDelete(dropDirB);
         }
     }
 
     [Fact]
     public async Task TriggerDailyReset_SkipsChannelsWithoutEodDropConfigured()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-dr-audit-" + Guid.NewGuid().ToString("N"));
         try
         {
@@ -186,15 +171,15 @@ public class DailyResetEodExportChainingTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
+            TempDirs.TryDelete(auditDir);
         }
     }
 
     [Fact]
     public async Task TriggerDailyReset_SwallowsMissingAuditLog_AndStillProcessesOtherChannels()
     {
-        var eqtPath = ResolveRepoFile("config/instruments-eqt.json");
-        var drvPath = ResolveRepoFile("config/instruments-drv.json");
+        var eqtPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+        var drvPath = TestPaths.ResolveRepoFile("config/instruments-drv.json");
         // Channel A has NO audit log written → export should swallow.
         // Channel B has yesterday's audit log → export must still succeed.
         var auditDirA = Path.Combine(Path.GetTempPath(), "b3-dr-audit-a-" + Guid.NewGuid().ToString("N"));
@@ -261,17 +246,17 @@ public class DailyResetEodExportChainingTests
         }
         finally
         {
-            TryDeleteDir(auditDirA);
-            TryDeleteDir(dropDirA);
-            TryDeleteDir(auditDirB);
-            TryDeleteDir(dropDirB);
+            TempDirs.TryDelete(auditDirA);
+            TempDirs.TryDelete(dropDirA);
+            TempDirs.TryDelete(auditDirB);
+            TempDirs.TryDelete(dropDirB);
         }
     }
 
     [Fact]
     public async Task AdminDailyReset_HttpEndpoint_AlsoTriggersEodExport()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-dr-audit-" + Guid.NewGuid().ToString("N"));
         var dropDir = Path.Combine(Path.GetTempPath(), "b3-dr-drop-" + Guid.NewGuid().ToString("N"));
         try
@@ -319,8 +304,8 @@ public class DailyResetEodExportChainingTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
-            TryDeleteDir(dropDir);
+            TempDirs.TryDelete(auditDir);
+            TempDirs.TryDelete(dropDir);
         }
     }
 }

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Umdf.WireEncoder;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -39,7 +40,7 @@ public class ExchangeHostE2ETests
 
     private static (HostConfig cfg, RecordingPacketSink sink) BuildConfig()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
             Auth = new AuthConfig { RequireFixpHandshake = false },
@@ -59,17 +60,6 @@ public class ExchangeHostE2ETests
         return (cfg, new RecordingPacketSink());
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task NewOrder_RoundTripsExecutionReportNew_ThenCrossingOrderProducesTrade()

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostSnapshotE2ETests.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Umdf.WireEncoder;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -28,22 +29,11 @@ public class ExchangeHostSnapshotE2ETests
         }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task SnapshotTick_AfterRestingOrders_PublishesBookStateOnSnapSink()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
             Auth = new AuthConfig { RequireFixpHandshake = false },
@@ -139,7 +129,7 @@ public class ExchangeHostSnapshotE2ETests
     [Fact]
     public async Task EmptyBook_PublishesIlliquidHeader()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
             Auth = new AuthConfig { RequireFixpHandshake = false },

--- a/tests/B3.Exchange.Host.Tests/GracefulShutdownTests.cs
+++ b/tests/B3.Exchange.Host.Tests/GracefulShutdownTests.cs
@@ -2,6 +2,7 @@ using System.Buffers.Binary;
 using System.Net.Sockets;
 using B3.EntryPoint.Wire;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -23,7 +24,7 @@ public class GracefulShutdownTests
 
     private static HostConfig BuildConfig()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         return new HostConfig
         {
             Auth = new AuthConfig { RequireFixpHandshake = false },
@@ -43,17 +44,6 @@ public class GracefulShutdownTests
         };
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task StopAsync_BroadcastsTerminateFinished_BeforeTcpClose()

--- a/tests/B3.Exchange.Host.Tests/HttpServerEodExportTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerEodExportTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Exchange.PostTrade;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -21,23 +22,7 @@ public class HttpServerEodExportTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
-    private static void TryDeleteDir(string dir)
-    {
-        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
-        catch { /* best-effort */ }
-    }
 
     private const byte Channel = 82;
     private static readonly DateOnly TestDate = new(2026, 5, 18);
@@ -87,7 +72,7 @@ public class HttpServerEodExportTests
     [Fact]
     public async Task Post_EodExport_ProducesCsvAndDoneFilesAndReturnsJson()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
         var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
         try
@@ -126,15 +111,15 @@ public class HttpServerEodExportTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
-            TryDeleteDir(dropDir);
+            TempDirs.TryDelete(auditDir);
+            TempDirs.TryDelete(dropDir);
         }
     }
 
     [Fact]
     public async Task Post_EodExport_Returns404_WhenChannelHasNoEodDropConfigured()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
         try
         {
@@ -153,14 +138,14 @@ public class HttpServerEodExportTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
+            TempDirs.TryDelete(auditDir);
         }
     }
 
     [Fact]
     public async Task Post_EodExport_Returns404_WhenAuditLogForDateIsMissing()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
         var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
         try
@@ -181,15 +166,15 @@ public class HttpServerEodExportTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
-            TryDeleteDir(dropDir);
+            TempDirs.TryDelete(auditDir);
+            TempDirs.TryDelete(dropDir);
         }
     }
 
     [Fact]
     public async Task Post_EodExport_Returns400_OnMissingOrInvalidQueryParams()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
         var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
         try
@@ -216,15 +201,15 @@ public class HttpServerEodExportTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
-            TryDeleteDir(dropDir);
+            TempDirs.TryDelete(auditDir);
+            TempDirs.TryDelete(dropDir);
         }
     }
 
     [Fact]
     public async Task Post_EodExport_IsIdempotent_AcrossSequentialReruns()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
         var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
         try
@@ -253,15 +238,15 @@ public class HttpServerEodExportTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
-            TryDeleteDir(dropDir);
+            TempDirs.TryDelete(auditDir);
+            TempDirs.TryDelete(dropDir);
         }
     }
 
     [Fact]
     public async Task Post_EodExport_RejectsConcurrentSameChannelDateWith409()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(), "b3-eod-audit-" + Guid.NewGuid().ToString("N"));
         var dropDir = Path.Combine(Path.GetTempPath(), "b3-eod-drop-" + Guid.NewGuid().ToString("N"));
         try
@@ -304,8 +289,8 @@ public class HttpServerEodExportTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
-            TryDeleteDir(dropDir);
+            TempDirs.TryDelete(auditDir);
+            TempDirs.TryDelete(dropDir);
         }
     }
 }

--- a/tests/B3.Exchange.Host.Tests/HttpServerHaltTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerHaltTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -14,18 +15,6 @@ public class HttpServerHaltTests
     private sealed class RecordingSink : IUmdfPacketSink
     {
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
-    }
-
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath}");
     }
 
     private static (HostConfig cfg, IUmdfPacketSink sink) BuildConfig()
@@ -43,7 +32,7 @@ public class HttpServerHaltTests
                     IncrementalGroup = "239.255.42.92",
                     IncrementalPort = 30192,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };

--- a/tests/B3.Exchange.Host.Tests/HttpServerPhaseTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerPhaseTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -14,18 +15,6 @@ public class HttpServerPhaseTests
     private sealed class RecordingSink : IUmdfPacketSink
     {
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
-    }
-
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath}");
     }
 
     private static (HostConfig cfg, IUmdfPacketSink sink) BuildConfig()
@@ -43,7 +32,7 @@ public class HttpServerPhaseTests
                     IncrementalGroup = "239.255.42.91",
                     IncrementalPort = 30191,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };

--- a/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HttpServerTests.cs
@@ -1,5 +1,6 @@
 using System.Net.Http;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -14,7 +15,7 @@ public class HttpServerTests
 {
     private static (HostConfig cfg, IUmdfPacketSink sink) BuildConfig(int livenessStaleMs = 5000)
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var cfg = new HostConfig
         {
             Auth = new AuthConfig { RequireFixpHandshake = false },
@@ -40,17 +41,6 @@ public class HttpServerTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task LiveAndReadyAndMetrics_AllReturn200_AfterStartup()

--- a/tests/B3.Exchange.Host.Tests/PostTradeAuditHostWiringTests.cs
+++ b/tests/B3.Exchange.Host.Tests/PostTradeAuditHostWiringTests.cs
@@ -1,5 +1,6 @@
 using B3.Exchange.Core;
 using B3.Exchange.PostTrade;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -17,23 +18,7 @@ public class PostTradeAuditHostWiringTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
-    private static void TryDeleteDir(string dir)
-    {
-        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
-        catch { /* best-effort */ }
-    }
 
     private static HostConfig BaseCfg(string instrumentsPath, PostTradeAuditConfig? audit, byte channel = 81)
         => new()
@@ -57,7 +42,7 @@ public class PostTradeAuditHostWiringTests
     [Fact]
     public async Task StartAsync_WithoutPostTradeAuditBlock_UsesNullSink()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var cfg = BaseCfg(instrumentsPath, audit: null);
 
         await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
@@ -69,7 +54,7 @@ public class PostTradeAuditHostWiringTests
     [Fact]
     public async Task StartAsync_WithDisabledAudit_DoesNotCreateAuditDir()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(),
             "b3-audit-disabled-" + Guid.NewGuid().ToString("N"));
         try
@@ -92,14 +77,14 @@ public class PostTradeAuditHostWiringTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
+            TempDirs.TryDelete(auditDir);
         }
     }
 
     [Fact]
     public async Task StartAsync_WithEnabledAudit_BootsCleanly()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(),
             "b3-audit-enabled-" + Guid.NewGuid().ToString("N"));
         try
@@ -123,14 +108,14 @@ public class PostTradeAuditHostWiringTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
+            TempDirs.TryDelete(auditDir);
         }
     }
 
     [Fact]
     public async Task StartAsync_WithEmptyDataDir_LogsWarningAndSkips()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var cfg = BaseCfg(instrumentsPath, new PostTradeAuditConfig
         {
             Enabled = true,
@@ -150,7 +135,7 @@ public class PostTradeAuditHostWiringTests
     [Fact]
     public async Task StartAsync_WithNegativeRetentionDays_Throws()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var auditDir = Path.Combine(Path.GetTempPath(),
             "b3-audit-neg-" + Guid.NewGuid().ToString("N"));
         try
@@ -168,7 +153,7 @@ public class PostTradeAuditHostWiringTests
         }
         finally
         {
-            TryDeleteDir(auditDir);
+            TempDirs.TryDelete(auditDir);
         }
     }
 }

--- a/tests/B3.Exchange.Host.Tests/PostTradeBustE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/PostTradeBustE2ETests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Exchange.PostTrade;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -67,17 +68,6 @@ public sealed class PostTradeBustE2ETests : IDisposable
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     private static PostTradeRecord MakeFill(uint id) => new(
         TradeId: id, TransactTimeNanos: TradeDateNanos + id * 1_000UL, SecurityId: Petr,
@@ -115,7 +105,7 @@ public sealed class PostTradeBustE2ETests : IDisposable
     [Fact]
     public async Task FullFlow_PreEodBust_FoldedOut_PostEodBust_PublishedToAmendmentsCsv()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
 
         // 1) Pre-seed three fills before host boot so the dedup index
         //    picks them up at startup and the validator can locate the

--- a/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
+++ b/tests/B3.Exchange.Host.Tests/SoakSmokeTests.cs
@@ -4,6 +4,7 @@ using B3.Exchange.Gateway;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using B3.Exchange.SyntheticTrader;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -77,7 +78,7 @@ public class SoakSmokeTests
             return;
         }
 
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var sink = new MonotonicSink();
         var hostCfg = new HostConfig
         {
@@ -207,15 +208,4 @@ public class SoakSmokeTests
         }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 }

--- a/tests/B3.Exchange.Host.Tests/WalHaltProbeRegistrationTests.cs
+++ b/tests/B3.Exchange.Host.Tests/WalHaltProbeRegistrationTests.cs
@@ -1,4 +1,5 @@
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Host.Tests;
 
@@ -17,28 +18,10 @@ public class WalHaltProbeRegistrationTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
-
-    private static void TryDeleteDir(string dir)
-    {
-        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
-        catch { /* best-effort cleanup */ }
-    }
-
     [Fact]
     public async Task StartAsync_WithWalHaltAndHttpEnabled_BootsCleanly()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var dataDir = Path.Combine(Path.GetTempPath(),
             "b3-walhalt-boot-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dataDir);
@@ -83,6 +66,6 @@ public class WalHaltProbeRegistrationTests
             using var resp = await client.GetAsync("/health/ready");
             Assert.True(resp.IsSuccessStatusCode);
         }
-        finally { TryDeleteDir(dataDir); }
+        finally { TempDirs.TryDelete(dataDir); }
     }
 }

--- a/tests/B3.Exchange.Interop.Tests/B3.Exchange.Interop.Tests.csproj
+++ b/tests/B3.Exchange.Interop.Tests/B3.Exchange.Interop.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
   </ItemGroup>

--- a/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
+++ b/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
@@ -5,6 +5,7 @@ using B3.EntryPoint.Client.Models;
 using B3.Exchange.Core;
 using B3.Exchange.Host;
 using Microsoft.Extensions.Logging;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.Interop.Tests;
 
@@ -27,17 +28,6 @@ public class EpcInteropTests : IAsyncLifetime
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Interlocked.Increment(ref Count);
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     private ExchangeHost _host = null!;
     private IPEndPoint _endpoint = null!;
@@ -85,7 +75,7 @@ public class EpcInteropTests : IAsyncLifetime
                     IncrementalGroup = "239.255.43.84",
                     IncrementalPort = port,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };

--- a/tests/B3.Exchange.ScenarioReplay.Tests/B3.Exchange.ScenarioReplay.Tests.csproj
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/B3.Exchange.ScenarioReplay.Tests.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
     <ProjectReference Include="..\..\tools\ScenarioReplay\ScenarioReplay.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />

--- a/tests/B3.Exchange.ScenarioReplay.Tests/EndToEndReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/EndToEndReplayTests.cs
@@ -1,6 +1,7 @@
 using B3.Exchange.Core;
 using B3.Exchange.Host;
 using B3.Exchange.SyntheticTrader;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.ScenarioReplay.Tests;
 
@@ -12,17 +13,6 @@ namespace B3.Exchange.ScenarioReplay.Tests;
 /// </summary>
 public class EndToEndReplayTests
 {
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     private sealed class CountingSink : IUmdfPacketSink
     {
@@ -33,7 +23,7 @@ public class EndToEndReplayTests
     [Fact]
     public async Task RunsScript_AgainstHost_AndCapturesExecReports()
     {
-        var instrumentsPath = ResolveRepoFile("config/instruments-eqt.json");
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
         var sink = new CountingSink();
         var cfg = new HostConfig
         {

--- a/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
+++ b/tests/B3.Exchange.ScenarioReplay.Tests/MultiSessionReplayTests.cs
@@ -2,6 +2,7 @@ using B3.Exchange.Core;
 using B3.Exchange.Host;
 using B3.Exchange.SyntheticTrader;
 using B3.Exchange.SyntheticTrader.Fixp;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.ScenarioReplay.Tests;
 
@@ -22,17 +23,6 @@ public class MultiSessionReplayTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Interlocked.Increment(ref Count);
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task TwoSessions_CrossingScript_LandsErTradesOnBothSides()
@@ -60,7 +50,7 @@ public class MultiSessionReplayTests
                     IncrementalGroup = "239.255.42.84",
                     IncrementalPort = 30192,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };
@@ -206,7 +196,7 @@ public class MultiSessionReplayTests
                     IncrementalGroup = "239.255.42.84",
                     IncrementalPort = 30193,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };

--- a/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/B3.Exchange.SyntheticTrader.Tests.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Host\B3.Exchange.Host.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />

--- a/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpClientHandshakeTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/Fixp/FixpClientHandshakeTests.cs
@@ -1,6 +1,7 @@
 using B3.Exchange.Core;
 using B3.Exchange.Host;
 using B3.Exchange.SyntheticTrader.Fixp;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.SyntheticTrader.Tests.Fixp;
 
@@ -22,17 +23,6 @@ public class FixpClientHandshakeTests
         public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Interlocked.Increment(ref Count);
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task FixpClient_HandshakeAndOrderRoundTrip()
@@ -58,7 +48,7 @@ public class FixpClientHandshakeTests
                     IncrementalGroup = "239.255.42.84",
                     IncrementalPort = 30190,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };
@@ -126,7 +116,7 @@ public class FixpClientHandshakeTests
                     IncrementalGroup = "239.255.42.84",
                     IncrementalPort = 30191,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };

--- a/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
+++ b/tests/B3.Exchange.SyntheticTrader.Tests/SyntheticTraderHostIntegrationTests.cs
@@ -1,5 +1,6 @@
 using B3.Exchange.Host;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 
 namespace B3.Exchange.SyntheticTrader.Tests;
 
@@ -26,17 +27,6 @@ public class SyntheticTraderHostIntegrationTests
             => Interlocked.Increment(ref _packetCount);
     }
 
-    private static string ResolveRepoFile(string relPath)
-    {
-        var dir = AppContext.BaseDirectory;
-        for (int i = 0; i < 8 && dir != null; i++)
-        {
-            var candidate = Path.Combine(dir, relPath);
-            if (File.Exists(candidate)) return candidate;
-            dir = Path.GetDirectoryName(dir);
-        }
-        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
-    }
 
     [Fact]
     public async Task SynthTrader_AgainstInProcHost_GeneratesTrades()
@@ -54,7 +44,7 @@ public class SyntheticTraderHostIntegrationTests
                     IncrementalGroup = "239.255.42.84",
                     IncrementalPort = 30185,
                     Ttl = 0,
-                    InstrumentsFile = ResolveRepoFile("config/instruments-eqt.json"),
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
                 },
             },
         };

--- a/tests/B3.Exchange.TestSupport/B3.Exchange.TestSupport.csproj
+++ b/tests/B3.Exchange.TestSupport/B3.Exchange.TestSupport.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/B3.Exchange.TestSupport/TempDirs.cs
+++ b/tests/B3.Exchange.TestSupport/TempDirs.cs
@@ -1,0 +1,26 @@
+namespace B3.Exchange.TestSupport;
+
+public static class TempDirs
+{
+    /// <summary>
+    /// Best-effort recursive delete; swallows exceptions (intended for
+    /// test cleanup in finally blocks).
+    /// </summary>
+    public static void TryDelete(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { /* best-effort */ }
+    }
+
+    /// <summary>
+    /// Create a fresh unique temp directory under <see cref="Path.GetTempPath"/>
+    /// with the given prefix (e.g. "b3-eod-audit-"); returns its absolute path.
+    /// Caller is responsible for cleanup via <see cref="TryDelete"/>.
+    /// </summary>
+    public static string Create(string prefix)
+    {
+        var d = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(d);
+        return d;
+    }
+}

--- a/tests/B3.Exchange.TestSupport/TempDirs.cs
+++ b/tests/B3.Exchange.TestSupport/TempDirs.cs
@@ -14,11 +14,28 @@ public static class TempDirs
 
     /// <summary>
     /// Create a fresh unique temp directory under <see cref="Path.GetTempPath"/>
-    /// with the given prefix (e.g. "b3-eod-audit-"); returns its absolute path.
-    /// Caller is responsible for cleanup via <see cref="TryDelete"/>.
+    /// with the given file-name-style prefix (e.g. "b3-eod-audit-"); returns
+    /// its absolute path. Caller is responsible for cleanup via
+    /// <see cref="TryDelete"/>.
     /// </summary>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="prefix"/> is null, rooted, or contains a directory
+    /// separator / parent-traversal segment — any of which would let the
+    /// returned path escape <see cref="Path.GetTempPath"/> and silently
+    /// violate the helper's contract.
+    /// </exception>
     public static string Create(string prefix)
     {
+        ArgumentNullException.ThrowIfNull(prefix);
+        if (Path.IsPathRooted(prefix)
+            || prefix.Contains(Path.DirectorySeparatorChar)
+            || prefix.Contains(Path.AltDirectorySeparatorChar)
+            || prefix.Contains(".."))
+        {
+            throw new ArgumentException(
+                "prefix must be a file-name-style fragment (no path separators, no '..', not rooted)",
+                nameof(prefix));
+        }
         var d = Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(d);
         return d;

--- a/tests/B3.Exchange.TestSupport/TestPaths.cs
+++ b/tests/B3.Exchange.TestSupport/TestPaths.cs
@@ -1,0 +1,21 @@
+namespace B3.Exchange.TestSupport;
+
+public static class TestPaths
+{
+    /// <summary>
+    /// Locate a repo-relative file (e.g. "config/instruments-eqt.json") by
+    /// walking up from <see cref="AppContext.BaseDirectory"/> up to 8 levels.
+    /// Throws <see cref="FileNotFoundException"/> when not found.
+    /// </summary>
+    public static string ResolveRepoFile(string relPath)
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 8 && dir != null; i++)
+        {
+            var candidate = Path.Combine(dir, relPath);
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new FileNotFoundException($"could not locate {relPath} from {AppContext.BaseDirectory}");
+    }
+}


### PR DESCRIPTION
Closes #386.

Per architectural review 2026-05-20 (refactor #7): `ResolveRepoFile` and `TryDeleteDir` were duplicated across **19 test files** in 4 test projects. When the bootstrap drifts, only some sites get updated and the suite becomes inconsistent.

## Changes
- New `tests/B3.Exchange.TestSupport/` library exposing:
  - `TestPaths.ResolveRepoFile(string)` — walk up from `AppContext.BaseDirectory` (≤8 levels).
  - `TempDirs.TryDelete(string)` — best-effort recursive delete (swallows; for `finally` blocks).
  - `TempDirs.Create(string prefix)` — fresh unique temp dir under `Path.GetTempPath()`. Available for future migration of scattered `Guid`-based temp-dir patterns (intentionally NOT migrated in this PR to keep the diff focused).
- 19 test files migrated; private duplicates deleted.
- 4 test csprojs gained a `ProjectReference` to the new library.

## Deliberately not in scope
- `AuditWatermarkCodecTests.cs:74-121` codec construction — no shared default-arg pattern (each `new FileAuditLogWriter` uses a unique `root` + `channel`); the watermark codec itself is static. No extraction warranted.
- Scattered `Path.Combine(GetTempPath(), prefix + Guid.NewGuid())` + `Directory.CreateDirectory` migration — `TempDirs.Create` is published for it but the 30+ call sites are out of scope here.

## Verification
- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test -c Release --no-build` — 1,217/1,217 passed
- `dotnet format --verify-no-changes` — clean