### PR TITLE
Support OrderMassAction filter fields

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Inbox.cs
@@ -141,10 +141,14 @@ public sealed partial class ChannelDispatcher
     /// </summary>
     public bool EnqueueResolvedMassCancel(IReadOnlyList<long> orderIds, SessionId session, uint enteringFirm,
         ulong enteredAtNanos)
+        => EnqueueResolvedMassCancel(orderIds, session, enteringFirm, new MassCancelCommand(0, null, enteredAtNanos));
+
+    public bool EnqueueResolvedMassCancel(IReadOnlyList<long> orderIds, SessionId session, uint enteringFirm,
+        MassCancelCommand command)
     {
         if (orderIds == null || orderIds.Count == 0) return true;
         if (RejectIfWalHalted(WorkKind.MassCancel)) return false;
-        var mc = new ResolvedMassCancel(orderIds, enteredAtNanos);
+        var mc = new ResolvedMassCancel(orderIds, command);
         using var act = StartEnqueueSpan(WorkKind.MassCancel, session, enteringFirm, 0, securityId: 0);
         var parent = act?.Context ?? System.Diagnostics.Activity.Current?.Context ?? default;
         if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.MassCancel, session, enteringFirm, true,

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -141,7 +141,7 @@ public sealed partial class ChannelDispatcher
             WorkKind.Cancel => item.Cancel?.EnteredAtNanos ?? ulong.MaxValue,
             WorkKind.Replace => item.Replace?.EnteredAtNanos ?? ulong.MaxValue,
             WorkKind.Cross => item.Cross?.Buy.EnteredAtNanos ?? ulong.MaxValue,
-            WorkKind.MassCancel => item.MassCancel?.EnteredAtNanos ?? ulong.MaxValue,
+            WorkKind.MassCancel => item.MassCancel?.Command.EnteredAtNanos ?? ulong.MaxValue,
             _ => ulong.MaxValue,
         };
         _packetWritten = 0;
@@ -312,7 +312,7 @@ public sealed partial class ChannelDispatcher
                         // Gateway router.
                         var mc = item.MassCancel!;
                         if (mc.OrderIds.Count > 0)
-                            _engine.MassCancel(mc.OrderIds, mc.EnteredAtNanos);
+                            _engine.MassCancel(mc.OrderIds, mc.Command);
                         break;
                     }
                 case WorkKind.DecodeError:

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -74,7 +74,7 @@ public sealed partial class ChannelDispatcher
     /// flat list of engine-assigned <c>OrderID</c>s plus the original
     /// inbound timestamp.
     /// </summary>
-    internal sealed record ResolvedMassCancel(IReadOnlyList<long> OrderIds, ulong EnteredAtNanos);
+    internal sealed record ResolvedMassCancel(IReadOnlyList<long> OrderIds, MassCancelCommand Command);
 
     /// <summary>
     /// Operator-triggered trade-bust payload (issue #15): identifies a

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -17,6 +17,7 @@ internal static partial class InboundMessageDecoder
     /// </summary>
     private static class NewOrderSingleOffsets
     {
+        public const int OrdTagID = 18;           // byte (0 == null)
         public const int MmProtectionReset = 19;  // bool byte (0=false)
         public const int ClOrdID = 20;            // ulong
         public const int Stp = 47;                // SelfTradePreventionInstruction (0=NONE)
@@ -31,6 +32,7 @@ internal static partial class InboundMessageDecoder
         public const int MinQty = 84;             // ulong (0 == null)
         public const int MaxFloor = 92;           // ulong (0 == null)
         public const int ExpireDate = 105;        // ushort (0 == null)
+        public const int InvestorID = 119;        // Prefix(2) + Document(4), all-zero == null
         // V6 trailer (BlockLength=133). Both fields use 0 as the SBE
         // null sentinel. Currently the engine rejects non-null values
         // with BMR(33003) since strategy routing / sub-account tagging
@@ -75,11 +77,14 @@ internal static partial class InboundMessageDecoder
         long stopPx = MemoryMarshal.Read<long>(body.Slice(NewOrderSingleOffsets.StopPxMantissa, 8));
         ulong minQty = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.MinQty, 8));
         ulong maxFloor = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.MaxFloor, 8));
+        byte ordTagId = body[NewOrderSingleOffsets.OrdTagID];
         byte mmpReset = body[NewOrderSingleOffsets.MmProtectionReset];
         byte stp = body[NewOrderSingleOffsets.Stp];
         ushort expireDate = MemoryMarshal.Read<ushort>(body.Slice(NewOrderSingleOffsets.ExpireDate, 2));
 
         clOrdIdValue = clOrdId;
+        var investorSpan = body.Slice(NewOrderSingleOffsets.InvestorID, 6);
+        InvestorId? investorId = IsAllZero(investorSpan) ? null : DecodeInvestorId(investorSpan);
 
         if (!TryMapSide(sideByte, out var side))
         {
@@ -185,6 +190,8 @@ internal static partial class InboundMessageDecoder
             MinQty = minQty,
             MaxFloor = maxFloor,
             StopPxMantissa = engineStopPx,
+            OrdTagId = ordTagId,
+            InvestorId = investorId,
         };
         return InboundDecodeOutcome.Success;
     }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderMassAction.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderMassAction.cs
@@ -26,8 +26,8 @@ internal static partial class InboundMessageDecoder
     /// Decodes an <c>OrderMassActionRequest</c> body (template 701, spec
     /// §4.8 / #GAP-19) into a <see cref="MassCancelCommand"/>. Returns
     /// <see cref="InboundDecodeOutcome.Success"/> when the request maps
-    /// onto the engine's supported subset (cancel-orders, optional Side
-    /// + SecurityID filters). Returns
+    /// onto the engine's supported subset (cancel-orders, optional Side,
+    /// SecurityID, OrdTagID, Asset and InvestorID filters). Returns
     /// <see cref="InboundDecodeOutcome.UnsupportedFeature"/> for
     /// schema-valid but unimplemented variants. Returns
     /// <see cref="InboundDecodeOutcome.DecodeError"/> for wire values
@@ -58,25 +58,13 @@ internal static partial class InboundMessageDecoder
             return InboundDecodeOutcome.DecodeError;
         }
 
-        if (ordTagId != 0)
-        {
-            message = "OrdTagID filter not supported (engine does not track ordTagID per order)";
-            return InboundDecodeOutcome.UnsupportedFeature;
-        }
-
         var assetSpan = body.Slice(OrderMassActionRequestOffsets.Asset, 6);
-        if (!IsAllZero(assetSpan))
-        {
-            message = "Asset filter not supported (engine does not track per-instrument asset)";
-            return InboundDecodeOutcome.UnsupportedFeature;
-        }
+        string? assetFilter = DecodeOptionalAscii(assetSpan);
 
         var investorSpan = body.Slice(OrderMassActionRequestOffsets.InvestorID, 6);
-        if (!IsMassActionInvestorEmpty(investorSpan))
-        {
-            message = "InvestorID (mass cancel on behalf) not supported";
-            return InboundDecodeOutcome.UnsupportedFeature;
-        }
+        InvestorId? investorFilter = IsMassActionInvestorEmpty(investorSpan)
+            ? null
+            : DecodeInvestorId(investorSpan);
 
         Side? sideFilter = null;
         if (sideByte != 0)
@@ -94,9 +82,27 @@ internal static partial class InboundMessageDecoder
         cmd = new MassCancelCommand(
             SecurityId: securityId,
             SideFilter: sideFilter,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            OrdTagIdFilter = ordTagId,
+            AssetFilter = assetFilter,
+            InvestorIdFilter = investorFilter,
+        };
         return InboundDecodeOutcome.Success;
     }
+
+    private static string? DecodeOptionalAscii(ReadOnlySpan<byte> span)
+    {
+        int end = span.Length;
+        while (end > 0 && (span[end - 1] == 0 || span[end - 1] == (byte)' ')) end--;
+        if (end == 0) return null;
+        return System.Text.Encoding.ASCII.GetString(span[..end]).ToUpperInvariant();
+    }
+
+    private static InvestorId DecodeInvestorId(ReadOnlySpan<byte> span)
+        => new(
+            Prefix: MemoryMarshal.Read<ushort>(span[..2]),
+            Document: MemoryMarshal.Read<uint>(span.Slice(2, 4)));
 
     private static bool IsAllZero(ReadOnlySpan<byte> span)
     {

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -125,7 +125,7 @@ public sealed class HostRouter : IInboundCommandSink
         bool allOk = true;
         foreach (var (disp, ids) in perChannel)
         {
-            if (!disp.EnqueueResolvedMassCancel(ids, session, enteringFirm, cmd.EnteredAtNanos))
+            if (!disp.EnqueueResolvedMassCancel(ids, session, enteringFirm, cmd))
                 allOk = false;
         }
         return allOk;

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -182,6 +182,10 @@ public sealed record NewOrderCommand(
     uint EnteringFirm,
     ulong EnteredAtNanos)
 {
+    public byte OrdTagId { get; init; }
+    public string? Asset { get; init; }
+    public InvestorId? InvestorId { get; init; }
+
     /// <summary>
     /// Optional minimum-fill (FIX MinQty). When non-zero, the engine
     /// requires that at submission time the immediately fillable quantity
@@ -360,6 +364,8 @@ public enum CrossPrioritization : byte
     SellPrioritized = 2,
 }
 
+public readonly record struct InvestorId(ushort Prefix, uint Document);
+
 /// <summary>
 /// Mass-cancel command (OrderMassActionRequest template 701, spec §4.8 /
 /// #GAP-19). Carries the wire-level filter as decoded from the inbound
@@ -374,4 +380,9 @@ public enum CrossPrioritization : byte
 public sealed record MassCancelCommand(
     long SecurityId,
     Side? SideFilter,
-    ulong EnteredAtNanos);
+    ulong EnteredAtNanos)
+{
+    public byte OrdTagIdFilter { get; init; }
+    public string? AssetFilter { get; init; }
+    public InvestorId? InvestorIdFilter { get; init; }
+}

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -58,7 +58,10 @@ public sealed record RestingOrderRecord(
     ulong InsertTimestampNanos,
     TimeInForce Tif,
     long MaxFloor,
-    long HiddenQuantity);
+    long HiddenQuantity,
+    byte OrdTagId = 0,
+    string? Asset = null,
+    InvestorId? InvestorId = null);
 
 /// <summary>
 /// Persistable view of a single untriggered stop order (issue #262). Mirrors

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -12,6 +12,9 @@ internal sealed class RestingOrder
     public required Side Side { get; init; }
     public required long PriceMantissa { get; init; }
     public required uint EnteringFirm { get; init; }
+    public byte OrdTagId { get; init; }
+    public string? Asset { get; init; }
+    public InvestorId? InvestorId { get; init; }
 
     /// <summary>
     /// Wall-clock timestamp at which the order entered (or last re-entered)
@@ -302,7 +305,10 @@ internal sealed class LimitOrderBook
                         InsertTimestampNanos: o.InsertTimestampNanos,
                         Tif: o.Tif,
                         MaxFloor: o.MaxFloor,
-                        HiddenQuantity: o.HiddenQuantity);
+                        HiddenQuantity: o.HiddenQuantity,
+                        OrdTagId: o.OrdTagId,
+                        Asset: o.Asset,
+                        InvestorId: o.InvestorId);
                 }
             }
         }
@@ -326,6 +332,9 @@ internal sealed class LimitOrderBook
             Side = record.Side,
             PriceMantissa = record.PriceMantissa,
             EnteringFirm = record.EnteringFirm,
+            OrdTagId = record.OrdTagId,
+            Asset = record.Asset,
+            InvestorId = record.InvestorId,
             InsertTimestampNanos = record.InsertTimestampNanos,
             Tif = record.Tif,
             MaxFloor = record.MaxFloor,

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -932,7 +932,7 @@ public sealed class MatchingEngine
             // rest cmd directly with cmd.PriceMantissa.
             if (phase == TradingPhase.Reserved || phase == TradingPhase.FinalClosingCall)
             {
-                RestForAuction(cmd, book);
+                RestForAuction(cmd, rules, book);
                 return;
             }
             ExecuteAggressor(cmd, rules, book, emitUnmatchedIocClose);
@@ -986,21 +986,18 @@ public sealed class MatchingEngine
     /// <c>OrderOwnership</c> map, so the engine sees only orderIds.
     /// </summary>
     public int MassCancel(IReadOnlyCollection<long> orderIds, ulong enteredAtNanos)
+        => MassCancel(orderIds, new MassCancelCommand(0, null, enteredAtNanos));
+
+    public int MassCancel(IReadOnlyCollection<long> orderIds, MassCancelCommand command)
     {
         ArgumentNullException.ThrowIfNull(orderIds);
+        ArgumentNullException.ThrowIfNull(command);
         if (orderIds.Count == 0) return 0;
         EnterDispatch();
         try
         {
-            // Single-pass resolution (round-2 perf #8): the previous
-            // implementation walked every (orderId × book) pair twice —
-            // once to bucket the (SecurityId, Side) summary counts and a
-            // second time to emit per-order cancels. We now resolve each
-            // orderId at most once, capture the (book, resting) pair in
-            // a reusable scratch list, and iterate it for both the
-            // grouped summary frames and the per-order cancels.
-            // Orders that no longer resolve are silently dropped,
-            // matching the prior behaviour.
+            // Single-pass resolution (round-2 perf #8): resolve each candidate
+            // once, then apply all MassAction filters before summary/cancel emit.
             var resolved = _massCancelResolved;
             resolved.Clear();
             Dictionary<(long securityId, Side side), int>? groups = null;
@@ -1010,6 +1007,8 @@ public sealed class MatchingEngine
                 {
                     if (book.TryGet(orderId, out var resting))
                     {
+                        if (!MatchesMassCancelFilter(book, resting, command))
+                            break;
                         resolved.Add((book, resting));
                         groups ??= new Dictionary<(long, Side), int>();
                         var key = (book.SecurityId, resting.Side);
@@ -1026,26 +1025,45 @@ public sealed class MatchingEngine
                         SecurityId: kv.Key.securityId,
                         Side: kv.Key.side,
                         CancelledCount: kv.Value,
-                        TransactTimeNanos: enteredAtNanos,
+                        TransactTimeNanos: command.EnteredAtNanos,
                         RptSeq: NextRptSeq()));
                 }
             }
 
             int cancelled = resolved.Count;
-            // Snapshot count BEFORE emitting because EmitCanceled mutates
-            // the underlying book; the scratch list itself is unchanged
-            // but we must not leave entries pointing at stale state if a
-            // sink throws partway through.
             for (int i = 0; i < resolved.Count; i++)
             {
                 var (book, resting) = resolved[i];
-                EmitCanceled(book, resting, enteredAtNanos, CancelReason.MassCancel);
+                EmitCanceled(book, resting, command.EnteredAtNanos, CancelReason.MassCancel);
             }
             resolved.Clear();
             return cancelled;
         }
         finally { ExitDispatch(); }
     }
+
+    private static bool MatchesMassCancelFilter(LimitOrderBook book, RestingOrder resting, MassCancelCommand command)
+    {
+        if (command.SecurityId != 0 && book.SecurityId != command.SecurityId) return false;
+        if (command.SideFilter.HasValue && resting.Side != command.SideFilter.Value) return false;
+        if (command.OrdTagIdFilter != 0 && resting.OrdTagId != command.OrdTagIdFilter) return false;
+        if (command.AssetFilter is { Length: > 0 } asset
+            && !string.Equals(resting.Asset, asset, StringComparison.Ordinal)) return false;
+        if (command.InvestorIdFilter.HasValue && resting.InvestorId != command.InvestorIdFilter) return false;
+        return true;
+    }
+
+    private static string DeriveAsset(string symbol)
+    {
+        int len = 0;
+        while (len < symbol.Length && len < 6 && char.IsLetter(symbol[len]))
+            len++;
+        if (len == 0) len = Math.Min(symbol.Length, 6);
+        return symbol[..len].ToUpperInvariant();
+    }
+
+    private static string OrderAsset(NewOrderCommand cmd, InstrumentTradingRules rules)
+        => string.IsNullOrWhiteSpace(cmd.Asset) ? DeriveAsset(rules.Instrument.Symbol) : cmd.Asset.Trim().ToUpperInvariant();
 
     public void Replace(ReplaceOrderCommand cmd)
     {
@@ -1167,7 +1185,13 @@ public sealed class MatchingEngine
                 PriceMantissa: effectiveType == OrderType.Market ? 0L : cmd.NewPriceMantissa,
                 Quantity: cmd.NewQuantity,
                 EnteringFirm: resting.EnteringFirm,
-                EnteredAtNanos: cmd.EnteredAtNanos);
+                EnteredAtNanos: cmd.EnteredAtNanos)
+            {
+                MaxFloor = resting.MaxFloor > 0 ? (ulong)resting.MaxFloor : 0UL,
+                OrdTagId = resting.OrdTagId,
+                Asset = resting.Asset,
+                InvestorId = resting.InvestorId,
+            };
 
             // Issue #228 / #229 (Onda M): in auction phases the replacement
             // must rest like a fresh accumulation order, not aggress. The
@@ -1175,7 +1199,7 @@ public sealed class MatchingEngine
             // AtClose (FinalClosingCall), both Limit-only.
             if (phase == TradingPhase.Reserved || phase == TradingPhase.FinalClosingCall)
             {
-                RestForAuction(replacement, book);
+                RestForAuction(replacement, rules, book);
                 return;
             }
             ExecuteAggressor(replacement, rules, book, emitUnmatchedIocClose: false);
@@ -1198,7 +1222,7 @@ public sealed class MatchingEngine
     /// (<see cref="NewOrderCommand.MaxFloor"/>) is honored so the visible
     /// slice on the book matches the continuous-Open semantics from #211.
     /// </summary>
-    private void RestForAuction(NewOrderCommand cmd, LimitOrderBook book)
+    private void RestForAuction(NewOrderCommand cmd, InstrumentTradingRules rules, LimitOrderBook book)
     {
         long visible = cmd.Quantity;
         long hidden = 0;
@@ -1214,6 +1238,9 @@ public sealed class MatchingEngine
             Side = cmd.Side,
             PriceMantissa = cmd.PriceMantissa,
             EnteringFirm = cmd.EnteringFirm,
+            OrdTagId = cmd.OrdTagId,
+            Asset = OrderAsset(cmd, rules),
+            InvestorId = cmd.InvestorId,
             InsertTimestampNanos = cmd.EnteredAtNanos,
             RemainingQuantity = visible,
             Tif = cmd.Tif,
@@ -1664,6 +1691,9 @@ public sealed class MatchingEngine
                 Side = cmd.Side,
                 PriceMantissa = limitPx,
                 EnteringFirm = cmd.EnteringFirm,
+                OrdTagId = cmd.OrdTagId,
+                Asset = OrderAsset(cmd, rules),
+                InvestorId = cmd.InvestorId,
                 InsertTimestampNanos = cmd.EnteredAtNanos,
                 RemainingQuantity = visible,
                 Tif = cmd.Tif,

--- a/tests/B3.Exchange.Gateway.Tests/OrderMassActionRequestDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/OrderMassActionRequestDecoderTests.cs
@@ -94,34 +94,36 @@ public class OrderMassActionRequestDecoderTests
     }
 
     [Fact]
-    public void UnsupportedFeature_OrdTagIdSet()
+    public void Success_OrdTagIdFilter()
     {
         var body = BuildRequest(ordTagId: 7);
         var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
-            body, 0UL, out _, out _, out var msg);
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("OrdTagID", msg);
+            body, 0UL, out var cmd, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(7, cmd.OrdTagIdFilter);
     }
 
     [Fact]
-    public void UnsupportedFeature_AssetSet()
+    public void Success_AssetFilter()
     {
         var body = BuildRequest(asset: new byte[] { (byte)'D', (byte)'O', (byte)'L', 0, 0, 0 });
         var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
-            body, 0UL, out _, out _, out var msg);
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("Asset", msg);
+            body, 0UL, out var cmd, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal("DOL", cmd.AssetFilter);
     }
 
     [Fact]
-    public void UnsupportedFeature_InvestorIdSet()
+    public void Success_InvestorIdFilter()
     {
-        // Non-"BVMF" bytes at offset 46 indicate V2 InvestorID is populated.
         var body = BuildRequest(investorId: new byte[] { 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC });
         var outcome = InboundMessageDecoder.TryDecodeOrderMassActionRequest(
-            body, 0UL, out _, out _, out var msg);
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("InvestorID", msg);
+            body, 0UL, out var cmd, out _, out var msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(new InvestorId(0x3412, 0xBC9A7856), cmd.InvestorIdFilter);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostE2ETests.cs
@@ -405,7 +405,7 @@ public class ExchangeHostE2ETests
     }
 
     [Fact]
-    public async Task OrderMassActionRequest_OrdTagIdFilter_RejectedAsUnsupportedFeature()
+    public async Task OrderMassActionRequest_OrdTagIdFilter_Accepted()
     {
         var (cfg, sink) = BuildConfig();
         await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
@@ -416,15 +416,14 @@ public class ExchangeHostE2ETests
         await client.ConnectAsync(ep.Address, ep.Port);
         var stream = client.GetStream();
 
-        // Build a request with OrdTagID set (unsupported feature).
+        // Build a request with OrdTagID set; no matching orders exist, but the filter is accepted.
         var frame = BuildOrderMassActionRequest(clOrdId: 9100, secId: Petr);
         frame[EntryPointFrameReader.WireHeaderSize + 29] = 7; // OrdTagID
         await stream.WriteAsync(frame);
 
         var report = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
         Assert.Equal(EntryPointFrameReader.TidOrderMassActionReport, report.TemplateId);
-        Assert.Equal((byte)'0', report.Body[44]); // MassActionResponse = REJECTED
-        Assert.Equal((byte)0, report.Body[45]);   // RejectReason = MASS_ACTION_NOT_SUPPORTED
+        Assert.Equal((byte)'1', report.Body[44]); // MassActionResponse = ACCEPTED
     }
 
     private static byte[] BuildOrderCancelRequest(ulong clOrdId, long secId, ulong orderId, ulong origClOrdId, char side)

--- a/tests/B3.Exchange.Matching.Tests/MassCancelFilterTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/MassCancelFilterTests.cs
@@ -1,0 +1,104 @@
+using B3.Exchange.Instruments;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+public class MassCancelFilterTests
+{
+    private const long ValeSecId = 900_000_000_002L;
+
+    [Fact]
+    public void MassCancel_FiltersByOrdTagId()
+    {
+        var eng = NewMultiInstrumentEngine(out var sink);
+        long keep = Rest(eng, sink, "keep", PetrSecId, Side.Buy, ordTagId: 1);
+        long cancel = Rest(eng, sink, "cancel", PetrSecId, Side.Sell, ordTagId: 2);
+        sink.Clear();
+
+        int n = eng.MassCancel(new[] { keep, cancel }, new MassCancelCommand(0, null, 9_000)
+        {
+            OrdTagIdFilter = 2,
+        });
+
+        Assert.Equal(1, n);
+        Assert.Equal(cancel, Assert.Single(sink.Canceled).OrderId);
+    }
+
+    [Fact]
+    public void MassCancel_FiltersByAsset()
+    {
+        var eng = NewMultiInstrumentEngine(out var sink);
+        long petr = Rest(eng, sink, "petr", PetrSecId, Side.Buy);
+        long vale = Rest(eng, sink, "vale", ValeSecId, Side.Buy);
+        sink.Clear();
+
+        int n = eng.MassCancel(new[] { petr, vale }, new MassCancelCommand(0, null, 9_000)
+        {
+            AssetFilter = "VALE",
+        });
+
+        Assert.Equal(1, n);
+        Assert.Equal(vale, Assert.Single(sink.Canceled).OrderId);
+    }
+
+    [Fact]
+    public void MassCancel_FiltersByInvestorId()
+    {
+        var eng = NewMultiInstrumentEngine(out var sink);
+        long keep = Rest(eng, sink, "keep", PetrSecId, Side.Buy, investorId: new InvestorId(10, 20));
+        long cancel = Rest(eng, sink, "cancel", PetrSecId, Side.Sell, investorId: new InvestorId(30, 40));
+        sink.Clear();
+
+        int n = eng.MassCancel(new[] { keep, cancel }, new MassCancelCommand(0, null, 9_000)
+        {
+            InvestorIdFilter = new InvestorId(30, 40),
+        });
+
+        Assert.Equal(1, n);
+        Assert.Equal(cancel, Assert.Single(sink.Canceled).OrderId);
+    }
+
+    [Fact]
+    public void MassCancel_AppliesAllFiltersTogether()
+    {
+        var eng = NewMultiInstrumentEngine(out var sink);
+        long wrongSide = Rest(eng, sink, "wrong-side", PetrSecId, Side.Sell, ordTagId: 7, investorId: new InvestorId(1, 2));
+        long wrongSecurity = Rest(eng, sink, "wrong-sec", ValeSecId, Side.Buy, ordTagId: 7, investorId: new InvestorId(1, 2));
+        long wrongTag = Rest(eng, sink, "wrong-tag", PetrSecId, Side.Buy, ordTagId: 8, investorId: new InvestorId(1, 2));
+        long wrongInvestor = Rest(eng, sink, "wrong-investor", PetrSecId, Side.Buy, ordTagId: 7, investorId: new InvestorId(9, 9));
+        long match = Rest(eng, sink, "match", PetrSecId, Side.Buy, ordTagId: 7, investorId: new InvestorId(1, 2));
+        sink.Clear();
+
+        int n = eng.MassCancel(new[] { wrongSide, wrongSecurity, wrongTag, wrongInvestor, match },
+            new MassCancelCommand(PetrSecId, Side.Buy, 9_000)
+            {
+                OrdTagIdFilter = 7,
+                AssetFilter = "PETR",
+                InvestorIdFilter = new InvestorId(1, 2),
+            });
+
+        Assert.Equal(1, n);
+        Assert.Equal(match, Assert.Single(sink.Canceled).OrderId);
+    }
+
+    private static MatchingEngine NewMultiInstrumentEngine(out RecordingSink sink)
+    {
+        sink = new RecordingSink();
+        var vale = Petr4 with { Symbol = "VALE3", SecurityId = ValeSecId, Isin = "BRVALEACNOR0" };
+        return new MatchingEngine(new[] { Petr4, vale }, sink, NullLogger<MatchingEngine>.Instance);
+    }
+
+    private static long Rest(MatchingEngine eng, RecordingSink sink, string clOrdId, long securityId, Side side,
+        byte ordTagId = 0, InvestorId? investorId = null)
+    {
+        long price = side == Side.Buy ? Px(10m) : Px(10.10m);
+        eng.Submit(new NewOrderCommand(clOrdId, securityId, side, OrderType.Limit, TimeInForce.Day, price, 100, 11, 1_000)
+        {
+            OrdTagId = ordTagId,
+            InvestorId = investorId,
+        });
+        return sink.Accepted[^1].OrderId;
+    }
+}


### PR DESCRIPTION
## Summary
- decode OrdTagID, Asset, and InvestorID mass-action filters instead of rejecting them
- carry order metadata through matching/restored state and apply all mass-cancel filters in MatchingEngine
- add matching tests for individual and combined filter dimensions

Fixes #412

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn