### PR TITLE
Fix keepAliveInterval minimum bound

### DIFF
--- a/src/B3.Exchange.Gateway/EstablishValidator.cs
+++ b/src/B3.Exchange.Gateway/EstablishValidator.cs
@@ -59,11 +59,8 @@ public sealed class EstablishValidator
     /// check (used by tests). Default 5 minutes.</summary>
     public ulong TimestampSkewToleranceNs { get; }
 
-    /// <summary>Inclusive lower bound for <c>keepAliveInterval</c> (ms).
-    /// Issue #43 acceptance criterion specifies <c>[1, 60000]</c>; the
-    /// SBE schema field description says <c>1000–60000</c>. We follow
-    /// the issue.</summary>
-    public const ulong MinKeepAliveIntervalMs = 1;
+    /// <summary>Inclusive lower bound for <c>keepAliveInterval</c> (ms).</summary>
+    public const ulong MinKeepAliveIntervalMs = 1_000;
     /// <summary>Inclusive upper bound for <c>keepAliveInterval</c> (ms).</summary>
     public const ulong MaxKeepAliveIntervalMs = 60_000;
 

--- a/tests/B3.Exchange.Gateway.Tests/EstablishValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishValidatorTests.cs
@@ -67,6 +67,7 @@ public class EstablishValidatorTests
 
     [Theory]
     [InlineData(0UL)]
+    [InlineData(999UL)]
     [InlineData(60_001UL)]
     public void Rejects_keepalive_out_of_range(ulong keep)
     {
@@ -74,6 +75,17 @@ public class EstablishValidatorTests
         var req = Req(sid: 100, ver: 1, keep: keep);
         var o = v.Validate(req, FixpState.Negotiated, 100, 1, 0);
         Assert.Equal(FixpSbe.EstablishRejectCode.INVALID_KEEPALIVE_INTERVAL, o.RejectCode);
+    }
+
+    [Theory]
+    [InlineData(1_000UL)]
+    [InlineData(60_000UL)]
+    public void Accepts_keepalive_at_spec_bounds(ulong keep)
+    {
+        var v = new EstablishValidator(timestampSkewToleranceNs: 0);
+        var req = Req(sid: 100, ver: 1, keep: keep);
+        var o = v.Validate(req, FixpState.Negotiated, 100, 1, 0);
+        Assert.True(o.IsAccepted);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- enforce the B3 spec minimum keepAliveInterval of 1000ms
- keep INVALID_KEEPALIVE_INTERVAL reject behavior for out-of-range values
- add EstablishValidator boundary tests for 999ms, 1000ms, and 60000ms

Fixes #408

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn