### PR TITLE
Fix negotiate unknown session reject code

### DIFF
--- a/src/B3.Exchange.Gateway/NegotiationValidator.cs
+++ b/src/B3.Exchange.Gateway/NegotiationValidator.cs
@@ -142,7 +142,7 @@ public sealed class NegotiationValidator
         var cred = _firms.FindSessionByWire(req.SessionId);
         if (cred is null)
             return NegotiationOutcome.Reject(
-                FixpSbe.NegotiationRejectCode.CREDENTIALS,
+                FixpSbe.NegotiationRejectCode.INVALID_SESSIONID,
                 $"unknown sessionID {req.SessionId}");
 
         var firm = _firms.FindFirm(cred.FirmId)

--- a/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NegotiationValidatorTests.cs
@@ -74,11 +74,12 @@ public class NegotiationValidatorTests
     }
 
     [Fact]
-    public void Unknown_session_rejected_credentials()
+    public void Unknown_session_rejected_invalid_sessionid()
     {
         var (v, _) = Build();
         var o = v.Validate(Req(sid: 99999), Cred(user: "99999"), FixpState.Idle);
-        Assert.Equal(FixpSbe.NegotiationRejectCode.CREDENTIALS, o.RejectCode);
+        Assert.False(o.IsAccepted);
+        Assert.Equal(FixpSbe.NegotiationRejectCode.INVALID_SESSIONID, o.RejectCode);
     }
 
     [Fact]
@@ -90,10 +91,11 @@ public class NegotiationValidatorTests
     }
 
     [Fact]
-    public void Wrong_access_key_rejected_credentials()
+    public void Known_session_wrong_access_key_rejected_credentials()
     {
         var (v, _) = Build();
         var o = v.Validate(Req(), Cred(key: "wrong"), FixpState.Idle);
+        Assert.False(o.IsAccepted);
         Assert.Equal(FixpSbe.NegotiationRejectCode.CREDENTIALS, o.RejectCode);
     }
 


### PR DESCRIPTION
## Summary
- Return INVALID_SESSIONID for unknown FIXP negotiate sessionID
- Keep CREDENTIALS for known-session credential mismatches
- Update NegotiationValidator tests for both cases

Fixes #413

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn