### PR TITLE
Fix idle keepalive termination

### DIFF
--- a/src/B3.EntryPoint.Wire/SessionRejectEncoder.cs
+++ b/src/B3.EntryPoint.Wire/SessionRejectEncoder.cs
@@ -39,6 +39,9 @@ public static class SessionRejectEncoder
         /// <summary>Peer sent an application message after Negotiate but
         /// before <c>Establish</c>. Spec §4.5 strict-gating rule.</summary>
         public const byte NotEstablished = 3;
+        /// <summary>Peer liveness was not observed within the negotiated
+        /// keep-alive interval plus watchdog grace.</summary>
+        public const byte KeepaliveIntervalLapsed = 10;
         public const byte UnrecognizedMessage = 15;
         public const byte InvalidSofh = 16;
         public const byte DecodingError = 17;

--- a/src/B3.Exchange.Gateway/CloseKind.cs
+++ b/src/B3.Exchange.Gateway/CloseKind.cs
@@ -50,6 +50,13 @@ public enum CloseKind
     TransportError,
 
     /// <summary>
+    /// Local watchdog emitted <c>Terminate(KEEPALIVE_INTERVAL_LAPSED)</c>
+    /// because inbound liveness expired. This is a protocol-level terminal
+    /// close, not an abrupt transport error.
+    /// </summary>
+    KeepaliveLapsed,
+
+    /// <summary>
     /// Suspended-state reaper aged the session out after the
     /// configured Suspended-window expired without re-attach. The
     /// session is considered abandoned; persisted state should be

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -25,6 +25,7 @@ namespace B3.Exchange.Gateway;
 internal sealed class FixpOutboundEncoder
 {
     private readonly Func<uint> _sessionId;
+    private readonly Func<ulong> _sessionVerId;
     private readonly Func<uint> _nextMsgSeqNum;
     private readonly Func<TcpTransport> _transport;
     private readonly RetransmitBuffer _retxBuffer;
@@ -42,6 +43,7 @@ internal sealed class FixpOutboundEncoder
 
     public FixpOutboundEncoder(
         Func<uint> sessionId,
+        Func<ulong> sessionVerId,
         Func<uint> nextMsgSeqNum,
         Func<TcpTransport> transport,
         RetransmitBuffer retxBuffer,
@@ -51,6 +53,7 @@ internal sealed class FixpOutboundEncoder
         Action close)
     {
         _sessionId = sessionId;
+        _sessionVerId = sessionVerId;
         _nextMsgSeqNum = nextMsgSeqNum;
         _transport = transport;
         _retxBuffer = retxBuffer;
@@ -186,7 +189,7 @@ internal sealed class FixpOutboundEncoder
     {
         if (!_isOpen()) return false;
         var exact = new byte[SessionRejectEncoder.TerminateTotal];
-        SessionRejectEncoder.EncodeTerminate(exact, _sessionId(), 0, terminationCode);
+        SessionRejectEncoder.EncodeTerminate(exact, _sessionId(), _sessionVerId(), terminationCode);
         bool result = _transport().TryEnqueueFrame(exact);
         _close();
         return result;

--- a/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
@@ -122,7 +122,7 @@ public sealed partial class FixpSession
     {
         if (!IsOpen) { Close(reason, kind); return; }
         var frame = new byte[SessionRejectEncoder.TerminateTotal];
-        SessionRejectEncoder.EncodeTerminate(frame, SessionId, 0, terminationCode);
+        SessionRejectEncoder.EncodeTerminate(frame, SessionId, SessionVerId, terminationCode);
         try
         {
             await _transport.SendDirectAsync(frame).ConfigureAwait(false);

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -204,6 +204,45 @@ public sealed partial class FixpSession
     }
 
     /// <summary>
+    /// Generation-aware graceful terminate: writes a Terminate frame to the
+    /// transport observed by the caller, then closes only if that transport is
+    /// still current. Used by the watchdog so stale ticks after re-attach cannot
+    /// tear down a fresh transport.
+    /// </summary>
+    private async Task SendTerminateIfTransportCurrentAndCloseAsync(
+        byte terminationCode, string reason, TcpTransport originatingTransport, CloseKind kind)
+    {
+        uint sessionId;
+        ulong sessionVerId;
+        lock (_attachLock)
+        {
+            if (!ReferenceEquals(_transport, originatingTransport)) return;
+            if (Volatile.Read(ref _isOpen) == 0) return;
+            sessionId = SessionId;
+            sessionVerId = SessionVerId;
+        }
+
+        var frame = new byte[SessionRejectEncoder.TerminateTotal];
+        SessionRejectEncoder.EncodeTerminate(frame, sessionId, sessionVerId, terminationCode);
+        try
+        {
+            await originatingTransport.SendDirectAsync(frame).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "fixp session {ConnectionId} failed to write Terminate({Code})",
+                ConnectionId, terminationCode);
+        }
+
+        lock (_attachLock)
+        {
+            if (!ReferenceEquals(_transport, originatingTransport)) return;
+            CloseLocked(reason, kind);
+        }
+    }
+
+    /// <summary>
     /// Closes the session with a diagnostic reason. Legacy overload
     /// kept for tests and existing call-sites that have not been
     /// classified yet; defaults to <see cref="CloseKind.PeerTerminate"/>
@@ -283,7 +322,9 @@ public sealed partial class FixpSession
         // recoverable serverFlow). Non-removing kinds also save the
         // final state so the resume point on reconnect is accurate.
         bool removePersistence =
-            kind == CloseKind.PeerTerminate || kind == CloseKind.SuspendedTimeout;
+            kind == CloseKind.PeerTerminate ||
+            kind == CloseKind.KeepaliveLapsed ||
+            kind == CloseKind.SuspendedTimeout;
         if (removePersistence)
         {
             if (_outboundJournal is not null && SessionId != 0)

--- a/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Watchdog.cs
@@ -76,7 +76,9 @@ public sealed partial class FixpSession
                     // raced in between the snapshot above and the close
                     // call below; CloseIfTransportCurrent re-validates
                     // under _attachLock.
-                    CloseIfTransportCurrent("idle-timeout", ownTransport);
+                    await SendTerminateIfTransportCurrentAndCloseAsync(
+                        SessionRejectEncoder.TerminationCode.KeepaliveIntervalLapsed,
+                        "idle-timeout", ownTransport, CloseKind.KeepaliveLapsed).ConfigureAwait(false);
                     return;
                 }
 

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -394,6 +394,7 @@ public sealed partial class FixpSession : IAsyncDisposable
             coldRead: coldRead);
         _outboundEncoder = new FixpOutboundEncoder(
             sessionId: () => SessionId,
+            sessionVerId: () => SessionVerId,
             nextMsgSeqNum: NextMsgSeqNum,
             transport: () => _transport!,
             retxBuffer: _retxBuffer,

--- a/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EntryPointHeartbeatTests.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using B3.Exchange.Contracts;
 using B3.EntryPoint.Wire;
 using System.Net;
@@ -82,12 +83,18 @@ public class EntryPointHeartbeatTests
         }
         catch (OperationCanceledException) { }
         catch (IOException) { }
-        // We should have received exactly one Sequence probe (SOFH+SBE+4 bytes) before EOF.
-        const int expectedFrameLen = EntryPointFrameReader.WireHeaderSize + 4;
+        // We should receive the Sequence probe and a protocol Terminate before EOF.
+        const int expectedFrameLen = EntryPointFrameReader.WireHeaderSize + 4
+            + SessionRejectEncoder.TerminateTotal;
         Assert.Equal(expectedFrameLen, total);
         // Header sanity: templateId == 9 at offset SOFH+2.
         ushort tid = BitConverter.ToUInt16(buf, EntryPointFrameReader.SofhSize + 2);
         Assert.Equal((ushort)EntryPointFrameReader.TidSequence, tid);
+        ushort terminateTid = BitConverter.ToUInt16(buf,
+            EntryPointFrameReader.WireHeaderSize + 4 + EntryPointFrameReader.SofhSize + 2);
+        Assert.Equal((ushort)EntryPointFrameReader.TidTerminate, terminateTid);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.KeepaliveIntervalLapsed,
+            buf[EntryPointFrameReader.WireHeaderSize + 4 + EntryPointFrameReader.WireHeaderSize + 12]);
     }
 
     [Fact]
