### PR TITLE
refactor(#382): unify time source via INanosTimeSource

### DIFF
--- a/src/B3.Exchange.Contracts/Time/INanosTimeSource.cs
+++ b/src/B3.Exchange.Contracts/Time/INanosTimeSource.cs
@@ -1,0 +1,21 @@
+namespace B3.Exchange.Contracts.Time;
+
+/// <summary>
+/// Single seam for "now" across the per-channel hot path and gateway
+/// state machines. Returns Unix-epoch nanoseconds; the production impl
+/// wraps <see cref="DateTimeOffset.UtcNow"/> and only delivers
+/// millisecond resolution dressed as nanos (the simulator does not
+/// need true nanosecond precision). Tests inject a deterministic
+/// fake — see <c>tests/.../FakeNanosTimeSource</c>.
+///
+/// Replaces the per-component <c>Func&lt;ulong&gt;? nowNanos = null</c>
+/// constructor parameters and the inline
+/// <c>DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL</c>
+/// arithmetic that had drifted across ~15 sites
+/// (issue #382, architectural review 2026-05-20, refactor #3).
+/// </summary>
+public interface INanosTimeSource
+{
+    /// <summary>Unix-epoch nanoseconds at the moment of the call.</summary>
+    ulong NowNanos();
+}

--- a/src/B3.Exchange.Contracts/Time/SystemNanosTimeSource.cs
+++ b/src/B3.Exchange.Contracts/Time/SystemNanosTimeSource.cs
@@ -1,0 +1,17 @@
+namespace B3.Exchange.Contracts.Time;
+
+/// <summary>
+/// Production <see cref="INanosTimeSource"/> backed by
+/// <see cref="DateTimeOffset.UtcNow"/>. Singleton — use
+/// <see cref="Instance"/>; allocating new instances is wasteful and
+/// makes test substitution harder.
+/// </summary>
+public sealed class SystemNanosTimeSource : INanosTimeSource
+{
+    public static readonly SystemNanosTimeSource Instance = new();
+
+    private SystemNanosTimeSource() { }
+
+    public ulong NowNanos()
+        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+}

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -323,7 +323,7 @@ public sealed partial class ChannelDispatcher
                         // prefers the ulong over ulong.TryParse(e.ClOrdId));
                         // skip the alloc.
                         _outbound.WriteExecutionReportReject(_currentSession,
-                            new RejectEvent(string.Empty, 0, 0, RejectReason.UnknownInstrument, _nowNanos()),
+                            new RejectEvent(string.Empty, 0, 0, RejectReason.UnknownInstrument, _timeSource.NowNanos()),
                             _currentClOrdId, CurrentDurability);
                         _metrics?.IncExecutionReport(ExecutionReportKind.Reject);
                     }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -40,7 +40,7 @@ public sealed partial class ChannelDispatcher
         var dst = ReserveOrFlush(B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
             + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
             + B3.Umdf.WireEncoder.WireOffsets.ChannelResetBlockLength);
-        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteChannelResetFrame(dst, _nowNanos());
+        int n = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteChannelResetFrame(dst, _timeSource.NowNanos());
         Commit(n);
         FlushPacket();
     }
@@ -63,7 +63,7 @@ public sealed partial class ChannelDispatcher
             + B3.Umdf.WireEncoder.WireOffsets.TradeBustBlockLength);
         int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
             bust.SecurityId, bust.PriceMantissa, bust.Size, bust.TradeId, bust.TradeDate,
-            _nowNanos(), rptSeq);
+            _timeSource.NowNanos(), rptSeq);
         Commit(written);
         FlushPacket();
     }
@@ -270,7 +270,7 @@ public sealed partial class ChannelDispatcher
                         int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
                             result.MatchedFill.SecurityId, result.MatchedFill.PriceMantissa,
                             result.MatchedFill.Quantity, op.TradeId, tradeDateDays,
-                            _nowNanos(), rptSeq);
+                            _timeSource.NowNanos(), rptSeq);
                         Commit(written);
                         FlushPacket();
                         // ADR 0008 §4: post-EOD busts publish/refresh
@@ -453,7 +453,7 @@ public sealed partial class ChannelDispatcher
             bool applied;
             try
             {
-                applied = _engine.SetTradingPhase(op.SecurityId, op.Phase, _nowNanos());
+                applied = _engine.SetTradingPhase(op.SecurityId, op.Phase, _timeSource.NowNanos());
             }
             catch (Exception ex)
             {
@@ -501,7 +501,7 @@ public sealed partial class ChannelDispatcher
             }
             try
             {
-                _engine.UncrossAuction(op.SecurityId, op.TargetPhase, _nowNanos());
+                _engine.UncrossAuction(op.SecurityId, op.TargetPhase, _timeSource.NowNanos());
             }
             catch (InvalidOperationException ex)
             {
@@ -588,7 +588,7 @@ public sealed partial class ChannelDispatcher
             bool stateChanged;
             try
             {
-                stateChanged = _engine.HaltInstrument(op.SecurityId, op.Reason, op.Note, _nowNanos());
+                stateChanged = _engine.HaltInstrument(op.SecurityId, op.Reason, op.Note, _timeSource.NowNanos());
             }
             catch (KeyNotFoundException ex)
             {
@@ -646,7 +646,7 @@ public sealed partial class ChannelDispatcher
             bool stateChanged;
             try
             {
-                stateChanged = _engine.ResumeInstrument(op.SecurityId, _nowNanos());
+                stateChanged = _engine.ResumeInstrument(op.SecurityId, _timeSource.NowNanos());
             }
             catch (KeyNotFoundException ex)
             {

--- a/src/B3.Exchange.Core/ChannelDispatcher.Packet.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Packet.cs
@@ -45,7 +45,7 @@ public sealed partial class ChannelDispatcher
             _retxBuffer?.Reset();
         }
         Volatile.Write(ref _sequenceNumber, _sequenceNumber + 1);
-        ulong now = _nowNanos();
+        ulong now = _timeSource.NowNanos();
         B3.Umdf.WireEncoder.UmdfWireEncoder.PatchPacketHeader(
             _packetBuf.AsSpan(0, B3.Umdf.WireEncoder.WireOffsets.PacketHeaderSize), _sequenceNumber, now);
         _packetSink.Publish(ChannelNumber, _packetBuf.AsSpan(0, _packetWritten));

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -1,4 +1,5 @@
 using B3.Exchange.Contracts;
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 
@@ -126,7 +127,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private readonly IUmdfPacketSink _liveSink;
     private readonly ICoreOutbound _liveOutbound;
     private readonly ILogger<ChannelDispatcher> _logger;
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     private readonly ushort _tradeDate;
     private readonly ChannelMetrics? _metrics;
     private readonly BoundedSessionFirmCounters? _sessionFirmCounters;
@@ -366,7 +367,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _packetSink = options.PacketSink;
         _outbound = options.Outbound;
         _logger = options.Logger;
-        _nowNanos = options.NowNanos ?? DefaultNowNanos;
+        _timeSource = options.TimeSource ?? SystemNanosTimeSource.Instance;
         _tradeDate = options.TradeDate;
         _metrics = options.Metrics;
         _sessionFirmCounters = options.SessionFirmCounters;
@@ -440,7 +441,4 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     public bool TryGetHaltSnapshot(long securityId, out HaltSnapshot state)
         => _haltSnapshot.TryGetValue(securityId, out state);
-
-    private static ulong DefaultNowNanos()
-        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
 }

--- a/src/B3.Exchange.Core/ChannelDispatcherOptions.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcherOptions.cs
@@ -1,4 +1,5 @@
 using B3.Exchange.Contracts;
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.PostTrade;
 using Microsoft.Extensions.Logging;
 
@@ -21,7 +22,7 @@ public sealed record ChannelDispatcherOptions
     public required ICoreOutbound Outbound { get; init; }
     public required ILogger<ChannelDispatcher> Logger { get; init; }
 
-    public Func<ulong>? NowNanos { get; init; }
+    public INanosTimeSource? TimeSource { get; init; }
     public ushort TradeDate { get; init; }
     public int InboundCapacity { get; init; } = ChannelDispatcher.DefaultInboundCapacity;
     public ChannelMetrics? Metrics { get; init; }

--- a/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
+++ b/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Instruments;
 using B3.Umdf.WireEncoder;
 
@@ -40,7 +41,7 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
 
     private readonly IReadOnlyList<Instrument> _instruments;
     private readonly IUmdfPacketSink _sink;
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     private readonly byte[] _packetBuf = new byte[MaxPacketBytes];
     private readonly object _publishLock = new();
 
@@ -52,7 +53,7 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
         IReadOnlyList<Instrument> instruments,
         IUmdfPacketSink sink,
         TimeSpan cadence,
-        Func<ulong>? nowNanos = null,
+        INanosTimeSource? timeSource = null,
         ushort sequenceVersion = 1)
     {
         ArgumentNullException.ThrowIfNull(instruments);
@@ -69,14 +70,12 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
         ChannelNumber = channelNumber;
         _instruments = instruments;
         _sink = sink;
-        _nowNanos = nowNanos ?? DefaultNowNanos;
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
         Cadence = cadence;
         SequenceVersion = sequenceVersion;
         SequenceNumber = 0;
     }
 
-    private static ulong DefaultNowNanos()
-        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
 
     /// <summary>
     /// Starts the periodic loop. Idempotent: a second call is a no-op.
@@ -155,7 +154,7 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
         SequenceNumber++;
         UmdfWireEncoder.PatchPacketHeader(
             _packetBuf.AsSpan(0, WireOffsets.PacketHeaderSize),
-            SequenceNumber, _nowNanos());
+            SequenceNumber, _timeSource.NowNanos());
         _sink.Publish(ChannelNumber, _packetBuf.AsSpan(0, written));
     }
 

--- a/src/B3.Exchange.Core/SnapshotRotator.cs
+++ b/src/B3.Exchange.Core/SnapshotRotator.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Matching;
 using B3.Umdf.WireEncoder;
 
@@ -40,7 +41,7 @@ public sealed class SnapshotRotator
     private readonly byte _channelNumber;
     private readonly ISnapshotBookSource _source;
     private readonly IUmdfPacketSink _sink;
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     private readonly int _maxEntriesPerChunk;
     private readonly byte[] _packetBuf;
 
@@ -55,7 +56,7 @@ public sealed class SnapshotRotator
         byte channelNumber,
         ISnapshotBookSource source,
         IUmdfPacketSink sink,
-        Func<ulong>? nowNanos = null,
+        INanosTimeSource? timeSource = null,
         int maxEntriesPerChunk = SnapshotPacketBuilder.MaxEntriesPerChunk,
         int packetBufferSize = SnapshotPacketBuilder.DefaultPacketBufferSize)
     {
@@ -68,13 +69,10 @@ public sealed class SnapshotRotator
         _channelNumber = channelNumber;
         _source = source;
         _sink = sink;
-        _nowNanos = nowNanos ?? DefaultNowNanos;
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
         _maxEntriesPerChunk = maxEntriesPerChunk;
         _packetBuf = new byte[packetBufferSize];
     }
-
-    private static ulong DefaultNowNanos()
-        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
 
     /// <summary>
     /// Bumps both the snapshot <see cref="SequenceVersion"/> and resets the
@@ -137,7 +135,7 @@ public sealed class SnapshotRotator
 
         ushort version = SequenceVersion;
         uint firstSeq = SequenceNumber + 1;
-        ulong nowNanos = _nowNanos();
+        ulong nowNanos = _timeSource.NowNanos();
         byte channel = _channelNumber;
         var sink = _sink;
 

--- a/src/B3.Exchange.Gateway/EstablishValidator.cs
+++ b/src/B3.Exchange.Gateway/EstablishValidator.cs
@@ -1,4 +1,5 @@
 using B3.EntryPoint.Wire;
+using B3.Exchange.Contracts.Time;
 using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
 
 namespace B3.Exchange.Gateway;
@@ -52,7 +53,7 @@ public readonly struct EstablishOutcome
 /// </summary>
 public sealed class EstablishValidator
 {
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     /// <summary>Maximum tolerated absolute clock skew (nanoseconds)
     /// between server and Establish <c>timestamp</c>. Zero disables the
     /// check (used by tests). Default 5 minutes.</summary>
@@ -66,10 +67,10 @@ public sealed class EstablishValidator
     /// <summary>Inclusive upper bound for <c>keepAliveInterval</c> (ms).</summary>
     public const ulong MaxKeepAliveIntervalMs = 60_000;
 
-    public EstablishValidator(Func<ulong>? nowNanos = null,
+    public EstablishValidator(INanosTimeSource? timeSource = null,
         ulong timestampSkewToleranceNs = 5UL * 60UL * 1_000_000_000UL)
     {
-        _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
         TimestampSkewToleranceNs = timestampSkewToleranceNs;
     }
 
@@ -110,7 +111,7 @@ public sealed class EstablishValidator
 
         if (TimestampSkewToleranceNs > 0 && req.TimestampNanos != 0)
         {
-            var now = _nowNanos();
+            var now = _timeSource.NowNanos();
             var diff = req.TimestampNanos > now ? req.TimestampNanos - now : now - req.TimestampNanos;
             if (diff > TimestampSkewToleranceNs)
                 return EstablishOutcome.Reject(

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using System.Buffers.Binary;
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Matching;
 using DurabilityHandle = B3.Exchange.Contracts.DurabilityHandle;
 
@@ -28,7 +29,7 @@ internal sealed class FixpOutboundEncoder
     private readonly Func<TcpTransport> _transport;
     private readonly RetransmitBuffer _retxBuffer;
     private readonly object _outboundLock;
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     private readonly Func<bool> _isOpen;
     private readonly Action _close;
 
@@ -45,7 +46,7 @@ internal sealed class FixpOutboundEncoder
         Func<TcpTransport> transport,
         RetransmitBuffer retxBuffer,
         object outboundLock,
-        Func<ulong> nowNanos,
+        INanosTimeSource timeSource,
         Func<bool> isOpen,
         Action close)
     {
@@ -54,7 +55,7 @@ internal sealed class FixpOutboundEncoder
         _transport = transport;
         _retxBuffer = retxBuffer;
         _outboundLock = outboundLock;
-        _nowNanos = nowNanos;
+        _timeSource = timeSource;
         _isOpen = isOpen;
         _close = close;
     }
@@ -201,7 +202,7 @@ internal sealed class FixpOutboundEncoder
         lock (_outboundLock)
         {
             BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(
-                exact, _sessionId(), _nextMsgSeqNum(), _nowNanos(),
+                exact, _sessionId(), _nextMsgSeqNum(), _timeSource.NowNanos(),
                 refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text);
             return AppendAndEnqueueLocked(exact);
         }

--- a/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
@@ -164,7 +164,7 @@ public sealed partial class FixpSession
         var cmd = new MassCancelCommand(
             SecurityId: 0,
             SideFilter: null,
-            EnteredAtNanos: _nowNanos());
+            EnteredAtNanos: _timeSource.NowNanos());
         _logger.LogInformation(
             "fixp session {ConnectionId} cancel-on-disconnect firing (mode={Mode} windowMs={WindowMs})",
             ConnectionId, CancelOnDisconnectType, CodTimeoutWindowMs);

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -34,7 +34,7 @@ public sealed partial class FixpSession
             decodeSpan.SetTag(ExchangeTelemetry.TagTemplate, (int)info.TemplateId);
         }
 
-        ulong now = _nowNanos();
+        ulong now = _timeSource.NowNanos();
         _logger.LogTrace("session {ConnectionId} inbound frame templateId={TemplateId} blockLength={BlockLength} varDataLength={VarDataLength}",
             ConnectionId, info.TemplateId, info.BlockLength, info.VarDataLength);
 

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -1,6 +1,7 @@
 using B3.EntryPoint.Wire;
 using System.Buffers;
 using B3.Exchange.Contracts;
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
 using ContractsSessionId = B3.Exchange.Contracts.SessionId;
@@ -34,7 +35,7 @@ public sealed partial class FixpSession : IAsyncDisposable
     private readonly ILogger<TcpTransport> _transportLogger;
     private readonly int _sendQueueCapacity;
     private CancellationTokenSource _cts = new();
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     private readonly FixpSessionOptions _options;
     private readonly Action<FixpSession, string>? _onClosed;
     private readonly NegotiationValidator? _validator;
@@ -265,7 +266,7 @@ public sealed partial class FixpSession : IAsyncDisposable
 
     public FixpSession(long connectionId, uint enteringFirm, uint sessionId,
         Stream stream, IInboundCommandSink sink, ILogger<FixpSession> logger,
-        Func<ulong>? nowNanos = null,
+        INanosTimeSource? timeSource = null,
         int sendQueueCapacity = DefaultSendQueueCapacity,
         FixpSessionOptions? options = null,
         Action<FixpSession, string>? onClosed = null,
@@ -287,7 +288,7 @@ public sealed partial class FixpSession : IAsyncDisposable
         _logger = logger;
         _transportLogger = transportLogger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TcpTransport>.Instance;
         _sendQueueCapacity = sendQueueCapacity;
-        _nowNanos = nowNanos ?? DefaultNowNanos;
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
         _nowMs = nowMs ?? (() => Environment.TickCount64);
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
@@ -321,7 +322,7 @@ public sealed partial class FixpSession : IAsyncDisposable
             transport: () => _transport!,
             retxBuffer: _retxBuffer,
             outboundLock: _outboundLock,
-            nowNanos: () => _nowNanos(),
+            timeSource: _timeSource,
             // Use IsRegistered (not IsOpen) so that passive ERs delivered while
             // the session is Suspended (transport down, but session-state alive)
             // are still encoded, sequenced, and appended to the FIXP retransmit
@@ -391,9 +392,6 @@ public sealed partial class FixpSession : IAsyncDisposable
         _recvTask = Task.Run(() => RunReceiveLoopAsync(_cts.Token));
         _watchdogTask = Task.Run(() => RunWatchdogLoopAsync(_cts.Token));
     }
-
-    private static ulong DefaultNowNanos()
-        => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
 
     private static long NowMs() => Environment.TickCount64;
 

--- a/src/B3.Exchange.Gateway/NegotiationValidator.cs
+++ b/src/B3.Exchange.Gateway/NegotiationValidator.cs
@@ -1,4 +1,5 @@
 using B3.EntryPoint.Wire;
+using B3.Exchange.Contracts.Time;
 using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
 
 namespace B3.Exchange.Gateway;
@@ -74,20 +75,20 @@ public sealed class NegotiationValidator
     private readonly FirmRegistry _firms;
     private readonly SessionClaimRegistry _claims;
     private readonly bool _devMode;
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
     /// <summary>Maximum tolerated absolute clock skew (nanoseconds)
     /// between server and Negotiate <c>timestamp</c>. Zero disables the
     /// check (used by tests). Default 5 minutes.</summary>
     public ulong TimestampSkewToleranceNs { get; }
 
     public NegotiationValidator(FirmRegistry firms, SessionClaimRegistry claims,
-        bool devMode, Func<ulong>? nowNanos = null,
+        bool devMode, INanosTimeSource? timeSource = null,
         ulong timestampSkewToleranceNs = 5UL * 60UL * 1_000_000_000UL)
     {
         _firms = firms ?? throw new ArgumentNullException(nameof(firms));
         _claims = claims ?? throw new ArgumentNullException(nameof(claims));
         _devMode = devMode;
-        _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
         TimestampSkewToleranceNs = timestampSkewToleranceNs;
     }
 
@@ -115,7 +116,7 @@ public sealed class NegotiationValidator
 
         if (TimestampSkewToleranceNs > 0 && req.TimestampNanos != 0)
         {
-            var now = _nowNanos();
+            var now = _timeSource.NowNanos();
             var diff = req.TimestampNanos > now ? req.TimestampNanos - now : now - req.TimestampNanos;
             if (diff > TimestampSkewToleranceNs)
                 return NegotiationOutcome.Reject(

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -1,4 +1,5 @@
 using B3.Exchange.Contracts;
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging;
@@ -31,11 +32,11 @@ public sealed class HostRouter : IInboundCommandSink
     private readonly IReadOnlyList<ChannelDispatcher> _allDispatchers;
     private readonly ICoreOutbound _outbound;
     private readonly ILogger<HostRouter> _logger;
-    private readonly Func<ulong> _nowNanos;
+    private readonly INanosTimeSource _timeSource;
 
     public HostRouter(IReadOnlyDictionary<long, ChannelDispatcher> routing, ICoreOutbound outbound,
         ILogger<HostRouter> logger,
-        Func<ulong>? nowNanos = null)
+        INanosTimeSource? timeSource = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(outbound);
@@ -44,7 +45,7 @@ public sealed class HostRouter : IInboundCommandSink
         _allDispatchers = routing.Values.Distinct().ToArray();
         _outbound = outbound;
         _logger = logger;
-        _nowNanos = nowNanos ?? (() => (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL);
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
     }
 
     public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue)
@@ -205,7 +206,7 @@ public sealed class HostRouter : IInboundCommandSink
         _outbound.WriteExecutionReportReject(session,
             new RejectEvent(ClOrdId: string.Empty,
                 SecurityId: secId, OrderIdOrZero: 0,
-                Reason: RejectReason.UnknownInstrument, TransactTimeNanos: _nowNanos()),
+                Reason: RejectReason.UnknownInstrument, TransactTimeNanos: _timeSource.NowNanos()),
             clOrdIdValue);
     }
 
@@ -216,7 +217,7 @@ public sealed class HostRouter : IInboundCommandSink
         _outbound.WriteExecutionReportReject(session,
             new RejectEvent(ClOrdId: string.Empty,
                 SecurityId: secId, OrderIdOrZero: 0,
-                Reason: RejectReason.UnknownOrderId, TransactTimeNanos: _nowNanos()),
+                Reason: RejectReason.UnknownOrderId, TransactTimeNanos: _timeSource.NowNanos()),
             clOrdIdValue);
     }
 }

--- a/src/B3.Exchange.Host/HttpServer.cs
+++ b/src/B3.Exchange.Host/HttpServer.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using B3.Exchange.Contracts.Time;
 using B3.Exchange.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -39,6 +40,7 @@ public sealed class HttpServer : IAsyncDisposable
     private readonly IReadOnlyDictionary<byte, IChannelStatePersister> _persisters;
     private readonly IReadOnlyDictionary<byte, IChannelWriteAheadLog> _wals;
     private readonly Action<string>? _log;
+    private readonly INanosTimeSource _timeSource;
     private WebApplication? _app;
 
     private static readonly DateOnly LocalMktDateEpoch = new(1970, 1, 1);
@@ -53,7 +55,8 @@ public sealed class HttpServer : IAsyncDisposable
         IReadOnlyDictionary<byte, IChannelStatePersister>? persisters = null,
         IReadOnlyDictionary<byte, IChannelWriteAheadLog>? wals = null,
         IReadOnlyDictionary<long, ChannelDispatcher>? instrumentRouting = null,
-        Func<byte, DateOnly, B3.Exchange.PostTrade.EodFillsExportResult?>? eodExportTrigger = null)
+        Func<byte, DateOnly, B3.Exchange.PostTrade.EodFillsExportResult?>? eodExportTrigger = null,
+        INanosTimeSource? timeSource = null)
     {
         _config = config;
         _metrics = metrics;
@@ -67,6 +70,7 @@ public sealed class HttpServer : IAsyncDisposable
         _instrumentRouting = instrumentRouting ?? new Dictionary<long, ChannelDispatcher>();
         _eodExportTrigger = eodExportTrigger;
         _log = log;
+        _timeSource = timeSource ?? SystemNanosTimeSource.Instance;
     }
 
     public IPEndPoint? LocalEndpoint { get; private set; }
@@ -564,7 +568,7 @@ public sealed class HttpServer : IAsyncDisposable
 
         var tcs = new TaskCompletionSource<B3.Exchange.Core.ChannelDispatcher.OperatorBustV2Outcome>(
             TaskCreationOptions.RunContinuationsAsynchronously);
-        ulong nowNanos = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL;
+        ulong nowNanos = _timeSource.NowNanos();
         if (!disp.EnqueueOperatorBustV2(tradeId, tradeDate, correlationId, reason, busterFirm,
                 securityIdEcho, nowNanos, tcs))
         {

--- a/src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
+++ b/src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
     <ProjectReference Include="..\B3.EntryPoint.Wire\B3.EntryPoint.Wire.csproj" />
+    <ProjectReference Include="..\B3.Exchange.Contracts\B3.Exchange.Contracts.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/B3.Exchange.SyntheticTrader/Fixp/FixpClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/Fixp/FixpClient.cs
@@ -462,7 +462,7 @@ public sealed class FixpClient : IAsyncDisposable
         else Interlocked.Exchange(ref _lastOutboundTicks, ticks);
     }
 
-    private static ulong NowNanos() => (ulong)(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000L);
+    private static ulong NowNanos() => B3.Exchange.Contracts.Time.SystemNanosTimeSource.Instance.NowNanos();
 
     /// <summary>
     /// Builds the gateway-expected credentials JSON document

--- a/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
+++ b/tests/B3.Exchange.Core.Tests/B3.Exchange.Core.Tests.csproj
@@ -17,6 +17,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Core\B3.Exchange.Core.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherPostTradeTests.cs
@@ -1,4 +1,5 @@
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 using B3.Exchange.Instruments;
 using B3.Exchange.Matching;
 using B3.Exchange.PostTrade;
@@ -44,7 +45,7 @@ public partial class ChannelDispatcherTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
                 PostTradeSink = audit,
             });
@@ -109,7 +110,7 @@ public partial class ChannelDispatcherTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
                 PostTradeSink = audit,
             });

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherRetxBufferTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using B3.Exchange.Contracts;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 using B3.Exchange.Instruments;
 using B3.Exchange.Matching;
 using B3.Umdf.WireEncoder;
@@ -69,7 +70,7 @@ public class ChannelDispatcherRetxBufferTests
                 PacketSink = pkt,
                 Outbound = new NoopOutbound(),
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
                 RetxBuffer = ring,
             });

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 using B3.Exchange.Matching;
 using B3.Umdf.WireEncoder;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -96,7 +97,7 @@ public partial class ChannelDispatcherTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
             });
         return (disp, pkt, outbound);
@@ -494,7 +495,7 @@ public partial class ChannelDispatcherTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
                 InboundCapacity = 1,
                 Metrics = metrics,
@@ -530,7 +531,7 @@ public partial class ChannelDispatcherTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
                 Metrics = metrics,
             });
@@ -586,7 +587,7 @@ public partial class ChannelDispatcherTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
                 Metrics = metrics,
             });

--- a/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
+++ b/tests/B3.Exchange.Core.Tests/CrossOrderSemanticsTests.cs
@@ -5,6 +5,7 @@ using TimeInForce = B3.Exchange.Matching.TimeInForce;
 using B3.Exchange.Gateway;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -97,7 +98,7 @@ public class CrossOrderSemanticsTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000_000_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
                 TradeDate = 19_000,
             });
         return (disp, pkt, outbound);

--- a/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using B3.Exchange.Instruments;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.WireEncoder;
 
@@ -50,7 +51,7 @@ public class InstrumentDefinitionPublisherTests
         var sink = new RecordingPacketSink();
         var pub = new InstrumentDefinitionPublisher(
             channelNumber: 184, instruments, sink,
-            cadence: TimeSpan.FromSeconds(60), nowNanos: () => 12345UL);
+            cadence: TimeSpan.FromSeconds(60), timeSource: new FakeNanosTimeSource(12345UL));
 
         pub.PublishOnce();
 
@@ -94,7 +95,7 @@ public class InstrumentDefinitionPublisherTests
         var instruments = new List<Instrument> { Inst("PETR4", 900_000_000_001L, "BRPETRACNPR6") };
         var sink = new RecordingPacketSink();
         var pub = new InstrumentDefinitionPublisher(
-            channelNumber: 200, instruments, sink, TimeSpan.FromMinutes(1), () => 1UL);
+            channelNumber: 200, instruments, sink, TimeSpan.FromMinutes(1), new FakeNanosTimeSource(1UL));
 
         pub.PublishOnce();
 
@@ -115,7 +116,7 @@ public class InstrumentDefinitionPublisherTests
         };
         var sink = new RecordingPacketSink();
         var pub = new InstrumentDefinitionPublisher(
-            channelNumber: 99, instruments, sink, TimeSpan.FromMinutes(1), () => 0UL);
+            channelNumber: 99, instruments, sink, TimeSpan.FromMinutes(1), new FakeNanosTimeSource(0UL));
 
         pub.PublishOnce();
         pub.PublishOnce();
@@ -143,7 +144,7 @@ public class InstrumentDefinitionPublisherTests
         }
         var sink = new RecordingPacketSink();
         var pub = new InstrumentDefinitionPublisher(
-            channelNumber: 7, instruments, sink, TimeSpan.FromMinutes(1), () => 0UL);
+            channelNumber: 7, instruments, sink, TimeSpan.FromMinutes(1), new FakeNanosTimeSource(0UL));
 
         pub.PublishOnce();
 
@@ -163,7 +164,7 @@ public class InstrumentDefinitionPublisherTests
         var instruments = new List<Instrument> { Inst("PETR4", 1L, "BRPETRACNPR6") };
         var sink = new RecordingPacketSink();
         await using var pub = new InstrumentDefinitionPublisher(
-            channelNumber: 1, instruments, sink, TimeSpan.FromMilliseconds(50), () => 0UL);
+            channelNumber: 1, instruments, sink, TimeSpan.FromMilliseconds(50), new FakeNanosTimeSource(0UL));
 
         pub.Start();
 

--- a/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
+++ b/tests/B3.Exchange.Core.Tests/SnapshotRotatorTests.cs
@@ -6,6 +6,7 @@ using TimeInForce = B3.Exchange.Matching.TimeInForce;
 using System.Runtime.InteropServices;
 using B3.Exchange.Core;
 using B3.Exchange.Matching;
+using B3.Exchange.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 using B3.Umdf.Mbo.Sbe.V16;
 using B3.Umdf.WireEncoder;
@@ -50,7 +51,7 @@ public class SnapshotRotatorTests
     {
         var src = new FakeSource { SecurityIds = new[] { 42L } };
         var sink = new CapturingSink();
-        var rot = new SnapshotRotator(channelNumber: 84, source: src, sink: sink, nowNanos: () => 1234UL);
+        var rot = new SnapshotRotator(channelNumber: 84, source: src, sink: sink, timeSource: new FakeNanosTimeSource(1234UL));
 
         int packets = rot.PublishNext();
 
@@ -268,12 +269,12 @@ public class ChannelDispatcherSnapshotTests
                 PacketSink = incSink,
                 Outbound = new ChannelDispatcherTests_RecordingOutbound(),
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1UL,
+                TimeSource = new FakeNanosTimeSource(1UL),
                 TradeDate = 1,
             });
         var rotator = new SnapshotRotator(channelNumber: 1,
             source: new MatchingEngineSnapshotSource(engine!, new[] { Petr }),
-            sink: snapSink, nowNanos: () => 1UL);
+            sink: snapSink, timeSource: new FakeNanosTimeSource(1UL));
         disp.AttachSnapshotRotator(rotator);
 
         // Synchronously drive: enqueue tick → drain.
@@ -299,12 +300,12 @@ public class ChannelDispatcherSnapshotTests
                 PacketSink = incSink,
                 Outbound = new ChannelDispatcherTests_RecordingOutbound(),
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1UL,
+                TimeSource = new FakeNanosTimeSource(1UL),
                 TradeDate = 1,
             });
         var rotator = new SnapshotRotator(channelNumber: 1,
             source: new MatchingEngineSnapshotSource(engine!, new[] { Petr }),
-            sink: snapSink, nowNanos: () => 1UL);
+            sink: snapSink, timeSource: new FakeNanosTimeSource(1UL));
         disp.AttachSnapshotRotator(rotator);
 
         // Submit a couple of resting orders so the snapshot has content.

--- a/tests/B3.Exchange.Core.Tests/TracingTests.cs
+++ b/tests/B3.Exchange.Core.Tests/TracingTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using B3.Exchange.Contracts;
 using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
 using B3.Exchange.Instruments;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -60,7 +61,7 @@ public class TracingTests
             PacketSink = new RecordingPacketSink(),
             Outbound = new NoopOutbound(),
             Logger = NullLogger<ChannelDispatcher>.Instance,
-            NowNanos = () => 1_000_000_000UL,
+            TimeSource = new FakeNanosTimeSource(1_000_000_000UL),
             TradeDate = 19_000,
         });
 

--- a/tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj
+++ b/tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\..\src\B3.EntryPoint.Sbe\B3.EntryPoint.Sbe.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Gateway\B3.Exchange.Gateway.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Gateway.Tests/EstablishValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishValidatorTests.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using B3.Exchange.Gateway;
+using B3.Exchange.TestSupport;
 using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
 
 namespace B3.Exchange.Gateway.Tests;
@@ -56,7 +57,8 @@ public class EstablishValidatorTests
     public void Rejects_timestamp_skew_beyond_tolerance()
     {
         ulong now = 1_000_000_000UL;
-        var v = new EstablishValidator(nowNanos: () => now,
+        var clock = new FakeNanosTimeSource(now);
+        var v = new EstablishValidator(timeSource: clock,
             timestampSkewToleranceNs: 1_000UL);
         var req = Req(sid: 100, ver: 1, ts: now + 10_000UL);
         var o = v.Validate(req, FixpState.Negotiated, 100, 1, 0);

--- a/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
@@ -1,5 +1,6 @@
 using B3.EntryPoint.Wire;
 using B3.Exchange.Gateway;
+using B3.Exchange.TestSupport;
 using FixpSbe = B3.Entrypoint.Fixp.Sbe.V6;
 
 namespace B3.Exchange.Gateway.Tests;
@@ -17,7 +18,7 @@ public class NegotiationValidatorTests
     {
         var claims = new SessionClaimRegistry();
         var v = new NegotiationValidator(BuildRegistry(), claims, devMode,
-            nowNanos: () => 1_000_000_000UL, timestampSkewToleranceNs: 0UL);
+            timeSource: new FakeNanosTimeSource(1_000_000_000UL), timestampSkewToleranceNs: 0UL);
         return (v, claims);
     }
 
@@ -136,7 +137,7 @@ public class NegotiationValidatorTests
     {
         var claims = new SessionClaimRegistry();
         var v = new NegotiationValidator(BuildRegistry(), claims, devMode: false,
-            nowNanos: () => 1_000_000_000UL,
+            timeSource: new FakeNanosTimeSource(1_000_000_000UL),
             timestampSkewToleranceNs: 100_000_000UL);
         // far-future timestamp
         var o = v.Validate(Req(ts: 5_000_000_000UL), Cred(), FixpState.Idle);

--- a/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
+++ b/tests/B3.Exchange.Host.Tests/B3.Exchange.Host.Tests.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
     <ProjectReference Include="..\..\src\B3.Umdf.WireEncoder\B3.Umdf.WireEncoder.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.SyntheticTrader\B3.Exchange.SyntheticTrader.csproj" />
+    <ProjectReference Include="..\B3.Exchange.TestSupport\B3.Exchange.TestSupport.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostRouterTests.cs
@@ -7,6 +7,7 @@ using B3.Exchange.Host;
 using B3.Exchange.Core;
 using B3.Exchange.Instruments;
 using B3.Exchange.Matching;
+using B3.Exchange.TestSupport;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace B3.Exchange.Host.Tests;
@@ -35,7 +36,7 @@ public class HostRouterTests
     {
         var routing = new Dictionary<long, ChannelDispatcher>(); // empty
         var outbound = new RecordingOutbound();
-        var router = new HostRouter(routing, outbound, NullLogger<HostRouter>.Instance, () => 1_000UL);
+        var router = new HostRouter(routing, outbound, NullLogger<HostRouter>.Instance, new FakeNanosTimeSource(1_000UL));
         router.EnqueueNewOrder(
             new NewOrderCommand("1", SecurityId: 12345, Side.Buy, OrderType.Limit, TimeInForce.Day, 100, 100, 1, 0),
             new B3.Exchange.Contracts.SessionId("s1"), enteringFirm: 1, clOrdIdValue: 1);
@@ -68,7 +69,7 @@ public class HostRouterTests
                 PacketSink = pkt,
                 Outbound = outbound,
                 Logger = NullLogger<ChannelDispatcher>.Instance,
-                NowNanos = () => 1_000UL,
+                TimeSource = new FakeNanosTimeSource(1_000UL),
             });
         // Dispatcher loop not started; we read inbound queue directly.
         var router = new HostRouter(new Dictionary<long, ChannelDispatcher> { [42] = disp }, outbound, NullLogger<HostRouter>.Instance);

--- a/tests/B3.Exchange.TestSupport/B3.Exchange.TestSupport.csproj
+++ b/tests/B3.Exchange.TestSupport/B3.Exchange.TestSupport.csproj
@@ -1,12 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <RootNamespace>B3.Exchange.TestSupport</RootNamespace>
+    <AssemblyName>B3.Exchange.TestSupport</AssemblyName>
     <IsPackable>false</IsPackable>
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\B3.Exchange.Contracts\B3.Exchange.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/B3.Exchange.TestSupport/FakeNanosTimeSource.cs
+++ b/tests/B3.Exchange.TestSupport/FakeNanosTimeSource.cs
@@ -1,0 +1,21 @@
+using B3.Exchange.Contracts.Time;
+
+namespace B3.Exchange.TestSupport;
+
+/// <summary>
+/// Deterministic <see cref="INanosTimeSource"/> for unit tests.
+/// Returns the value last set by <see cref="Set"/> / <see cref="Advance"/>
+/// or 0 by default. Not thread-safe — call from a single test thread.
+/// </summary>
+public sealed class FakeNanosTimeSource : INanosTimeSource
+{
+    private ulong _now;
+
+    public FakeNanosTimeSource(ulong initial = 0) { _now = initial; }
+
+    public ulong NowNanos() => _now;
+
+    public void Set(ulong nanos) => _now = nanos;
+
+    public void Advance(ulong deltaNanos) => _now += deltaNanos;
+}


### PR DESCRIPTION
Closes #382.

Per Opus 4.7 architectural review 2026-05-20 (refactor #3): the same `Func<ulong>? nowNanos = null` + `DateTimeOffset.UtcNow * 1_000_000UL` shape was duplicated across 15+ ctors plus 8 inline arithmetic sites. Tests had to thread the Func through 3-4 layers any time they wanted a fake clock.

## Approach

Chose option 2 from the issue (custom `INanosTimeSource` in Contracts) over `System.TimeProvider` — `TimeProvider` doesn't natively return Unix-epoch-nanos and the codebase has no prior TimeProvider adoption to consistency-anchor against. One interface, one method, one singleton production impl, one fake for tests.

## Changes

- **New** `B3.Exchange.Contracts.Time.INanosTimeSource` + `SystemNanosTimeSource` (singleton wrapping `DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL`).
- **New** `B3.Exchange.TestSupport.FakeNanosTimeSource` (deterministic `Set` / `Advance`).
- **Production migrations**: every `Func<ulong>? nowNanos` ctor parameter → `INanosTimeSource? timeSource`. Nullable defaults to `SystemNanosTimeSource.Instance`. Covered: `ChannelDispatcher` (+ `Options`, `Loop`, `Operator`, `Packet`, `Lifecycle`, `Persistence`), `HostRouter`, `SnapshotRotator`, `InstrumentDefinitionPublisher`, `EstablishValidator`, `NegotiationValidator`, `FixpSession` (+ partials `CancelOnDisconnect`, `Dispatch`), `FixpOutboundEncoder`, `FixpClient`, `HttpServer`, `BackgroundSnapshotWriter`.
- **Inline arithmetic** `DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000UL` → `_timeSource.NowNanos()` in every site listed by the issue.
- **Test fixtures** migrated to `FakeNanosTimeSource` where they were threading Func closures.
- Host wiring (`ExchangeHost`) uses `SystemNanosTimeSource.Instance` for production.

Verified: `grep 'Func<ulong>' src/` → zero matches.

## Verification
- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test  -c Release --no-build` — 1,217/1,217 passed
- `dotnet format --verify-no-changes` — clean