### PR TITLE
fix(gateway): emit live sessionVerID in Terminate frames (#407)

### DIFF
--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -25,6 +25,7 @@ namespace B3.Exchange.Gateway;
 internal sealed class FixpOutboundEncoder
 {
     private readonly Func<uint> _sessionId;
+    private readonly Func<ulong> _sessionVerId;
     private readonly Func<uint> _nextMsgSeqNum;
     private readonly Func<TcpTransport> _transport;
     private readonly RetransmitBuffer _retxBuffer;
@@ -42,6 +43,7 @@ internal sealed class FixpOutboundEncoder
 
     public FixpOutboundEncoder(
         Func<uint> sessionId,
+        Func<ulong> sessionVerId,
         Func<uint> nextMsgSeqNum,
         Func<TcpTransport> transport,
         RetransmitBuffer retxBuffer,
@@ -51,6 +53,7 @@ internal sealed class FixpOutboundEncoder
         Action close)
     {
         _sessionId = sessionId;
+        _sessionVerId = sessionVerId;
         _nextMsgSeqNum = nextMsgSeqNum;
         _transport = transport;
         _retxBuffer = retxBuffer;
@@ -186,7 +189,7 @@ internal sealed class FixpOutboundEncoder
     {
         if (!_isOpen()) return false;
         var exact = new byte[SessionRejectEncoder.TerminateTotal];
-        SessionRejectEncoder.EncodeTerminate(exact, _sessionId(), 0, terminationCode);
+        SessionRejectEncoder.EncodeTerminate(exact, _sessionId(), _sessionVerId(), terminationCode);
         bool result = _transport().TryEnqueueFrame(exact);
         _close();
         return result;

--- a/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
@@ -122,7 +122,7 @@ public sealed partial class FixpSession
     {
         if (!IsOpen) { Close(reason, kind); return; }
         var frame = new byte[SessionRejectEncoder.TerminateTotal];
-        SessionRejectEncoder.EncodeTerminate(frame, SessionId, 0, terminationCode);
+        SessionRejectEncoder.EncodeTerminate(frame, SessionId, SessionVerId, terminationCode);
         try
         {
             await _transport.SendDirectAsync(frame).ConfigureAwait(false);

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -394,6 +394,7 @@ public sealed partial class FixpSession : IAsyncDisposable
             coldRead: coldRead);
         _outboundEncoder = new FixpOutboundEncoder(
             sessionId: () => SessionId,
+            sessionVerId: () => SessionVerId,
             nextMsgSeqNum: NextMsgSeqNum,
             transport: () => _transport!,
             retxBuffer: _retxBuffer,

--- a/tests/B3.Exchange.Gateway.Tests/FixpInboundTerminateTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpInboundTerminateTests.cs
@@ -1,6 +1,7 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using B3.EntryPoint.Wire;
 using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
@@ -33,6 +34,29 @@ public class FixpInboundTerminateTests
         var buf = new byte[EntryPointFixpFrameCodec.TerminateBlock + EntryPointFrameReader.WireHeaderSize];
         EntryPointFixpFrameCodec.EncodeTerminate(buf, sessionId, sessionVerId, code);
         return buf;
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(NetworkStream stream)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var head = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactlyAsync(stream, head, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(head.AsSpan(0, 2));
+        var frame = new byte[messageLength];
+        head.CopyTo(frame.AsSpan());
+        await ReadExactlyAsync(stream, frame.AsMemory(head.Length), cts.Token);
+        return frame;
+    }
+
+    private static async Task ReadExactlyAsync(NetworkStream stream, Memory<byte> buffer, CancellationToken cancellationToken)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer[read..], cancellationToken);
+            if (n <= 0) throw new EndOfStreamException("connection closed before expected frame was received");
+            read += n;
+        }
     }
 
     [Fact]
@@ -80,6 +104,58 @@ public class FixpInboundTerminateTests
             byte echoedCode = buf[EntryPointFrameReader.WireHeaderSize + 12];
             Assert.Equal(SessionRejectEncoder.TerminationCode.Finished, echoedCode);
 
+        }
+    }
+
+    [Fact]
+    public async Task EstablishedSession_TerminateEchoCarriesLiveSessionVerId()
+    {
+        const uint sessionId = 100;
+        const ulong sessionVerId = 42;
+
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            NullLoggerFactory.Instance);
+        listener.Start();
+        await using (listener)
+        using (var client = new TcpClient())
+        {
+            await client.ConnectAsync(listener.LocalEndpoint!.Address, listener.LocalEndpoint!.Port);
+            var ns = client.GetStream();
+            var frame = new byte[256];
+
+            int negotiateLen = EntryPointFixpFrameCodec.EncodeNegotiate(frame,
+                sessionId, sessionVerId, timestampNanos: 1UL, enteringFirm: 42u, onBehalfFirm: null,
+                credentials: Encoding.UTF8.GetBytes("{}"),
+                clientIp: ReadOnlySpan<byte>.Empty,
+                clientAppName: ReadOnlySpan<byte>.Empty,
+                clientAppVersion: ReadOnlySpan<byte>.Empty);
+            await ns.WriteAsync(frame.AsMemory(0, negotiateLen));
+            byte[] negotiateResponse = await ReadFrameAsync(ns);
+            Assert.Equal(EntryPointFrameReader.TidNegotiateResponse,
+                BinaryPrimitives.ReadUInt16LittleEndian(negotiateResponse.AsSpan(EntryPointFrameReader.SofhSize + 2, 2)));
+
+            int establishLen = EntryPointFixpFrameCodec.EncodeEstablish(frame,
+                sessionId, sessionVerId, timestampNanos: 2UL, keepAliveIntervalMillis: 60_000UL,
+                nextSeqNo: 1u, cancelOnDisconnectType: 0, codTimeoutWindowMillis: 0UL,
+                credentials: ReadOnlySpan<byte>.Empty);
+            await ns.WriteAsync(frame.AsMemory(0, establishLen));
+            byte[] establishAck = await ReadFrameAsync(ns);
+            Assert.Equal(EntryPointFrameReader.TidEstablishAck,
+                BinaryPrimitives.ReadUInt16LittleEndian(establishAck.AsSpan(EntryPointFrameReader.SofhSize + 2, 2)));
+
+            byte[] terminate = EncodeInboundTerminate(sessionId, sessionVerId,
+                SessionRejectEncoder.TerminationCode.Finished);
+            await ns.WriteAsync(terminate);
+
+            byte[] echo = await ReadFrameAsync(ns);
+            Assert.Equal(EntryPointFrameReader.TidTerminate,
+                BinaryPrimitives.ReadUInt16LittleEndian(echo.AsSpan(EntryPointFrameReader.SofhSize + 2, 2)));
+            Assert.Equal(sessionVerId,
+                BinaryPrimitives.ReadUInt64LittleEndian(echo.AsSpan(EntryPointFrameReader.WireHeaderSize + 4, 8)));
+            Assert.Equal(SessionRejectEncoder.TerminationCode.Finished,
+                echo[EntryPointFrameReader.WireHeaderSize + 12]);
         }
     }
 }


### PR DESCRIPTION
Fixes #407

## Summary
- Pass the live FixpSession.SessionVerId into all outbound Terminate encoders instead of hardcoding 0.
- Wire FixpOutboundEncoder to read the owning session's current sessionVerID.
- Add a gateway test that negotiates/establishes sessionVerID=N and verifies the Terminate echo carries N.

## Spec
B3 Binary EntryPoint Messaging Guidelines 8.4.2.1 / Terminate message: sessionVerID must echo the active session.

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn