### PR TITLE
refactor(#389): split FileChannelWriteAheadLog into WalAppender + WalReplay + WalDurabilityCoordinator

### DIFF
--- a/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
+++ b/src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs
@@ -1,7 +1,4 @@
 using System.Globalization;
-using System.Text;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using B3.Exchange.Core;
 using Microsoft.Extensions.Logging;
 
@@ -50,47 +47,24 @@ namespace B3.Exchange.Persistence;
 /// (tmp + rename + dir fsync) so a crash during truncate either keeps
 /// the previous WAL intact or atomically swaps it for an empty file —
 /// never leaves a partial truncation visible.</para>
+///
+/// <para>Issue #389: implementation is a thin facade composing three
+/// internal collaborators: <see cref="WalReplay"/> (read/parse/CRC),
+/// <see cref="WalDurabilityCoordinator"/> (pending/durable seq +
+/// group-commit bg thread), and <see cref="WalAppender"/> (file
+/// stream ownership, append, truncate, reset). Public API,
+/// on-disk format and threading semantics are unchanged.</para>
 /// </summary>
 public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposable
 {
     private const string WalFileNameFormat = "channel-{0}.wal";
-    private const string WalTempFileNameFormat = "channel-{0}.wal.tmp";
-    private const byte CrcSeparator = (byte)'\t';
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        WriteIndented = false,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters =
-        {
-            new JsonStringEnumConverter(),
-        },
-    };
-
-    private readonly string _path;
-    private readonly string _dataDir;
-    private readonly bool _fsyncPerWrite;
-    private readonly long _maxBytes;
-    private readonly WalSizeCapPolicy _onFull;
     private readonly ILogger<FileChannelWriteAheadLog> _logger;
     private readonly byte _channelNumber;
-    private readonly object _writeLock = new();
-    private FileStream? _appendStream;
-    private long _currentSize;
-    private long _dropsOnFull;
-
-    // Issue #312 (Tier-2 perf): GroupCommit mode infrastructure.
-    // _pendingSeq advances in Append (under _writeLock); _durableSeq
-    // advances after the background fsync completes. Waiters block on
-    // _durabilityLock and are pulsed when _durableSeq advances.
-    private readonly bool _groupCommit;
-    private readonly TimeSpan _groupCommitInterval;
-    private readonly object _durabilityLock = new();
-    private readonly ManualResetEventSlim _fsyncSignal;
-    private readonly CancellationTokenSource? _stopFsyncThread;
-    private readonly Thread? _fsyncThread;
-    private long _pendingSeq;
-    private long _durableSeq;
+    private readonly WalAppender _appender;
+    private readonly WalDurabilityCoordinator _durability;
+    private int _lastReadCorruptCount;
+    private int _lastReadLegacyCount;
 
     /// <summary>
     /// Number of records the most recent <see cref="ReadAll"/> call
@@ -98,7 +72,7 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     /// payload (bit-rot). The dispatcher reads this after replay and
     /// bumps <c>exch_wal_record_corruption_total</c>.
     /// </summary>
-    public int LastReadCorruptCount { get; private set; }
+    public int LastReadCorruptCount => _lastReadCorruptCount;
 
     /// <summary>
     /// Number of records the most recent <see cref="ReadAll"/> call
@@ -106,25 +80,25 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     /// pre-#285 host). Useful for tracking the migration window
     /// after upgrading.
     /// </summary>
-    public int LastReadLegacyCount { get; private set; }
+    public int LastReadLegacyCount => _lastReadLegacyCount;
 
     /// <summary>Issue #291: current on-disk size in bytes; surfaces
     /// <c>exch_wal_size_bytes</c> via <see cref="CurrentSizeBytes"/>.</summary>
-    public long CurrentSizeBytes => Interlocked.Read(ref _currentSize);
+    public long CurrentSizeBytes => _appender.CurrentSize;
 
     /// <summary>Issue #291: cumulative count of appends silently
     /// skipped under <see cref="WalSizeCapPolicy.Drop"/>.</summary>
-    public long DropsOnFullCount => Interlocked.Read(ref _dropsOnFull);
+    public long DropsOnFullCount => _appender.DropsOnFull;
 
     /// <summary>Issue #312: see
     /// <see cref="IChannelWriteAheadLog.PendingDurableSeqOrZero"/>.</summary>
-    public long PendingDurableSeqOrZero => Interlocked.Read(ref _pendingSeq);
+    public long PendingDurableSeqOrZero => _durability.PendingSeq;
 
     /// <summary>Issue #312: see
     /// <see cref="IChannelWriteAheadLog.DurableSeqOrZero"/>.</summary>
-    public long DurableSeqOrZero => Interlocked.Read(ref _durableSeq);
+    public long DurableSeqOrZero => _durability.DurableSeq;
 
-    public string Path => _path;
+    public string Path => _appender.Path;
 
     public FileChannelWriteAheadLog(
         string dataDirectory,
@@ -204,442 +178,55 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
                 "WalFsyncMode.GroupCommit is incompatible with fsyncPerWrite=true; choose one durability strategy.",
                 nameof(fsyncMode));
         }
-        _dataDir = System.IO.Path.GetFullPath(dataDirectory);
-        Directory.CreateDirectory(_dataDir);
+        var dataDir = System.IO.Path.GetFullPath(dataDirectory);
+        Directory.CreateDirectory(dataDir);
         _channelNumber = channelNumber;
-        _fsyncPerWrite = fsyncPerWrite;
-        _maxBytes = maxBytes > 0 ? maxBytes : 0;
-        _onFull = onFull;
         _logger = logger;
-        _path = System.IO.Path.Combine(_dataDir,
+        var path = System.IO.Path.Combine(dataDir,
             string.Format(CultureInfo.InvariantCulture, WalFileNameFormat, channelNumber));
-        // Initialise the size counter from any existing on-disk file
-        // so a host restart inherits the pre-restart usage instead of
-        // claiming the WAL is empty until the next truncation.
-        if (File.Exists(_path))
+        long initialSize = 0;
+        if (File.Exists(path))
         {
-            try { _currentSize = new FileInfo(_path).Length; }
-            catch { _currentSize = 0; }
+            try { initialSize = new FileInfo(path).Length; }
+            catch { initialSize = 0; }
         }
 
-        _groupCommit = fsyncMode == WalFsyncMode.GroupCommit;
-        _groupCommitInterval = _groupCommit
-            ? (groupCommitInterval > TimeSpan.Zero ? groupCommitInterval : TimeSpan.FromMilliseconds(1))
-            : TimeSpan.Zero;
-        _fsyncSignal = new ManualResetEventSlim(initialState: false);
-        if (_groupCommit)
-        {
-            _stopFsyncThread = new CancellationTokenSource();
-            _fsyncThread = new Thread(GroupCommitFsyncLoop)
-            {
-                IsBackground = true,
-                Name = $"wal-fsync-ch{channelNumber}",
-            };
-            _fsyncThread.Start();
-        }
+        var resolvedMaxBytes = maxBytes > 0 ? maxBytes : 0;
+        _appender = new WalAppender(
+            path, dataDir, channelNumber, fsyncPerWrite,
+            resolvedMaxBytes, onFull, initialSize, logger);
+        bool groupCommit = fsyncMode == WalFsyncMode.GroupCommit;
+        _durability = new WalDurabilityCoordinator(
+            channelNumber, groupCommit, groupCommitInterval,
+            _appender.FsyncToDisk, logger);
+        _appender.AttachDurability(_durability);
     }
 
-    public int Append(WalRecord record)
-    {
-        ArgumentNullException.ThrowIfNull(record);
-        lock (_writeLock)
-        {
-            var json = JsonSerializer.SerializeToUtf8Bytes(record, WalJsonContext.Default.WalRecord);
-            // Layout: <json bytes> \t <8-hex Crc32C> \n
-            int recordBytes = json.Length + 1 /* \t */ + 8 /* hex crc */ + 1 /* \n */;
-            // Issue #291: enforce on-disk size cap before opening the
-            // append stream so a Drop policy never even creates the
-            // file when the cap is already exceeded by replay state.
-            if (_maxBytes > 0 && _currentSize + recordBytes > _maxBytes)
-            {
-                if (_onFull == WalSizeCapPolicy.Drop)
-                {
-                    Interlocked.Increment(ref _dropsOnFull);
-                    _logger.LogWarning(
-                        "WAL channel-{Channel}: size cap reached (current={Current}B, incoming={Incoming}B, max={Max}B); dropping record (onFull=drop)",
-                        _channelNumber, _currentSize, recordBytes, _maxBytes);
-                    return 0;
-                }
-                throw new WalSizeCapExceededException(_currentSize, _maxBytes, recordBytes);
-            }
-            _appendStream ??= new FileStream(_path,
-                FileMode.Append, FileAccess.Write, FileShare.Read);
-            uint crc = Crc32C.Compute(json);
-            Span<byte> crcBytes = stackalloc byte[8];
-            WriteHexUtf8(crc, crcBytes);
-            _appendStream.Write(json, 0, json.Length);
-            _appendStream.WriteByte(CrcSeparator);
-            _appendStream.Write(crcBytes);
-            _appendStream.WriteByte((byte)'\n');
-            if (_groupCommit)
-            {
-                // Push bytes to the OS so the background fsync thread
-                // (which doesn't take _writeLock) sees a consistent
-                // snapshot of the file contents. The disk-level sync
-                // is deferred to GroupCommitFsyncLoop.
-                _appendStream.Flush();
-                Interlocked.Exchange(ref _pendingSeq, record.Seq);
-                _fsyncSignal.Set();
-            }
-            else if (_fsyncPerWrite)
-            {
-                _appendStream.Flush(flushToDisk: true);
-                Interlocked.Exchange(ref _pendingSeq, record.Seq);
-                Interlocked.Exchange(ref _durableSeq, record.Seq);
-            }
-            else
-            {
-                _appendStream.Flush();
-                Interlocked.Exchange(ref _pendingSeq, record.Seq);
-            }
-            Interlocked.Add(ref _currentSize, recordBytes);
-            return recordBytes;
-        }
-    }
+    public int Append(WalRecord record) => _appender.Append(record);
 
     public void WaitForDurable(long seq, CancellationToken cancellationToken = default)
-    {
-        if (seq <= 0) return;
-        if (Interlocked.Read(ref _durableSeq) >= seq) return;
-        if (!_groupCommit)
-        {
-            // PerWrite / fire-and-forget Flush modes advance _durableSeq
-            // (or skip durability entirely) inside Append itself; if we
-            // haven't reached `seq` yet it never will via this WAL.
-            return;
-        }
-        // Nudge the bg thread in case the signal was missed (e.g. a
-        // caller blocked between Append and WaitForDurable while the
-        // bg thread was already sleeping).
-        _fsyncSignal.Set();
-        lock (_durabilityLock)
-        {
-            while (Interlocked.Read(ref _durableSeq) < seq)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                Monitor.Wait(_durabilityLock, _groupCommitInterval);
-            }
-        }
-    }
-
-    private void GroupCommitFsyncLoop()
-    {
-        var stopToken = _stopFsyncThread!.Token;
-        while (!stopToken.IsCancellationRequested)
-        {
-            try { _fsyncSignal.Wait(_groupCommitInterval, stopToken); }
-            catch (OperationCanceledException) { break; }
-            _fsyncSignal.Reset();
-            FsyncOnce();
-        }
-        // Final pass on shutdown so anything appended between the last
-        // signal and the cancellation request still hits the disk.
-        FsyncOnce();
-    }
-
-    private void FsyncOnce()
-    {
-        long pending;
-        lock (_writeLock)
-        {
-            if (_appendStream is null) return;
-            pending = Interlocked.Read(ref _pendingSeq);
-            if (pending <= Interlocked.Read(ref _durableSeq)) return;
-            try
-            {
-                _appendStream.Flush(flushToDisk: true);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "channel {ChannelNumber}: WAL background fsync failed; durable seq stays at {Durable}",
-                    _channelNumber, Interlocked.Read(ref _durableSeq));
-                return;
-            }
-        }
-        // Publish the new durability watermark and pulse waiters
-        // outside the write lock so an Append on the dispatch thread
-        // never contends with a wakeup.
-        lock (_durabilityLock)
-        {
-            // Use Math.Max because pending may have advanced again
-            // between our snapshot above and the lock acquisition; we
-            // only ever want to MOVE FORWARD here.
-            long current = Interlocked.Read(ref _durableSeq);
-            if (pending > current)
-            {
-                Interlocked.Exchange(ref _durableSeq, pending);
-            }
-            Monitor.PulseAll(_durabilityLock);
-        }
-    }
+        => _durability.WaitForDurable(seq, cancellationToken);
 
     public IReadOnlyList<WalRecord> ReadAll()
     {
-        LastReadCorruptCount = 0;
-        LastReadLegacyCount = 0;
-        if (!File.Exists(_path)) return Array.Empty<WalRecord>();
-        // Close any open append handle so reads see all flushed bytes
-        // and the read can re-open the file with shared access.
-        lock (_writeLock)
-        {
-            if (_appendStream is not null)
-            {
-                _appendStream.Flush(flushToDisk: true);
-                _appendStream.Dispose();
-                _appendStream = null;
-            }
-        }
-        var result = new List<WalRecord>();
-        // Buffer all physical lines first so we can distinguish a
-        // torn final write (tolerable) from mid-stream corruption
-        // (must halt). The legacy "skip and keep going" path was
-        // unsafe — see WalCorruptionException for the rationale.
-        List<string> rawLines;
+        _appender.CloseAppendStream();
+        var counters = new WalReplayCounters();
         try
         {
-            using var fs = new FileStream(_path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
-            using var reader = new StreamReader(fs, Encoding.UTF8);
-            rawLines = new List<string>();
-            string? line;
-            while ((line = reader.ReadLine()) is not null)
-            {
-                rawLines.Add(line);
-            }
+            var result = WalReplay.ReadAll(_appender.Path, _channelNumber, _logger, counters);
+            _lastReadCorruptCount = result.CorruptCount;
+            _lastReadLegacyCount = result.LegacyCount;
+            return result.Records;
         }
-        catch (Exception ex)
+        catch
         {
-            _logger.LogError(ex,
-                "channel {ChannelNumber}: failed to read WAL at {Path}; treating as empty",
-                _channelNumber, _path);
-            return Array.Empty<WalRecord>();
-        }
-
-        // Find the index of the LAST non-empty line — only that line
-        // is allowed to fail integrity (torn-tail tolerance). Lines
-        // beyond it must be empty (a partial trailing newline is fine).
-        int lastNonEmptyIdx = -1;
-        for (int i = rawLines.Count - 1; i >= 0; i--)
-        {
-            if (rawLines[i].Length > 0) { lastNonEmptyIdx = i; break; }
-        }
-
-        long? prevSeq = null;
-        for (int i = 0; i <= lastNonEmptyIdx; i++)
-        {
-            var line = rawLines[i];
-            int lineNumber = i + 1;
-            bool isLastNonEmpty = i == lastNonEmptyIdx;
-            if (line.Length == 0) continue;
-
-            int tab = line.LastIndexOf('\t');
-            if (tab >= 0 && line.Length - tab - 1 == 8)
-            {
-                // Modern format: JSON \t crc8 .
-                var crcHex = line.AsSpan(tab + 1, 8);
-                if (!TryParseHex32(crcHex, out uint storedCrc))
-                {
-                    // Suffix isn't a valid 8-hex CRC — treat as legacy
-                    // (no CRC) and fall through.
-                    if (!ConsumeLegacyLine(line, lineNumber, isLastNonEmpty, result, ref prevSeq))
-                        break;
-                    continue;
-                }
-                var jsonBytes = Encoding.UTF8.GetBytes(line[..tab]);
-                uint computedCrc = Crc32C.Compute(jsonBytes);
-                if (computedCrc != storedCrc)
-                {
-                    LastReadCorruptCount++;
-                    if (isLastNonEmpty)
-                    {
-                        // Torn final write — tolerate and stop.
-                        _logger.LogWarning(
-                            "channel {ChannelNumber}: WAL line {LineNumber} CRC mismatch on the FINAL record (stored=0x{StoredCrc:X8} computed=0x{ComputedCrc:X8}); treating as torn-tail and truncating replay here",
-                            _channelNumber, lineNumber, storedCrc, computedCrc);
-                        break;
-                    }
-                    // Mid-stream corruption — refuse to fabricate a
-                    // book state by skipping past the gap.
-                    var msg = $"channel {_channelNumber}: WAL line {lineNumber} CRC mismatch (stored=0x{storedCrc:X8} computed=0x{computedCrc:X8}) and a well-formed record exists after it; refusing to replay around mid-stream corruption";
-                    _logger.LogCritical("{Message}", msg);
-                    throw new WalCorruptionException(_channelNumber, lineNumber, msg);
-                }
-                WalRecord? rec;
-                try
-                {
-                    rec = JsonSerializer.Deserialize<WalRecord>(jsonBytes, JsonOptions);
-                }
-                catch (Exception ex)
-                {
-                    // CRC matched but JSON failed — the on-disk bytes
-                    // are coherent w.r.t. their checksum but the
-                    // schema is wrong (e.g. an enum value the loader
-                    // does not recognize). That is a persistent
-                    // corruption-equivalent condition, never a torn
-                    // write; halt regardless of position.
-                    LastReadCorruptCount++;
-                    var msg = $"channel {_channelNumber}: WAL line {lineNumber} JSON parse failed despite CRC match: {ex.Message}";
-                    _logger.LogCritical(ex, "{Message}", msg);
-                    throw new WalCorruptionException(_channelNumber, lineNumber, msg, ex);
-                }
-                if (rec is null)
-                {
-                    var msg = $"channel {_channelNumber}: WAL line {lineNumber} deserialized to null";
-                    _logger.LogCritical("{Message}", msg);
-                    throw new WalCorruptionException(_channelNumber, lineNumber, msg);
-                }
-                CheckSeqContiguity(rec.Seq, lineNumber, ref prevSeq);
-                result.Add(rec);
-            }
-            else
-            {
-                if (!ConsumeLegacyLine(line, lineNumber, isLastNonEmpty, result, ref prevSeq))
-                    break;
-            }
-        }
-        return result;
-    }
-
-    /// <summary>
-    /// Enforces strict monotonic-by-1 ordering on WAL record
-    /// sequences. A gap means we lost a write between the surviving
-    /// records — replaying the records on either side of the gap
-    /// applies state transitions out of order, so we treat any
-    /// non-contiguous seq as mid-stream corruption.
-    /// </summary>
-    private void CheckSeqContiguity(long currentSeq, int lineNumber, ref long? prevSeq)
-    {
-        if (prevSeq.HasValue && currentSeq != prevSeq.Value + 1)
-        {
-            var msg = $"channel {_channelNumber}: WAL line {lineNumber} seq={currentSeq} is not contiguous after seq={prevSeq.Value}; refusing to replay around the gap";
-            _logger.LogCritical("{Message}", msg);
-            throw new WalCorruptionException(_channelNumber, lineNumber, msg);
-        }
-        prevSeq = currentSeq;
-    }
-
-    /// <summary>
-    /// Handles a line written by a pre-#285 host (no <c>\t</c>+CRC
-    /// suffix). Returns <c>false</c> to signal the caller to stop
-    /// further line processing — preserving the original "torn-final
-    /// stops replay" behavior for legacy files when the failure is on
-    /// the final line. A parse failure on a NON-final legacy line is
-    /// promoted to a <see cref="WalCorruptionException"/> for the
-    /// same reason mid-stream modern corruption is fatal: skipping
-    /// past it would replay state transitions out of order.
-    /// </summary>
-    private bool ConsumeLegacyLine(string line, int lineNumber, bool isLastNonEmpty, List<WalRecord> result, ref long? prevSeq)
-    {
-        WalRecord? rec;
-        try
-        {
-            rec = JsonSerializer.Deserialize<WalRecord>(line, JsonOptions);
-        }
-        catch (Exception ex)
-        {
-            if (isLastNonEmpty)
-            {
-                _logger.LogWarning(ex,
-                    "channel {ChannelNumber}: legacy WAL line {LineNumber} failed to parse on the FINAL record; treating as torn-tail and truncating replay here",
-                    _channelNumber, lineNumber);
-                return false;
-            }
-            var msg = $"channel {_channelNumber}: legacy WAL line {lineNumber} failed to parse and a well-formed record exists after it; refusing to replay around mid-stream corruption";
-            _logger.LogCritical(ex, "{Message}", msg);
-            throw new WalCorruptionException(_channelNumber, lineNumber, msg, ex);
-        }
-        if (rec is null)
-        {
-            if (isLastNonEmpty) return false;
-            var msg = $"channel {_channelNumber}: legacy WAL line {lineNumber} deserialized to null mid-stream";
-            _logger.LogCritical("{Message}", msg);
-            throw new WalCorruptionException(_channelNumber, lineNumber, msg);
-        }
-        CheckSeqContiguity(rec.Seq, lineNumber, ref prevSeq);
-        result.Add(rec);
-        LastReadLegacyCount++;
-        return true;
-    }
-
-    private static void WriteHexUtf8(uint value, Span<byte> dst)
-    {
-        // dst is exactly 8 bytes; write big-endian-nibble hex digits.
-        const string Hex = "0123456789ABCDEF";
-        for (int i = 7; i >= 0; i--)
-        {
-            dst[i] = (byte)Hex[(int)(value & 0xF)];
-            value >>= 4;
-        }
-    }
-
-    private static bool TryParseHex32(ReadOnlySpan<char> chars, out uint value)
-    {
-        value = 0;
-        if (chars.Length != 8) return false;
-        for (int i = 0; i < 8; i++)
-        {
-            int d = HexDigit(chars[i]);
-            if (d < 0) return false;
-            value = (value << 4) | (uint)d;
-        }
-        return true;
-
-        static int HexDigit(char c) => c switch
-        {
-            >= '0' and <= '9' => c - '0',
-            >= 'a' and <= 'f' => c - 'a' + 10,
-            >= 'A' and <= 'F' => c - 'A' + 10,
-            _ => -1,
-        };
-    }
-
-    public void Truncate()
-    {
-        lock (_writeLock)
-        {
-            TruncateLocked();
-        }
-    }
-
-    private void TruncateLocked()
-    {
-        if (_appendStream is not null)
-        {
-            _appendStream.Dispose();
-            _appendStream = null;
-        }
-        // Atomic truncate: write empty file to tmp, rename over.
-        var tmp = System.IO.Path.Combine(_dataDir,
-            string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
-        try
-        {
-            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
-            {
-                fs.Flush(flushToDisk: true);
-            }
-            File.Move(tmp, _path, overwrite: true);
-            FsyncDirectory(_dataDir);
-            Interlocked.Exchange(ref _currentSize, 0);
-            // Issue #312: every previously-appended record is now
-            // either durable (it was fsynced into the old file
-            // before snapshot persist asked us to truncate) or
-            // intentionally discarded — either way it can't be
-            // replayed any more, so it counts as "durable" for
-            // any caller still waiting on its seq. Advancing
-            // _durableSeq here unblocks them instead of letting
-            // them spin until the fsync thread notices the empty
-            // file.
-            AdvanceDurableSeqOnTruncate();
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex,
-                "channel {ChannelNumber}: failed to truncate WAL at {Path}",
-                _channelNumber, _path);
-            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
+            _lastReadCorruptCount = counters.CorruptCount;
+            _lastReadLegacyCount = counters.LegacyCount;
             throw;
         }
     }
+
+    public void Truncate() => _appender.Truncate();
 
     /// <summary>
     /// Issue #348: atomic prefix truncate — drops every record with
@@ -651,170 +238,14 @@ public sealed class FileChannelWriteAheadLog : IChannelWriteAheadLog, IDisposabl
     /// <c>onSaved</c> callback firing; a full <see cref="Truncate"/>
     /// in that window would silently drop the tail and a subsequent
     /// crash would lose it.
-    ///
-    /// <para>Implementation: under <c>_writeLock</c>, reads the
-    /// surviving tail via <see cref="ReadAll"/>, writes a fresh tmp
-    /// file containing only the kept records, atomically renames
-    /// over the live WAL, fsyncs the directory. Equivalent to
-    /// <see cref="Truncate"/> when no records survive (kept=0); a
-    /// no-op when every record is above the cutoff.</para>
     /// </summary>
-    public void TruncateThrough(long throughSeq)
-    {
-        lock (_writeLock)
-        {
-            // Snapshot the surviving tail BEFORE we touch the file —
-            // ReadAll opens its own FileStream with FileShare.Read, so
-            // this is safe even while _appendStream is still open. We
-            // close _appendStream below so the rename can succeed on
-            // Windows (Move-with-overwrite refuses an open file).
-            var all = ReadAll();
-            var kept = new List<WalRecord>(all.Count);
-            foreach (var rec in all)
-            {
-                if (rec.Seq > throughSeq) kept.Add(rec);
-            }
-            if (kept.Count == all.Count)
-            {
-                // Cutoff is below every record on disk → nothing to do.
-                return;
-            }
-            if (kept.Count == 0)
-            {
-                // Equivalent to a full truncate.
-                TruncateLocked();
-                return;
-            }
-            if (_appendStream is not null)
-            {
-                _appendStream.Dispose();
-                _appendStream = null;
-            }
-            var tmp = System.IO.Path.Combine(_dataDir,
-                string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
-            try
-            {
-                long newSize = 0;
-                Span<byte> crcBytes = stackalloc byte[8];
-                using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
-                {
-                    foreach (var rec in kept)
-                    {
-                        var json = JsonSerializer.SerializeToUtf8Bytes(rec, WalJsonContext.Default.WalRecord);
-                        uint crc = Crc32C.Compute(json);
-                        WriteHexUtf8(crc, crcBytes);
-                        fs.Write(json, 0, json.Length);
-                        fs.WriteByte(CrcSeparator);
-                        fs.Write(crcBytes);
-                        fs.WriteByte((byte)'\n');
-                        newSize += json.Length + 1 + 8 + 1;
-                    }
-                    fs.Flush(flushToDisk: true);
-                }
-                File.Move(tmp, _path, overwrite: true);
-                FsyncDirectory(_dataDir);
-                Interlocked.Exchange(ref _currentSize, newSize);
-                // The kept tail records were already durable before
-                // this call (they were fsynced on Append), so the
-                // post-rewrite durable seq is the highest seq in the
-                // surviving tail — which is also _pendingSeq's value
-                // (or higher) for any caller still parked.
-                AdvanceDurableSeqOnTruncate();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "channel {ChannelNumber}: failed to prefix-truncate WAL at {Path} (throughSeq={ThroughSeq}, kept={Kept})",
-                    _channelNumber, _path, throughSeq, kept.Count);
-                try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
-                throw;
-            }
-        }
-    }
+    public void TruncateThrough(long throughSeq) => _appender.TruncateThrough(throughSeq);
 
-    public void Reset()
-    {
-        lock (_writeLock)
-        {
-            if (_appendStream is not null)
-            {
-                _appendStream.Dispose();
-                _appendStream = null;
-            }
-            try
-            {
-                if (File.Exists(_path)) File.Delete(_path);
-                var tmp = System.IO.Path.Combine(_dataDir,
-                    string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
-                if (File.Exists(tmp)) File.Delete(tmp);
-                FsyncDirectory(_dataDir);
-                Interlocked.Exchange(ref _currentSize, 0);
-                _logger.LogInformation(
-                    "channel {ChannelNumber}: admin Reset removed WAL at {Path}",
-                    _channelNumber, _path);
-                AdvanceDurableSeqOnTruncate();
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "channel {ChannelNumber}: failed to reset WAL at {Path}",
-                    _channelNumber, _path);
-                throw;
-            }
-        }
-    }
+    public void Reset() => _appender.Reset();
 
     public void Dispose()
     {
-        // Issue #312: stop the bg fsync thread before tearing down the
-        // append stream so its final flush sees a live FileStream.
-        // Order matters: cancel + signal + join, then dispose stream.
-        if (_groupCommit && _stopFsyncThread is not null && _fsyncThread is not null)
-        {
-            try { _stopFsyncThread.Cancel(); } catch { /* ignore */ }
-            _fsyncSignal.Set();
-            try { _fsyncThread.Join(TimeSpan.FromSeconds(5)); } catch { /* ignore */ }
-            _stopFsyncThread.Dispose();
-        }
-        _fsyncSignal.Dispose();
-        lock (_writeLock)
-        {
-            _appendStream?.Dispose();
-            _appendStream = null;
-        }
-        // Anyone still parked in WaitForDurable on a disposed log
-        // should bail; pulse the monitor so the loop wakes and re-checks
-        // (cancellation token is the contractual exit, but disposing
-        // the WAL while someone waits is undefined and we'd rather
-        // unblock than deadlock).
-        lock (_durabilityLock)
-        {
-            Monitor.PulseAll(_durabilityLock);
-        }
-    }
-
-    private void AdvanceDurableSeqOnTruncate()
-    {
-        long pending = Interlocked.Read(ref _pendingSeq);
-        long durable = Interlocked.Read(ref _durableSeq);
-        if (pending > durable)
-        {
-            Interlocked.Exchange(ref _durableSeq, pending);
-            lock (_durabilityLock) Monitor.PulseAll(_durabilityLock);
-        }
-    }
-
-    private static void FsyncDirectory(string dir)
-    {
-        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
-        try
-        {
-            using var dirHandle = File.OpenHandle(dir, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, FileOptions.None);
-            RandomAccess.FlushToDisk(dirHandle);
-        }
-        catch
-        {
-            // Best-effort.
-        }
+        _durability.Dispose();
+        _appender.Dispose();
     }
 }

--- a/src/B3.Exchange.Persistence/WalAppender.cs
+++ b/src/B3.Exchange.Persistence/WalAppender.cs
@@ -1,0 +1,310 @@
+using System.Globalization;
+using System.Text.Json;
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Persistence;
+
+/// <summary>
+/// Owns the WAL file's append stream + write lock and implements
+/// append / truncate / reset. Extracted from
+/// <see cref="FileChannelWriteAheadLog"/>; threading and on-disk
+/// semantics are unchanged.
+/// </summary>
+internal sealed class WalAppender : IDisposable
+{
+    private const string WalTempFileNameFormat = "channel-{0}.wal.tmp";
+    private const byte CrcSeparator = (byte)'\t';
+
+    private readonly string _path;
+    private readonly string _dataDir;
+    private readonly byte _channelNumber;
+    private readonly bool _fsyncPerWrite;
+    private readonly long _maxBytes;
+    private readonly WalSizeCapPolicy _onFull;
+    private readonly ILogger _logger;
+    private readonly object _writeLock = new();
+    private FileStream? _appendStream;
+    private long _currentSize;
+    private long _dropsOnFull;
+    private WalDurabilityCoordinator? _durability;
+
+    public WalAppender(
+        string path,
+        string dataDir,
+        byte channelNumber,
+        bool fsyncPerWrite,
+        long maxBytes,
+        WalSizeCapPolicy onFull,
+        long initialSize,
+        ILogger logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(dataDir);
+        ArgumentNullException.ThrowIfNull(logger);
+        _path = path;
+        _dataDir = dataDir;
+        _channelNumber = channelNumber;
+        _fsyncPerWrite = fsyncPerWrite;
+        _maxBytes = maxBytes > 0 ? maxBytes : 0;
+        _onFull = onFull;
+        _logger = logger;
+        _currentSize = initialSize > 0 ? initialSize : 0;
+    }
+
+    public string Path => _path;
+    public long CurrentSize => Interlocked.Read(ref _currentSize);
+    public long DropsOnFull => Interlocked.Read(ref _dropsOnFull);
+
+    public void AttachDurability(WalDurabilityCoordinator coordinator)
+    {
+        ArgumentNullException.ThrowIfNull(coordinator);
+        _durability = coordinator;
+    }
+
+    public int Append(WalRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        lock (_writeLock)
+        {
+            var json = JsonSerializer.SerializeToUtf8Bytes(record, WalJsonContext.Default.WalRecord);
+            int recordBytes = json.Length + 1 /* \t */ + 8 /* hex crc */ + 1 /* \n */;
+            if (_maxBytes > 0 && _currentSize + recordBytes > _maxBytes)
+            {
+                if (_onFull == WalSizeCapPolicy.Drop)
+                {
+                    Interlocked.Increment(ref _dropsOnFull);
+                    _logger.LogWarning(
+                        "WAL channel-{Channel}: size cap reached (current={Current}B, incoming={Incoming}B, max={Max}B); dropping record (onFull=drop)",
+                        _channelNumber, _currentSize, recordBytes, _maxBytes);
+                    return 0;
+                }
+                throw new WalSizeCapExceededException(_currentSize, _maxBytes, recordBytes);
+            }
+            _appendStream ??= new FileStream(_path,
+                FileMode.Append, FileAccess.Write, FileShare.Read);
+            uint crc = Crc32C.Compute(json);
+            Span<byte> crcBytes = stackalloc byte[8];
+            WriteHexUtf8(crc, crcBytes);
+            _appendStream.Write(json, 0, json.Length);
+            _appendStream.WriteByte(CrcSeparator);
+            _appendStream.Write(crcBytes);
+            _appendStream.WriteByte((byte)'\n');
+            if (_fsyncPerWrite)
+            {
+                _appendStream.Flush(flushToDisk: true);
+                _durability!.RecordPendingAndDurable(record.Seq);
+            }
+            else
+            {
+                _appendStream.Flush();
+                _durability!.RecordPending(record.Seq);
+            }
+            Interlocked.Add(ref _currentSize, recordBytes);
+            return recordBytes;
+        }
+    }
+
+    public long FsyncToDisk()
+    {
+        lock (_writeLock)
+        {
+            if (_appendStream is null) return 0;
+            long pending = _durability!.PendingSeq;
+            if (pending <= _durability.DurableSeq) return 0;
+            try
+            {
+                _appendStream.Flush(flushToDisk: true);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: WAL background fsync failed; durable seq stays at {Durable}",
+                    _channelNumber, _durability.DurableSeq);
+                return 0;
+            }
+            return pending;
+        }
+    }
+
+    public void CloseAppendStream()
+    {
+        lock (_writeLock)
+        {
+            if (_appendStream is not null)
+            {
+                _appendStream.Flush(flushToDisk: true);
+                _appendStream.Dispose();
+                _appendStream = null;
+            }
+        }
+    }
+
+    public void Truncate()
+    {
+        lock (_writeLock)
+        {
+            TruncateLocked();
+        }
+    }
+
+    public void TruncateThrough(long throughSeq)
+    {
+        lock (_writeLock)
+        {
+            // Close the append stream BEFORE reading so reads see all
+            // flushed bytes and the rename below can succeed on Windows.
+            if (_appendStream is not null)
+            {
+                _appendStream.Flush(flushToDisk: true);
+                _appendStream.Dispose();
+                _appendStream = null;
+            }
+            var replay = WalReplay.ReadAll(_path, _channelNumber, _logger);
+            var all = replay.Records;
+            var kept = new List<WalRecord>(all.Count);
+            foreach (var rec in all)
+            {
+                if (rec.Seq > throughSeq) kept.Add(rec);
+            }
+            if (kept.Count == all.Count)
+            {
+                return;
+            }
+            if (kept.Count == 0)
+            {
+                TruncateLocked();
+                return;
+            }
+            var tmp = System.IO.Path.Combine(_dataDir,
+                string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
+            try
+            {
+                long newSize = 0;
+                Span<byte> crcBytes = stackalloc byte[8];
+                using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+                {
+                    foreach (var rec in kept)
+                    {
+                        var json = JsonSerializer.SerializeToUtf8Bytes(rec, WalJsonContext.Default.WalRecord);
+                        uint crc = Crc32C.Compute(json);
+                        WriteHexUtf8(crc, crcBytes);
+                        fs.Write(json, 0, json.Length);
+                        fs.WriteByte(CrcSeparator);
+                        fs.Write(crcBytes);
+                        fs.WriteByte((byte)'\n');
+                        newSize += json.Length + 1 + 8 + 1;
+                    }
+                    fs.Flush(flushToDisk: true);
+                }
+                File.Move(tmp, _path, overwrite: true);
+                FsyncDirectory(_dataDir);
+                Interlocked.Exchange(ref _currentSize, newSize);
+                _durability!.AdvanceDurableSeqOnTruncate();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: failed to prefix-truncate WAL at {Path} (throughSeq={ThroughSeq}, kept={Kept})",
+                    _channelNumber, _path, throughSeq, kept.Count);
+                try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
+                throw;
+            }
+        }
+    }
+
+    public void Reset()
+    {
+        lock (_writeLock)
+        {
+            if (_appendStream is not null)
+            {
+                _appendStream.Dispose();
+                _appendStream = null;
+            }
+            try
+            {
+                if (File.Exists(_path)) File.Delete(_path);
+                var tmp = System.IO.Path.Combine(_dataDir,
+                    string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
+                if (File.Exists(tmp)) File.Delete(tmp);
+                FsyncDirectory(_dataDir);
+                Interlocked.Exchange(ref _currentSize, 0);
+                _logger.LogInformation(
+                    "channel {ChannelNumber}: admin Reset removed WAL at {Path}",
+                    _channelNumber, _path);
+                _durability!.AdvanceDurableSeqOnTruncate();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "channel {ChannelNumber}: failed to reset WAL at {Path}",
+                    _channelNumber, _path);
+                throw;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_writeLock)
+        {
+            _appendStream?.Dispose();
+            _appendStream = null;
+        }
+    }
+
+    private void TruncateLocked()
+    {
+        if (_appendStream is not null)
+        {
+            _appendStream.Dispose();
+            _appendStream = null;
+        }
+        var tmp = System.IO.Path.Combine(_dataDir,
+            string.Format(CultureInfo.InvariantCulture, WalTempFileNameFormat, _channelNumber));
+        try
+        {
+            using (var fs = new FileStream(tmp, FileMode.Create, FileAccess.Write, FileShare.None))
+            {
+                fs.Flush(flushToDisk: true);
+            }
+            File.Move(tmp, _path, overwrite: true);
+            FsyncDirectory(_dataDir);
+            Interlocked.Exchange(ref _currentSize, 0);
+            _durability!.AdvanceDurableSeqOnTruncate();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: failed to truncate WAL at {Path}",
+                _channelNumber, _path);
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* ignore */ }
+            throw;
+        }
+    }
+
+    private static void WriteHexUtf8(uint value, Span<byte> dst)
+    {
+        const string Hex = "0123456789ABCDEF";
+        for (int i = 7; i >= 0; i--)
+        {
+            dst[i] = (byte)Hex[(int)(value & 0xF)];
+            value >>= 4;
+        }
+    }
+
+    private static void FsyncDirectory(string dir)
+    {
+        if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS()) return;
+        try
+        {
+            using var dirHandle = File.OpenHandle(dir, FileMode.Open, FileAccess.Read, FileShare.ReadWrite, FileOptions.None);
+            RandomAccess.FlushToDisk(dirHandle);
+        }
+        catch
+        {
+            // Best-effort.
+        }
+    }
+}

--- a/src/B3.Exchange.Persistence/WalDurabilityCoordinator.cs
+++ b/src/B3.Exchange.Persistence/WalDurabilityCoordinator.cs
@@ -1,0 +1,147 @@
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Persistence;
+
+/// <summary>
+/// Tracks pending / durable seq watermarks and owns the optional
+/// background fsync thread used in
+/// <see cref="WalFsyncMode.GroupCommit"/> mode. Extracted from
+/// <see cref="FileChannelWriteAheadLog"/>; semantics are
+/// unchanged.
+/// </summary>
+internal sealed class WalDurabilityCoordinator : IDisposable
+{
+    private readonly bool _groupCommit;
+    private readonly TimeSpan _groupCommitInterval;
+    private readonly Func<long> _fsyncCallback;
+    private readonly object _durabilityLock = new();
+    private readonly ManualResetEventSlim _fsyncSignal;
+    private readonly CancellationTokenSource? _stopFsyncThread;
+    private readonly Thread? _fsyncThread;
+    private long _pendingSeq;
+    private long _durableSeq;
+
+    public WalDurabilityCoordinator(
+        byte channelNumber,
+        bool groupCommit,
+        TimeSpan groupCommitInterval,
+        Func<long> fsyncCallback,
+        ILogger logger)
+    {
+        ArgumentNullException.ThrowIfNull(fsyncCallback);
+        ArgumentNullException.ThrowIfNull(logger);
+        _groupCommit = groupCommit;
+        _groupCommitInterval = groupCommit
+            ? (groupCommitInterval > TimeSpan.Zero ? groupCommitInterval : TimeSpan.FromMilliseconds(1))
+            : TimeSpan.Zero;
+        _fsyncCallback = fsyncCallback;
+        _fsyncSignal = new ManualResetEventSlim(initialState: false);
+        if (_groupCommit)
+        {
+            _stopFsyncThread = new CancellationTokenSource();
+            _fsyncThread = new Thread(GroupCommitFsyncLoop)
+            {
+                IsBackground = true,
+                Name = $"wal-fsync-ch{channelNumber}",
+            };
+            _fsyncThread.Start();
+        }
+    }
+
+    public long PendingSeq => Interlocked.Read(ref _pendingSeq);
+    public long DurableSeq => Interlocked.Read(ref _durableSeq);
+
+    public void RecordPending(long seq)
+    {
+        Interlocked.Exchange(ref _pendingSeq, seq);
+        if (_groupCommit)
+        {
+            _fsyncSignal.Set();
+        }
+    }
+
+    public void RecordPendingAndDurable(long seq)
+    {
+        Interlocked.Exchange(ref _pendingSeq, seq);
+        Interlocked.Exchange(ref _durableSeq, seq);
+    }
+
+    public void WaitForDurable(long seq, CancellationToken cancellationToken = default)
+    {
+        if (seq <= 0) return;
+        if (Interlocked.Read(ref _durableSeq) >= seq) return;
+        if (!_groupCommit)
+        {
+            return;
+        }
+        _fsyncSignal.Set();
+        lock (_durabilityLock)
+        {
+            while (Interlocked.Read(ref _durableSeq) < seq)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                Monitor.Wait(_durabilityLock, _groupCommitInterval);
+            }
+        }
+    }
+
+    public void AdvanceDurableSeqOnTruncate()
+    {
+        long pending = Interlocked.Read(ref _pendingSeq);
+        long durable = Interlocked.Read(ref _durableSeq);
+        if (pending > durable)
+        {
+            Interlocked.Exchange(ref _durableSeq, pending);
+            lock (_durabilityLock) Monitor.PulseAll(_durabilityLock);
+        }
+    }
+
+    public void PulseShutdown()
+    {
+        lock (_durabilityLock)
+        {
+            Monitor.PulseAll(_durabilityLock);
+        }
+    }
+
+    private void GroupCommitFsyncLoop()
+    {
+        var stopToken = _stopFsyncThread!.Token;
+        while (!stopToken.IsCancellationRequested)
+        {
+            try { _fsyncSignal.Wait(_groupCommitInterval, stopToken); }
+            catch (OperationCanceledException) { break; }
+            _fsyncSignal.Reset();
+            FsyncOnce();
+        }
+        FsyncOnce();
+    }
+
+    private void FsyncOnce()
+    {
+        long pending = _fsyncCallback();
+        if (pending <= 0) return;
+        lock (_durabilityLock)
+        {
+            long current = Interlocked.Read(ref _durableSeq);
+            if (pending > current)
+            {
+                Interlocked.Exchange(ref _durableSeq, pending);
+            }
+            Monitor.PulseAll(_durabilityLock);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_groupCommit && _stopFsyncThread is not null && _fsyncThread is not null)
+        {
+            try { _stopFsyncThread.Cancel(); } catch { /* ignore */ }
+            _fsyncSignal.Set();
+            try { _fsyncThread.Join(TimeSpan.FromSeconds(5)); } catch { /* ignore */ }
+            _stopFsyncThread.Dispose();
+        }
+        _fsyncSignal.Dispose();
+        PulseShutdown();
+    }
+}

--- a/src/B3.Exchange.Persistence/WalReplay.cs
+++ b/src/B3.Exchange.Persistence/WalReplay.cs
@@ -1,0 +1,219 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Persistence;
+
+internal readonly record struct WalReplayResult(
+    IReadOnlyList<WalRecord> Records,
+    int CorruptCount,
+    int LegacyCount);
+
+/// <summary>
+/// Mutable counter holder so callers observe partial counts even
+/// when <see cref="WalReplay.ReadAll"/> throws — preserving the
+/// pre-refactor behaviour where <c>LastReadCorruptCount</c> was
+/// incremented inline before raising
+/// <see cref="WalCorruptionException"/>.
+/// </summary>
+internal sealed class WalReplayCounters
+{
+    public int CorruptCount;
+    public int LegacyCount;
+}
+
+/// <summary>
+/// Pure-function WAL reader extracted from
+/// <see cref="FileChannelWriteAheadLog"/>. Parses the JSON-Lines +
+/// per-record Crc32C framing, distinguishes torn-final writes
+/// (tolerated, return the prefix) from mid-stream corruption
+/// (throws <see cref="WalCorruptionException"/>), and counts legacy
+/// records (pre-#285 lines without a CRC suffix).
+/// </summary>
+internal static class WalReplay
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters =
+        {
+            new JsonStringEnumConverter(),
+        },
+    };
+
+    public static WalReplayResult ReadAll(string path, byte channelNumber, ILogger logger, WalReplayCounters? counters = null)
+    {
+        counters ??= new WalReplayCounters();
+        counters.CorruptCount = 0;
+        counters.LegacyCount = 0;
+        if (!File.Exists(path))
+        {
+            return new WalReplayResult(Array.Empty<WalRecord>(), 0, 0);
+        }
+        var result = new List<WalRecord>();
+        List<string> rawLines;
+        try
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs, Encoding.UTF8);
+            rawLines = new List<string>();
+            string? line;
+            while ((line = reader.ReadLine()) is not null)
+            {
+                rawLines.Add(line);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "channel {ChannelNumber}: failed to read WAL at {Path}; treating as empty",
+                channelNumber, path);
+            return new WalReplayResult(Array.Empty<WalRecord>(), 0, 0);
+        }
+
+        int lastNonEmptyIdx = -1;
+        for (int i = rawLines.Count - 1; i >= 0; i--)
+        {
+            if (rawLines[i].Length > 0) { lastNonEmptyIdx = i; break; }
+        }
+
+        long? prevSeq = null;
+        for (int i = 0; i <= lastNonEmptyIdx; i++)
+        {
+            var line = rawLines[i];
+            int lineNumber = i + 1;
+            bool isLastNonEmpty = i == lastNonEmptyIdx;
+            if (line.Length == 0) continue;
+
+            int tab = line.LastIndexOf('\t');
+            if (tab >= 0 && line.Length - tab - 1 == 8)
+            {
+                var crcHex = line.AsSpan(tab + 1, 8);
+                if (!TryParseHex32(crcHex, out uint storedCrc))
+                {
+                    if (!ConsumeLegacyLine(line, lineNumber, isLastNonEmpty, channelNumber, logger, result, ref prevSeq, counters))
+                        break;
+                    continue;
+                }
+                var jsonBytes = Encoding.UTF8.GetBytes(line[..tab]);
+                uint computedCrc = Crc32C.Compute(jsonBytes);
+                if (computedCrc != storedCrc)
+                {
+                    counters.CorruptCount++;
+                    if (isLastNonEmpty)
+                    {
+                        logger.LogWarning(
+                            "channel {ChannelNumber}: WAL line {LineNumber} CRC mismatch on the FINAL record (stored=0x{StoredCrc:X8} computed=0x{ComputedCrc:X8}); treating as torn-tail and truncating replay here",
+                            channelNumber, lineNumber, storedCrc, computedCrc);
+                        break;
+                    }
+                    var msg = $"channel {channelNumber}: WAL line {lineNumber} CRC mismatch (stored=0x{storedCrc:X8} computed=0x{computedCrc:X8}) and a well-formed record exists after it; refusing to replay around mid-stream corruption";
+                    logger.LogCritical("{Message}", msg);
+                    throw new WalCorruptionException(channelNumber, lineNumber, msg);
+                }
+                WalRecord? rec;
+                try
+                {
+                    rec = JsonSerializer.Deserialize<WalRecord>(jsonBytes, JsonOptions);
+                }
+                catch (Exception ex)
+                {
+                    counters.CorruptCount++;
+                    var msg = $"channel {channelNumber}: WAL line {lineNumber} JSON parse failed despite CRC match: {ex.Message}";
+                    logger.LogCritical(ex, "{Message}", msg);
+                    throw new WalCorruptionException(channelNumber, lineNumber, msg, ex);
+                }
+                if (rec is null)
+                {
+                    var msg = $"channel {channelNumber}: WAL line {lineNumber} deserialized to null";
+                    logger.LogCritical("{Message}", msg);
+                    throw new WalCorruptionException(channelNumber, lineNumber, msg);
+                }
+                CheckSeqContiguity(rec.Seq, lineNumber, channelNumber, logger, ref prevSeq);
+                result.Add(rec);
+            }
+            else
+            {
+                if (!ConsumeLegacyLine(line, lineNumber, isLastNonEmpty, channelNumber, logger, result, ref prevSeq, counters))
+                    break;
+            }
+        }
+        return new WalReplayResult(result, counters.CorruptCount, counters.LegacyCount);
+    }
+
+    private static void CheckSeqContiguity(long currentSeq, int lineNumber, byte channelNumber, ILogger logger, ref long? prevSeq)
+    {
+        if (prevSeq.HasValue && currentSeq != prevSeq.Value + 1)
+        {
+            var msg = $"channel {channelNumber}: WAL line {lineNumber} seq={currentSeq} is not contiguous after seq={prevSeq.Value}; refusing to replay around the gap";
+            logger.LogCritical("{Message}", msg);
+            throw new WalCorruptionException(channelNumber, lineNumber, msg);
+        }
+        prevSeq = currentSeq;
+    }
+
+    private static bool ConsumeLegacyLine(
+        string line,
+        int lineNumber,
+        bool isLastNonEmpty,
+        byte channelNumber,
+        ILogger logger,
+        List<WalRecord> result,
+        ref long? prevSeq,
+        WalReplayCounters counters)
+    {
+        WalRecord? rec;
+        try
+        {
+            rec = JsonSerializer.Deserialize<WalRecord>(line, JsonOptions);
+        }
+        catch (Exception ex)
+        {
+            if (isLastNonEmpty)
+            {
+                logger.LogWarning(ex,
+                    "channel {ChannelNumber}: legacy WAL line {LineNumber} failed to parse on the FINAL record; treating as torn-tail and truncating replay here",
+                    channelNumber, lineNumber);
+                return false;
+            }
+            var msg = $"channel {channelNumber}: legacy WAL line {lineNumber} failed to parse and a well-formed record exists after it; refusing to replay around mid-stream corruption";
+            logger.LogCritical(ex, "{Message}", msg);
+            throw new WalCorruptionException(channelNumber, lineNumber, msg, ex);
+        }
+        if (rec is null)
+        {
+            if (isLastNonEmpty) return false;
+            var msg = $"channel {channelNumber}: legacy WAL line {lineNumber} deserialized to null mid-stream";
+            logger.LogCritical("{Message}", msg);
+            throw new WalCorruptionException(channelNumber, lineNumber, msg);
+        }
+        CheckSeqContiguity(rec.Seq, lineNumber, channelNumber, logger, ref prevSeq);
+        result.Add(rec);
+        counters.LegacyCount++;
+        return true;
+    }
+
+    private static bool TryParseHex32(ReadOnlySpan<char> chars, out uint value)
+    {
+        value = 0;
+        if (chars.Length != 8) return false;
+        for (int i = 0; i < 8; i++)
+        {
+            int d = HexDigit(chars[i]);
+            if (d < 0) return false;
+            value = (value << 4) | (uint)d;
+        }
+        return true;
+
+        static int HexDigit(char c) => c switch
+        {
+            >= '0' and <= '9' => c - '0',
+            >= 'a' and <= 'f' => c - 'a' + 10,
+            >= 'A' and <= 'F' => c - 'A' + 10,
+            _ => -1,
+        };
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalAppenderTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAppenderTests.cs
@@ -1,0 +1,159 @@
+using B3.Exchange.Core;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+public sealed class WalAppenderTests
+{
+    private static string NewTempDir() => Directory.CreateTempSubdirectory("wal-app-").FullName;
+
+    private static WalRecord NewRecord(long seq)
+        => new(
+            seq,
+            WalRecordKind.NewOrder,
+            SessionValue: "S",
+            Firm: 1u,
+            ClOrdId: (ulong)seq,
+            OrigClOrdId: 0,
+            NewOrder: null,
+            Cancel: null,
+            Replace: null);
+
+    private static (WalAppender appender, WalDurabilityCoordinator coord, string path) MakeAppender(
+        string dir,
+        byte channel = 1,
+        bool fsyncPerWrite = false,
+        long maxBytes = 0,
+        WalSizeCapPolicy onFull = WalSizeCapPolicy.Halt)
+    {
+        var path = Path.Combine(dir, $"channel-{channel}.wal");
+        var coord = new WalDurabilityCoordinator(
+            channel, groupCommit: false, TimeSpan.Zero, () => 0, NullLogger.Instance);
+        var appender = new WalAppender(
+            path, dir, channel, fsyncPerWrite, maxBytes, onFull, initialSize: 0, NullLogger.Instance);
+        appender.AttachDurability(coord);
+        return (appender, coord, path);
+    }
+
+    [Fact]
+    public void Append_writes_framed_records_on_disk()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, path) = MakeAppender(dir);
+        using (appender) using (coord)
+        {
+            appender.Append(NewRecord(1));
+            appender.Append(NewRecord(2));
+            appender.Append(NewRecord(3));
+            appender.CloseAppendStream();
+        }
+
+        var lines = File.ReadAllLines(path);
+        Assert.Equal(3, lines.Length);
+        foreach (var line in lines)
+        {
+            int tab = line.LastIndexOf('\t');
+            Assert.True(tab > 0, "missing tab separator");
+            Assert.Equal(8, line.Length - tab - 1);
+        }
+    }
+
+    [Fact]
+    public void Append_throws_on_size_cap_halt()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, _) = MakeAppender(dir, maxBytes: 64, onFull: WalSizeCapPolicy.Halt);
+        using (appender) using (coord)
+        {
+            // First write fits; second should exceed and throw.
+            Assert.Throws<WalSizeCapExceededException>(() =>
+            {
+                for (int i = 1; i < 100; i++) appender.Append(NewRecord(i));
+            });
+        }
+    }
+
+    [Fact]
+    public void Append_drops_silently_on_size_cap_drop()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, _) = MakeAppender(dir, maxBytes: 64, onFull: WalSizeCapPolicy.Drop);
+        using (appender) using (coord)
+        {
+            for (int i = 1; i < 50; i++) appender.Append(NewRecord(i));
+            Assert.True(appender.DropsOnFull > 0);
+        }
+    }
+
+    [Fact]
+    public void Truncate_empties_file_and_resets_size()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, path) = MakeAppender(dir);
+        using (appender) using (coord)
+        {
+            appender.Append(NewRecord(1));
+            appender.Append(NewRecord(2));
+            Assert.True(appender.CurrentSize > 0);
+
+            appender.Truncate();
+
+            Assert.Equal(0, appender.CurrentSize);
+            Assert.Equal(0, new FileInfo(path).Length);
+        }
+    }
+
+    [Fact]
+    public void TruncateThrough_keeps_tail_above_cutoff()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, _) = MakeAppender(dir);
+        using (appender) using (coord)
+        {
+            for (long i = 1; i <= 5; i++) appender.Append(NewRecord(i));
+
+            appender.TruncateThrough(3);
+
+            appender.CloseAppendStream();
+            var replay = WalReplay.ReadAll(appender.Path, 1, NullLogger.Instance);
+            Assert.Equal(new long[] { 4, 5 }, replay.Records.Select(r => r.Seq));
+        }
+    }
+
+    [Fact]
+    public void TruncateThrough_below_all_records_is_noop()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, _) = MakeAppender(dir);
+        using (appender) using (coord)
+        {
+            for (long i = 5; i <= 7; i++) appender.Append(NewRecord(i));
+            long sizeBefore = appender.CurrentSize;
+
+            appender.TruncateThrough(1); // all records have Seq >= 5
+
+            Assert.Equal(sizeBefore, appender.CurrentSize);
+            appender.CloseAppendStream();
+            var replay = WalReplay.ReadAll(appender.Path, 1, NullLogger.Instance);
+            Assert.Equal(3, replay.Records.Count);
+        }
+    }
+
+    [Fact]
+    public void Reset_removes_file()
+    {
+        var dir = NewTempDir();
+        var (appender, coord, path) = MakeAppender(dir);
+        using (appender) using (coord)
+        {
+            appender.Append(NewRecord(1));
+            Assert.True(File.Exists(path));
+
+            appender.Reset();
+
+            Assert.False(File.Exists(path));
+            Assert.Equal(0, appender.CurrentSize);
+        }
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalDurabilityCoordinatorTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalDurabilityCoordinatorTests.cs
@@ -1,0 +1,89 @@
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+public sealed class WalDurabilityCoordinatorTests
+{
+    [Fact]
+    public void WaitForDurable_zero_returns_immediately()
+    {
+        using var coord = new WalDurabilityCoordinator(
+            1, groupCommit: false, TimeSpan.Zero, () => 0, NullLogger.Instance);
+
+        coord.WaitForDurable(0); // must not block
+    }
+
+    [Fact]
+    public void PerWrite_mode_records_pending_and_durable()
+    {
+        using var coord = new WalDurabilityCoordinator(
+            1, groupCommit: false, TimeSpan.Zero, () => 0, NullLogger.Instance);
+
+        coord.RecordPendingAndDurable(5);
+
+        Assert.Equal(5, coord.PendingSeq);
+        Assert.Equal(5, coord.DurableSeq);
+
+        // No-op (already at 5).
+        coord.WaitForDurable(5);
+        // Early-out: not groupCommit, so never blocks even on higher seq.
+        coord.WaitForDurable(6);
+    }
+
+    [Fact]
+    public void GroupCommit_advances_durable_via_callback()
+    {
+        long pendingFromCallback = 0;
+        using var callbackFired = new ManualResetEventSlim(false);
+        long Callback()
+        {
+            callbackFired.Set();
+            return Interlocked.Read(ref pendingFromCallback);
+        }
+
+        using var coord = new WalDurabilityCoordinator(
+            1, groupCommit: true, TimeSpan.FromMilliseconds(5),
+            Callback, NullLogger.Instance);
+
+        Interlocked.Exchange(ref pendingFromCallback, 7);
+        coord.RecordPending(7);
+
+        Assert.True(callbackFired.Wait(TimeSpan.FromSeconds(2)));
+        coord.WaitForDurable(7, CancellationToken.None);
+        Assert.Equal(7, coord.DurableSeq);
+    }
+
+    [Fact]
+    public async Task AdvanceDurableSeqOnTruncate_pulses_waiters()
+    {
+        // groupCommit=true to enable parking, but the callback never
+        // advances anything; AdvanceDurableSeqOnTruncate should.
+        using var coord = new WalDurabilityCoordinator(
+            1, groupCommit: true, TimeSpan.FromMilliseconds(50),
+            () => 0, NullLogger.Instance);
+
+        coord.RecordPending(9);
+        Assert.Equal(0, coord.DurableSeq);
+
+        var waiter = Task.Run(() => coord.WaitForDurable(9, CancellationToken.None));
+
+        // Give the waiter a moment to park.
+        await Task.Delay(50);
+        coord.AdvanceDurableSeqOnTruncate();
+
+        await waiter.WaitAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(9, coord.DurableSeq);
+    }
+
+    [Fact]
+    public async Task Dispose_joins_background_thread()
+    {
+        var coord = new WalDurabilityCoordinator(
+            1, groupCommit: true, TimeSpan.FromMilliseconds(5),
+            () => 0, NullLogger.Instance);
+
+        var disposed = Task.Run(coord.Dispose);
+        await disposed.WaitAsync(TimeSpan.FromSeconds(6));
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/WalReplayTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalReplayTests.cs
@@ -1,0 +1,181 @@
+using System.Text;
+using B3.Exchange.Core;
+using B3.Exchange.Persistence;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Persistence.Tests;
+
+public sealed class WalReplayTests
+{
+    private static string NewTempDir() => Directory.CreateTempSubdirectory("wal-rpl-").FullName;
+
+    private static WalRecord NewRecord(long seq)
+        => new(
+            seq,
+            WalRecordKind.NewOrder,
+            SessionValue: "S",
+            Firm: 1u,
+            ClOrdId: (ulong)seq,
+            OrigClOrdId: 0,
+            NewOrder: null,
+            Cancel: null,
+            Replace: null);
+
+    private static void WriteFramedLine(FileStream fs, byte[] json)
+    {
+        uint crc = Crc32C.Compute(json);
+        fs.Write(json, 0, json.Length);
+        fs.WriteByte((byte)'\t');
+        var hex = crc.ToString("X8");
+        fs.Write(Encoding.ASCII.GetBytes(hex));
+        fs.WriteByte((byte)'\n');
+    }
+
+    private static byte[] SerializeRecord(WalRecord rec)
+        => System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(rec, WalJsonContext.Default.WalRecord);
+
+    [Fact]
+    public void ReadAll_returns_empty_when_file_missing()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+
+        var result = WalReplay.ReadAll(path, 1, NullLogger.Instance);
+
+        Assert.Empty(result.Records);
+        Assert.Equal(0, result.CorruptCount);
+        Assert.Equal(0, result.LegacyCount);
+    }
+
+    [Fact]
+    public void ReadAll_reads_back_framed_records()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+        var recs = new[] { NewRecord(1), NewRecord(2), NewRecord(3) };
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        {
+            foreach (var r in recs)
+            {
+                WriteFramedLine(fs, SerializeRecord(r));
+            }
+        }
+
+        var result = WalReplay.ReadAll(path, 1, NullLogger.Instance);
+
+        Assert.Equal(3, result.Records.Count);
+        Assert.Equal(new long[] { 1, 2, 3 }, result.Records.Select(r => r.Seq));
+        Assert.Equal(0, result.CorruptCount);
+        Assert.Equal(0, result.LegacyCount);
+    }
+
+    [Fact]
+    public void ReadAll_tolerates_torn_final_crc()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+        var good = new[] { NewRecord(1), NewRecord(2) };
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        {
+            foreach (var r in good)
+            {
+                WriteFramedLine(fs, SerializeRecord(r));
+            }
+            // Final line with bad CRC.
+            var json = SerializeRecord(NewRecord(3));
+            fs.Write(json, 0, json.Length);
+            fs.WriteByte((byte)'\t');
+            fs.Write(Encoding.ASCII.GetBytes("DEADBEEF"));
+            fs.WriteByte((byte)'\n');
+        }
+
+        var result = WalReplay.ReadAll(path, 1, NullLogger.Instance);
+
+        Assert.Equal(2, result.Records.Count);
+        Assert.Equal(1, result.CorruptCount);
+    }
+
+    [Fact]
+    public void ReadAll_throws_on_midstream_crc_mismatch()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        {
+            WriteFramedLine(fs, SerializeRecord(NewRecord(1)));
+            // Bad CRC in the middle.
+            var json = SerializeRecord(NewRecord(2));
+            fs.Write(json, 0, json.Length);
+            fs.WriteByte((byte)'\t');
+            fs.Write(Encoding.ASCII.GetBytes("DEADBEEF"));
+            fs.WriteByte((byte)'\n');
+            WriteFramedLine(fs, SerializeRecord(NewRecord(3)));
+        }
+
+        Assert.Throws<WalCorruptionException>(() =>
+            WalReplay.ReadAll(path, 1, NullLogger.Instance));
+    }
+
+    [Fact]
+    public void ReadAll_throws_on_seq_gap()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        {
+            WriteFramedLine(fs, SerializeRecord(NewRecord(1)));
+            WriteFramedLine(fs, SerializeRecord(NewRecord(2)));
+            // Gap: skip 3.
+            WriteFramedLine(fs, SerializeRecord(NewRecord(4)));
+        }
+
+        Assert.Throws<WalCorruptionException>(() =>
+            WalReplay.ReadAll(path, 1, NullLogger.Instance));
+    }
+
+    [Fact]
+    public void ReadAll_counts_legacy_lines_without_crc()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        {
+            // Two legacy records (no CRC suffix), followed by one modern.
+            var l1 = SerializeRecord(NewRecord(1));
+            fs.Write(l1, 0, l1.Length);
+            fs.WriteByte((byte)'\n');
+            var l2 = SerializeRecord(NewRecord(2));
+            fs.Write(l2, 0, l2.Length);
+            fs.WriteByte((byte)'\n');
+            WriteFramedLine(fs, SerializeRecord(NewRecord(3)));
+        }
+
+        var result = WalReplay.ReadAll(path, 1, NullLogger.Instance);
+
+        Assert.Equal(3, result.Records.Count);
+        Assert.Equal(2, result.LegacyCount);
+        Assert.Equal(0, result.CorruptCount);
+    }
+
+    [Fact]
+    public void ReadAll_tolerates_legacy_parse_fail_on_final_line()
+    {
+        var dir = NewTempDir();
+        var path = Path.Combine(dir, "channel-1.wal");
+        using (var fs = new FileStream(path, FileMode.Create, FileAccess.Write))
+        {
+            var l1 = SerializeRecord(NewRecord(1));
+            fs.Write(l1, 0, l1.Length);
+            fs.WriteByte((byte)'\n');
+            // Final legacy line with broken JSON.
+            fs.Write(Encoding.UTF8.GetBytes("{not valid json"));
+            fs.WriteByte((byte)'\n');
+        }
+
+        var result = WalReplay.ReadAll(path, 1, NullLogger.Instance);
+
+        Assert.Single(result.Records);
+        Assert.Equal(1, result.Records[0].Seq);
+        Assert.Equal(1, result.LegacyCount);
+    }
+}


### PR DESCRIPTION
Closes #389. Per GPT-5.5 architectural review 2026-05-20 (refactor #6).

## Motivation

`FileChannelWriteAheadLog.cs` was 820 LOC mixing five concerns — append, group-commit fsync loop, replay, truncate, corruption/torn-final policy — each its own failure domain. Pure structural refactor: **public API, on-disk format, and threading semantics unchanged**.

## Structure

The 820-LOC class becomes a thin facade composing three focused collaborators in `B3.Exchange.Persistence`:

| New | LOC | Responsibility |
|---|---|---|
| `WalReplay` (static) | 219 | Read/parse/CRC-validate. Owns torn-tail vs mid-stream-corruption policy. `ReadAll(path,ch,logger) → WalReplayResult`. |
| `WalDurabilityCoordinator` | 147 | Pending/durable seq, group-commit bg thread, `WaitForDurable` parking, truncate-side durability advance. |
| `WalAppender` | 310 | File stream + write-lock + size cap + append + atomic full/prefix truncate + Reset. |
| `FileChannelWriteAheadLog` (rewritten) | ~60 | Facade composing the three. |

## Tests added

- `WalReplayTests.cs` (7 cases) — empty file, normal records, torn final, mid-stream CRC throw, seq gap throw, legacy line counting, legacy final-line torn-tail tolerance.
- `WalDurabilityCoordinatorTests.cs` (5 cases) — wait-on-zero early-out, PerWrite immediate-durable, GroupCommit signal-driven advance, truncate-side advance, dispose joins bg thread.
- `WalAppenderTests.cs` (7 cases) — byte-format check, size-cap Halt throw, size-cap Drop counter, Truncate, TruncateThrough keep-tail and no-op, Reset.

Existing `FileChannelWriteAheadLog*Tests.cs` are kept verbatim — they exercise the facade and now serve as integration tests for the composition.

## Hard constraints honored

- Public API unchanged (all 3 ctor overloads, all 7 methods, all 7 properties).
- On-disk format byte-identical (`<json>\t<8hex>\n`, same filenames, same atomic rename, same directory fsync).
- Threading semantics identical: bg fsync thread still acquires the file write-lock via `WalAppender.FsyncToDisk`; `WaitForDurable` still parks on the durability lock; Dispose still cancels → signals → joins → disposes in the original order.
- All log message strings preserved verbatim — operators may grep for them.

## Verification

- `dotnet build -c Release` — 0 warnings / 0 errors
- `dotnet test -c Release` — 1,270 tests, 1 pre-existing env-dependent flake on this local machine (`FixpSessionPassiveErBufferingTests.PassiveTrade_WhileSuspended_AppendsToRetransmitRing` — already filed as #399 — passes on CI Release lane; unrelated to WAL).
- `dotnet format --verify-no-changes` — clean

## Diff stat
- `src/B3.Exchange.Persistence/FileChannelWriteAheadLog.cs` — 820 → 149 LOC (facade)
- 3 new collaborator files + 3 new test files

ADR not required (no decision change).