### PR TITLE
Fix CoD on peer Terminate

### DIFF
--- a/src/B3.Exchange.Gateway/CloseKind.cs
+++ b/src/B3.Exchange.Gateway/CloseKind.cs
@@ -23,14 +23,19 @@ namespace B3.Exchange.Gateway;
 public enum CloseKind
 {
     /// <summary>
-    /// Peer-initiated graceful logout (received <c>Terminate(Finished)</c>
-    /// or local code chose to terminate the session for protocol /
-    /// auth reasons). After this close the peer is not expected to
-    /// resume the same session; persisted state should be removed.
-    /// Default for legacy <c>Close(string)</c> call sites to preserve
-    /// pre-#405 behavior until the journal wire-up commit.
+    /// Peer-initiated graceful logout (received <c>Terminate(Finished)</c>).
+    /// After this close the peer is not expected to resume the same session;
+    /// persisted state should be removed. This is also a CoD
+    /// terminate-trigger for modes 2 and 3.
     /// </summary>
     PeerTerminate,
+
+    /// <summary>
+    /// Local code chose to terminate or dispose the session for protocol /
+    /// auth / test-cleanup reasons. Terminal for persistence, but not a
+    /// peer-Terminate CoD trigger.
+    /// </summary>
+    LocalTerminate,
 
     /// <summary>
     /// Host process is shutting down gracefully (SIGTERM,

--- a/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.CancelOnDisconnect.cs
@@ -86,15 +86,21 @@ public sealed partial class FixpSession
     /// <summary>
     /// Returns true when the session's Establish-time
     /// <see cref="CancelOnDisconnectType"/> covers the
-    /// transport-disconnect trigger (modes <c>1</c> and <c>3</c>). The
-    /// explicit-Terminate trigger (modes <c>2</c> and <c>3</c>) is
-    /// deferred until inbound peer-Terminate framing is wired.
+    /// close trigger represented by <paramref name="kind"/>. Transport
+    /// disconnects cover modes <c>1</c> and <c>3</c>; peer-initiated
+    /// Terminate frames cover modes <c>2</c> and <c>3</c>.
     /// </summary>
-    private bool CodCoversDisconnect()
+    private bool CodCoversDisconnect(CloseKind kind)
     {
         var t = CancelOnDisconnectType;
-        return t == B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_ONLY
-            || t == B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_OR_TERMINATE;
+        return kind switch
+        {
+            CloseKind.TransportError => t == B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_ONLY
+                || t == B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_OR_TERMINATE,
+            CloseKind.PeerTerminate => t == B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_TERMINATE_ONLY
+                || t == B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_OR_TERMINATE,
+            _ => false,
+        };
     }
 
     /// <summary>
@@ -105,7 +111,7 @@ public sealed partial class FixpSession
     private void ScheduleCodTimerLocked()
     {
         if (_codTimer is not null) return;
-        if (!CodCoversDisconnect()) return;
+        if (!CodCoversDisconnect(CloseKind.TransportError)) return;
         var window = CodTimeoutWindowMs;
         if (window < 0) window = 0;
         _logger.LogInformation(
@@ -158,6 +164,14 @@ public sealed partial class FixpSession
         try { originating.Dispose(); } catch { }
         if (!fire) return;
 
+        FireCancelOnDisconnect();
+    }
+
+    /// <summary>
+    /// Fires a session-scoped mass cancel for a committed CoD trigger.
+    /// </summary>
+    private void FireCancelOnDisconnect()
+    {
         // SecurityId=0 + SideFilter=null ⇒ "every resting order owned by
         // this session" — HostRouter resolves the actual order list via
         // OrderOwnershipMap.FilterMassCancel(session, firm, null, 0).

--- a/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Inbound.cs
@@ -99,11 +99,11 @@ public sealed partial class FixpSession
     /// directly to the underlying stream (bypassing the send queue), and
     /// closes the session. <paramref name="kind"/> classifies the close
     /// for the persistence layer (issue #405); defaults to
-    /// <see cref="CloseKind.PeerTerminate"/> for the decoding-error /
+    /// <see cref="CloseKind.LocalTerminate"/> for the decoding-error /
     /// reject paths inside this class.
     /// </summary>
     private async Task TerminateAndCloseAsync(byte terminationCode, string reason,
-        CloseKind kind = CloseKind.PeerTerminate)
+        CloseKind kind = CloseKind.LocalTerminate)
         => await SendTerminateAndCloseAsync(terminationCode, reason, kind).ConfigureAwait(false);
 
     /// <summary>
@@ -118,7 +118,7 @@ public sealed partial class FixpSession
     /// the process exit and the peer can resync on reconnect.
     /// </summary>
     public async Task SendTerminateAndCloseAsync(byte terminationCode, string reason,
-        CloseKind kind = CloseKind.PeerTerminate)
+        CloseKind kind = CloseKind.LocalTerminate)
     {
         if (!IsOpen) { Close(reason, kind); return; }
         var frame = new byte[SessionRejectEncoder.TerminateTotal];

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -245,11 +245,11 @@ public sealed partial class FixpSession
     /// <summary>
     /// Closes the session with a diagnostic reason. Legacy overload
     /// kept for tests and existing call-sites that have not been
-    /// classified yet; defaults to <see cref="CloseKind.PeerTerminate"/>
-    /// to preserve pre-#405 behavior (the persistence delete-vs-keep
-    /// decision is wired in a later commit).
+    /// classified yet; defaults to <see cref="CloseKind.LocalTerminate"/>
+    /// so generic local teardown remains terminal without being treated
+    /// as a peer-Terminate CoD trigger.
     /// </summary>
-    public void Close(string reason) => Close(reason, CloseKind.PeerTerminate);
+    public void Close(string reason) => Close(reason, CloseKind.LocalTerminate);
 
     /// <summary>
     /// Classified close (issue #405). The <paramref name="kind"/>
@@ -285,6 +285,10 @@ public sealed partial class FixpSession
         _logger.LogInformation(
             "fixp session {ConnectionId} closing (kind={Kind})",
             ConnectionId, kind);
+        if (CodCoversDisconnect(kind))
+        {
+            FireCancelOnDisconnect();
+        }
         try { _cts.Cancel(); } catch (ObjectDisposedException) { /* concurrent dispose race; benign */ }
         // The transport may have already closed (it's the source of the
         // callback in IO-error paths). Either way, ensure it's down so the
@@ -316,15 +320,16 @@ public sealed partial class FixpSession
         }
         // Issue #289 / #405: terminal close ⇒ drop the persisted
         // retransmit ring file AND the unbounded outbound journal AND
-        // the state snapshot. Scoped to {PeerTerminate, SuspendedTimeout}
+        // the state snapshot. Scoped to terminal close kinds
         // so transport-error and host-shutdown closes preserve state for
         // the reconnecting peer to resync against (SBE 5.2 §1.5
         // recoverable serverFlow). Non-removing kinds also save the
         // final state so the resume point on reconnect is accurate.
         bool removePersistence =
-            kind == CloseKind.PeerTerminate ||
-            kind == CloseKind.KeepaliveLapsed ||
-            kind == CloseKind.SuspendedTimeout;
+            kind == CloseKind.PeerTerminate
+            || kind == CloseKind.LocalTerminate
+            || kind == CloseKind.KeepaliveLapsed
+            || kind == CloseKind.SuspendedTimeout;
         if (removePersistence)
         {
             if (_outboundJournal is not null && SessionId != 0)

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCloseKindTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCloseKindTests.cs
@@ -61,7 +61,7 @@ public sealed class FixpSessionCloseKindTests
             var session = NewSession(serverSide);
             Assert.Null(session.LastCloseKind);
             session.Close("test");
-            Assert.Equal(CloseKind.PeerTerminate, session.LastCloseKind);
+            Assert.Equal(CloseKind.LocalTerminate, session.LastCloseKind);
         }
         finally
         {
@@ -109,6 +109,7 @@ public sealed class FixpSessionCloseKindTests
 
     [Theory]
     [InlineData(CloseKind.PeerTerminate)]
+    [InlineData(CloseKind.LocalTerminate)]
     [InlineData(CloseKind.HostShutdown)]
     [InlineData(CloseKind.TransportError)]
     [InlineData(CloseKind.KeepaliveLapsed)]

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCodTests.cs
@@ -1,3 +1,4 @@
+using B3.EntryPoint.Wire;
 using B3.Exchange.Contracts;
 using System.Collections.Concurrent;
 using System.Net;
@@ -22,10 +23,9 @@ namespace B3.Exchange.Gateway.Tests;
 /// gateway-side <c>OrderOwnershipMap</c> resolves it to the resting
 /// orders this session owned. A reconnect (TryReattach) inside the
 /// grace window must cancel the pending CoD trigger; full
-/// <c>Close</c> must dispose the timer too. The on-terminate half of
-/// modes <c>CANCEL_ON_TERMINATE_ONLY</c> /
-/// <c>CANCEL_ON_DISCONNECT_OR_TERMINATE</c> is deferred until inbound
-/// peer-Terminate framing is wired (out of scope for this PR).
+/// <c>Close</c> must dispose the timer too. Peer-initiated Terminate
+/// frames must trigger modes <c>CANCEL_ON_TERMINATE_ONLY</c> and
+/// <c>CANCEL_ON_DISCONNECT_OR_TERMINATE</c>.
 /// </summary>
 public class FixpSessionCodTests
 {
@@ -77,6 +77,26 @@ public class FixpSessionCodTests
         session.ApplyTransition(FixpEvent.Establish);
         session.SetCancelOnDisconnectForTest(codType, codWindowMs);
         return session;
+    }
+
+    private static byte[] EncodeInboundTerminate(uint sessionId, ulong sessionVerId)
+    {
+        var buf = new byte[EntryPointFixpFrameCodec.TerminateBlock + EntryPointFrameReader.WireHeaderSize];
+        EntryPointFixpFrameCodec.EncodeTerminate(
+            buf,
+            sessionId,
+            sessionVerId,
+            SessionRejectEncoder.TerminationCode.Finished);
+        return buf;
+    }
+
+    private static async Task SendPeerTerminateAndAwaitCloseAsync(FixpSession session, TcpClient client)
+    {
+        var frame = EncodeInboundTerminate(session.SessionId, session.SessionVerId);
+        await client.GetStream().WriteAsync(frame);
+        Assert.True(await TestUtil.WaitUntilAsync(() => session.LastCloseKind is not null,
+            TimeSpan.FromSeconds(3)));
+        Assert.Equal(CloseKind.PeerTerminate, session.LastCloseKind);
     }
 
     private static async Task DropAndAwaitSuspendAsync(FixpSession session, TcpClient client)
@@ -173,8 +193,7 @@ public class FixpSessionCodTests
     {
         // CANCEL_ON_TERMINATE_ONLY must NOT fire on a bare transport
         // drop — the trigger is an explicit Terminate frame from the
-        // peer (deferred from this PR until inbound Terminate framing
-        // lands). Verifying this guard here so a future change that
+        // peer. Verifying this guard here so a future change that
         // mis-classifies the trigger fails loudly.
         var (tcp, serverStream, client) = await ConnectPairAsync();
         try
@@ -188,6 +207,75 @@ public class FixpSessionCodTests
             await Task.Delay(200);
             Assert.Empty(sink.MassCancels);
             session.Close("test-cleanup");
+        }
+        finally
+        {
+            try { serverStream.Dispose(); } catch { }
+            try { client.Dispose(); } catch { }
+            tcp.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Mode2_FiresMassCancel_OnPeerTerminate()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new RecordingEngineSink();
+            var session = DriveToSuspended(serverStream, sink,
+                FixpSbe.CancelOnDisconnectType.CANCEL_ON_TERMINATE_ONLY,
+                codWindowMs: 50);
+
+            await SendPeerTerminateAndAwaitCloseAsync(session, client);
+
+            Assert.Single(sink.MassCancels);
+        }
+        finally
+        {
+            try { serverStream.Dispose(); } catch { }
+            try { client.Dispose(); } catch { }
+            tcp.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Mode3_FiresMassCancel_OnPeerTerminate()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new RecordingEngineSink();
+            var session = DriveToSuspended(serverStream, sink,
+                FixpSbe.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_OR_TERMINATE,
+                codWindowMs: 50);
+
+            await SendPeerTerminateAndAwaitCloseAsync(session, client);
+
+            Assert.Single(sink.MassCancels);
+        }
+        finally
+        {
+            try { serverStream.Dispose(); } catch { }
+            try { client.Dispose(); } catch { }
+            tcp.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task Mode0_DoesNotFire_OnPeerTerminate()
+    {
+        var (tcp, serverStream, client) = await ConnectPairAsync();
+        try
+        {
+            var sink = new RecordingEngineSink();
+            var session = DriveToSuspended(serverStream, sink,
+                FixpSbe.CancelOnDisconnectType.DO_NOT_CANCEL_ON_DISCONNECT_OR_TERMINATE,
+                codWindowMs: 50);
+
+            await SendPeerTerminateAndAwaitCloseAsync(session, client);
+
+            Assert.Empty(sink.MassCancels);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- trigger Cancel-on-Disconnect modes 2/3 on peer-initiated Terminate closes
- split generic local terminal closes from peer Terminate so cleanup/protocol rejects do not fire terminate CoD
- add gateway tests for Terminate CoD modes 0/2/3 and update close-kind expectations

Fixes #410

## Tests
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn