### PR TITLE
Validate inbound sendingTime skew

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -11,7 +11,8 @@
     "enteringFirm": 1,
     "heartbeatIntervalMs": 30000,
     "idleTimeoutMs": 30000,
-    "testRequestGraceMs": 5000
+    "testRequestGraceMs": 5000,
+    "sendingTimeSkewToleranceMs": 5000
   },
   // Authentication. devMode=true bypasses access-key validation during
   // FIXP Negotiate (#42) — useful for local dev / tests. Production

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -76,7 +76,8 @@ Exposes:
     "enteringFirm": 1,
     "heartbeatIntervalMs": 30000,
     "idleTimeoutMs": 30000,
-    "testRequestGraceMs": 5000
+    "testRequestGraceMs": 5000,
+    "sendingTimeSkewToleranceMs": 5000
   },
   "auth": { "devMode": true },
   "firms": [
@@ -143,6 +144,9 @@ Exposes:
   the session is closed; a `BusinessReject` (templateId=206) framing the
   reason is the responsibility of issue #11 — `EntryPointSession.Close(reason)`
   exposes the seam.
+* `tcp.sendingTimeSkewToleranceMs` — maximum absolute skew tolerated between
+  the server clock and an inbound application message's
+  `InboundBusinessHeader.sendingTime`. Default `5000`; set `0` to disable.
 * `http` — **optional** Kestrel-hosted operability endpoint exposing
   `/health/live`, `/health/ready`, and `/metrics`. Omit the entire block to
   disable HTTP.

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -100,6 +100,12 @@ public sealed partial class FixpSession
             if (!TryAcceptBusinessHeaderSessionId(info.TemplateId, fixedBlock))
                 return true;
 
+            // §4.6.3.1: sendingTime is an epoch-nanos client timestamp.
+            // Reject out-of-tolerance clocks with BMR and do not consume
+            // MsgSeqNum.
+            if (!TryAcceptBusinessHeaderSendingTime(info.TemplateId, fixedBlock))
+                return true;
+
             // §4.5.5 / §4.6.2 (#GAP-07): inbound MsgSeqNum gap detection.
             // On gap (received > expected) emit NotApplied(fromSeqNo=expected,
             // count=received-expected) AND advance expected past the gap

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -56,6 +56,42 @@ public sealed partial class FixpSession
     }
 
     /// <summary>
+    /// Validates <c>InboundBusinessHeader.sendingTime</c> against the server
+    /// clock. The B3 schema's <c>UTCTimestampNanosOptional</c> type is a
+    /// uint64 Unix-epoch nanosecond timestamp with null value 0; a null or
+    /// out-of-window value is rejected with <c>BusinessMessageReject</c> and
+    /// the session remains open.
+    /// </summary>
+    internal bool TryAcceptBusinessHeaderSendingTime(ushort templateId, ReadOnlySpan<byte> fixedBlock)
+    {
+        ulong hdrSendingTime = System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(8, 8));
+        ulong tolerance = _options.SendingTimeSkewToleranceNs;
+        if (tolerance == 0)
+            return true;
+
+        ulong now = _timeSource.NowNanos();
+        ulong diff = hdrSendingTime > now ? hdrSendingTime - now : now - hdrSendingTime;
+        if (hdrSendingTime != 0 && diff <= tolerance)
+            return true;
+
+        uint hdrMsgSeqNum = System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4));
+        ulong refClOrdId = fixedBlock.Length >= 28
+            ? System.Buffers.Binary.BinaryPrimitives.ReadUInt64LittleEndian(fixedBlock.Slice(20, 8))
+            : 0UL;
+
+        WriteBusinessMessageReject(
+            refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(templateId),
+            refSeqNum: hdrMsgSeqNum,
+            businessRejectRefId: refClOrdId,
+            businessRejectReason: BusinessMessageRejectEncoder.Reason.Other,
+            text: "sendingTime outside tolerance");
+        _logger.LogWarning(
+            "fixp session {ConnectionId} rejected business message: sendingTime {SendingTime} differs from server clock {Now} by {Diff}ns (tolerance={Tolerance}ns, template={Template})",
+            ConnectionId, hdrSendingTime, now, diff, tolerance, templateId);
+        return false;
+    }
+
+    /// <summary>
     /// Emits a <c>BusinessMessageReject(33003)</c> for an application
     /// frame whose wire body decoded but requested an unsupported
     /// sub-feature (e.g. stop-order, iceberg, RLP, GTC). The session

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -41,6 +41,15 @@ public sealed record FixpSessionOptions
     public int FirstFrameTimeoutMs { get; init; } = 5_000;
 
     /// <summary>
+    /// Maximum tolerated absolute clock skew between the server clock and an
+    /// inbound application message's <c>InboundBusinessHeader.sendingTime</c>.
+    /// The schema defines the field as Unix-epoch nanoseconds; no tighter
+    /// venue-specific window is documented in the vendored schema, so the
+    /// default is 5 seconds. Set to <c>0</c> to disable the check.
+    /// </summary>
+    public ulong SendingTimeSkewToleranceNs { get; init; } = 5UL * 1_000_000_000UL;
+
+    /// <summary>
     /// Per-session capacity (in frames) of the outbound retransmission
     /// ring buffer that backs FIXP <c>RetransmitRequest</c> recovery
     /// (issue #46, spec §4.5.6). Buffered templates are

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -465,6 +465,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             HeartbeatIntervalMs = _config.Tcp.HeartbeatIntervalMs,
             IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,
             TestRequestGraceMs = _config.Tcp.TestRequestGraceMs,
+            SendingTimeSkewToleranceNs = (ulong)Math.Max(_config.Tcp.SendingTimeSkewToleranceMs, 0) * 1_000_000UL,
             LifecycleMetrics = _metrics.Sessions,
             ThrottleTimeWindowMs = _config.Tcp.Throttle?.TimeWindowMs ?? 0,
             ThrottleMaxMessages = _config.Tcp.Throttle?.MaxMessages ?? 0,

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -87,6 +87,12 @@ public sealed class TcpConfig
     [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
 
     /// <summary>
+    /// Maximum absolute skew tolerated for inbound application
+    /// InboundBusinessHeader.sendingTime. Default: 5 s. Set to 0 to disable.
+    /// </summary>
+    [JsonPropertyName("sendingTimeSkewToleranceMs")] public int SendingTimeSkewToleranceMs { get; set; } = 5_000;
+
+    /// <summary>
     /// Per-session inbound sliding-window throttle (issue #56 / GAP-20,
     /// guidelines §4.9). Omit (or set both fields to 0) to disable
     /// throttling. Defaults to 100 application messages per 1000 ms when

--- a/src/B3.Exchange.SyntheticTrader/Fixp/FixpClient.cs
+++ b/src/B3.Exchange.SyntheticTrader/Fixp/FixpClient.cs
@@ -146,13 +146,14 @@ public sealed class FixpClient : IAsyncDisposable
     /// <summary>
     /// Patches the 18-byte <c>InboundBusinessHeader</c> at the start of
     /// <paramref name="bodyAfterWireHeader"/>: <c>sessionID</c>(4) at
-    /// offset 0 and <c>msgSeqNum</c>(4) at offset 4. Returns the assigned
+    /// offset 0, <c>msgSeqNum</c>(4) at offset 4, and
+    /// <c>sendingTime</c>(8) at offset 8. Returns the assigned
     /// <c>msgSeqNum</c>. Thread-safe; serializes assignment so the wire
     /// order matches numeric order.
     /// </summary>
     public uint AssignOutboundBusinessHeader(Span<byte> bodyAfterWireHeader)
     {
-        if (bodyAfterWireHeader.Length < 8)
+        if (bodyAfterWireHeader.Length < 16)
             throw new ArgumentException("body too small for InboundBusinessHeader", nameof(bodyAfterWireHeader));
         uint assigned;
         lock (_seqLock)
@@ -161,6 +162,7 @@ public sealed class FixpClient : IAsyncDisposable
         }
         BinaryPrimitives.WriteUInt32LittleEndian(bodyAfterWireHeader.Slice(0, 4), _sessionIdNumeric);
         BinaryPrimitives.WriteUInt32LittleEndian(bodyAfterWireHeader.Slice(4, 4), assigned);
+        BinaryPrimitives.WriteUInt64LittleEndian(bodyAfterWireHeader.Slice(8, 8), NowNanos());
         return assigned;
     }
 

--- a/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSendingTimeValidationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/BusinessHeaderSendingTimeValidationTests.cs
@@ -1,0 +1,171 @@
+using B3.Exchange.Contracts;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Matching;
+using B3.Exchange.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Buffers.Binary;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class BusinessHeaderSendingTimeValidationTests
+{
+    private const ulong NowNanos = 1_700_000_000_000_000_000UL;
+    private const ulong ToleranceNanos = 5UL * 1_000_000_000UL;
+
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue) => true;
+        public bool EnqueueCancel(in CancelOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueCross(in CrossOrderCommand cmd, SessionId session, uint enteringFirm) => true;
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, SessionId session, uint enteringFirm) => true;
+        public void OnDecodeError(SessionId session, string error) { }
+        public void OnSessionClosed(SessionId session) { }
+    }
+
+    private static async Task<(NetworkStream ServerSide, TcpClient Client)> ConnectPairAsync()
+    {
+        var tcp = new TcpListener(IPAddress.Loopback, 0);
+        tcp.Start();
+        var client = new TcpClient();
+        var connectTask = client.ConnectAsync(IPAddress.Loopback, ((IPEndPoint)tcp.LocalEndpoint).Port);
+        var serverSock = await tcp.AcceptSocketAsync();
+        await connectTask;
+        tcp.Stop();
+        return (new NetworkStream(serverSock, ownsSocket: true), client);
+    }
+
+    private static byte[] BuildBody(ulong sendingTime, uint msgSeqNum = 7, ulong clOrdId = 42)
+    {
+        var body = new byte[82];
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(0, 4), 100);
+        BinaryPrimitives.WriteUInt32LittleEndian(body.AsSpan(4, 4), msgSeqNum);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(8, 8), sendingTime);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.AsSpan(20, 8), clOrdId);
+        return body;
+    }
+
+    private static FixpSession NewSession(NetworkStream server)
+        => new(
+            connectionId: 1,
+            enteringFirm: 7,
+            sessionId: 100,
+            stream: server,
+            sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance,
+            timeSource: new FakeNanosTimeSource(NowNanos),
+            options: new FixpSessionOptions { SendingTimeSkewToleranceNs = ToleranceNanos });
+
+    private static async Task<(byte RefMsgType, uint RefSeqNum, ulong RefId, uint Reason)> ReadBusinessRejectAsync(TcpClient client)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+        var ns = client.GetStream();
+        var head = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(ns, head, cts.Token);
+
+        ushort msgLen = BinaryPrimitives.ReadUInt16LittleEndian(head.AsSpan(0, 2));
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(head.AsSpan(EntryPointFrameReader.SofhSize + 2, 2));
+        Assert.Equal(EntryPointFrameReader.TidBusinessMessageReject, tid);
+
+        var body = new byte[msgLen - EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(ns, body, cts.Token);
+
+        return (
+            body[18],
+            BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(20, 4)),
+            BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(24, 8)),
+            BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(32, 4)));
+    }
+
+    private static async Task ReadExactAsync(NetworkStream ns, byte[] buffer, CancellationToken cancellationToken)
+    {
+        var read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await ns.ReadAsync(buffer.AsMemory(read), cancellationToken);
+            if (n <= 0) throw new EndOfStreamException();
+            read += n;
+        }
+    }
+
+    [Fact]
+    public async Task SendingTime_within_tolerance_is_accepted()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewSession(server);
+            var body = BuildBody(NowNanos + ToleranceNanos);
+
+            Assert.True(session.TryAcceptBusinessHeaderSendingTime(EntryPointFrameReader.TidSimpleNewOrder, body));
+            Assert.Equal(0, client.Available);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Future_sendingTime_outside_tolerance_emits_BusinessMessageReject()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewSession(server);
+            session.Start();
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+            var body = BuildBody(NowNanos + ToleranceNanos + 1, msgSeqNum: 13, clOrdId: 4242);
+
+            Assert.False(session.TryAcceptBusinessHeaderSendingTime(EntryPointFrameReader.TidSimpleNewOrder, body));
+
+            var bmr = await ReadBusinessRejectAsync(client);
+            Assert.Equal((byte)15, bmr.RefMsgType);
+            Assert.Equal(13u, bmr.RefSeqNum);
+            Assert.Equal(4242UL, bmr.RefId);
+            Assert.Equal(BusinessMessageRejectEncoder.Reason.Other, bmr.Reason);
+            Assert.Equal(0u, session.LastIncomingSeqNo);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Past_sendingTime_outside_tolerance_emits_BusinessMessageReject()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            var session = NewSession(server);
+            session.Start();
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+            var body = BuildBody(NowNanos - ToleranceNanos - 1, msgSeqNum: 14, clOrdId: 4343);
+
+            Assert.False(session.TryAcceptBusinessHeaderSendingTime(EntryPointFrameReader.TidSimpleNewOrder, body));
+
+            var bmr = await ReadBusinessRejectAsync(client);
+            Assert.Equal((byte)15, bmr.RefMsgType);
+            Assert.Equal(14u, bmr.RefSeqNum);
+            Assert.Equal(4343UL, bmr.RefId);
+            Assert.Equal(BusinessMessageRejectEncoder.Reason.Other, bmr.Reason);
+            Assert.Equal(0u, session.LastIncomingSeqNo);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+}

--- a/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
+++ b/tests/B3.Exchange.Interop.Tests/EpcInteropTests.cs
@@ -58,7 +58,12 @@ public class EpcInteropTests : IAsyncLifetime
         var hostCfg = new HostConfig
         {
             Auth = new AuthConfig { RequireFixpHandshake = true, DevMode = true },
-            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = EnteringFirm },
+            Tcp = new TcpConfig
+            {
+                Listen = "127.0.0.1:0",
+                EnteringFirm = EnteringFirm,
+                SendingTimeSkewToleranceMs = 0,
+            },
             Firms = new()
             {
                 new FirmConfig { Id = "firmA", Name = "Firm A", EnteringFirmCode = EnteringFirm },


### PR DESCRIPTION
## Summary
- validate inbound business-header sendingTime against server clock with a configurable 5s default tolerance
- emit BusinessMessageReject and skip MsgSeqNum consumption for missing/out-of-window sendingTime
- add deterministic gateway tests and document tcp.sendingTimeSkewToleranceMs

Fixes #414

## Tests
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn