### PR TITLE
Return unsupported order characteristics as ER rejects

### DIFF
--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -270,6 +270,7 @@ internal sealed class FixpOutboundEncoder
         // surfaced in the audit log.
         RejectReason.InstrumentHalted => 13u,
         RejectReason.TimeInForceNotSupported => 11u,
+        RejectReason.UnsupportedOrderCharacteristic => 11u,
         RejectReason.MinQtyNotMet => 0u,
         RejectReason.InvalidField => 11u,
         _ => 0u,

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -277,7 +277,15 @@ public sealed partial class FixpSession
                     }
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
                     {
-                        WriteApplicationBusinessReject(info.TemplateId, fixedBlock, nosClOrd, nosMsg ?? "unsupported");
+                        if (nos is not null)
+                        {
+                            if (!_sink.EnqueueNewOrder(nos, Identity, EnteringFirm, nosClOrd))
+                                WriteSystemBusyReject(info.TemplateId, fixedBlock, nosClOrd, "New");
+                        }
+                        else
+                        {
+                            WriteApplicationBusinessReject(info.TemplateId, fixedBlock, nosClOrd, nosMsg ?? "unsupported");
+                        }
                         return true;
                     }
                     _sink.OnDecodeError(Identity, nosMsg ?? "decode error: NewOrderSingle");
@@ -296,7 +304,15 @@ public sealed partial class FixpSession
                     }
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature)
                     {
-                        WriteApplicationBusinessReject(info.TemplateId, fixedBlock, ocrClOrd, ocrMsg ?? "unsupported");
+                        if (ocr is not null)
+                        {
+                            if (!_sink.EnqueueReplace(ocr, Identity, EnteringFirm, ocrClOrd, ocrOrigClOrd))
+                                WriteSystemBusyReject(info.TemplateId, fixedBlock, ocrClOrd, "Replace");
+                        }
+                        else
+                        {
+                            WriteApplicationBusinessReject(info.TemplateId, fixedBlock, ocrClOrd, ocrMsg ?? "unsupported");
+                        }
                         return true;
                     }
                     _sink.OnDecodeError(Identity, ocrMsg ?? "decode error: OrderCancelReplaceRequest");

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -92,10 +92,12 @@ public sealed partial class FixpSession
     }
 
     /// <summary>
-    /// Emits a <c>BusinessMessageReject(33003)</c> for an application
-    /// frame whose wire body decoded but requested an unsupported
-    /// sub-feature (e.g. stop-order, iceberg, RLP, GTC). The session
-    /// stays open; spec §4.10 / #GAP-15. <paramref name="fixedBlock"/>
+    /// Emits a <c>BusinessMessageReject(33003)</c> for unsupported
+    /// application messages that do not have a per-order ER reject path
+    /// (for example unsupported cross variants). Per-order unsupported
+    /// characteristics are routed to the engine as
+    /// <c>ExecutionReport_Reject</c>. The session stays open; spec §4.10 /
+    /// #GAP-15. <paramref name="fixedBlock"/>
     /// is the inbound body whose first 8 bytes are the
     /// <c>InboundBusinessHeader</c>: <c>sessionID</c> (offset 0) and
     /// <c>msgSeqNum</c> (offset 4). The supplied

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -11,9 +11,9 @@ internal static partial class InboundMessageDecoder
     /// OrdType/TimeInForce/OrderQty/Price) plus the sub-feature flags
     /// (StopPx/MinQty/MaxFloor/RoutingInstruction/MmProtectionReset/
     /// SelfTradePreventionInstruction/ExpireDate) that the engine does
-    /// not implement; presence of the latter triggers a
-    /// <c>BusinessMessageReject(33003)</c> rather than terminating the
-    /// session (#GAP-15).
+    /// not implement; presence of the latter is forwarded to the engine as
+    /// an <c>ExecutionReport_Reject</c> rather than terminating the session
+    /// (#GAP-15 / #415).
     /// </summary>
     private static class NewOrderSingleOffsets
     {
@@ -34,9 +34,9 @@ internal static partial class InboundMessageDecoder
         public const int ExpireDate = 105;        // ushort (0 == null)
         public const int InvestorID = 119;        // Prefix(2) + Document(4), all-zero == null
         // V6 trailer (BlockLength=133). Both fields use 0 as the SBE
-        // null sentinel. Currently the engine rejects non-null values
-        // with BMR(33003) since strategy routing / sub-account tagging
-        // aren't supported (issue #238).
+        // null sentinel. Currently the engine rejects non-null values with
+        // ER_Reject since strategy routing / sub-account tagging aren't
+        // supported (issue #238).
         public const int StrategyID = 125;        // int32 (0 == null)
         public const int TradingSubAccount = 129; // uint32 (0 == null)
     }
@@ -51,9 +51,10 @@ internal static partial class InboundMessageDecoder
     /// onto the engine's supported subset (Market/Limit, Day/IOC/FOK, no
     /// stop / iceberg / minimum-fill / RLP). Returns
     /// <see cref="InboundDecodeOutcome.UnsupportedFeature"/> with a
-    /// <c>BusinessMessageReject(33003)</c>-bound text when the wire fields
-    /// are individually valid but request a feature the engine does not
-    /// implement; the caller emits BMR and keeps the session open.
+    /// diagnostic text when the wire fields are individually valid but
+    /// request a feature the engine does not implement; the caller enqueues
+    /// the populated command so the engine emits ER_Reject and keeps the
+    /// session open.
     /// Returns <see cref="InboundDecodeOutcome.DecodeError"/> for wire
     /// values that violate the SBE schema (unmapped Side / OrdType / TIF
     /// bytes); the caller terminates with DECODING_ERROR.
@@ -91,23 +92,43 @@ internal static partial class InboundMessageDecoder
             message = $"invalid Side={sideByte}";
             return InboundDecodeOutcome.DecodeError;
         }
+
+        NewOrderCommand UnsupportedCommand(OrderType type, TimeInForce tifValue, long stopPxForCommand = 0L)
+        {
+            long unsupportedPrice = (type == OrderType.Market || type == OrderType.MarketWithLeftover)
+                ? 0L
+                : (priceMantissa == PriceNull ? 0L : priceMantissa);
+            return new NewOrderCommand(clOrdId.ToString(), secId, side, type, tifValue, unsupportedPrice, qty, enteringFirm, enteredAtNanos)
+            {
+                MinQty = minQty,
+                MaxFloor = maxFloor,
+                StopPxMantissa = stopPxForCommand,
+                UnsupportedOrderCharacteristic = true,
+            };
+        }
+
+        TimeInForce tifForUnsupported = TryClassifyTif(tifByte, out var preclassifiedTif, out _)
+            ? preclassifiedTif
+            : TimeInForce.Day;
         if (!TryClassifyOrdType(ordTypeByte, out var ordType, out var ordTypeUnsupported))
         {
             message = ordTypeUnsupported is not null
                 ? $"OrdType={ordTypeByte:X2} not supported (only Market, Limit)"
                 : $"invalid OrdType={ordTypeByte}";
-            return ordTypeUnsupported is not null
-                ? InboundDecodeOutcome.UnsupportedFeature
-                : InboundDecodeOutcome.DecodeError;
+            if (ordTypeUnsupported is null)
+                return InboundDecodeOutcome.DecodeError;
+            cmd = UnsupportedCommand(OrderType.Limit, tifForUnsupported);
+            return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (!TryClassifyTif(tifByte, out var tif, out var tifUnsupported))
         {
             message = tifUnsupported is not null
                 ? $"TimeInForce={(char)tifByte} not supported (only Day, IOC, FOK)"
                 : $"invalid TimeInForce={tifByte}";
-            return tifUnsupported is not null
-                ? InboundDecodeOutcome.UnsupportedFeature
-                : InboundDecodeOutcome.DecodeError;
+            if (tifUnsupported is null)
+                return InboundDecodeOutcome.DecodeError;
+            cmd = UnsupportedCommand(ordType, TimeInForce.Day);
+            return InboundDecodeOutcome.UnsupportedFeature;
         }
         bool isStop = ordType == OrderType.StopLoss || ordType == OrderType.StopLimit;
         if (isStop)
@@ -115,12 +136,14 @@ internal static partial class InboundMessageDecoder
             if (stopPx == PriceNull)
             {
                 message = "Stop orders require StopPx";
+                cmd = UnsupportedCommand(ordType, tif);
                 return InboundDecodeOutcome.UnsupportedFeature;
             }
         }
         else if (stopPx != PriceNull)
         {
             message = "StopPx only valid on Stop orders";
+            cmd = UnsupportedCommand(ordType, tif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (maxFloor != 0)
@@ -131,21 +154,25 @@ internal static partial class InboundMessageDecoder
         if (routing != RoutingInstructionNull && routing != RoutingInstructionDefault)
         {
             message = $"RoutingInstruction={routing} not supported";
+            cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (mmpReset != 0)
         {
             message = "MMProtectionReset not supported";
+            cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (stp != 0)
         {
             message = "SelfTradePreventionInstruction not supported";
+            cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (expireDate != 0)
         {
             message = "ExpireDate not supported (only Day/IOC/FOK)";
+            cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
 
@@ -153,7 +180,7 @@ internal static partial class InboundMessageDecoder
         // +tradingSubAccount@129 (uint32, 0=null). The body span has
         // already been sliced to BlockLength by the FIXP dispatch, so
         // the trailer is present iff body.Length > V2 size. Engine
-        // doesn't honor either field — surface a BMR rather than
+        // doesn't honor either field — surface an ER_Reject rather than
         // silently ignore so partners notice.
         if (body.Length > NewOrderSingleV2BodySize)
         {
@@ -162,11 +189,13 @@ internal static partial class InboundMessageDecoder
             if (strategyId != 0)
             {
                 message = $"StrategyID={strategyId} not supported";
+                cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
                 return InboundDecodeOutcome.UnsupportedFeature;
             }
             if (tradingSubAccount != 0)
             {
                 message = $"TradingSubAccount={tradingSubAccount} not supported";
+                cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
                 return InboundDecodeOutcome.UnsupportedFeature;
             }
         }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -74,14 +74,29 @@ internal static partial class InboundMessageDecoder
             message = $"invalid Side={sideByte}";
             return InboundDecodeOutcome.DecodeError;
         }
+
+        ReplaceOrderCommand UnsupportedCommand(OrderType? type, TimeInForce? tifOverride)
+        {
+            long unsupportedPrice = type == OrderType.Market ? 0L : (priceMantissa == PriceNull ? 0L : priceMantissa);
+            return new ReplaceOrderCommand(clOrdId.ToString(), secId, (long)orderId, unsupportedPrice, qty, enteredAtNanos)
+            {
+                NewOrdType = type,
+                NewTif = tifOverride,
+                UnsupportedOrderCharacteristic = true,
+            };
+        }
+
+        TimeInForce? tifForUnsupported = tifByte != TimeInForceOptionalNull
+            && TryClassifyTif(tifByte, out var preclassifiedTif, out _) ? preclassifiedTif : null;
         if (!TryClassifyOrdType(ordTypeByte, out var ordType, out var ordTypeUnsupported))
         {
             message = ordTypeUnsupported is not null
                 ? $"OrdType={ordTypeByte:X2} not supported (only Market, Limit)"
                 : $"invalid OrdType={ordTypeByte}";
-            return ordTypeUnsupported is not null
-                ? InboundDecodeOutcome.UnsupportedFeature
-                : InboundDecodeOutcome.DecodeError;
+            if (ordTypeUnsupported is null)
+                return InboundDecodeOutcome.DecodeError;
+            cmd = UnsupportedCommand(OrderType.Limit, tifForUnsupported);
+            return InboundDecodeOutcome.UnsupportedFeature;
         }
         // #204: TimeInForce on this template is optional; absence means
         // "preserve the resting order's original TIF". When present, any
@@ -94,45 +109,53 @@ internal static partial class InboundMessageDecoder
                 message = tifUnsupported is not null
                     ? $"TimeInForce={(char)tifByte} not supported"
                     : $"invalid TimeInForce={tifByte}";
-                return tifUnsupported is not null
-                    ? InboundDecodeOutcome.UnsupportedFeature
-                    : InboundDecodeOutcome.DecodeError;
+                if (tifUnsupported is null)
+                    return InboundDecodeOutcome.DecodeError;
+                cmd = UnsupportedCommand(ordType, null);
+                return InboundDecodeOutcome.UnsupportedFeature;
             }
             newTif = tifValue;
         }
         if (stopPx != PriceNull)
         {
             message = "Stop orders not supported (StopPx must be NULL)";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (maxFloor != 0)
         {
             message = "Iceberg orders not supported (MaxFloor must be NULL)";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (minQty != 0)
         {
             message = "Minimum-fill orders not supported (MinQty must be NULL)";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (routing != RoutingInstructionNull && routing != RoutingInstructionDefault)
         {
             message = $"RoutingInstruction={routing} not supported";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (mmpReset != 0)
         {
             message = "MMProtectionReset not supported";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (stp != 0)
         {
             message = "SelfTradePreventionInstruction not supported";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         if (expireDate != 0)
         {
             message = "ExpireDate not supported (only Day/IOC/FOK)";
+            cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
         // #238: V6 trailer reject — see NewOrderSingle decoder.
@@ -143,11 +166,13 @@ internal static partial class InboundMessageDecoder
             if (strategyId != 0)
             {
                 message = $"StrategyID={strategyId} not supported";
+                cmd = UnsupportedCommand(ordType, newTif);
                 return InboundDecodeOutcome.UnsupportedFeature;
             }
             if (tradingSubAccount != 0)
             {
                 message = $"TradingSubAccount={tradingSubAccount} not supported";
+                cmd = UnsupportedCommand(ordType, newTif);
                 return InboundDecodeOutcome.UnsupportedFeature;
             }
         }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -92,6 +92,11 @@ public enum RejectReason : byte
     /// rejected with this reason; cancels are allowed so participants can
     /// pull resting orders during the halt.</summary>
     InstrumentHalted,
+    /// <summary>The order requested a wire-valid characteristic the simulator
+    /// does not implement. The gateway forwards these to the engine so the
+    /// client receives an <c>ExecutionReport_Reject</c> with FIX
+    /// OrdRejReason=11 instead of a <c>BusinessMessageReject</c>.</summary>
+    UnsupportedOrderCharacteristic,
 }
 
 /// <summary>
@@ -229,6 +234,8 @@ public sealed record NewOrderCommand(
     /// as a Limit order at <see cref="PriceMantissa"/>. Issue #214.
     /// </summary>
     public long StopPxMantissa { get; init; }
+
+    public bool UnsupportedOrderCharacteristic { get; init; }
 }
 
 public sealed record CancelOrderCommand(
@@ -271,6 +278,8 @@ public sealed record ReplaceOrderCommand(
     /// coded to <see cref="TimeInForce.Day"/>).
     /// </summary>
     public TimeInForce? NewTif { get; init; }
+
+    public bool UnsupportedOrderCharacteristic { get; init; }
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -766,6 +766,12 @@ public sealed class MatchingEngine
         EnterDispatch();
         try
         {
+            if (cmd.UnsupportedOrderCharacteristic)
+            {
+                Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.UnsupportedOrderCharacteristic, cmd.EnteredAtNanos);
+                return;
+            }
+
             if (!_rulesById.TryGetValue(cmd.SecurityId, out var rules))
             {
                 Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.UnknownInstrument, cmd.EnteredAtNanos);
@@ -1070,6 +1076,9 @@ public sealed class MatchingEngine
         EnterDispatch();
         try
         {
+            if (cmd.UnsupportedOrderCharacteristic)
+            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnsupportedOrderCharacteristic, cmd.EnteredAtNanos); return; }
+
             if (!_rulesById.TryGetValue(cmd.SecurityId, out var rules))
             { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnknownInstrument, cmd.EnteredAtNanos); return; }
             // Issue #322: replace under an administrative halt is rejected

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -48,6 +48,7 @@ public partial class ChannelDispatcherTests
         public List<OrderAcceptedEvent> News { get; } = new();
         public List<OrderCanceledEvent> Cancels { get; } = new();
         public List<RejectEvent> Rejects { get; } = new();
+        public List<ulong> RejectClOrdIds { get; } = new();
         public List<TradeEvent> Trades { get; } = new();
         public List<(long LeavesQty, long CumQty)> TradeQty { get; } = new();
         public bool CaptureCancelIds { get; set; }
@@ -83,7 +84,7 @@ public partial class ChannelDispatcherTests
         public bool WriteExecutionReportModify(B3.Exchange.Contracts.SessionId session, long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue, Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq, ulong receivedTimeNanos = ulong.MaxValue, DurabilityHandle d = default)
         { if (Find(session) is { } s) { s.Calls.Add("Modify"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default)
-        { if (Find(session) is { } s) { s.Rejects.Add(e); s.Calls.Add("Reject"); } return true; }
+        { if (Find(session) is { } s) { s.Rejects.Add(e); s.RejectClOrdIds.Add(clOrdIdValue); s.Calls.Add("Reject"); } return true; }
     }
 
     private static (ChannelDispatcher disp, RecordingPacketSink pkt, RecordingOutbound outbound) NewDispatcher()
@@ -129,6 +130,27 @@ public partial class ChannelDispatcherTests
         // SecurityId in body (after PacketHeader+Framing+SbeHeader)
         int bodyStart = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
         Assert.Equal(Petr, MemoryMarshal.Read<long>(packet.AsSpan(bodyStart + WireOffsets.OrderBodySecurityIdOffset, 8)));
+    }
+
+    [Fact]
+    public void NewOrder_UnsupportedCharacteristic_EmitsExecutionReportReject_NoUmdfPacket()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("415", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL)
+        {
+            UnsupportedOrderCharacteristic = true,
+        }, reply.Id, reply.EnteringFirm, clOrdIdValue: 415UL);
+
+        DrainInbound(disp);
+
+        Assert.Empty(pkt.Packets);
+        Assert.Empty(reply.News);
+        var reject = Assert.Single(reply.Rejects);
+        Assert.Equal(RejectReason.UnsupportedOrderCharacteristic, reject.Reason);
+        Assert.Equal("415", reject.ClOrdId);
+        Assert.Equal(415UL, Assert.Single(reply.RejectClOrdIds));
     }
 
     [Fact]

--- a/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
@@ -29,6 +29,7 @@ public class MapRejectReasonTests
     [InlineData(RejectReason.SelfTradePrevention, 0u)]
     [InlineData(RejectReason.MinQtyNotMet, 0u)]
     [InlineData(RejectReason.InvalidField, 11u)]
+    [InlineData(RejectReason.UnsupportedOrderCharacteristic, 11u)]
     public void MapRejectReason_ProducesExpectedWireCode(RejectReason reason, uint expected)
     {
         Assert.Equal(expected, FixpSession.MapRejectReason(reason));

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -280,14 +280,15 @@ public class NewOrderSingleAndReplaceDecoderTests
     [Theory]
     [InlineData((byte)'W')] // RLP
     [InlineData((byte)'P')] // PEGGED_MIDPOINT
-    public void NewOrderSingle_UnsupportedOrdTypeReturnsBmr(byte ordTypeByte)
+    public void NewOrderSingle_UnsupportedOrdTypeReturnsEngineRejectCommand(byte ordTypeByte)
     {
         var body = BuildNewOrderSingleV2(ordType: ordTypeByte);
 
         var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
-            body, 1, 0, out _, out _, out var msg);
+            body, 1, 0, out var cmd, out _, out var msg);
 
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.True(cmd.UnsupportedOrderCharacteristic);
         Assert.Contains("OrdType", msg);
     }
 


### PR DESCRIPTION
## Summary
- Route unsupported NewOrderSingle/OrderCancelReplace characteristics through the dispatcher/engine instead of direct BusinessMessageReject.
- Add UnsupportedOrderCharacteristic reject reason mapped to OrdRejReason=11.
- Add decoder/core tests covering unsupported OrdType and ER_Reject routing with ClOrdID preservation.

Fixes #415

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release (initial full run had 2 host timeout flakes; rerun passed)
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn