### PR TITLE
Fix daily reset FIXP persistence cleanup

### DIFF
--- a/src/B3.Exchange.Gateway/CloseKind.cs
+++ b/src/B3.Exchange.Gateway/CloseKind.cs
@@ -38,13 +38,19 @@ public enum CloseKind
     LocalTerminate,
 
     /// <summary>
-    /// Host process is shutting down gracefully (SIGTERM,
-    /// daily-rollover, etc.). The peer is expected to reconnect when
-    /// the host comes back; persisted state must be preserved so the
-    /// resumed session can replay every event produced before the
-    /// shutdown.
+    /// Host process is shutting down gracefully (SIGTERM, operator stop,
+    /// etc.). The peer is expected to reconnect when the host comes back;
+    /// persisted state must be preserved so the resumed session can
+    /// replay every event produced before the shutdown.
     /// </summary>
     HostShutdown,
+
+    /// <summary>
+    /// Trading-day rollover. The peer must reconnect with fresh daily
+    /// FIXP sequence state; persisted state and last-seen SessionVerID
+    /// should be removed rather than preserved for resync.
+    /// </summary>
+    DailyReset,
 
     /// <summary>
     /// Underlying TCP transport dropped (read/write error, peer RST,

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -31,7 +31,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly B3.Exchange.Contracts.RetransmitMetrics? _retransmitMetrics;
     private readonly B3.Exchange.Gateway.Persistence.IFixpOutboundJournal? _outboundJournal;
     private readonly B3.Exchange.Gateway.Persistence.IFixpSessionStatePersister? _statePersister;
-    private readonly IReadOnlyDictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>? _persistedSessionStates;
+    private readonly IDictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>? _persistedSessionStates;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
@@ -89,7 +89,9 @@ public sealed class EntryPointListener : IAsyncDisposable
         _retransmitMetrics = retransmitMetrics;
         _outboundJournal = outboundJournal;
         _statePersister = statePersister;
-        _persistedSessionStates = persistedSessionStates;
+        _persistedSessionStates = persistedSessionStates is null
+            ? null
+            : new Dictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>(persistedSessionStates);
         if ((_negotiationValidator is null) ^ (_sessionClaims is null))
         {
             throw new ArgumentException(
@@ -219,7 +221,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     /// not nest the listener's mutex. Safe to call from the HTTP thread
     /// or from the daily-rollover scheduler timer.</para>
     /// </summary>
-    public int TerminateAllSessions(string reason)
+    public int TerminateAllSessions(string reason, CloseKind closeKind = CloseKind.HostShutdown)
     {
         ArgumentException.ThrowIfNullOrEmpty(reason);
         FixpSession[] snapshot;
@@ -230,10 +232,9 @@ public sealed class EntryPointListener : IAsyncDisposable
             if (!s.IsOpen) continue;
             try
             {
-                // Daily-rollover / admin terminate-all is treated as a
-                // host-driven shutdown (issue #405): peer is expected
-                // to reconnect and we want persisted state preserved.
-                s.Close(reason, CloseKind.HostShutdown);
+                s.Close(reason, closeKind);
+                if (closeKind == CloseKind.DailyReset)
+                    _persistedSessionStates?.Remove(s.SessionId);
                 closed++;
             }
             catch (Exception ex)

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -295,10 +295,12 @@ public sealed partial class FixpSession
         // send loop wakes up and exits.
         _transport.Close(reason);
         // Release the FIXP session claim (if any) so the same sessionID
-        // can be re-negotiated by a future transport.
+        // can be re-negotiated by a future transport. Daily reset also
+        // clears the last-seen SessionVerID because B3 daily state starts
+        // fresh rather than obeying prior-day monotonicity.
         if (_claimedSessionId != 0 && _claims is not null)
         {
-            try { _claims.Release(_claimedSessionId, this); }
+            try { _claims.Release(_claimedSessionId, this, forgetLastVersion: kind == CloseKind.DailyReset); }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex,
@@ -318,7 +320,7 @@ public sealed partial class FixpSession
                 "fixp session {ConnectionId} OnSessionClosed callback threw",
                 ConnectionId);
         }
-        // Issue #289 / #405: terminal close ⇒ drop the persisted
+        // Issue #289 / #405 / #416: terminal close ⇒ drop the persisted
         // retransmit ring file AND the unbounded outbound journal AND
         // the state snapshot. Scoped to terminal close kinds
         // so transport-error and host-shutdown closes preserve state for
@@ -329,7 +331,8 @@ public sealed partial class FixpSession
             kind == CloseKind.PeerTerminate
             || kind == CloseKind.LocalTerminate
             || kind == CloseKind.KeepaliveLapsed
-            || kind == CloseKind.SuspendedTimeout;
+            || kind == CloseKind.SuspendedTimeout
+            || kind == CloseKind.DailyReset;
         if (removePersistence)
         {
             if (_outboundJournal is not null && SessionId != 0)

--- a/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
+++ b/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
@@ -177,11 +177,13 @@ public sealed class SessionClaimRegistry
     /// Releases the claim for <paramref name="sessionId"/> if (and only
     /// if) it is currently held by <paramref name="claimToken"/>. Safe to
     /// call from any thread; safe to call multiple times. Does not
-    /// reset the recorded last-seen sessionVerID — that persists for
-    /// the life of the process so reconnects can be checked for
-    /// monotonicity.
+    /// reset the recorded last-seen sessionVerID unless
+    /// <paramref name="forgetLastVersion"/> is true. Normal reconnects
+    /// need monotonicity to survive for the process lifetime; daily
+    /// trading-day resets explicitly clear it so SessionVerID starts
+    /// fresh.
     /// </summary>
-    public void Release(uint sessionId, object claimToken)
+    public void Release(uint sessionId, object claimToken, bool forgetLastVersion = false)
     {
         ArgumentNullException.ThrowIfNull(claimToken);
         lock (_lock)
@@ -190,6 +192,10 @@ public sealed class SessionClaimRegistry
                 ReferenceEquals(owner, claimToken))
             {
                 _activeClaims.Remove(sessionId);
+            }
+            if (forgetLastVersion)
+            {
+                _lastSessionVerId.Remove(sessionId);
             }
         }
     }

--- a/src/B3.Exchange.Host/DailyResetScheduler.cs
+++ b/src/B3.Exchange.Host/DailyResetScheduler.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using B3.Exchange.Gateway;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Exchange.Host;
@@ -19,13 +20,21 @@ public sealed class DailyResetScheduler : IAsyncDisposable
 {
     private readonly TimeSpan _localTime;
     private readonly TimeZoneInfo _timezone;
-    private readonly Action _action;
+    private readonly Action<CloseKind> _action;
     private readonly ILogger<DailyResetScheduler> _logger;
     private readonly Func<DateTimeOffset>? _utcNowOverride;
     private Timer? _timer;
     private int _disposed;
 
     public DailyResetScheduler(string schedule, string timezone, Action action,
+        ILogger<DailyResetScheduler> logger,
+        Func<DateTimeOffset>? utcNowOverride = null)
+        : this(schedule, timezone, _ => action(), logger, utcNowOverride)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+    }
+
+    public DailyResetScheduler(string schedule, string timezone, Action<CloseKind> action,
         ILogger<DailyResetScheduler> logger,
         Func<DateTimeOffset>? utcNowOverride = null)
     {
@@ -60,7 +69,7 @@ public sealed class DailyResetScheduler : IAsyncDisposable
     /// NOT shift the next scheduled firing.</summary>
     public void Trigger()
     {
-        try { _action(); }
+        try { _action(CloseKind.DailyReset); }
         catch (Exception ex)
         {
             _logger.LogError(ex, "daily-reset action threw on manual trigger");
@@ -74,7 +83,7 @@ public sealed class DailyResetScheduler : IAsyncDisposable
         try
         {
             _logger.LogInformation("daily-reset firing (scheduled)");
-            _action();
+            _action(CloseKind.DailyReset);
         }
         catch (Exception ex)
         {

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -79,10 +79,10 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// or -1 if the host has not finished <see cref="StartAsync"/>.
     /// Safe to call from any thread.
     /// </summary>
-    public int TriggerDailyReset(string reason = "operator-trigger")
+    public int TriggerDailyReset(string reason = "operator-trigger", CloseKind closeKind = CloseKind.DailyReset)
     {
         var listener = _listener;
-        int terminated = listener is null ? -1 : listener.TerminateAllSessions(reason);
+        int terminated = listener is null ? -1 : listener.TerminateAllSessions(reason, closeKind);
         // Issue #330 PR-3 (review BLOCKING): drain per-channel inbound
         // queues before reading yesterday's audit log. TerminateAllSessions
         // only closes live FIXP transports; commands already decoded and
@@ -600,7 +600,7 @@ public sealed class ExchangeHost : IAsyncDisposable
                 // through TriggerDailyReset so the listener-terminate +
                 // EOD-export chaining (#330 PR-3) is identical for
                 // automated and manual rollovers.
-                action: () => TriggerDailyReset("daily-reset"),
+                action: kind => TriggerDailyReset("daily-reset", kind),
                 logger: _loggerFactory.CreateLogger<DailyResetScheduler>());
             _dailyReset.Start();
         }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionCloseKindTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionCloseKindTests.cs
@@ -111,6 +111,7 @@ public sealed class FixpSessionCloseKindTests
     [InlineData(CloseKind.PeerTerminate)]
     [InlineData(CloseKind.LocalTerminate)]
     [InlineData(CloseKind.HostShutdown)]
+    [InlineData(CloseKind.DailyReset)]
     [InlineData(CloseKind.TransportError)]
     [InlineData(CloseKind.KeepaliveLapsed)]
     [InlineData(CloseKind.SuspendedTimeout)]

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionPersistenceWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionPersistenceWiringTests.cs
@@ -246,6 +246,34 @@ public sealed class FixpSessionPersistenceWiringTests
     }
 
     [Fact]
+    public async Task DailyReset_close_removes_journal_and_state()
+    {
+        var (listener, serverSide, client) = await ConnectPairAsync();
+        try
+        {
+            var journal = new FakeJournal();
+            var state = new FakeStatePersister();
+            var session = new FixpSession(
+                connectionId: 1, enteringFirm: 1, sessionId: 88,
+                stream: serverSide,
+                sink: new NoOpEngineSink(),
+                logger: NullLogger<FixpSession>.Instance,
+                outboundJournal: journal,
+                statePersister: state);
+
+            session.Close("daily reset", CloseKind.DailyReset);
+
+            Assert.Equal(1, journal.RemoveCalls);
+            Assert.Equal(1, state.RemoveCalls);
+        }
+        finally
+        {
+            client.Close();
+            listener.Stop();
+        }
+    }
+
+    [Fact]
     public async Task HostShutdown_close_preserves_journal_and_saves_final_snapshot()
     {
         var (listener, serverSide, client) = await ConnectPairAsync();

--- a/tests/B3.Exchange.Host.Tests/DailyResetFixpPersistenceTests.cs
+++ b/tests/B3.Exchange.Host.Tests/DailyResetFixpPersistenceTests.cs
@@ -1,0 +1,162 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using System.Text;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway.Persistence;
+using B3.Exchange.TestSupport;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Host.Tests;
+
+public sealed class DailyResetFixpPersistenceTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_DropsPersistedFixpState_AndReconnectStartsFresh()
+    {
+        const uint sessionId = 12345;
+        const uint enteringFirm = 7;
+        const ulong previousVerId = 77;
+        const ulong freshVerId = 1;
+
+        var root = CreateRepoTestDir("daily-reset-fixp-");
+        try
+        {
+            var persister = new FileFixpSessionStatePersister(root, NullLogger<FileFixpSessionStatePersister>.Instance);
+            persister.Save(new FixpSessionStateSnapshot(sessionId, previousVerId, 42, 0, enteringFirm, 0));
+            persister.Dispose();
+
+            var cfg = BuildConfig(root, sessionId, enteringFirm);
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var resumedClient = new TcpClient();
+            await resumedClient.ConnectAsync(ep.Address, ep.Port);
+            var resumedStream = resumedClient.GetStream();
+            await WriteEstablishAsync(resumedStream, sessionId, previousVerId, nextSeqNo: 1);
+            var resumedAck = await ReadFrameAsync(resumedStream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidEstablishAck, resumedAck.TemplateId);
+            Assert.True(EntryPointFixpFrameCodec.TryDecodeEstablishAck(resumedAck.Body, out var oldAck));
+            Assert.Equal(previousVerId, oldAck.SessionVerId);
+            Assert.Equal(43u, oldAck.NextSeqNo);
+
+            Assert.Equal(1, host.TriggerDailyReset("test-daily-reset"));
+            resumedClient.Close();
+
+            using var freshClient = new TcpClient();
+            await freshClient.ConnectAsync(ep.Address, ep.Port);
+            var freshStream = freshClient.GetStream();
+            await WriteNegotiateAsync(freshStream, sessionId, freshVerId, enteringFirm);
+            var negotiate = await ReadFrameAsync(freshStream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidNegotiateResponse, negotiate.TemplateId);
+            Assert.True(EntryPointFixpFrameCodec.TryDecodeNegotiateResponse(negotiate.Body, out var negotiateResponse));
+            Assert.Equal(freshVerId, negotiateResponse.SessionVerId);
+
+            await WriteEstablishAsync(freshStream, sessionId, freshVerId, nextSeqNo: 1);
+            var freshAckFrame = await ReadFrameAsync(freshStream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidEstablishAck, freshAckFrame.TemplateId);
+            Assert.True(EntryPointFixpFrameCodec.TryDecodeEstablishAck(freshAckFrame.Body, out var freshAck));
+            Assert.Equal(freshVerId, freshAck.SessionVerId);
+            Assert.Equal(1u, freshAck.NextSeqNo);
+
+            await host.StopAsync();
+        }
+        finally
+        {
+            TryDelete(root);
+        }
+    }
+
+    private static HostConfig BuildConfig(string persistenceDir, uint sessionId, uint enteringFirm)
+        => new()
+        {
+            Auth = new AuthConfig { DevMode = true, RequireFixpHandshake = true },
+            Tcp = new TcpConfig
+            {
+                Listen = "127.0.0.1:0",
+                EnteringFirm = enteringFirm,
+                RetransmitPersistenceDir = persistenceDir,
+                HeartbeatIntervalMs = 60_000,
+                IdleTimeoutMs = 60_000,
+                TestRequestGraceMs = 60_000,
+            },
+            Firms = { new FirmConfig { Id = "firm", Name = "firm", EnteringFirmCode = enteringFirm } },
+            Sessions = { new SessionConfig { SessionId = sessionId.ToString(System.Globalization.CultureInfo.InvariantCulture), FirmId = "firm" } },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30184,
+                    Ttl = 0,
+                    InstrumentsFile = TestPaths.ResolveRepoFile("config/instruments-eqt.json"),
+                },
+            },
+        };
+
+    private static async Task WriteNegotiateAsync(NetworkStream stream, uint sessionId, ulong sessionVerId, uint enteringFirm)
+    {
+        var credentials = Encoding.ASCII.GetBytes($"{{\"auth_type\":\"basic\",\"username\":\"{sessionId}\",\"access_key\":\"\"}}");
+        var buffer = new byte[EntryPointFrameReader.MaxInboundMessageLength];
+        int length = EntryPointFixpFrameCodec.EncodeNegotiate(buffer, sessionId, sessionVerId, timestampNanos: 0, enteringFirm, onBehalfFirm: null, credentials, clientIp: "127.0.0.1"u8, clientAppName: "test"u8, clientAppVersion: "1"u8);
+        await stream.WriteAsync(buffer.AsMemory(0, length));
+    }
+
+    private static async Task WriteEstablishAsync(NetworkStream stream, uint sessionId, ulong sessionVerId, uint nextSeqNo)
+    {
+        var buffer = new byte[EntryPointFrameReader.MaxInboundMessageLength];
+        int length = EntryPointFixpFrameCodec.EncodeEstablish(buffer, sessionId, sessionVerId, timestampNanos: 0, keepAliveIntervalMillis: 60_000, nextSeqNo, cancelOnDisconnectType: 0, codTimeoutWindowMillis: 0, credentials: ReadOnlySpan<byte>.Empty);
+        await stream.WriteAsync(buffer.AsMemory(0, length));
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var header = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, header, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(header.AsSpan(6, 2));
+        int bodyLength = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLength];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+
+    private static string CreateRepoTestDir(string prefix)
+    {
+        var config = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+        var repoRoot = Directory.GetParent(Path.GetDirectoryName(config)!)!.FullName;
+        var dir = Path.Combine(repoRoot, "artifacts", "test-dirs", prefix + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true); }
+        catch { }
+    }
+}


### PR DESCRIPTION
## Summary
- add CloseKind.DailyReset and route scheduler/manual daily reset through it
- delete FIXP journal/state and clear in-process SessionVerID on daily reset
- add gateway lifecycle and host reconnect regression tests

Fixes #416

## Tests
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release (first run hit one unrelated reaper flake; rerun passed)
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn