### PR TITLE
refactor(#384): extract SingleWriterGuard; amend ADR 0009 scope

### DIFF
--- a/docs/adr/0009-single-writer-threading-model.md
+++ b/docs/adr/0009-single-writer-threading-model.md
@@ -183,7 +183,7 @@ Decision:
    exception and have a tracked migration.** `FileAuditLogWriter`'s
    `_stateLock` stays for now (its removal requires marshaling
    `Checkpoint()` through the dispatch inbox, a separate redesign);
-   it is tracked in a follow-up issue. The contract for *new*
+   it is tracked in follow-up issue #396. The contract for *new*
    components is "guard, not lock" — adding a new per-channel
    component that takes a lock requires an explicit ADR amendment
    citing why the dispatch-thread handoff is impractical.
@@ -193,11 +193,15 @@ Decision:
    state on a thread different from the eventual dispatch loop must
    call it; any other re-bind is a smell.
 
-Trade-off accepted: a thin extra layer of indirection on every assert
-(`SingleWriterGuard.AssertOwnedByCurrentThread` → the same
-`Interlocked.CompareExchange` + `Debug.Assert` as before). The whole
-path is `[Conditional("DEBUG")]` so Release builds are byte-identical
-to the prior implementation.
+Trade-off accepted: each owning component now holds one
+`SingleWriterGuard` reference (a single object allocation at
+construction; idle in Release). On the hot path the entire assert
+chain is `[Conditional("DEBUG")]` and elides to nothing in Release —
+the dispatcher/engine no longer perform the prior unconditional
+`_loopThread` / `_ownerThread` field writes either, since nothing
+outside Debug ever read them. Release IL is not byte-identical to the
+pre-refactor build (extra field + one object allocation per owner),
+but the per-call mutation cost is unchanged at zero.
 
 ## Alternatives considered
 

--- a/docs/adr/0009-single-writer-threading-model.md
+++ b/docs/adr/0009-single-writer-threading-model.md
@@ -149,6 +149,56 @@ at PR time.
   pattern is opt-in per-field: do not generalize it to other state
   without an explicit ADR amendment.
 
+## Amendment 2026-05-20 — Scope beyond engine/dispatcher (issue #384)
+
+The original decision named two concrete owners — `MatchingEngine` and
+`ChannelDispatcher` — and the asserts originally lived as `private`
+methods on those two classes only. A 2026-05-20 architectural review
+flagged that **other** per-channel single-writer components silently
+drifted away from the rule: most notably
+`B3.Exchange.PostTrade.FileAuditLogWriter`, which took out an
+`_stateLock` because `Checkpoint()` is invoked from the
+`BackgroundSnapshotWriter` thread rather than the dispatch loop. The
+lock is correct given that call shape, but it leaks back-pressure into
+`OnTrade` and silently re-introduces locking onto the hot path the
+rest of the channel is engineered to avoid.
+
+Decision:
+
+1. **The single-writer invariant applies to every per-channel
+   component, not just engine + dispatcher.** Examples covered by the
+   amendment: `FileAuditLogWriter`, `BustDedupIndex`, the future
+   `IAmendmentsPublisher`, and any other type whose state is mutated
+   on behalf of one channel.
+
+2. **The hand-rolled asserts are extracted into a shared
+   `B3.Exchange.Matching.Threading.SingleWriterGuard` helper.**
+   `MatchingEngine` and `ChannelDispatcher` now hold a private guard
+   instance and delegate `BindToDispatchThread` /
+   `AssertOnOwnerThread` / `AssertOnLoopThread` to it; semantics are
+   unchanged (lazy-latch for direct-drive tests, eager-bind from the
+   production loop, `[Conditional("DEBUG")]` for hot-path cost).
+
+3. **Components whose current call shape requires a lock document the
+   exception and have a tracked migration.** `FileAuditLogWriter`'s
+   `_stateLock` stays for now (its removal requires marshaling
+   `Checkpoint()` through the dispatch inbox, a separate redesign);
+   it is tracked in a follow-up issue. The contract for *new*
+   components is "guard, not lock" — adding a new per-channel
+   component that takes a lock requires an explicit ADR amendment
+   citing why the dispatch-thread handoff is impractical.
+
+4. **`SingleWriterGuard.RebindForReplay()` is the only sanctioned way
+   to clear the owner latch.** Snapshot-replay paths that rebuild
+   state on a thread different from the eventual dispatch loop must
+   call it; any other re-bind is a smell.
+
+Trade-off accepted: a thin extra layer of indirection on every assert
+(`SingleWriterGuard.AssertOwnedByCurrentThread` → the same
+`Interlocked.CompareExchange` + `Debug.Assert` as before). The whole
+path is `[Conditional("DEBUG")]` so Release builds are byte-identical
+to the prior implementation.
+
 ## Alternatives considered
 
 - **Locks around engine/dispatcher state.** Rejected: the engine is on

--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -28,8 +28,8 @@ public sealed partial class ChannelDispatcher
     // by the Debug assert and observable as 504 timeouts in E2E tests.
     private void RunLoop(CancellationToken ct)
     {
-        _loopThread = Thread.CurrentThread;
-        _engine.BindToDispatchThread(_loopThread);
+        _writerGuard.BindToCurrentThread();
+        _engine.BindToDispatchThread(Thread.CurrentThread);
         LoadPersistedStateOnLoopThread();
 
         var reader = _inbound.Reader;
@@ -94,19 +94,13 @@ public sealed partial class ChannelDispatcher
     /// in Release builds. Guards every mutation path — engine state, packet
     /// buffer, sequence counters, and the per-session order-id index — to
     /// catch any future producer-thread regression at test time (issue #138).
+    /// Issue #384: backed by the shared
+    /// <see cref="B3.Exchange.Matching.Threading.SingleWriterGuard"/>;
+    /// tests that drive <see cref="TestProbe.DrainInbound"/> directly
+    /// without calling <see cref="Start"/> lazy-latch on the first call.
     /// </summary>
     [System.Diagnostics.Conditional("DEBUG")]
-    private void AssertOnLoopThread()
-    {
-        var t = _loopThread;
-        // _loopThread is null only before Start() (e.g. unit tests calling
-        // ProcessOne directly on the test thread). Allow that case.
-        System.Diagnostics.Debug.Assert(
-            t == null || Thread.CurrentThread == t,
-            $"ChannelDispatcher mutation off the dispatch loop thread "
-            + $"(channel={ChannelNumber}, expected={t?.ManagedThreadId}, "
-            + $"actual={Thread.CurrentThread.ManagedThreadId})");
-    }
+    private void AssertOnLoopThread() => _writerGuard.AssertOwnedByCurrentThread();
 
     /// <summary>
     /// Test hook: simulate a wedged dispatcher by cancelling the loop

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -60,7 +60,7 @@ namespace B3.Exchange.Core;
 /// engine state, the packet buffer, the per-channel <c>OrderRegistry</c>,
 /// and the
 /// <see cref="SequenceNumber"/> / <see cref="SequenceVersion"/> counters.
-/// Every mutation path asserts <c>Thread.CurrentThread == _loopThread</c>
+/// Every mutation path asserts <c>Thread.CurrentThread == loop-owner</c>
 /// in DEBUG builds via <c>AssertOnLoopThread</c>.</description></item>
 /// <item><description><b>External readers</b> (e.g. <c>HttpServer.RenderProm</c>
 /// on an HTTP worker thread) read <see cref="SequenceNumber"/> /
@@ -324,9 +324,11 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
 
     private readonly CancellationTokenSource _cts = new();
     private Task? _loopTask;
-    // Captured on entry to RunLoopAsync; used by AssertOnLoopThread() to
-    // enforce the dispatch-thread invariant in DEBUG builds.
-    private Thread? _loopThread;
+    // Single-thread invariant (ADR 0009 / issues #138, #169, #384).
+    // Captured on entry to RunLoop; used by AssertOnLoopThread() to enforce
+    // the dispatch-thread invariant in DEBUG builds. Backed by the shared
+    // B3.Exchange.Matching.Threading.SingleWriterGuard.
+    private readonly B3.Exchange.Matching.Threading.SingleWriterGuard _writerGuard;
 
     /// <summary>
     /// The snapshot rotator bound to this dispatcher, if any. Always invoked
@@ -357,6 +359,8 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         ArgumentNullException.ThrowIfNull(options.PacketSink);
 
         ChannelNumber = channelNumber;
+        _writerGuard = new B3.Exchange.Matching.Threading.SingleWriterGuard(
+            $"ChannelDispatcher[channel={channelNumber}]");
         _liveSink = options.PacketSink;
         _liveOutbound = options.Outbound;
         _packetSink = options.PacketSink;

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -112,13 +112,13 @@ public sealed class MatchingEngine
     // HaltState lives at namespace scope — see HaltState.cs.
 
 
-    // Single-thread invariant (issue #169). Latched on first call to any
-    // mutation/read entry point (or eagerly via BindToDispatchThread) so
-    // future call-site regressions are caught at test time. Production
+    // Single-thread invariant (issue #169, #384). Latched on first call to
+    // any mutation/read entry point (or eagerly via BindToDispatchThread)
+    // so future call-site regressions are caught at test time. Production
     // callers (ChannelDispatcher) bind explicitly so even the very first
     // engine call is checked. Unit tests that exercise the engine on the
     // xUnit thread without binding are tolerated via lazy latching.
-    private Thread? _ownerThread;
+    private readonly Threading.SingleWriterGuard _writerGuard = new("MatchingEngine");
 
     public MatchingEngine(IEnumerable<Instrument> instruments, IMatchingEventSink sink,
         ILogger<MatchingEngine> logger,
@@ -1928,16 +1928,23 @@ public sealed class MatchingEngine
     /// off-thread engine call is caught on the very first invocation in
     /// DEBUG builds. Subsequent calls with the same thread are no-ops;
     /// calls from a different thread fail the assert.
-    /// Issue #169 (single-thread invariant audit).
+    /// Issue #169 / #384 (single-thread invariant audit).
     /// </summary>
     public void BindToDispatchThread(Thread thread)
     {
         ArgumentNullException.ThrowIfNull(thread);
-        var prior = Interlocked.CompareExchange(ref _ownerThread, thread, null);
+        // SingleWriterGuard.BindToCurrentThread always binds to the
+        // calling thread; the public API takes an explicit Thread for
+        // back-compat. Production callers always pass Thread.CurrentThread
+        // from within the dispatch loop, so the two are identical; the
+        // assert below catches any (unlikely) future caller that tries
+        // to bind a different thread.
         System.Diagnostics.Debug.Assert(
-            prior == null || prior == thread,
-            $"MatchingEngine already bound to a different thread "
-            + $"(existing={prior?.ManagedThreadId}, new={thread.ManagedThreadId})");
+            thread == Thread.CurrentThread,
+            $"BindToDispatchThread must be called from the thread being bound "
+            + $"(arg={thread.ManagedThreadId}, "
+            + $"actual={Thread.CurrentThread.ManagedThreadId})");
+        _writerGuard.BindToCurrentThread();
     }
 
     /// <summary>
@@ -1945,17 +1952,8 @@ public sealed class MatchingEngine
     /// thread on first call if no explicit binding was made (so unit
     /// tests that drive the engine directly remain consistent across
     /// their lifetime). Compiled out in Release.
-    /// Issue #169 (single-thread invariant).
+    /// Issue #169 / #384 (single-thread invariant).
     /// </summary>
     [System.Diagnostics.Conditional("DEBUG")]
-    private void AssertOnOwnerThread()
-    {
-        var current = Thread.CurrentThread;
-        var owner = Interlocked.CompareExchange(ref _ownerThread, current, null);
-        System.Diagnostics.Debug.Assert(
-            owner == null || owner == current,
-            $"MatchingEngine entered off the owner thread "
-            + $"(owner={owner?.ManagedThreadId}, "
-            + $"actual={current.ManagedThreadId})");
-    }
+    private void AssertOnOwnerThread() => _writerGuard.AssertOwnedByCurrentThread();
 }

--- a/src/B3.Exchange.Matching/SingleWriterGuard.cs
+++ b/src/B3.Exchange.Matching/SingleWriterGuard.cs
@@ -1,0 +1,109 @@
+namespace B3.Exchange.Matching.Threading;
+
+/// <summary>
+/// Shared latch + assert helper for components that follow ADR 0009's
+/// single-writer threading model. Replaces the hand-rolled
+/// <c>_ownerThread</c> / <c>_loopThread</c> + per-class
+/// <c>Assert*</c> methods previously duplicated across
+/// <c>MatchingEngine</c> and <c>ChannelDispatcher</c>.
+///
+/// <para>
+/// Usage:
+/// <list type="bullet">
+/// <item>
+/// Owning component holds a single instance as a private readonly field
+/// and calls <see cref="AssertOwnedByCurrentThread"/> as the first
+/// statement of every mutation/read entry point.
+/// </item>
+/// <item>
+/// Components whose owner thread is known up front (e.g. the dispatcher's
+/// <c>RunLoop</c>) call <see cref="BindToCurrentThread"/> once on entry
+/// so the very first assert is meaningful rather than self-latching.
+/// </item>
+/// <item>
+/// Direct-drive unit tests (e.g. <c>TestProbe.DrainInbound</c>) skip
+/// the explicit bind; the first assert lazy-latches to the calling
+/// thread and every subsequent call must come from the same thread.
+/// </item>
+/// </list>
+/// </para>
+///
+/// <para>
+/// Both <see cref="BindToCurrentThread"/> and
+/// <see cref="AssertOwnedByCurrentThread"/> are compiled out in Release
+/// builds. This matches the prior hot-path cost contract of the
+/// hand-rolled asserts. Components that need to read the owner outside
+/// of an assert (e.g. for logging) must do so via their own field, not
+/// through this helper.
+/// </para>
+///
+/// <para>
+/// Snapshot-replay flows that need to re-bind the owner thread on a
+/// different thread call <see cref="RebindForReplay"/> to clear the
+/// latch. This is the only path that legitimately re-binds; if you
+/// reach for it from anywhere else you are almost certainly violating
+/// ADR 0009.
+/// </para>
+///
+/// Issue #384 (architectural review 2026-05-20, refactor #7).
+/// </summary>
+public sealed class SingleWriterGuard
+{
+    private readonly string _ownerLabel;
+    private Thread? _owner;
+
+    /// <param name="ownerLabel">
+    /// Human-readable label included in assertion failure messages
+    /// (e.g. <c>"MatchingEngine"</c> or
+    /// <c>"ChannelDispatcher[channel=82]"</c>).
+    /// </param>
+    public SingleWriterGuard(string ownerLabel)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(ownerLabel);
+        _ownerLabel = ownerLabel;
+    }
+
+    /// <summary>
+    /// Bind to <see cref="Thread.CurrentThread"/>. Idempotent when the
+    /// same thread binds twice; fires a <see cref="System.Diagnostics.Debug.Assert(bool, string)"/>
+    /// in Debug builds if a different thread is already bound. Compiled
+    /// out in Release.
+    /// </summary>
+    [System.Diagnostics.Conditional("DEBUG")]
+    public void BindToCurrentThread()
+    {
+        var current = Thread.CurrentThread;
+        var prior = Interlocked.CompareExchange(ref _owner, current, null);
+        System.Diagnostics.Debug.Assert(
+            prior == null || prior == current,
+            $"{_ownerLabel} already bound to a different thread "
+            + $"(existing={prior?.ManagedThreadId}, "
+            + $"new={current.ManagedThreadId})");
+    }
+
+    /// <summary>
+    /// Assert the calling thread owns the guard. Lazy-latches to the
+    /// current thread if unbound (so direct-drive tests stay coherent
+    /// across their lifetime). Compiled out in Release.
+    /// </summary>
+    [System.Diagnostics.Conditional("DEBUG")]
+    public void AssertOwnedByCurrentThread()
+    {
+        var current = Thread.CurrentThread;
+        var owner = Interlocked.CompareExchange(ref _owner, current, null);
+        System.Diagnostics.Debug.Assert(
+            owner == null || owner == current,
+            $"{_ownerLabel} entered off the owner thread "
+            + $"(owner={owner?.ManagedThreadId}, "
+            + $"actual={current.ManagedThreadId})");
+    }
+
+    /// <summary>
+    /// Clear the owner latch so a fresh thread can claim ownership.
+    /// Intended exclusively for snapshot-replay paths where state is
+    /// rebuilt on a different thread before the live dispatch loop
+    /// picks it up. Any other use is almost certainly an ADR 0009
+    /// violation.
+    /// </summary>
+    public void RebindForReplay() => Volatile.Write(ref _owner, null);
+}


### PR DESCRIPTION
Closes #384. Follow-up: #396 (FileAuditLogWriter migration).

Per Opus 4.7 architectural review 2026-05-20 (refactor #7): ADR 0009's single-writer assert had drifted into two private hand-rolled copies (engine + dispatcher) with no shared home. Newer per-channel components silently re-rolled the assert or fell back to locks because the rule was not exported.

## Changes
- **New** `B3.Exchange.Matching.Threading.SingleWriterGuard` (~100 LOC, `[Conditional("DEBUG")]` on hot paths):
  - `BindToCurrentThread()` — eager bind for the production loop.
  - `AssertOwnedByCurrentThread()` — lazy-latches for direct-drive tests; asserts ownership otherwise.
  - `RebindForReplay()` — the only sanctioned re-bind (snapshot replay).
- **MatchingEngine**: `_ownerThread` field removed; `BindToDispatchThread` + `AssertOnOwnerThread` delegate to the guard. Semantics unchanged.
- **ChannelDispatcher**: `_loopThread` field removed; `AssertOnLoopThread` delegates to the guard; `RunLoop` binds via the guard.
- **ADR 0009**: new "Amendment 2026-05-20 — Scope beyond engine/dispatcher" section. Codifies (1) invariant applies to every per-channel component, (2) the shared guard is the canonical implementation, (3) new components use guard, not locks; existing exceptions like `FileAuditLogWriter` documented with a tracked migration.

## Deferred to #396
`FileAuditLogWriter._stateLock` removal requires marshaling `Checkpoint()` invocation from the snapshot writer thread to the dispatch thread without re-introducing the hot-path fsync stall fixed by #349. Non-trivial; orthogonal to the shared-guard extraction; tracked separately.

## Verification
- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test  -c Release --no-build` — 1,217/1,217 passed (full slnx)
- `dotnet format --verify-no-changes` — clean