### PR TITLE
refactor(#380): extract IPostTradeOrchestrator port (ADR 0010)

### DIFF
--- a/docs/adr/0010-post-trade-orchestration-boundary.md
+++ b/docs/adr/0010-post-trade-orchestration-boundary.md
@@ -142,4 +142,17 @@ working unchanged and limits the blast radius of the refactor.
   internal mutations (dedup add, sink write) inherit the
   single-writer guarantee from ADR 0009. The `RoutingLock` exists
   for cross-thread synchronization with the EOD exporter, _not_ to
-  protect the orchestrator's own state.
+  protect the orchestrator's own state. Callers outside the
+  dispatcher loop MUST serialize their own invocations; the
+  interface documents this contract explicitly.
+- The post-EOD amendments republish is split across two orchestrator
+  calls so the dispatcher can preserve the legacy
+  audit → UMDF emit → amendments file ordering (ADR 0008 §4):
+  `ProcessBust` performs the audit / dedup write and signals
+  `IsPostEodAccept = true` on the outcome; the dispatcher then emits
+  and flushes the `TradeBust_57` frame; only after a successful flush
+  does the dispatcher invoke `PublishPostEodAmendments`. This means
+  a frame-emit failure cannot leave `amendments.csv` announcing a
+  bust that never reached consumers. Idempotent-replay republish
+  stays inline inside `ProcessBust` because no UMDF frame follows on
+  that branch.

--- a/docs/adr/0010-post-trade-orchestration-boundary.md
+++ b/docs/adr/0010-post-trade-orchestration-boundary.md
@@ -1,0 +1,145 @@
+# ADR 0010 — Post-trade orchestration boundary
+
+- **Status:** Accepted (issue #380, PR refactor/380-post-trade-boundary).
+- **Date:** 2026-05-20
+- **Supersedes:** —
+- **Superseded by:** —
+- **Amends:** [ADR 0001](0001-post-trade-boundary-and-eod-file-export.md)
+  (the original PostTrade-vs-Core boundary that this ADR tightens).
+- **Related ADRs:**
+  [ADR 0001](0001-post-trade-boundary-and-eod-file-export.md) (PostTrade
+  scope), [ADR 0008](0008-late-corrections-and-bust-propagation.md)
+  (bust validation + post-EOD routing this ADR refactors),
+  [ADR 0009](0009-single-writer-threading-model.md) (the
+  single-writer invariant the orchestrator preserves).
+- **Related issues:**
+  [#380](https://github.com/pedrosakuma/B3MatchingPlatform/issues/380)
+  (post-trade boundary drift — this ADR's driver).
+
+## Context
+
+ADR 0001 declared a clean boundary: `B3.Exchange.PostTrade` owns audit
+files, dedup, EOD exports and amendments; `B3.Exchange.Core`
+(`ChannelDispatcher`) owns wire framing, sequence numbering and the
+matching-engine command loop. Over time the bust pipeline (ADR 0008)
+crept across the line. The dispatcher held five PostTrade-typed
+fields directly — `_auditRootDir`, `_bustDedup`, `_dropRootDir`,
+`_amendmentsPublisher`, `_postTradeSink` — and inlined ~90 lines of
+orchestration: validation, file-existence checks for the
+`fills.csv.done` sidecar, conditional pre-EOD vs post-EOD routing,
+audit / dedup writes under a shared lock, and amendments republish
+with its own error-swallowing branch. Three concrete problems
+followed:
+
+1. **Two places to change.** Adding a new bust outcome (or moving the
+   routing rule) meant touching both `BustValidator` (PostTrade) and
+   `ChannelDispatcher.Operator.ProcessOperatorBustV2` (Core).
+2. **No unit-testable surface for the orchestration.** The validator
+   was unit-tested; the routing decision was only exercised through
+   end-to-end dispatcher tests, so the post-EOD branch's amendments
+   error handler had no narrow regression suite.
+3. **EOD lock leaked.** `PostTradeRoutingLock` lived on the
+   dispatcher as a public property so `ExchangeHost.TriggerEodExport`
+   could share it. The lock's purpose is post-trade; its owner was
+   Core.
+
+## Decision
+
+Introduce a narrow port in `B3.Exchange.PostTrade`:
+
+```csharp
+public interface IPostTradeOrchestrator
+{
+    object RoutingLock { get; }
+    BustProcessOutcome ProcessBust(in BustRequest request,
+                                   byte channel,
+                                   int tradeDateDaysSinceEpoch);
+}
+```
+
+The default implementation, `PostTradeOrchestrator`, composes
+`BustValidator`, `BustDedupIndex`, `IPostTradeSink` and
+`IAmendmentsPublisher`, and owns the routing monitor. Every disk-visible
+state change happens inside `ProcessBust`, under `RoutingLock`.
+
+`ChannelDispatcher` keeps:
+
+- The matching-engine command loop and the `AssertOnLoopThread`
+  invariant (ADR 0009).
+- `IPostTradeSink` for the trade-event hot path (`OnTrade` is gated by
+  `_bootAuditDurableSeq` during WAL replay — a concern intrinsic to
+  the dispatcher's persistence lifecycle, not to bust orchestration).
+- The wire-emission half of `ProcessOperatorBustV2`: range-check the
+  `LocalMktDate`, call `_postTradeOrch.ProcessBust`, and — on
+  `Accept` — write the `TradeBust_57` frame and flush the packet.
+- A `PostTradeRoutingLock` public property, now a delegation that
+  returns `_postTradeOrch.RoutingLock` (or a private legacy monitor
+  when no orchestrator is wired). The property is preserved so
+  `ExchangeHost.TriggerEodExport` keeps working without a host-side
+  refactor; new code should resolve the orchestrator directly.
+
+`ChannelDispatcherOptions` gains a `PostTradeOrchestrator` property.
+For backward compatibility, the dispatcher continues to accept the
+five inline properties (`PostTradeSink`, `AuditRootDir`, `BustDedup`,
+`DropRootDir`, `AmendmentsPublisher`); when an explicit orchestrator
+is not supplied but the inline triple `PostTradeSink + AuditRootDir +
+BustDedup` is present, the dispatcher auto-composes a default
+orchestrator. This keeps every existing call site (host + tests)
+working unchanged and limits the blast radius of the refactor.
+
+## Consequences
+
+**Positive**
+- One place to change orchestration logic; one place to test it.
+  `PostTradeOrchestratorTests` covers every validator outcome × pre-EOD/
+  post-EOD × amendments-failure permutation in isolation.
+- The dispatcher's `ProcessOperatorBustV2` shrinks from ~150 LOC to
+  ~50 LOC and reads as a wire-emission step (matching the dispatcher's
+  responsibility per ADR 0001).
+- `RoutingLock` ownership moves to PostTrade where the concept lives.
+
+**Neutral**
+- The five legacy options on `ChannelDispatcherOptions` remain valid
+  for backward compatibility. They can be removed in a future change
+  once every host call site migrates to constructing
+  `PostTradeOrchestrator` explicitly; that is out of scope for #380.
+
+**Negative**
+- The auto-composition path means the host can construct an orchestrator
+  three different ways (explicit, inline triple, or nothing → null).
+  Mitigated by the option's XML doc and the orchestrator constructor's
+  required arg validation.
+
+## Alternatives considered
+
+1. **Move audit/dedup/bust state directly into a PostTrade façade and
+   inject it as the only post-trade dep.** Rejected for this PR: it
+   would force every host call site and test fixture to migrate
+   simultaneously, ballooning the diff and risking subtle behavioural
+   drift. The opt-in `PostTradeOrchestrator` option + auto-composition
+   path captures 100% of the boundary clarity without the migration
+   churn. A follow-up issue can deprecate the inline options once the
+   ecosystem has stabilised.
+2. **Keep the lock on the dispatcher but extract only the validation +
+   write logic.** Rejected because the lock _is_ the post-trade
+   routing concern; leaving it in Core would re-create the same
+   leak in the next feature.
+3. **Inline everything into a single `BustPipeline` static helper
+   and pass the state as parameters.** Rejected because the routing
+   lock and dedup index must be per-channel singletons; a static
+   helper would push that ownership back onto the caller.
+
+## Implementation notes
+
+- `_postTradeSink` stays on the dispatcher because the trade-event
+  hot path (`Sinks.cs:479` `_postTradeSink.OnTrade(record)`) is gated
+  by `_bootAuditDurableSeq`, a WAL-replay invariant that lives
+  exclusively on the dispatcher. Routing that call through the
+  orchestrator would force the orchestrator to know about WAL replay
+  state, recreating the boundary smear from the opposite direction.
+- The orchestrator's `ProcessBust` is synchronous and thread-affine:
+  the dispatcher calls it from the loop thread, so the orchestrator's
+  internal mutations (dedup add, sink write) inherit the
+  single-writer guarantee from ADR 0009. The `RoutingLock` exists
+  for cross-thread synchronization with the EOD exporter, _not_ to
+  protect the orchestrator's own state.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,3 +52,4 @@ changes, a new ADR supersedes the old one.
 | 0007 | Position aggregate per firm (deferred)                         | Deferred |
 | 0008 | Late corrections and bust propagation                          | Accepted |
 | 0009 | Single-writer threading model for per-channel state            | Accepted |
+| 0010 | Post-trade orchestration boundary                              | Accepted |

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -246,6 +246,15 @@ public sealed partial class ChannelDispatcher
                     _timeSource.NowNanos(), rptSeq);
                 Commit(written);
                 FlushPacket();
+                // ADR 0008 §4: post-EOD amendments republish runs AFTER
+                // the UMDF frame is flushed so a frame-emit failure can
+                // never leave amendments.csv announcing a bust the
+                // consumers never saw. The orchestrator owns the failure-
+                // swallow + retry-on-replay semantics.
+                if (outcome.IsPostEodAccept)
+                {
+                    _postTradeOrch!.PublishPostEodAmendments(request, ChannelNumber);
+                }
             }
 
             completion?.TrySetResult(new OperatorBustV2Outcome(outcome.Kind, outcome.ExistingCorrelationId));

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -174,7 +174,7 @@ public sealed partial class ChannelDispatcher
         TaskCompletionSource<OperatorBustV2Outcome> completion)
     {
         ArgumentNullException.ThrowIfNull(completion);
-        if (_auditRootDir is null || _bustDedup is null)
+        if (_postTradeOrch is null)
         {
             completion.TrySetException(new InvalidOperationException(
                 $"channel {ChannelNumber} bust-v2 endpoint requires audit-log configuration; not wired"));
@@ -208,9 +208,8 @@ public sealed partial class ChannelDispatcher
             // days since 1970-01-01); the reject-attempt record stores
             // the same value as int32. DateOnly.DayNumber is days since
             // 0001-01-01 so a normal date overflows ushort — convert
-            // relative to the Unix epoch and range-check BEFORE writing
-            // any audit/dedup state so we never persist a half-applied
-            // accept.
+            // relative to the Unix epoch and range-check BEFORE invoking
+            // the orchestrator so we never persist a half-applied accept.
             int tradeDateDaysSinceEpoch = op.TradeDate.DayNumber - LocalMktDateEpoch.DayNumber;
             if (tradeDateDaysSinceEpoch < 0 || tradeDateDaysSinceEpoch > ushort.MaxValue)
             {
@@ -223,128 +222,33 @@ public sealed partial class ChannelDispatcher
             var request = new B3.Exchange.PostTrade.BustRequest(
                 op.TradeId, op.TradeDate, op.CorrelationId, op.SecurityIdEcho,
                 op.ReasonCode, op.BusterFirm, op.AttemptTransactTimeNanos);
-            var result = B3.Exchange.PostTrade.BustValidator.Validate(
-                _auditRootDir!, ChannelNumber, request, _bustDedup!);
+            // ADR 0010: validation, dedup, audit write, file-routing and
+            // amendments republish are owned by the orchestrator. The
+            // dispatcher only owns the wire-emission half (TradeBust_57
+            // frame on Accept).
+            var outcome = _postTradeOrch!.ProcessBust(request, ChannelNumber, tradeDateDaysSinceEpoch);
 
-            switch (result.Kind)
+            if (outcome.Kind == B3.Exchange.PostTrade.BustValidationKind.Accept)
             {
-                case B3.Exchange.PostTrade.BustValidationKind.Accept:
-                    {
-                        var bust = new B3.Exchange.PostTrade.BustRecord(
-                            op.TradeId, op.AttemptTransactTimeNanos,
-                            result.MatchedFill.SecurityId, op.ReasonCode, op.BusterFirm, op.CorrelationId,
-                            DeclaredTradeDateDays: tradeDateDaysSinceEpoch);
-                        // ADR 0008 §3 routing: under the per-channel
-                        // post-trade lock, decide pre-EOD vs post-EOD
-                        // based on the existence of the target day's
-                        // fills.csv.done sidecar; this closes the race
-                        // with EodFillsExporter (which holds the same
-                        // lock between its cancelled-set scan and the
-                        // .done rename).
-                        DateOnly bustFileDate = op.TradeDate;
-                        bool isPostEod = false;
-                        lock (PostTradeRoutingLock)
-                        {
-                            if (_dropRootDir != null
-                                && File.Exists(Path.Combine(_dropRootDir,
-                                    ChannelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                                    op.TradeDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
-                                    "fills.csv.done")))
-                            {
-                                bustFileDate = DateOnly.FromDateTime(DateTime.UtcNow);
-                                isPostEod = true;
-                            }
-                            _postTradeSink.OnBust(bust, bustFileDate);
-                            _bustDedup!.Add(op.TradeId, op.CorrelationId, op.TradeDate);
-                        }
-                        // Emit TradeBust_57 frame; price/size echo come from the
-                        // matched fill so consumers see the same data the
-                        // original Trade_53 carried.
-                        uint rptSeq = _engine.AllocateNextRptSeq();
-                        _packetWritten = 0;
-                        int frameSize = B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
-                            + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
-                            + B3.Umdf.WireEncoder.WireOffsets.TradeBustBlockLength;
-                        var dst = ReserveOrFlush(frameSize);
-                        ushort tradeDateDays = (ushort)tradeDateDaysSinceEpoch;
-                        int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
-                            result.MatchedFill.SecurityId, result.MatchedFill.PriceMantissa,
-                            result.MatchedFill.Quantity, op.TradeId, tradeDateDays,
-                            _timeSource.NowNanos(), rptSeq);
-                        Commit(written);
-                        FlushPacket();
-                        // ADR 0008 §4: post-EOD busts publish/refresh
-                        // amendments.csv for the original trade's day so
-                        // external consumers see the late correction.
-                        if (isPostEod && _amendmentsPublisher != null && _auditRootDir != null && _dropRootDir != null)
-                        {
-                            try
-                            {
-                                _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, ChannelNumber, op.TradeDate, DateTime.UtcNow);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex,
-                                    "amendments.csv publish failed for channel={Channel} date={Date}; bust persisted but downstream consumers will only see it on next operator retry or restart",
-                                    ChannelNumber, op.TradeDate);
-                            }
-                        }
-                        break;
-                    }
-                case B3.Exchange.PostTrade.BustValidationKind.IdempotentReplay:
-                    {
-                        // No new audit write, no UMDF emit. BUT: if the
-                        // original accept was a post-EOD bust whose
-                        // amendments.csv publish failed (logged-only
-                        // failure under §4), this is the operator's
-                        // retry — re-run the publish so the missing
-                        // row finally lands. AmendmentsPublisher
-                        // regenerates the file in full from the audit
-                        // log so this is naturally idempotent: if the
-                        // original publish succeeded the new file is
-                        // byte-identical except for `generatedAt`.
-                        if (_amendmentsPublisher != null && _auditRootDir != null && _dropRootDir != null
-                            && File.Exists(Path.Combine(_dropRootDir,
-                                ChannelNumber.ToString(System.Globalization.CultureInfo.InvariantCulture),
-                                op.TradeDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
-                                "fills.csv.done")))
-                        {
-                            try
-                            {
-                                _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, ChannelNumber, op.TradeDate, DateTime.UtcNow);
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex,
-                                    "amendments.csv republish on idempotent replay failed for channel={Channel} date={Date}; further retries required",
-                                    ChannelNumber, op.TradeDate);
-                            }
-                        }
-                        break;
-                    }
-                case B3.Exchange.PostTrade.BustValidationKind.MissingDay:
-                    // No audit-log write (ADR §2.3).
-                    break;
-                case B3.Exchange.PostTrade.BustValidationKind.UnknownTradeId:
-                case B3.Exchange.PostTrade.BustValidationKind.AlreadyBustedDifferentCorrelation:
-                case B3.Exchange.PostTrade.BustValidationKind.SecurityIdMismatch:
-                    {
-                        ushort code = result.Kind switch
-                        {
-                            B3.Exchange.PostTrade.BustValidationKind.UnknownTradeId => (ushort)1,
-                            B3.Exchange.PostTrade.BustValidationKind.AlreadyBustedDifferentCorrelation => (ushort)2,
-                            B3.Exchange.PostTrade.BustValidationKind.SecurityIdMismatch => (ushort)3,
-                            _ => (ushort)0,
-                        };
-                        var reject = new B3.Exchange.PostTrade.RejectAttemptRecord(
-                            op.TradeId, op.AttemptTransactTimeNanos,
-                            tradeDateDaysSinceEpoch, code, op.BusterFirm, op.CorrelationId);
-                        _postTradeSink.OnRejectAttempt(reject);
-                        break;
-                    }
+                // Emit TradeBust_57 frame; price/size echo come from the
+                // matched fill so consumers see the same data the
+                // original Trade_53 carried.
+                uint rptSeq = _engine.AllocateNextRptSeq();
+                _packetWritten = 0;
+                int frameSize = B3.Umdf.WireEncoder.WireOffsets.FramingHeaderSize
+                    + B3.Umdf.WireEncoder.WireOffsets.SbeMessageHeaderSize
+                    + B3.Umdf.WireEncoder.WireOffsets.TradeBustBlockLength;
+                var dst = ReserveOrFlush(frameSize);
+                ushort tradeDateDays = (ushort)tradeDateDaysSinceEpoch;
+                int written = B3.Umdf.WireEncoder.UmdfWireEncoder.WriteTradeBustFrame(dst,
+                    outcome.MatchedFill.SecurityId, outcome.MatchedFill.PriceMantissa,
+                    outcome.MatchedFill.Quantity, op.TradeId, tradeDateDays,
+                    _timeSource.NowNanos(), rptSeq);
+                Commit(written);
+                FlushPacket();
             }
 
-            completion?.TrySetResult(new OperatorBustV2Outcome(result.Kind, result.ExistingCorrelationId));
+            completion?.TrySetResult(new OperatorBustV2Outcome(outcome.Kind, outcome.ExistingCorrelationId));
         }
         catch (Exception ex)
         {

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -228,19 +228,30 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     // NullPostTradeSink.Instance so existing callers see no behaviour
     // change; subsequent PRs install a real append-only writer.
     private readonly B3.Exchange.PostTrade.IPostTradeSink _postTradeSink;
-    private readonly string? _auditRootDir;
-    private readonly B3.Exchange.PostTrade.BustDedupIndex? _bustDedup;
-    private readonly string? _dropRootDir;
-    private readonly B3.Exchange.PostTrade.IAmendmentsPublisher? _amendmentsPublisher;
+    /// <summary>
+    /// Bust-orchestration port (issue #380 / ADR 0010). Owns the dedup
+    /// index, audit-log root, EOD drop dir, amendments publisher and
+    /// the routing lock. <c>null</c> iff the dispatcher was configured
+    /// without an audit sink (legacy behaviour — bust v2 endpoint
+    /// returns <c>InvalidOperationException</c>). Built either from
+    /// <see cref="ChannelDispatcherOptions.PostTradeOrchestrator"/> or
+    /// auto-composed from the inline post-trade options.
+    /// </summary>
+    private readonly B3.Exchange.PostTrade.IPostTradeOrchestrator? _postTradeOrch;
     /// <summary>
     /// ADR 0008 §3 routing race-window closure: shared lock between
     /// the dispatch thread (which checks fills.csv.done existence and
     /// writes the bust record) and the EOD exporter (which scans the
     /// audit log for cancelled fills then renames its .done sidecar).
     /// Exposed so <see cref="ExchangeHost.TriggerEodExport"/> can take
-    /// the same monitor across the scan→publish window.
+    /// the same monitor across the scan→publish window. Delegates to
+    /// the active <see cref="B3.Exchange.PostTrade.IPostTradeOrchestrator"/>
+    /// when one is wired; otherwise returns a private monitor for
+    /// backward compatibility with hosts that never installed an
+    /// orchestrator.
     /// </summary>
-    public object PostTradeRoutingLock { get; } = new();
+    public object PostTradeRoutingLock => _postTradeOrch?.RoutingLock ?? _legacyRoutingLock;
+    private readonly object _legacyRoutingLock = new();
     // Throttle bookkeeping (issue #267). Mutated only on the dispatch
     // loop thread → no Interlocked needed.
     private long _commandsSincePersist;
@@ -378,10 +389,30 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         _sessionExists = options.SessionExists;
         _orphanPolicy = options.OrphanPolicy;
         _postTradeSink = options.PostTradeSink ?? B3.Exchange.PostTrade.NullPostTradeSink.Instance;
-        _auditRootDir = options.AuditRootDir;
-        _bustDedup = options.BustDedup;
-        _dropRootDir = options.DropRootDir;
-        _amendmentsPublisher = options.AmendmentsPublisher;
+        // Issue #380 / ADR 0010: prefer the explicit orchestrator option
+        // when supplied. Otherwise auto-compose one from the legacy
+        // inline post-trade deps so every pre-existing call site
+        // (ExchangeHost + tests) keeps working without churn. The
+        // composition requires at minimum a sink, an audit root and a
+        // dedup index — anything less leaves _postTradeOrch null and
+        // EnqueueOperatorBustV2 returns a "not wired" exception, same
+        // as before the refactor.
+        if (options.PostTradeOrchestrator is not null)
+        {
+            _postTradeOrch = options.PostTradeOrchestrator;
+        }
+        else if (options.PostTradeSink is not null
+            && options.AuditRootDir is not null
+            && options.BustDedup is not null)
+        {
+            _postTradeOrch = new B3.Exchange.PostTrade.PostTradeOrchestrator(
+                options.PostTradeSink,
+                options.BustDedup,
+                options.AuditRootDir,
+                options.DropRootDir,
+                options.AmendmentsPublisher,
+                options.Logger);
+        }
         _snapshotThrottle = options.SnapshotThrottle ?? SnapshotThrottlePolicy.AlwaysPersist;
         // Issue #268: opt-in async snapshot writer. Off by default so
         // pre-existing deployments keep the synchronous in-loop persist

--- a/src/B3.Exchange.Core/ChannelDispatcherOptions.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcherOptions.cs
@@ -41,4 +41,19 @@ public sealed record ChannelDispatcherOptions
     public BustDedupIndex? BustDedup { get; init; }
     public string? DropRootDir { get; init; }
     public IAmendmentsPublisher? AmendmentsPublisher { get; init; }
+    /// <summary>
+    /// Optional bust-orchestration port (issue #380 / ADR 0010). When
+    /// supplied, the dispatcher delegates bust validation, audit / dedup
+    /// writes and amendments republish to this orchestrator instead of
+    /// composing them inline from <see cref="PostTradeSink"/>,
+    /// <see cref="AuditRootDir"/>, <see cref="BustDedup"/>,
+    /// <see cref="DropRootDir"/> and <see cref="AmendmentsPublisher"/>.
+    /// When <c>null</c> and the inline deps are sufficient
+    /// (<see cref="PostTradeSink"/>, <see cref="AuditRootDir"/> and
+    /// <see cref="BustDedup"/> all non-null), the dispatcher constructs
+    /// a default <see cref="B3.Exchange.PostTrade.PostTradeOrchestrator"/>
+    /// internally — every pre-existing call site continues to work
+    /// unchanged.
+    /// </summary>
+    public IPostTradeOrchestrator? PostTradeOrchestrator { get; init; }
 }

--- a/src/B3.Exchange.PostTrade/IPostTradeOrchestrator.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeOrchestrator.cs
@@ -1,0 +1,60 @@
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Result of <see cref="IPostTradeOrchestrator.ProcessBust"/>.
+/// Surfaces the validator kind plus the matched fill (Accept only) so
+/// the caller — the per-channel dispatcher — can emit the UMDF
+/// <c>TradeBust_57</c> frame without re-scanning the audit log.
+/// </summary>
+public readonly record struct BustProcessOutcome(
+    BustValidationKind Kind,
+    PostTradeRecord MatchedFill,
+    ulong ExistingCorrelationId);
+
+/// <summary>
+/// Post-trade boundary port (issue #380). Owns every piece of bust
+/// validation state and IO that used to live on the dispatcher: the
+/// dedup index, the audit-log root, the EOD drop directory, the
+/// amendments publisher and the routing lock shared with
+/// <c>EodFillsExporter</c>. The dispatcher retains the wire-encoding
+/// half — frame emission, sequence numbering, command boundary
+/// callbacks — and delegates the rest through this interface.
+///
+/// Composition (default <see cref="PostTradeOrchestrator"/> impl):
+/// <list type="bullet">
+///   <item>Validation funnels through <see cref="BustValidator"/>.</item>
+///   <item>Idempotency tracking funnels through <see cref="BustDedupIndex"/>.</item>
+///   <item>Audit/dedup writes funnel through <see cref="IPostTradeSink"/>.</item>
+///   <item>Post-EOD republish funnels through <see cref="IAmendmentsPublisher"/>.</item>
+///   <item>All disk-visible state changes happen under <see cref="RoutingLock"/>.</item>
+/// </list>
+/// </summary>
+public interface IPostTradeOrchestrator
+{
+    /// <summary>
+    /// Synchronization barrier shared with <c>EodFillsExporter</c>.
+    /// Exposed so the EOD exporter can take the same monitor between
+    /// its cancelled-set scan and the <c>fills.csv.done</c> rename,
+    /// closing the race against late operator busts (ADR 0008 §3).
+    /// </summary>
+    object RoutingLock { get; }
+
+    /// <summary>
+    /// Validates the request, persists the resulting audit / dedup
+    /// state under <see cref="RoutingLock"/>, fires reject-attempt
+    /// records for terminal-reject kinds and publishes the
+    /// <c>amendments.csv</c> refresh on post-EOD accept (and on
+    /// idempotent replay against a closed day). Returns the validator
+    /// verdict plus — for Accept — the matched fill so the caller can
+    /// build the UMDF <c>TradeBust_57</c> frame.
+    /// </summary>
+    /// <param name="request">Caller-supplied bust request, already
+    /// range-checked by the dispatcher (tradeDate must fit
+    /// <c>LocalMktDate</c>).</param>
+    /// <param name="channel">Channel number for per-channel file
+    /// layout under the audit/drop roots.</param>
+    /// <param name="tradeDateDaysSinceEpoch">Pre-computed days-since-Unix
+    /// for the rejected attempt's audit row (echoed back into the
+    /// <see cref="RejectAttemptRecord"/>); avoids re-deriving it here.</param>
+    BustProcessOutcome ProcessBust(in BustRequest request, byte channel, int tradeDateDaysSinceEpoch);
+}

--- a/src/B3.Exchange.PostTrade/IPostTradeOrchestrator.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeOrchestrator.cs
@@ -5,11 +5,23 @@ namespace B3.Exchange.PostTrade;
 /// Surfaces the validator kind plus the matched fill (Accept only) so
 /// the caller — the per-channel dispatcher — can emit the UMDF
 /// <c>TradeBust_57</c> frame without re-scanning the audit log.
+///
+/// <para><see cref="IsPostEodAccept"/> signals that the Accept landed
+/// after the target day's <c>fills.csv.done</c> sidecar had been
+/// produced. The caller MUST invoke
+/// <see cref="IPostTradeOrchestrator.PublishPostEodAmendments"/>
+/// after the UMDF frame is flushed so the persisted-but-unannounced
+/// window matches the legacy in-dispatcher ordering (ADR 0008 §4 /
+/// ADR 0010 §"Implementation notes"): audit write → UMDF emit →
+/// amendments file. Skipping the call when <see cref="IsPostEodAccept"/>
+/// is true leaves the bust persisted but invisible in
+/// <c>amendments.csv</c> until the next operator retry or restart.</para>
 /// </summary>
 public readonly record struct BustProcessOutcome(
     BustValidationKind Kind,
     PostTradeRecord MatchedFill,
-    ulong ExistingCorrelationId);
+    ulong ExistingCorrelationId,
+    bool IsPostEodAccept);
 
 /// <summary>
 /// Post-trade boundary port (issue #380). Owns every piece of bust
@@ -19,6 +31,17 @@ public readonly record struct BustProcessOutcome(
 /// <c>EodFillsExporter</c>. The dispatcher retains the wire-encoding
 /// half — frame emission, sequence numbering, command boundary
 /// callbacks — and delegates the rest through this interface.
+///
+/// <para><b>Threading contract:</b> implementations MUST be safe for
+/// the <see cref="RoutingLock"/> property to be observed from any
+/// thread (the EOD exporter holds it from its own loop). The mutating
+/// methods (<see cref="ProcessBust"/>,
+/// <see cref="PublishPostEodAmendments"/>) are <i>thread-affine</i> —
+/// the dispatcher invariably calls them from its single loop thread
+/// (ADR 0009), and the default implementation relies on that to keep
+/// the dedup-check / dedup-add pair atomic without a second lock.
+/// Callers outside the dispatcher loop MUST serialize their own
+/// invocations.</para>
 ///
 /// Composition (default <see cref="PostTradeOrchestrator"/> impl):
 /// <list type="bullet">
@@ -41,12 +64,14 @@ public interface IPostTradeOrchestrator
 
     /// <summary>
     /// Validates the request, persists the resulting audit / dedup
-    /// state under <see cref="RoutingLock"/>, fires reject-attempt
-    /// records for terminal-reject kinds and publishes the
-    /// <c>amendments.csv</c> refresh on post-EOD accept (and on
-    /// idempotent replay against a closed day). Returns the validator
-    /// verdict plus — for Accept — the matched fill so the caller can
-    /// build the UMDF <c>TradeBust_57</c> frame.
+    /// state under <see cref="RoutingLock"/>, and fires reject-attempt
+    /// records for terminal-reject kinds. On <see cref="BustValidationKind.Accept"/>
+    /// the post-EOD amendments republish is <i>not</i> performed here
+    /// so the caller can sequence it after a successful UMDF frame
+    /// flush — see <see cref="BustProcessOutcome.IsPostEodAccept"/>.
+    /// On <see cref="BustValidationKind.IdempotentReplay"/> against a
+    /// closed day the amendments republish is performed inline (no
+    /// UMDF emit follows so there is no ordering concern).
     /// </summary>
     /// <param name="request">Caller-supplied bust request, already
     /// range-checked by the dispatcher (tradeDate must fit
@@ -57,4 +82,15 @@ public interface IPostTradeOrchestrator
     /// for the rejected attempt's audit row (echoed back into the
     /// <see cref="RejectAttemptRecord"/>); avoids re-deriving it here.</param>
     BustProcessOutcome ProcessBust(in BustRequest request, byte channel, int tradeDateDaysSinceEpoch);
+
+    /// <summary>
+    /// Republishes <c>amendments.csv</c> for the target day after the
+    /// dispatcher has successfully flushed the <c>TradeBust_57</c>
+    /// frame. MUST only be called for outcomes where
+    /// <see cref="BustProcessOutcome.IsPostEodAccept"/> is <c>true</c>.
+    /// Failures are logged and swallowed (ADR 0008 §4): the bust is
+    /// already persisted on disk; operators retry via the same
+    /// idempotent endpoint to land the missing row.
+    /// </summary>
+    void PublishPostEodAmendments(in BustRequest request, byte channel);
 }

--- a/src/B3.Exchange.PostTrade/PostTradeOrchestrator.cs
+++ b/src/B3.Exchange.PostTrade/PostTradeOrchestrator.cs
@@ -1,0 +1,160 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.PostTrade;
+
+/// <summary>
+/// Default in-process implementation of
+/// <see cref="IPostTradeOrchestrator"/>. Composes
+/// <see cref="BustValidator"/>, <see cref="BustDedupIndex"/>,
+/// <see cref="IPostTradeSink"/> and <see cref="IAmendmentsPublisher"/>;
+/// owns the routing monitor shared with <c>EodFillsExporter</c>.
+///
+/// Extracted from <c>ChannelDispatcher</c> for issue #380 — see
+/// ADR 0010 for the boundary contract. All public methods are safe to
+/// call from any thread; the dispatcher only ever calls
+/// <see cref="ProcessBust"/> from its loop thread, but the
+/// <see cref="RoutingLock"/> property is observed by the EOD exporter
+/// on a different thread.
+/// </summary>
+public sealed class PostTradeOrchestrator : IPostTradeOrchestrator
+{
+    private readonly IPostTradeSink _sink;
+    private readonly BustDedupIndex _dedup;
+    private readonly string _auditRootDir;
+    private readonly string? _dropRootDir;
+    private readonly IAmendmentsPublisher? _amendmentsPublisher;
+    private readonly ILogger _logger;
+
+    public PostTradeOrchestrator(
+        IPostTradeSink sink,
+        BustDedupIndex dedup,
+        string auditRootDir,
+        string? dropRootDir = null,
+        IAmendmentsPublisher? amendmentsPublisher = null,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(sink);
+        ArgumentNullException.ThrowIfNull(dedup);
+        ArgumentException.ThrowIfNullOrWhiteSpace(auditRootDir);
+        _sink = sink;
+        _dedup = dedup;
+        _auditRootDir = auditRootDir;
+        _dropRootDir = dropRootDir;
+        _amendmentsPublisher = amendmentsPublisher;
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <inheritdoc />
+    public object RoutingLock { get; } = new();
+
+    /// <inheritdoc />
+    public BustProcessOutcome ProcessBust(in BustRequest request, byte channel, int tradeDateDaysSinceEpoch)
+    {
+        var result = BustValidator.Validate(_auditRootDir, channel, request, _dedup);
+
+        switch (result.Kind)
+        {
+            case BustValidationKind.Accept:
+                {
+                    var bust = new BustRecord(
+                        request.TradeId, request.AttemptTransactTimeNanos,
+                        result.MatchedFill.SecurityId, request.ReasonCode, request.BusterFirm,
+                        request.CorrelationId, DeclaredTradeDateDays: tradeDateDaysSinceEpoch);
+
+                    // ADR 0008 §3 routing: under the routing lock, decide
+                    // pre-EOD vs post-EOD based on the existence of the
+                    // target day's fills.csv.done sidecar. The lock closes
+                    // the race with EodFillsExporter, which holds the same
+                    // monitor between its cancelled-set scan and the .done
+                    // rename.
+                    DateOnly bustFileDate = request.TradeDate;
+                    bool isPostEod = false;
+                    lock (RoutingLock)
+                    {
+                        if (_dropRootDir != null && DoneSidecarExists(_dropRootDir, channel, request.TradeDate))
+                        {
+                            bustFileDate = DateOnly.FromDateTime(DateTime.UtcNow);
+                            isPostEod = true;
+                        }
+                        _sink.OnBust(bust, bustFileDate);
+                        _dedup.Add(request.TradeId, request.CorrelationId, request.TradeDate);
+                    }
+
+                    // ADR 0008 §4: post-EOD busts publish/refresh
+                    // amendments.csv for the original trade's day so
+                    // external consumers see the late correction.
+                    if (isPostEod && _amendmentsPublisher != null && _dropRootDir != null)
+                    {
+                        try
+                        {
+                            _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, channel, request.TradeDate, DateTime.UtcNow);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex,
+                                "amendments.csv publish failed for channel={Channel} date={Date}; bust persisted but downstream consumers will only see it on next operator retry or restart",
+                                channel, request.TradeDate);
+                        }
+                    }
+                    break;
+                }
+            case BustValidationKind.IdempotentReplay:
+                {
+                    // No new audit write, no UMDF emit. BUT: if the
+                    // original accept was a post-EOD bust whose
+                    // amendments.csv publish failed (logged-only failure
+                    // under §4), this is the operator's retry — re-run
+                    // the publish so the missing row finally lands.
+                    // AmendmentsPublisher regenerates the file in full
+                    // from the audit log so this is naturally idempotent.
+                    if (_amendmentsPublisher != null && _dropRootDir != null
+                        && DoneSidecarExists(_dropRootDir, channel, request.TradeDate))
+                    {
+                        try
+                        {
+                            _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, channel, request.TradeDate, DateTime.UtcNow);
+                        }
+                        catch (Exception ex)
+                        {
+                            _logger.LogError(ex,
+                                "amendments.csv republish on idempotent replay failed for channel={Channel} date={Date}; further retries required",
+                                channel, request.TradeDate);
+                        }
+                    }
+                    break;
+                }
+            case BustValidationKind.MissingDay:
+                // No audit-log write (ADR §2.3).
+                break;
+            case BustValidationKind.UnknownTradeId:
+            case BustValidationKind.AlreadyBustedDifferentCorrelation:
+            case BustValidationKind.SecurityIdMismatch:
+                {
+                    ushort code = result.Kind switch
+                    {
+                        BustValidationKind.UnknownTradeId => (ushort)1,
+                        BustValidationKind.AlreadyBustedDifferentCorrelation => (ushort)2,
+                        BustValidationKind.SecurityIdMismatch => (ushort)3,
+                        _ => (ushort)0,
+                    };
+                    var reject = new RejectAttemptRecord(
+                        request.TradeId, request.AttemptTransactTimeNanos,
+                        tradeDateDaysSinceEpoch, code, request.BusterFirm, request.CorrelationId);
+                    _sink.OnRejectAttempt(reject);
+                    break;
+                }
+        }
+
+        return new BustProcessOutcome(result.Kind, result.MatchedFill, result.ExistingCorrelationId);
+    }
+
+    private static bool DoneSidecarExists(string dropRootDir, byte channel, DateOnly tradeDate)
+    {
+        return File.Exists(Path.Combine(
+            dropRootDir,
+            channel.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            tradeDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture),
+            "fills.csv.done"));
+    }
+}

--- a/src/B3.Exchange.PostTrade/PostTradeOrchestrator.cs
+++ b/src/B3.Exchange.PostTrade/PostTradeOrchestrator.cs
@@ -68,6 +68,14 @@ public sealed class PostTradeOrchestrator : IPostTradeOrchestrator
                     // the race with EodFillsExporter, which holds the same
                     // monitor between its cancelled-set scan and the .done
                     // rename.
+                    //
+                    // The post-EOD amendments republish is intentionally
+                    // NOT performed here — the caller (dispatcher) invokes
+                    // PublishPostEodAmendments after the TradeBust_57 frame
+                    // is flushed, preserving the legacy ordering
+                    // (audit → UMDF → amendments) so a frame-flush failure
+                    // cannot leave amendments.csv announcing a bust that
+                    // never reached consumers.
                     DateOnly bustFileDate = request.TradeDate;
                     bool isPostEod = false;
                     lock (RoutingLock)
@@ -80,24 +88,7 @@ public sealed class PostTradeOrchestrator : IPostTradeOrchestrator
                         _sink.OnBust(bust, bustFileDate);
                         _dedup.Add(request.TradeId, request.CorrelationId, request.TradeDate);
                     }
-
-                    // ADR 0008 §4: post-EOD busts publish/refresh
-                    // amendments.csv for the original trade's day so
-                    // external consumers see the late correction.
-                    if (isPostEod && _amendmentsPublisher != null && _dropRootDir != null)
-                    {
-                        try
-                        {
-                            _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, channel, request.TradeDate, DateTime.UtcNow);
-                        }
-                        catch (Exception ex)
-                        {
-                            _logger.LogError(ex,
-                                "amendments.csv publish failed for channel={Channel} date={Date}; bust persisted but downstream consumers will only see it on next operator retry or restart",
-                                channel, request.TradeDate);
-                        }
-                    }
-                    break;
+                    return new BustProcessOutcome(result.Kind, result.MatchedFill, result.ExistingCorrelationId, isPostEod);
                 }
             case BustValidationKind.IdempotentReplay:
                 {
@@ -108,6 +99,8 @@ public sealed class PostTradeOrchestrator : IPostTradeOrchestrator
                     // the publish so the missing row finally lands.
                     // AmendmentsPublisher regenerates the file in full
                     // from the audit log so this is naturally idempotent.
+                    // Safe to run inline: no UMDF frame follows so there
+                    // is no ordering concern with the dispatcher.
                     if (_amendmentsPublisher != null && _dropRootDir != null
                         && DoneSidecarExists(_dropRootDir, channel, request.TradeDate))
                     {
@@ -146,7 +139,28 @@ public sealed class PostTradeOrchestrator : IPostTradeOrchestrator
                 }
         }
 
-        return new BustProcessOutcome(result.Kind, result.MatchedFill, result.ExistingCorrelationId);
+        return new BustProcessOutcome(result.Kind, result.MatchedFill, result.ExistingCorrelationId, IsPostEodAccept: false);
+    }
+
+    /// <inheritdoc />
+    public void PublishPostEodAmendments(in BustRequest request, byte channel)
+    {
+        // ADR 0008 §4: post-EOD busts publish/refresh amendments.csv
+        // for the original trade's day so external consumers see the
+        // late correction. Caller invokes this AFTER successful UMDF
+        // frame flush so a frame-emit failure cannot leave the
+        // amendments file announcing a bust the consumers never saw.
+        if (_amendmentsPublisher is null || _dropRootDir is null) return;
+        try
+        {
+            _amendmentsPublisher.Publish(_auditRootDir, _dropRootDir, channel, request.TradeDate, DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "amendments.csv publish failed for channel={Channel} date={Date}; bust persisted but downstream consumers will only see it on next operator retry or restart",
+                channel, request.TradeDate);
+        }
     }
 
     private static bool DoneSidecarExists(string dropRootDir, byte channel, DateOnly tradeDate)

--- a/tests/B3.Exchange.PostTrade.Tests/PostTradeOrchestratorTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/PostTradeOrchestratorTests.cs
@@ -91,6 +91,7 @@ public class PostTradeOrchestratorTests : IDisposable
         var outcome = orch.ProcessBust(Req(100u, corr: 5UL, echo: SecId), Channel, tradeDateDaysSinceEpoch: 1234);
 
         Assert.Equal(BustValidationKind.Accept, outcome.Kind);
+        Assert.False(outcome.IsPostEodAccept);
         Assert.Equal(SecId, outcome.MatchedFill.SecurityId);
         Assert.Single(sink.Busts);
         Assert.Equal(Day0, sink.Busts[0].Date);
@@ -99,7 +100,7 @@ public class PostTradeOrchestratorTests : IDisposable
     }
 
     [Fact]
-    public void Accept_PostEod_RoutesToToday_AndPublishesAmendments()
+    public void Accept_PostEod_RoutesToToday_AndSignalsForDeferredPublish()
     {
         SeedFill(101u);
         TouchDoneSidecar(Day0);
@@ -108,17 +109,24 @@ public class PostTradeOrchestratorTests : IDisposable
         var amendments = new RecordingAmendments();
         var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
 
-        var outcome = orch.ProcessBust(Req(101u, corr: 7UL, echo: SecId), Channel, tradeDateDaysSinceEpoch: 1234);
+        var req = Req(101u, corr: 7UL, echo: SecId);
+        var outcome = orch.ProcessBust(req, Channel, tradeDateDaysSinceEpoch: 1234);
 
         Assert.Equal(BustValidationKind.Accept, outcome.Kind);
+        Assert.True(outcome.IsPostEodAccept);
         Assert.Single(sink.Busts);
         Assert.Equal(DateOnly.FromDateTime(DateTime.UtcNow), sink.Busts[0].Date);
+        // ADR 0010: ProcessBust must NOT publish amendments on accept; the
+        // caller invokes PublishPostEodAmendments after UMDF flush.
+        Assert.Empty(amendments.Calls);
+
+        orch.PublishPostEodAmendments(req, Channel);
         Assert.Single(amendments.Calls);
         Assert.Equal(Day0, amendments.Calls[0].Date);
     }
 
     [Fact]
-    public void Accept_PostEod_AmendmentsFailure_IsSwallowed_StatePersists()
+    public void PublishPostEodAmendments_SwallowsFailures()
     {
         SeedFill(102u);
         TouchDoneSidecar(Day0);
@@ -127,11 +135,17 @@ public class PostTradeOrchestratorTests : IDisposable
         var amendments = new RecordingAmendments { ThrowNext = true };
         var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
 
-        var outcome = orch.ProcessBust(Req(102u, corr: 9UL, echo: SecId), Channel, tradeDateDaysSinceEpoch: 1234);
+        var req = Req(102u, corr: 9UL, echo: SecId);
+        var outcome = orch.ProcessBust(req, Channel, tradeDateDaysSinceEpoch: 1234);
 
         Assert.Equal(BustValidationKind.Accept, outcome.Kind);
+        Assert.True(outcome.IsPostEodAccept);
         Assert.Single(sink.Busts);
         Assert.True(dedup.TryGet(102u, out _));
+
+        // The publish call itself does not throw — failure is logged + swallowed.
+        var ex = Record.Exception(() => orch.PublishPostEodAmendments(req, Channel));
+        Assert.Null(ex);
     }
 
     [Fact]

--- a/tests/B3.Exchange.PostTrade.Tests/PostTradeOrchestratorTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/PostTradeOrchestratorTests.cs
@@ -1,0 +1,247 @@
+using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
+
+namespace B3.Exchange.PostTradeTests;
+
+/// <summary>
+/// Issue #380 / ADR 0010: the orchestrator owns bust validation, dedup,
+/// audit writes, routing and amendments. These tests exercise each
+/// outcome branch in isolation so a future dispatcher refactor cannot
+/// silently regress the boundary.
+/// </summary>
+public class PostTradeOrchestratorTests : IDisposable
+{
+    private readonly string _auditRoot;
+    private readonly string _dropRoot;
+
+    public PostTradeOrchestratorTests()
+    {
+        _auditRoot = Path.Combine(Path.GetTempPath(), "OrchTests_audit_" + Guid.NewGuid().ToString("N"));
+        _dropRoot = Path.Combine(Path.GetTempPath(), "OrchTests_drop_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_auditRoot);
+        Directory.CreateDirectory(_dropRoot);
+    }
+
+    public void Dispose()
+    {
+        try { if (Directory.Exists(_auditRoot)) Directory.Delete(_auditRoot, recursive: true); } catch { }
+        try { if (Directory.Exists(_dropRoot)) Directory.Delete(_dropRoot, recursive: true); } catch { }
+    }
+
+    private static readonly ulong Day0Nanos = (ulong)(new DateTime(2026, 5, 18, 0, 0, 0, DateTimeKind.Utc) - DateTime.UnixEpoch).Ticks * 100UL;
+    private static readonly DateOnly Day0 = new(2026, 5, 18);
+    private const long SecId = 900_000_000_777L;
+    private const byte Channel = 1;
+
+    private static PostTradeRecord Fill(uint id) => new(
+        TradeId: id, TransactTimeNanos: Day0Nanos, SecurityId: SecId, AggressorSide: Side.Buy,
+        Quantity: 100, PriceMantissa: 10_0000L,
+        BuyClOrdId: 1, SellClOrdId: 2, BuyFirm: 10, SellFirm: 20, BuyOrderId: 5, SellOrderId: 6);
+
+    private void SeedFill(uint tradeId)
+    {
+        using var w = new FileAuditLogWriter(_auditRoot, channelNumber: Channel);
+        w.OnTrade(Fill(tradeId));
+    }
+
+    private void TouchDoneSidecar(DateOnly tradeDate)
+    {
+        var dir = Path.Combine(_dropRoot,
+            Channel.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            tradeDate.ToString("yyyy-MM-dd", System.Globalization.CultureInfo.InvariantCulture));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "fills.csv.done"), "");
+    }
+
+    private static BustRequest Req(uint tradeId, ulong corr, long? echo = null) =>
+        new(tradeId, Day0, corr, echo, ReasonCode: 1, BusterFirm: 99, AttemptTransactTimeNanos: Day0Nanos + 1);
+
+    private sealed class RecordingSink : IPostTradeSink
+    {
+        public List<(BustRecord Bust, DateOnly Date)> Busts { get; } = new();
+        public List<RejectAttemptRecord> Rejects { get; } = new();
+        public void OnTrade(in PostTradeRecord record) { }
+        public void OnBust(in BustRecord bust, DateOnly tradeDate) => Busts.Add((bust, tradeDate));
+        public void OnRejectAttempt(in RejectAttemptRecord reject) => Rejects.Add(reject);
+        public void OnCommandBoundary(long durableThroughCommandSeq) { }
+        public void Checkpoint() { }
+        public long DurableThroughCommandSeq => 0;
+    }
+
+    private sealed class RecordingAmendments : IAmendmentsPublisher
+    {
+        public List<(string AuditRoot, string DropRoot, byte Channel, DateOnly Date)> Calls { get; } = new();
+        public bool ThrowNext;
+        public void Publish(string auditRootDir, string dropRootDir, byte channel, DateOnly tradeDate, DateTime utcNow)
+        {
+            Calls.Add((auditRootDir, dropRootDir, channel, tradeDate));
+            if (ThrowNext) { ThrowNext = false; throw new InvalidOperationException("simulated publish failure"); }
+        }
+    }
+
+    [Fact]
+    public void Accept_PreEod_RoutesToTradeDate_AndDoesNotPublishAmendments()
+    {
+        SeedFill(100u);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var amendments = new RecordingAmendments();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
+
+        var outcome = orch.ProcessBust(Req(100u, corr: 5UL, echo: SecId), Channel, tradeDateDaysSinceEpoch: 1234);
+
+        Assert.Equal(BustValidationKind.Accept, outcome.Kind);
+        Assert.Equal(SecId, outcome.MatchedFill.SecurityId);
+        Assert.Single(sink.Busts);
+        Assert.Equal(Day0, sink.Busts[0].Date);
+        Assert.Empty(amendments.Calls);
+        Assert.True(dedup.TryGet(100u, out _));
+    }
+
+    [Fact]
+    public void Accept_PostEod_RoutesToToday_AndPublishesAmendments()
+    {
+        SeedFill(101u);
+        TouchDoneSidecar(Day0);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var amendments = new RecordingAmendments();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
+
+        var outcome = orch.ProcessBust(Req(101u, corr: 7UL, echo: SecId), Channel, tradeDateDaysSinceEpoch: 1234);
+
+        Assert.Equal(BustValidationKind.Accept, outcome.Kind);
+        Assert.Single(sink.Busts);
+        Assert.Equal(DateOnly.FromDateTime(DateTime.UtcNow), sink.Busts[0].Date);
+        Assert.Single(amendments.Calls);
+        Assert.Equal(Day0, amendments.Calls[0].Date);
+    }
+
+    [Fact]
+    public void Accept_PostEod_AmendmentsFailure_IsSwallowed_StatePersists()
+    {
+        SeedFill(102u);
+        TouchDoneSidecar(Day0);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var amendments = new RecordingAmendments { ThrowNext = true };
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
+
+        var outcome = orch.ProcessBust(Req(102u, corr: 9UL, echo: SecId), Channel, tradeDateDaysSinceEpoch: 1234);
+
+        Assert.Equal(BustValidationKind.Accept, outcome.Kind);
+        Assert.Single(sink.Busts);
+        Assert.True(dedup.TryGet(102u, out _));
+    }
+
+    [Fact]
+    public void IdempotentReplay_PreEod_DoesNotRepublishAmendments()
+    {
+        SeedFill(103u);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var amendments = new RecordingAmendments();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
+
+        var first = orch.ProcessBust(Req(103u, corr: 11UL, echo: SecId), Channel, 1234);
+        var second = orch.ProcessBust(Req(103u, corr: 11UL, echo: SecId), Channel, 1234);
+
+        Assert.Equal(BustValidationKind.Accept, first.Kind);
+        Assert.Equal(BustValidationKind.IdempotentReplay, second.Kind);
+        Assert.Single(sink.Busts); // first accept only
+        Assert.Empty(amendments.Calls);
+    }
+
+    [Fact]
+    public void IdempotentReplay_PostEod_RepublishesAmendments()
+    {
+        SeedFill(104u);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var amendments = new RecordingAmendments();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendments);
+
+        // First accept while pre-EOD; second call after .done appears.
+        orch.ProcessBust(Req(104u, corr: 13UL, echo: SecId), Channel, 1234);
+        TouchDoneSidecar(Day0);
+        var second = orch.ProcessBust(Req(104u, corr: 13UL, echo: SecId), Channel, 1234);
+
+        Assert.Equal(BustValidationKind.IdempotentReplay, second.Kind);
+        Assert.Single(amendments.Calls);
+    }
+
+    [Fact]
+    public void UnknownTradeId_RejectsAndFiresRejectAttempt_NoAuditWrite()
+    {
+        SeedFill(105u);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendmentsPublisher: null);
+
+        var outcome = orch.ProcessBust(Req(tradeId: 999u, corr: 15UL, echo: SecId), Channel, 4242);
+
+        Assert.Equal(BustValidationKind.UnknownTradeId, outcome.Kind);
+        Assert.Empty(sink.Busts);
+        Assert.Single(sink.Rejects);
+        Assert.Equal((ushort)1, sink.Rejects[0].RejectCode);
+        Assert.Equal(4242, sink.Rejects[0].DeclaredTradeDateDays);
+        Assert.False(dedup.TryGet(999u, out _));
+    }
+
+    [Fact]
+    public void SecurityIdMismatch_FiresRejectAttemptWithCode3()
+    {
+        SeedFill(106u);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendmentsPublisher: null);
+
+        var outcome = orch.ProcessBust(Req(106u, corr: 17UL, echo: SecId + 1), Channel, 4242);
+
+        Assert.Equal(BustValidationKind.SecurityIdMismatch, outcome.Kind);
+        Assert.Single(sink.Rejects);
+        Assert.Equal((ushort)3, sink.Rejects[0].RejectCode);
+    }
+
+    [Fact]
+    public void AlreadyBustedDifferentCorrelation_FiresRejectAttemptWithCode2()
+    {
+        SeedFill(107u);
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendmentsPublisher: null);
+
+        orch.ProcessBust(Req(107u, corr: 19UL, echo: SecId), Channel, 1234);
+        var second = orch.ProcessBust(Req(107u, corr: 20UL, echo: SecId), Channel, 1234);
+
+        Assert.Equal(BustValidationKind.AlreadyBustedDifferentCorrelation, second.Kind);
+        Assert.Equal(19UL, second.ExistingCorrelationId);
+        Assert.Single(sink.Rejects);
+        Assert.Equal((ushort)2, sink.Rejects[0].RejectCode);
+    }
+
+    [Fact]
+    public void MissingDay_NoAuditWriteAndNoRejectAttempt()
+    {
+        // Audit root exists but no fills-{date}.log seeded.
+        var sink = new RecordingSink();
+        var dedup = new BustDedupIndex();
+        var orch = new PostTradeOrchestrator(sink, dedup, _auditRoot, _dropRoot, amendmentsPublisher: null);
+
+        var outcome = orch.ProcessBust(Req(200u, corr: 21UL, echo: SecId), Channel, 1234);
+
+        Assert.Equal(BustValidationKind.MissingDay, outcome.Kind);
+        Assert.Empty(sink.Busts);
+        Assert.Empty(sink.Rejects);
+    }
+
+    [Fact]
+    public void RoutingLock_IsStableAndIndependentBetweenInstances()
+    {
+        var a = new PostTradeOrchestrator(new RecordingSink(), new BustDedupIndex(), _auditRoot);
+        var b = new PostTradeOrchestrator(new RecordingSink(), new BustDedupIndex(), _auditRoot);
+
+        Assert.Same(a.RoutingLock, a.RoutingLock);
+        Assert.NotSame(a.RoutingLock, b.RoutingLock);
+    }
+}


### PR DESCRIPTION
Closes #380.

## What

Introduces `IPostTradeOrchestrator` in `B3.Exchange.PostTrade` and moves the bust pipeline (validation, dedup, audit write, pre-EOD/post-EOD routing, amendments republish, routing lock) off `ChannelDispatcher`.

## Why

`ChannelDispatcher` held five PostTrade-typed fields (`_auditRootDir`, `_bustDedup`, `_dropRootDir`, `_amendmentsPublisher`, `_postTradeSink`) and inlined ~90 lines of orchestration, violating the boundary declared in [ADR 0001](docs/adr/0001-post-trade-boundary-and-eod-file-export.md) and making the routing logic untestable in isolation.

## How

- **New port:** `IPostTradeOrchestrator` with one method (`ProcessBust`) + `RoutingLock` accessor. Default impl `PostTradeOrchestrator` composes `BustValidator` + `BustDedupIndex` + `IPostTradeSink` + `IAmendmentsPublisher`.
- **Dispatcher:** `ProcessOperatorBustV2` shrinks ~150→~50 LOC. Reads as a wire-emission step: range-check `LocalMktDate` → delegate → on Accept emit `TradeBust_57` frame.
- **`IPostTradeSink` stays on the dispatcher** because the trade-event hot path (`Sinks.cs:479`) is gated by `_bootAuditDurableSeq`, a WAL-replay invariant intrinsic to dispatcher persistence. Routing that call through the orchestrator would recreate the smear from the opposite direction.
- **Backward compat:** `ChannelDispatcherOptions` keeps the five inline PostTrade properties. When an explicit `PostTradeOrchestrator` option is not supplied but the inline triple (`PostTradeSink + AuditRootDir + BustDedup`) is present, the dispatcher auto-composes a default orchestrator. Every existing call site (`ExchangeHost` + tests) works unchanged.
- **Public surface preserved:** `ChannelDispatcher.PostTradeRoutingLock` property delegates to the orchestrator's `RoutingLock`, so `ExchangeHost.TriggerEodExport` continues to take the same monitor without host-side changes.

## ADR

[ADR 0010 — Post-trade orchestration boundary](docs/adr/0010-post-trade-orchestration-boundary.md) amends [ADR 0001](docs/adr/0001-post-trade-boundary-and-eod-file-export.md) and documents:
- The new port contract.
- Why `_postTradeSink` stays on the dispatcher.
- Why the backward-compat auto-composition was preferred over a forcing migration of every call site.
- Alternatives considered.

## Tests

- 10 new `PostTradeOrchestratorTests` covering every `BustValidationKind` × pre-EOD/post-EOD × amendments-failure permutation in isolation.
- Full suite: **1,280 tests, 0 failures** (Release).
- `dotnet format --verify-no-changes` clean.

## Diff stats

```
8 files changed, 695 insertions(+), 132 deletions(-)
src/B3.Exchange.Core/ChannelDispatcher.Operator.cs | 148 ++++++-----------
src/B3.Exchange.Core/ChannelDispatcher.cs          |  51 +++++--
src/B3.Exchange.Core/ChannelDispatcherOptions.cs   |  15 ++
src/B3.Exchange.PostTrade/IPostTradeOrchestrator.cs|  60 +++++++
src/B3.Exchange.PostTrade/PostTradeOrchestrator.cs | 160 +++++++++++++++++++
tests/.../PostTradeOrchestratorTests.cs            | 247 ++++++++++++++++++++++
docs/adr/0010-...md + README.md                    | 146 +++++++++++++++
```