@@ -133,6 +140,81 @@ public class EntryPointHeartbeatTests
     }
 
     [Fact]
+    public async Task EstablishedIdleSession_EmitsKeepaliveLapsedTerminateBeforeClose()
+    {
+        var sem = new SemaphoreSlim(0, 1);
+        FixpSession? closedSession = null;
+        string? closeReason = null;
+        var options = new FixpSessionOptions
+        {
+            HeartbeatIntervalMs = 10_000,
+            IdleTimeoutMs = 10_000,
+            TestRequestGraceMs = 100,
+        };
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            NullLoggerFactory.Instance,
+            sessionOptions: options,
+            onSessionClosed: (s, reason) =>
+            {
+                closedSession = s;
+                closeReason = reason;
+                sem.Release();
+            });
+        listener.Start();
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(listener.LocalEndpoint!.Address, listener.LocalEndpoint.Port);
+        var ns = client.GetStream();
+
+        const uint sessionId = 10101;
+        const ulong sessionVerId = 77;
+        var handshake = new byte[256];
+        int negotiateLen = EntryPointFixpFrameCodec.EncodeNegotiate(handshake,
+            sessionId, sessionVerId, timestampNanos: 0, enteringFirm: 42,
+            onBehalfFirm: null,
+            credentials: ReadOnlySpan<byte>.Empty,
+            clientIp: ReadOnlySpan<byte>.Empty,
+            clientAppName: ReadOnlySpan<byte>.Empty,
+            clientAppVersion: ReadOnlySpan<byte>.Empty);
+        await ns.WriteAsync(handshake.AsMemory(0, negotiateLen));
+        var negotiateResponse = await ReadFrameAsync(ns, TimeSpan.FromSeconds(3));
+        Assert.Equal((ushort)EntryPointFrameReader.TidNegotiateResponse,
+            BinaryPrimitives.ReadUInt16LittleEndian(negotiateResponse.AsSpan(EntryPointFrameReader.SofhSize + 2, 2)));
+
+        int establishLen = EntryPointFixpFrameCodec.EncodeEstablish(handshake,
+            sessionId, sessionVerId, timestampNanos: 0, keepAliveIntervalMillis: 100,
+            nextSeqNo: 1, cancelOnDisconnectType: 0, codTimeoutWindowMillis: 0,
+            credentials: ReadOnlySpan<byte>.Empty);
+        await ns.WriteAsync(handshake.AsMemory(0, establishLen));
+        var establishAck = await ReadFrameAsync(ns, TimeSpan.FromSeconds(3));
+        Assert.Equal((ushort)EntryPointFrameReader.TidEstablishAck,
+            BinaryPrimitives.ReadUInt16LittleEndian(establishAck.AsSpan(EntryPointFrameReader.SofhSize + 2, 2)));
+
+        byte[]? terminate = null;
+        while (terminate is null)
+        {
+            var frame = await ReadFrameAsync(ns, TimeSpan.FromSeconds(5));
+            ushort frameTid = BinaryPrimitives.ReadUInt16LittleEndian(
+                frame.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+            if (frameTid == EntryPointFrameReader.TidTerminate)
+                terminate = frame;
+        }
+
+        Assert.True(EntryPointFixpFrameCodec.TryDecodeTerminate(
+            terminate.AsSpan(EntryPointFrameReader.WireHeaderSize), out var decoded));
+        Assert.Equal(sessionId, decoded.SessionId);
+        Assert.Equal(sessionVerId, decoded.SessionVerId);
+        Assert.Equal(SessionRejectEncoder.TerminationCode.KeepaliveIntervalLapsed,
+            decoded.TerminationCode);
+
+        Assert.True(await sem.WaitAsync(TimeSpan.FromSeconds(3)), "session did not close after Terminate");
+        Assert.Equal("idle-timeout", closeReason);
+        Assert.Equal(CloseKind.KeepaliveLapsed, closedSession?.LastCloseKind);
+    }
+
+    [Fact]
     public async Task ServerEmitsHeartbeat_WhenOutboundIdle()
     {
         var options = new FixpSessionOptions
@@ -169,5 +251,27 @@ public class EntryPointHeartbeatTests
         Assert.Equal(expectedFrameLen, total);
         Assert.Equal((ushort)EntryPointFrameReader.TidSequence, BitConverter.ToUInt16(buf, EntryPointFrameReader.SofhSize + 2));
         Assert.Equal((ushort)4, BitConverter.ToUInt16(buf, EntryPointFrameReader.SofhSize)); // BlockLength
+    }
+
+    private static async Task<byte[]> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var prefix = new byte[EntryPointFrameReader.SofhSize];
+        await ReadExactAsync(stream, prefix, cts.Token);
+        ushort len = BinaryPrimitives.ReadUInt16LittleEndian(prefix);
+        var frame = new byte[len];
+        prefix.CopyTo(frame, 0);
+        await ReadExactAsync(stream, frame.AsMemory(prefix.Length), cts.Token);
+        return frame;
+    }
+
+    private static async Task ReadExactAsync(Stream stream, Memory<byte> buffer, CancellationToken ct)
+    {
+        while (!buffer.IsEmpty)
+        {
+            int n = await stream.ReadAsync(buffer, ct);
+            if (n == 0) throw new EndOfStreamException();
+            buffer = buffer.Slice(n);
+        }
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCloseKindTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCloseKindTests.cs
@@ -111,6 +111,7 @@ public sealed class FixpSessionCloseKindTests
     [InlineData(CloseKind.PeerTerminate)]
     [InlineData(CloseKind.HostShutdown)]
     [InlineData(CloseKind.TransportError)]
+    [InlineData(CloseKind.KeepaliveLapsed)]
     [InlineData(CloseKind.SuspendedTimeout)]
     public async Task Every_CloseKind_propagates(CloseKind kind)
     {


### PR DESCRIPTION
## Summary
- send Terminate(KEEPALIVE_INTERVAL_LAPSED=10) before watchdog idle teardown
- preserve sessionVerID in Terminate encoders
- add gateway coverage for idle Terminate frames

Fixes #409

## Tests
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn