### PR TITLE
Echo EntryPoint memo varData

### DIFF
--- a/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
+++ b/src/B3.Exchange.Gateway/BusinessMessageRejectEncoder.cs
@@ -29,18 +29,13 @@ internal static class BusinessMessageRejectEncoder
     public const int BusinessRejectBlock = 36;
     private const ulong UTCTimestampNullValue = ulong.MaxValue;
 
-    /// <summary>
-    /// Maximum text varData length (schema cap). The memo segment is always
-    /// emitted empty (we never echo a client-provided memo today).
-    /// </summary>
+    /// <summary>Maximum varData lengths (schema caps).</summary>
+    public const int MaxMemoLength = 40;
     public const int MaxTextLength = 250;
 
-    /// <summary>
-    /// Maximum total wire size when <paramref name="textLen"/> bytes of
-    /// text varData are present (memo is always 0 bytes).
-    /// </summary>
-    public static int TotalSize(int textLen)
-        => HeaderSize + BusinessRejectBlock + 1 /*memo len*/ + 1 /*text len*/ + textLen;
+    public static int TotalSize(int textLen) => TotalSize(0, textLen);
+    public static int TotalSize(int memoLen, int textLen)
+        => HeaderSize + BusinessRejectBlock + 1 + memoLen + 1 + textLen;
 
     /// <summary>
     /// <c>RefMsgType</c> wire value derived from the inbound
@@ -85,12 +80,13 @@ internal static class BusinessMessageRejectEncoder
     public static int EncodeBusinessMessageReject(Span<byte> dst,
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         byte refMsgType, uint refSeqNum, ulong businessRejectRefId, uint businessRejectReason,
-        ReadOnlySpan<byte> textAscii)
+        ReadOnlySpan<byte> textAscii, ReadOnlySpan<byte> memo = default)
     {
+        if (memo.Length > MaxMemoLength) throw new ArgumentException($"memo exceeds {MaxMemoLength} bytes", nameof(memo));
         if (textAscii.Length > MaxTextLength)
             throw new ArgumentException($"text exceeds {MaxTextLength} bytes", nameof(textAscii));
 
-        int total = TotalSize(textAscii.Length);
+        int total = TotalSize(memo.Length, textAscii.Length);
         if (dst.Length < total)
             throw new ArgumentException("buffer too small for BusinessMessageReject", nameof(dst));
 
@@ -112,11 +108,13 @@ internal static class BusinessMessageRejectEncoder
         MemoryMarshal.Write(body.Slice(24, 8), in businessRejectRefId);     // 0 == null
         MemoryMarshal.Write(body.Slice(32, 4), in businessRejectReason);
 
-        // varData: memo (always empty) + text
+        // varData: memo + text
         var trailer = dst.Slice(HeaderSize + BusinessRejectBlock, total - HeaderSize - BusinessRejectBlock);
-        trailer[0] = 0;                                                     // memo length
-        trailer[1] = (byte)textAscii.Length;                                // text length
-        if (textAscii.Length > 0) textAscii.CopyTo(trailer.Slice(2));
+        trailer[0] = (byte)memo.Length;
+        if (memo.Length > 0) memo.CopyTo(trailer.Slice(1));
+        int textLenOffset = 1 + memo.Length;
+        trailer[textLenOffset] = (byte)textAscii.Length;
+        if (textAscii.Length > 0) textAscii.CopyTo(trailer.Slice(textLenOffset + 1));
         return total;
     }
 
@@ -128,17 +126,17 @@ internal static class BusinessMessageRejectEncoder
     public static int EncodeBusinessMessageRejectWithText(Span<byte> dst,
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         byte refMsgType, uint refSeqNum, ulong businessRejectRefId, uint businessRejectReason,
-        string? text)
+        string? text, ReadOnlySpan<byte> memo = default)
     {
         if (string.IsNullOrEmpty(text))
         {
             return EncodeBusinessMessageReject(dst, sessionId, msgSeqNum, sendingTimeNanos,
-                refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, ReadOnlySpan<byte>.Empty);
+                refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, ReadOnlySpan<byte>.Empty, memo);
         }
         var truncated = text.Length > MaxTextLength ? text.Substring(0, MaxTextLength) : text;
         Span<byte> tmp = stackalloc byte[MaxTextLength];
         int n = Encoding.ASCII.GetBytes(truncated, tmp);
         return EncodeBusinessMessageReject(dst, sessionId, msgSeqNum, sendingTimeNanos,
-            refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, tmp.Slice(0, n));
+            refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, tmp.Slice(0, n), memo);
     }
 }

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -55,12 +55,28 @@ internal static class ExecutionReportEncoder
     public const int ExecReportCancelBlock = 182;
     public const int ExecReportTradeBlock = 174;
     public const int ExecReportRejectBlock = 164;
+    public const int MaxMemoLength = 40;
 
-    public const int ExecReportNewTotal = HeaderSize + ExecReportNewBlock;
-    public const int ExecReportModifyTotal = HeaderSize + ExecReportModifyBlock;
-    public const int ExecReportCancelTotal = HeaderSize + ExecReportCancelBlock;
-    public const int ExecReportTradeTotal = HeaderSize + ExecReportTradeBlock;
-    public const int ExecReportRejectTotal = HeaderSize + ExecReportRejectBlock;
+    public const int ExecReportNewTotal = HeaderSize + ExecReportNewBlock + 1;
+    public const int ExecReportModifyTotal = HeaderSize + ExecReportModifyBlock + 1;
+    public const int ExecReportCancelTotal = HeaderSize + ExecReportCancelBlock + 1;
+    public const int ExecReportTradeTotal = HeaderSize + ExecReportTradeBlock + 1;
+    public const int ExecReportRejectTotal = HeaderSize + ExecReportRejectBlock + 1;
+
+    public static int TotalSize(int blockLength, int memoLength) => HeaderSize + blockLength + 1 + memoLength;
+
+    private static int WriteMemoTrailer(Span<byte> dst, int blockLength, ReadOnlySpan<byte> memo)
+    {
+        if (memo.Length > MaxMemoLength)
+            throw new ArgumentException($"memo exceeds {MaxMemoLength} bytes", nameof(memo));
+        int total = TotalSize(blockLength, memo.Length);
+        if (dst.Length < total)
+            throw new ArgumentException("buffer too small for ExecutionReport", nameof(dst));
+        var trailer = dst.Slice(HeaderSize + blockLength, 1 + memo.Length);
+        trailer[0] = (byte)memo.Length;
+        memo.CopyTo(trailer.Slice(1));
+        return total;
+    }
 
     private const byte SideBuy = (byte)'1';
     private const byte SideSell = (byte)'2';
@@ -122,10 +138,11 @@ internal static class ExecutionReportEncoder
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         Matching.Side side, ulong clOrdIdValue, long secondaryOrderId, long securityId, long orderId,
         ulong execId, ulong transactTimeNanos, Matching.OrderType ordType, Matching.TimeInForce tif,
-        long orderQty, long? priceMantissa, ulong receivedTimeNanos = UTCTimestampNullValue)
+        long orderQty, long? priceMantissa, ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue)
     {
-        if (dst.Length < ExecReportNewTotal) throw new ArgumentException("buffer too small for ER_New", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportNewTotal,
+        int total = TotalSize(ExecReportNewBlock, memo.Length);
+        if (dst.Length < total) throw new ArgumentException("buffer too small for ER_New", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
             ExecReportNewBlock, EntryPointFrameReader.TidExecutionReportNew, version: 6);
         var body = dst.Slice(HeaderSize, ExecReportNewBlock);
         body.Clear();
@@ -156,7 +173,7 @@ internal static class ExecutionReportEncoder
         body[164] = 255;                                                    // MmProtectionReset null
         // V6 trailing field: tradingSubAccount@172 (uint, null=0) — covered
         // by body.Clear() above. strategyID@168 (int, null=0) ditto.
-        return ExecReportNewTotal;
+        return WriteMemoTrailer(dst, ExecReportNewBlock, memo);
     }
 
     public static int EncodeExecReportModify(Span<byte> dst,
@@ -164,10 +181,11 @@ internal static class ExecutionReportEncoder
         Matching.Side side, ulong clOrdIdValue, ulong origClOrdIdValue, long secondaryOrderId,
         long securityId, long orderId, ulong execId, ulong transactTimeNanos,
         long leavesQty, long cumQty, long orderQty, long priceMantissa,
-        ulong receivedTimeNanos = UTCTimestampNullValue)
+        ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue)
     {
-        if (dst.Length < ExecReportModifyTotal) throw new ArgumentException("buffer too small for ER_Modify", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportModifyTotal,
+        int total = TotalSize(ExecReportModifyBlock, memo.Length);
+        if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Modify", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
             ExecReportModifyBlock, EntryPointFrameReader.TidExecutionReportModify, version: 6);
         var body = dst.Slice(HeaderSize, ExecReportModifyBlock);
         body.Clear();
@@ -201,7 +219,7 @@ internal static class ExecutionReportEncoder
         body[179] = 255;                                                    // ExecRestatementReason null
         // strategyID@180 (int, null=0) and tradingSubAccount@184 (uint,
         // null=0) covered by body.Clear() above.
-        return ExecReportModifyTotal;
+        return WriteMemoTrailer(dst, ExecReportModifyBlock, memo);
     }
 
     public static int EncodeExecReportCancel(Span<byte> dst,
@@ -209,10 +227,11 @@ internal static class ExecutionReportEncoder
         Matching.Side side, ulong clOrdIdValue, ulong origClOrdIdValue, long secondaryOrderId,
         long securityId, long orderId, ulong execId, ulong transactTimeNanos,
         long cumQty, long orderQty, long? priceMantissa,
-        ulong receivedTimeNanos = UTCTimestampNullValue)
+        ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue)
     {
-        if (dst.Length < ExecReportCancelTotal) throw new ArgumentException("buffer too small for ER_Cancel", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportCancelTotal,
+        int total = TotalSize(ExecReportCancelBlock, memo.Length);
+        if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Cancel", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
             ExecReportCancelBlock, EntryPointFrameReader.TidExecutionReportCancel, version: 6);
         var body = dst.Slice(HeaderSize, ExecReportCancelBlock);
         body.Clear();
@@ -240,7 +259,7 @@ internal static class ExecutionReportEncoder
         // V3 trailing fields: receivedTime@156 + ordTagID/investorID/strategyID/actionRequestedFromSessionID
         // null sentinels are all zero (handled by body.Clear() above).
         MemoryMarshal.Write(body.Slice(156, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
-        return ExecReportCancelTotal;
+        return WriteMemoTrailer(dst, ExecReportCancelBlock, memo);
     }
 
     public static int EncodeExecReportTrade(Span<byte> dst,
@@ -248,10 +267,11 @@ internal static class ExecutionReportEncoder
         Matching.Side side, ulong clOrdIdValue, long secondaryOrderId,
         long securityId, long orderId, long lastQty, long lastPxMantissa,
         ulong execId, ulong transactTimeNanos, long leavesQty, long cumQty,
-        bool aggressor, uint tradeId, uint contraBroker, ushort tradeDate, long orderQty)
+        bool aggressor, uint tradeId, uint contraBroker, ushort tradeDate, long orderQty, ReadOnlySpan<byte> memo = default)
     {
-        if (dst.Length < ExecReportTradeTotal) throw new ArgumentException("buffer too small for ER_Trade", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportTradeTotal,
+        int total = TotalSize(ExecReportTradeBlock, memo.Length);
+        if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Trade", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
             ExecReportTradeBlock, EntryPointFrameReader.TidExecutionReportTrade, version: 6);
         var body = dst.Slice(HeaderSize, ExecReportTradeBlock);
         body.Clear();
@@ -286,17 +306,18 @@ internal static class ExecutionReportEncoder
         // strategyID@160 (int, null=0), impliedEventID@164 (6 bytes; eventID
         // and noRelatedTrades both null=0) and tradingSubAccount@170 (uint,
         // null=0) are covered by body.Clear() above.
-        return ExecReportTradeTotal;
+        return WriteMemoTrailer(dst, ExecReportTradeBlock, memo);
     }
 
     public static int EncodeExecReportReject(Span<byte> dst,
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
         ulong clOrdIdValue, ulong origClOrdIdValue, long securityId, long orderIdOrZero,
         uint rejectReason, ulong transactTimeNanos,
-        ulong receivedTimeNanos = UTCTimestampNullValue)
+        ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue)
     {
-        if (dst.Length < ExecReportRejectTotal) throw new ArgumentException("buffer too small for ER_Reject", nameof(dst));
-        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)ExecReportRejectTotal,
+        int total = TotalSize(ExecReportRejectBlock, memo.Length);
+        if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Reject", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
             ExecReportRejectBlock, EntryPointFrameReader.TidExecutionReportReject, version: 6);
         var body = dst.Slice(HeaderSize, ExecReportRejectBlock);
         body.Clear();
@@ -330,6 +351,6 @@ internal static class ExecutionReportEncoder
         // (int null=0), tradingSubAccount@160 (uint null=0) — all covered
         // by body.Clear() above.
         MemoryMarshal.Write(body.Slice(138, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
-        return ExecReportRejectTotal;
+        return WriteMemoTrailer(dst, ExecReportRejectBlock, memo);
     }
 }

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -65,7 +65,7 @@ internal sealed class FixpOutboundEncoder
 
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
         DurabilityHandle durability = default,
-        ulong clOrdIdValue = 0)
+        ulong clOrdIdValue = 0, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
         // Round-2 perf #14: prefer the ulong threaded from the dispatch
@@ -73,7 +73,7 @@ internal sealed class FixpOutboundEncoder
         // fall back to TryParse only when callers don't supply it
         // (legacy tests). Avoids a ~50–100 ns parse on every ER hot path.
         ulong clOrd = clOrdIdValue != 0 ? clOrdIdValue : (ulong.TryParse(e.ClOrdId, out var v) ? v : 0);
-        var exact = new byte[ExecutionReportEncoder.ExecReportNewTotal];
+        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportNewBlock, memo.Length)];
         lock (_outboundLock)
         {
             ExecutionReportEncoder.EncodeExecReportNew(exact,
@@ -82,17 +82,17 @@ internal sealed class FixpOutboundEncoder
                 (ulong)e.RptSeq, e.InsertTimestampNanos,
                 OrderType.Limit, TimeInForce.Day,
                 e.RemainingQuantity, e.PriceMantissa,
-                receivedTimeNanos);
+                memo.Span, receivedTimeNanos);
             return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
     public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
-        DurabilityHandle durability = default)
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
         var side = isAggressor ? e.AggressorSide : (e.AggressorSide == Side.Buy ? Side.Sell : Side.Buy);
-        var exact = new byte[ExecutionReportEncoder.ExecReportTradeTotal];
+        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportTradeBlock, memo.Length)];
         lock (_outboundLock)
         {
             ExecutionReportEncoder.EncodeExecReportTrade(exact,
@@ -103,17 +103,17 @@ internal sealed class FixpOutboundEncoder
                 isAggressor, e.TradeId,
                 isAggressor ? e.RestingFirm : e.AggressorFirm,
                 tradeDate: 0,
-                orderQty: leavesQty + cumQty);
+                orderQty: leavesQty + cumQty, memo.Span);
             return AppendAndEnqueueLocked(exact, durability);
         }
     }
 
     public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue,
         ulong receivedTimeNanos = ulong.MaxValue,
-        DurabilityHandle durability = default)
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
-        var exact = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportCancelBlock, memo.Length)];
         lock (_outboundLock)
         {
             ExecutionReportEncoder.EncodeExecReportCancel(exact,
@@ -121,8 +121,8 @@ internal sealed class FixpOutboundEncoder
                 e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
                 e.SecurityId, e.OrderId,
                 (ulong)e.RptSeq, e.TransactTimeNanos,
-                cumQty: 0, e.RemainingQuantityAtCancel, e.PriceMantissa,
-                receivedTimeNanos);
+                cumQty: 0, orderQty: e.RemainingQuantityAtCancel, priceMantissa: e.PriceMantissa,
+                memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
             return AppendAndEnqueueLocked(exact, durability);
         }
     }
@@ -130,10 +130,10 @@ internal sealed class FixpOutboundEncoder
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
         Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
         ulong receivedTimeNanos = ulong.MaxValue,
-        DurabilityHandle durability = default)
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
-        var exact = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportModifyBlock, memo.Length)];
         lock (_outboundLock)
         {
             ExecutionReportEncoder.EncodeExecReportModify(exact,
@@ -141,7 +141,7 @@ internal sealed class FixpOutboundEncoder
                 side, clOrdIdValue, origClOrdIdValue, orderId,
                 securityId, orderId, (ulong)rptSeq, transactTimeNanos,
                 leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa,
-                receivedTimeNanos: receivedTimeNanos);
+                memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
             return AppendAndEnqueueLocked(exact, durability);
         }
     }
@@ -170,17 +170,17 @@ internal sealed class FixpOutboundEncoder
     }
 
     public bool WriteExecutionReportReject(in RejectEvent e, ulong clOrdIdValue,
-        DurabilityHandle durability = default)
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
         uint rej = MapRejectReason(e.Reason);
-        var exact = new byte[ExecutionReportEncoder.ExecReportRejectTotal];
+        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportRejectBlock, memo.Length)];
         lock (_outboundLock)
         {
             ExecutionReportEncoder.EncodeExecReportReject(exact,
                 _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
                 clOrdIdValue, origClOrdIdValue: 0, e.SecurityId, e.OrderIdOrZero,
-                rej, e.TransactTimeNanos);
+                rej, e.TransactTimeNanos, memo.Span);
             return AppendAndEnqueueLocked(exact, durability);
         }
     }
@@ -196,17 +196,17 @@ internal sealed class FixpOutboundEncoder
     }
 
     public bool WriteBusinessMessageReject(byte refMsgType, uint refSeqNum, ulong businessRejectRefId,
-        uint businessRejectReason, string? text = null)
+        uint businessRejectReason, string? text = null, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
         int textLen = string.IsNullOrEmpty(text) ? 0 : Math.Min(text.Length, BusinessMessageRejectEncoder.MaxTextLength);
-        int total = BusinessMessageRejectEncoder.TotalSize(textLen);
+        int total = BusinessMessageRejectEncoder.TotalSize(memo.Length, textLen);
         var exact = new byte[total];
         lock (_outboundLock)
         {
             BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(
                 exact, _sessionId(), _nextMsgSeqNum(), _timeSource.NowNanos(),
-                refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text);
+                refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text, memo.Span);
             return AppendAndEnqueueLocked(exact);
         }
     }

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -160,6 +160,8 @@ public sealed partial class FixpSession
             }
         }
 
+        byte[] inboundMemo = ExtractInboundMemo(info.TemplateId, varData);
+
         // §4.10 (#GAP-21): CR/LF in fixed-block identifier slots
         // (senderLocation / enteringTrader / executingTrader) on the four
         // application templates that carry them must answer with
@@ -248,6 +250,7 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidSimpleNewOrder:
                 if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
                 {
+                    no = no with { Memo = inboundMemo };
                     if (!_sink.EnqueueNewOrder(no, Identity, EnteringFirm, noClOrd))
                         WriteSystemBusyReject(info.TemplateId, fixedBlock, noClOrd, "New");
                     return true;
@@ -258,6 +261,7 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidSimpleModifyOrder:
                 if (InboundMessageDecoder.TryDecodeReplace(fixedBlock, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr))
                 {
+                    rp = rp with { Memo = inboundMemo };
                     if (!_sink.EnqueueReplace(rp, Identity, EnteringFirm, rpClOrd, rpOrigClOrd))
                         WriteSystemBusyReject(info.TemplateId, fixedBlock, rpClOrd, "Replace");
                     return true;
@@ -271,6 +275,7 @@ public sealed partial class FixpSession
                         fixedBlock, EnteringFirm, now, out var nos, out var nosClOrd, out var nosMsg);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
+                        nos = nos with { Memo = inboundMemo };
                         if (!_sink.EnqueueNewOrder(nos, Identity, EnteringFirm, nosClOrd))
                             WriteSystemBusyReject(info.TemplateId, fixedBlock, nosClOrd, "New");
                         return true;
@@ -279,12 +284,13 @@ public sealed partial class FixpSession
                     {
                         if (nos is not null)
                         {
+                            nos = nos with { Memo = inboundMemo };
                             if (!_sink.EnqueueNewOrder(nos, Identity, EnteringFirm, nosClOrd))
                                 WriteSystemBusyReject(info.TemplateId, fixedBlock, nosClOrd, "New");
                         }
                         else
                         {
-                            WriteApplicationBusinessReject(info.TemplateId, fixedBlock, nosClOrd, nosMsg ?? "unsupported");
+                            WriteApplicationBusinessReject(info.TemplateId, fixedBlock, nosClOrd, nosMsg ?? "unsupported", inboundMemo);
                         }
                         return true;
                     }
@@ -298,6 +304,7 @@ public sealed partial class FixpSession
                         fixedBlock, now, out var ocr, out var ocrClOrd, out var ocrOrigClOrd, out var ocrMsg);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
+                        ocr = ocr with { Memo = inboundMemo };
                         if (!_sink.EnqueueReplace(ocr, Identity, EnteringFirm, ocrClOrd, ocrOrigClOrd))
                             WriteSystemBusyReject(info.TemplateId, fixedBlock, ocrClOrd, "Replace");
                         return true;
@@ -306,12 +313,13 @@ public sealed partial class FixpSession
                     {
                         if (ocr is not null)
                         {
+                            ocr = ocr with { Memo = inboundMemo };
                             if (!_sink.EnqueueReplace(ocr, Identity, EnteringFirm, ocrClOrd, ocrOrigClOrd))
                                 WriteSystemBusyReject(info.TemplateId, fixedBlock, ocrClOrd, "Replace");
                         }
                         else
                         {
-                            WriteApplicationBusinessReject(info.TemplateId, fixedBlock, ocrClOrd, ocrMsg ?? "unsupported");
+                            WriteApplicationBusinessReject(info.TemplateId, fixedBlock, ocrClOrd, ocrMsg ?? "unsupported", inboundMemo);
                         }
                         return true;
                     }
@@ -347,6 +355,7 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidOrderCancelRequest:
                 if (InboundMessageDecoder.TryDecodeCancel(fixedBlock, now, out var cn, out var cnClOrd, out var cnOrigClOrd, out var cnErr))
                 {
+                    cn = cn with { Memo = inboundMemo };
                     if (!_sink.EnqueueCancel(cn, Identity, EnteringFirm, cnClOrd, cnOrigClOrd))
                         WriteSystemBusyReject(info.TemplateId, fixedBlock, cnClOrd, "Cancel");
                     return true;
@@ -428,4 +437,35 @@ public sealed partial class FixpSession
         || templateId == EntryPointFrameReader.TidOrderCancelRequest
         || templateId == EntryPointFrameReader.TidNewOrderCross
         || templateId == EntryPointFrameReader.TidOrderMassActionRequest;
+    private static byte[] ExtractInboundMemo(ushort templateId, ReadOnlySpan<byte> varData)
+    {
+        if (varData.IsEmpty) return [];
+        static bool TryReadAt(ReadOnlySpan<byte> data, int offset, out ReadOnlySpan<byte> segment, out int next)
+        {
+            segment = default;
+            next = offset;
+            if ((uint)offset >= (uint)data.Length) return false;
+            int len = data[offset];
+            int start = offset + 1;
+            next = start + len;
+            if (next > data.Length) return false;
+            segment = data.Slice(start, len);
+            return true;
+        }
+
+        ReadOnlySpan<byte> memo;
+        switch (templateId)
+        {
+            case EntryPointFrameReader.TidSimpleNewOrder:
+            case EntryPointFrameReader.TidSimpleModifyOrder:
+                return TryReadAt(varData, 0, out memo, out _) && !memo.IsEmpty ? memo.ToArray() : [];
+            case EntryPointFrameReader.TidNewOrderSingle:
+            case EntryPointFrameReader.TidOrderCancelReplaceRequest:
+            case EntryPointFrameReader.TidOrderCancelRequest:
+                if (!TryReadAt(varData, 0, out _, out int next)) return [];
+                return TryReadAt(varData, next, out memo, out _) && !memo.IsEmpty ? memo.ToArray() : [];
+            default:
+                return [];
+        }
+    }
 }

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -104,7 +104,7 @@ public sealed partial class FixpSession
     /// <paramref name="clOrdId"/> is forwarded as
     /// <c>businessRejectRefId</c> so the peer can correlate.
     /// </summary>
-    private void WriteApplicationBusinessReject(ushort templateId, ReadOnlySpan<byte> fixedBlock, ulong clOrdId, string text)
+    private void WriteApplicationBusinessReject(ushort templateId, ReadOnlySpan<byte> fixedBlock, ulong clOrdId, string text, ReadOnlyMemory<byte> memo = default)
     {
         uint refSeqNum = fixedBlock.Length >= 8
             ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
@@ -114,7 +114,8 @@ public sealed partial class FixpSession
             refSeqNum: refSeqNum,
             businessRejectRefId: clOrdId,
             businessRejectReason: 33003,
-            text: text);
+            text: text,
+            memo: memo);
         _logger.LogWarning(
             "fixp session {ConnectionId} business reject (unsupported feature) template={Template} text={Text}",
             ConnectionId, templateId, text);
@@ -128,7 +129,7 @@ public sealed partial class FixpSession
     /// are already bumped by the dispatcher (<c>exch_dispatch_queue_full_total</c>);
     /// this method is purely about telling the offending peer.
     /// </summary>
-    internal void WriteSystemBusyReject(ushort templateId, ReadOnlySpan<byte> fixedBlock, ulong clOrdId, string workKindLabel)
+    internal void WriteSystemBusyReject(ushort templateId, ReadOnlySpan<byte> fixedBlock, ulong clOrdId, string workKindLabel, ReadOnlyMemory<byte> memo = default)
     {
         uint refSeqNum = fixedBlock.Length >= 8
             ? System.Buffers.Binary.BinaryPrimitives.ReadUInt32LittleEndian(fixedBlock.Slice(4, 4))
@@ -138,7 +139,8 @@ public sealed partial class FixpSession
             refSeqNum: refSeqNum,
             businessRejectRefId: clOrdId,
             businessRejectReason: BusinessMessageRejectEncoder.Reason.SystemBusy,
-            text: "System busy: dispatcher queue full");
+            text: "System busy: dispatcher queue full",
+            memo: memo);
         _logger.LogWarning(
             "fixp session {ConnectionId} system-busy reject (dispatcher queue full) template={Template} workKind={WorkKind}",
             ConnectionId, templateId, workKindLabel);

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -528,24 +528,25 @@ public sealed partial class FixpSession : IAsyncDisposable
 
     public bool WriteExecutionReportNew(in OrderAcceptedEvent e, ulong receivedTimeNanos = ulong.MaxValue,
         DurabilityHandle durability = default,
-        ulong clOrdIdValue = 0)
-        => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos, durability, clOrdIdValue);
+        ulong clOrdIdValue = 0, ReadOnlyMemory<byte> memo = default)
+        => _outboundEncoder.WriteExecutionReportNew(e, receivedTimeNanos, durability, clOrdIdValue, memo);
 
     public bool WriteExecutionReportTrade(in TradeEvent e, bool isAggressor, long ownerOrderId, ulong clOrdIdValue, long leavesQty, long cumQty,
-        DurabilityHandle durability = default)
-        => _outboundEncoder.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty, durability);
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
+        => _outboundEncoder.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty, durability, memo);
 
     public bool WriteExecutionReportCancel(in OrderCanceledEvent e, ulong clOrdIdValue, ulong origClOrdIdValue,
         ulong receivedTimeNanos = ulong.MaxValue,
-        DurabilityHandle durability = default)
-        => _outboundEncoder.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos, durability);
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
+        => _outboundEncoder.WriteExecutionReportCancel(e, clOrdIdValue, origClOrdIdValue, receivedTimeNanos, durability, memo);
 
     public bool WriteExecutionReportModify(long securityId, long orderId, ulong clOrdIdValue, ulong origClOrdIdValue,
         B3.Exchange.Matching.Side side, long newPriceMantissa, long newRemainingQty, ulong transactTimeNanos, uint rptSeq,
         ulong receivedTimeNanos = ulong.MaxValue,
-        DurabilityHandle durability = default)
+        DurabilityHandle durability = default,
+        ReadOnlyMemory<byte> memo = default)
         => _outboundEncoder.WriteExecutionReportModify(securityId, orderId, clOrdIdValue, origClOrdIdValue,
-            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos, durability);
+            side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos, durability, memo);
 
     /// <summary>
     /// Encodes and enqueues an <c>OrderMassActionReport</c> (template 702,
@@ -561,16 +562,16 @@ public sealed partial class FixpSession : IAsyncDisposable
             massActionRejectReason, side, securityId, transactTimeNanos, text);
 
     public bool WriteExecutionReportReject(in B3.Exchange.Matching.RejectEvent e, ulong clOrdIdValue,
-        DurabilityHandle durability = default)
-        => _outboundEncoder.WriteExecutionReportReject(e, clOrdIdValue, durability);
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
+        => _outboundEncoder.WriteExecutionReportReject(e, clOrdIdValue, durability, memo);
 
     public bool WriteSessionReject(byte terminationCode)
         => _outboundEncoder.WriteSessionReject(terminationCode);
 
     public bool WriteBusinessMessageReject(byte refMsgType, uint refSeqNum, ulong businessRejectRefId,
-        uint businessRejectReason, string? text = null)
+        uint businessRejectReason, string? text = null, ReadOnlyMemory<byte> memo = default)
         => _outboundEncoder.WriteBusinessMessageReject(refMsgType, refSeqNum, businessRejectRefId,
-            businessRejectReason, text);
+            businessRejectReason, text, memo);
 
     /// <summary>
     /// Maps engine <see cref="RejectReason"/> to the FIX OrdRejReason wire code

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -51,7 +51,7 @@ public sealed class GatewayRouter : ICoreOutbound
         DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportNew"); return false; }
-        return s.WriteExecutionReportNew(e, receivedTimeNanos, durability, clOrdIdValue);
+        return s.WriteExecutionReportNew(e, receivedTimeNanos, durability, clOrdIdValue, e.Memo ?? ReadOnlyMemory<byte>.Empty);
     }
 
     public bool WriteExecutionReportTrade(ContractsSessionId session, in TradeEvent e, bool isAggressor,
@@ -59,7 +59,7 @@ public sealed class GatewayRouter : ICoreOutbound
         DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportTrade"); return false; }
-        return s.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty, durability);
+        return s.WriteExecutionReportTrade(e, isAggressor, ownerOrderId, clOrdIdValue, leavesQty, cumQty, durability, isAggressor ? (e.AggressorMemo ?? ReadOnlyMemory<byte>.Empty) : (e.RestingMemo ?? ReadOnlyMemory<byte>.Empty));
     }
 
     public bool WriteExecutionReportPassiveTrade(ContractsSessionId ownerSession, ulong ownerClOrdId, long restingOrderId,
@@ -67,7 +67,8 @@ public sealed class GatewayRouter : ICoreOutbound
         DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportPassiveTrade"); return false; }
-        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, ownerClOrdId, leavesQty, cumQty, durability);
+        return s.WriteExecutionReportTrade(e, isAggressor: false, restingOrderId, ownerClOrdId, leavesQty, cumQty, durability,
+            e.RestingMemo ?? ReadOnlyMemory<byte>.Empty);
     }
 
     public bool WriteExecutionReportPassiveCancel(ContractsSessionId ownerSession, ulong ownerClOrdId, long orderId,
@@ -76,7 +77,7 @@ public sealed class GatewayRouter : ICoreOutbound
     {
         if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportPassiveCancel"); return false; }
         ulong clOrdIdOnWire = requesterClOrdIdOrZero != 0 ? requesterClOrdIdOrZero : ownerClOrdId;
-        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, ownerClOrdId, receivedTimeNanos, durability);
+        return s.WriteExecutionReportCancel(e, clOrdIdOnWire, ownerClOrdId, receivedTimeNanos, durability, e.Memo ?? ReadOnlyMemory<byte>.Empty);
     }
 
     public bool WriteExecutionReportModify(ContractsSessionId session, long securityId, long orderId,
@@ -94,7 +95,7 @@ public sealed class GatewayRouter : ICoreOutbound
         DurabilityHandle durability = default)
     {
         if (!_registry.TryGet(session, out var s)) { LogMiss(session, "ExecReportReject"); return false; }
-        return s.WriteExecutionReportReject(e, clOrdIdValue, durability);
+        return s.WriteExecutionReportReject(e, clOrdIdValue, durability, e.Memo ?? ReadOnlyMemory<byte>.Empty);
     }
 
     private void LogMiss(ContractsSessionId session, string kind)

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -55,7 +55,7 @@ public sealed class HostRouter : IInboundCommandSink
         // Unknown-instrument is a *deterministic business reject* the router
         // emits inline; from the caller's perspective the work is done, so
         // return true (the false return is reserved for backpressure only).
-        RejectUnknownInstrument(cmd.SecurityId, session, clOrdIdValue);
+        RejectUnknownInstrument(cmd.SecurityId, session, clOrdIdValue, cmd.Memo);
         return true;
     }
 
@@ -65,12 +65,12 @@ public sealed class HostRouter : IInboundCommandSink
         var resolved = ResolveOrderIdIfNeeded(cmd, enteringFirm, origClOrdIdValue, out var ok);
         if (!ok)
         {
-            RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue);
+            RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue, cmd.Memo);
             return true;
         }
         if (_bySecId.TryGetValue(resolved.SecurityId, out var disp))
             return disp.EnqueueCancel(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
-        RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
+        RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue, cmd.Memo);
         return true;
     }
 
@@ -80,12 +80,12 @@ public sealed class HostRouter : IInboundCommandSink
         var resolved = ResolveOrderIdIfNeeded(cmd, enteringFirm, origClOrdIdValue, out var ok);
         if (!ok)
         {
-            RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue);
+            RejectUnknownOrderId(cmd.SecurityId, session, clOrdIdValue, cmd.Memo);
             return true;
         }
         if (_bySecId.TryGetValue(resolved.SecurityId, out var disp))
             return disp.EnqueueReplace(resolved, session, enteringFirm, clOrdIdValue, origClOrdIdValue);
-        RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue);
+        RejectUnknownInstrument(resolved.SecurityId, session, clOrdIdValue, cmd.Memo);
         return true;
     }
 
@@ -94,7 +94,7 @@ public sealed class HostRouter : IInboundCommandSink
         // Both legs MUST belong to the same security (decoder enforces).
         if (_bySecId.TryGetValue(cmd.Buy.SecurityId, out var disp))
             return disp.EnqueueCross(cmd, session, enteringFirm);
-        RejectUnknownInstrument(cmd.Buy.SecurityId, session, cmd.BuyClOrdIdValue);
+        RejectUnknownInstrument(cmd.Buy.SecurityId, session, cmd.BuyClOrdIdValue, cmd.Buy.Memo);
         return true;
     }
 
@@ -199,25 +199,25 @@ public sealed class HostRouter : IInboundCommandSink
         return false;
     }
 
-    private void RejectUnknownInstrument(long secId, SessionId session, ulong clOrdIdValue)
+    private void RejectUnknownInstrument(long secId, SessionId session, ulong clOrdIdValue, byte[]? memo = null)
     {
         _logger.LogWarning("rejecting clOrdId={ClOrdId} from session {Session}: unknown securityId={SecurityId}",
             clOrdIdValue, session, secId);
         _outbound.WriteExecutionReportReject(session,
             new RejectEvent(ClOrdId: string.Empty,
                 SecurityId: secId, OrderIdOrZero: 0,
-                Reason: RejectReason.UnknownInstrument, TransactTimeNanos: _timeSource.NowNanos()),
+                Reason: RejectReason.UnknownInstrument, TransactTimeNanos: _timeSource.NowNanos(), Memo: memo),
             clOrdIdValue);
     }
 
-    private void RejectUnknownOrderId(long secId, SessionId session, ulong clOrdIdValue)
+    private void RejectUnknownOrderId(long secId, SessionId session, ulong clOrdIdValue, byte[]? memo = null)
     {
         _logger.LogWarning("rejecting clOrdId={ClOrdId} from session {Session}: unknown orderId / OrigClOrdID",
             clOrdIdValue, session);
         _outbound.WriteExecutionReportReject(session,
             new RejectEvent(ClOrdId: string.Empty,
                 SecurityId: secId, OrderIdOrZero: 0,
-                Reason: RejectReason.UnknownOrderId, TransactTimeNanos: _timeSource.NowNanos()),
+                Reason: RejectReason.UnknownOrderId, TransactTimeNanos: _timeSource.NowNanos(), Memo: memo),
             clOrdIdValue);
     }
 }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -236,13 +236,18 @@ public sealed record NewOrderCommand(
     public long StopPxMantissa { get; init; }
 
     public bool UnsupportedOrderCharacteristic { get; init; }
+
+    public byte[] Memo { get; init; } = [];
 }
 
 public sealed record CancelOrderCommand(
     string ClOrdId,
     long SecurityId,
     long OrderId,
-    ulong EnteredAtNanos);
+    ulong EnteredAtNanos)
+{
+    public byte[] Memo { get; init; } = [];
+}
 
 /// <summary>
 /// Replace command. <see cref="NewQuantity"/> is interpreted as the new
@@ -280,6 +285,8 @@ public sealed record ReplaceOrderCommand(
     public TimeInForce? NewTif { get; init; }
 
     public bool UnsupportedOrderCharacteristic { get; init; }
+
+    public byte[] Memo { get; init; } = [];
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -61,7 +61,10 @@ public sealed record RestingOrderRecord(
     long HiddenQuantity,
     byte OrdTagId = 0,
     string? Asset = null,
-    InvestorId? InvestorId = null);
+    InvestorId? InvestorId = null)
+{
+    public byte[] Memo { get; init; } = [];
+}
 
 /// <summary>
 /// Persistable view of a single untriggered stop order (issue #262). Mirrors
@@ -82,4 +85,7 @@ public sealed record RestingStopRecord(
     long LimitPriceMantissa,
     long Quantity,
     uint EnteringFirm,
-    ulong EnteredAtNanos);
+    ulong EnteredAtNanos)
+{
+    public byte[] Memo { get; init; } = [];
+}

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -19,7 +19,8 @@ public readonly record struct OrderAcceptedEvent(
     long RemainingQuantity,
     uint EnteringFirm,
     ulong InsertTimestampNanos,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when a resting order's remaining quantity is reduced as a passive maker
@@ -34,7 +35,8 @@ public readonly record struct OrderQuantityReducedEvent(
     long NewRemainingQuantity,
     ulong InsertTimestampNanos,
     ulong TransactTimeNanos,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when a resting order is removed from the book — either because it was
@@ -49,7 +51,8 @@ public readonly record struct OrderCanceledEvent(
     long RemainingQuantityAtCancel,
     ulong TransactTimeNanos,
     CancelReason Reason,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when a resting order is fully consumed by trades. The integration layer
@@ -82,14 +85,17 @@ public readonly record struct TradeEvent(
     long RestingOrderId,
     uint RestingFirm,
     ulong TransactTimeNanos,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? AggressorMemo = null,
+    byte[]? RestingMemo = null);
 
 public readonly record struct RejectEvent(
     string ClOrdId,
     long SecurityId,
     long OrderIdOrZero,
     RejectReason Reason,
-    ulong TransactTimeNanos);
+    ulong TransactTimeNanos,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when the trading phase for an instrument transitions. Carries
@@ -253,7 +259,8 @@ public readonly record struct StopOrderAcceptedEvent(
     long Quantity,
     uint EnteringFirm,
     ulong InsertTimestampNanos,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when a parked stop order's trigger condition fires. Issue #214.
@@ -287,7 +294,8 @@ public readonly record struct StopOrderCanceledEvent(
     long StopPxMantissa,
     long RemainingQuantityAtCancel,
     ulong TransactTimeNanos,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when a resting order has been successfully replaced by a client
@@ -309,7 +317,8 @@ public readonly record struct OrderModifiedEvent(
     long NewPriceMantissa,
     long NewRemainingQuantity,
     ulong TransactTimeNanos,
-    uint RptSeq);
+    uint RptSeq,
+    byte[]? Memo = null);
 
 /// <summary>
 /// Fired when an instrument is placed into administrative halt via

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -15,6 +15,7 @@ internal sealed class RestingOrder
     public byte OrdTagId { get; init; }
     public string? Asset { get; init; }
     public InvestorId? InvestorId { get; init; }
+    public byte[] Memo { get; init; } = [];
 
     /// <summary>
     /// Wall-clock timestamp at which the order entered (or last re-entered)
@@ -308,7 +309,8 @@ internal sealed class LimitOrderBook
                         HiddenQuantity: o.HiddenQuantity,
                         OrdTagId: o.OrdTagId,
                         Asset: o.Asset,
-                        InvestorId: o.InvestorId);
+                        InvestorId: o.InvestorId)
+                    { Memo = o.Memo };
                 }
             }
         }
@@ -340,6 +342,7 @@ internal sealed class LimitOrderBook
             MaxFloor = record.MaxFloor,
             HiddenQuantity = record.HiddenQuantity,
             RemainingQuantity = record.RemainingQuantity,
+            Memo = record.Memo,
         };
         Insert(order);
     }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -99,6 +99,7 @@ public sealed class MatchingEngine
         long ImbalanceQuantity);
 
     private bool _dispatching;
+    private byte[] _currentMemo = [];
 
     // Issue #322: per-instrument administrative-halt overlay. While an
     // entry is present here, Submit and Replace are short-circuited
@@ -196,7 +197,8 @@ public sealed class MatchingEngine
                     LimitPriceMantissa: s.LimitPriceMantissa,
                     Quantity: s.Quantity,
                     EnteringFirm: s.EnteringFirm,
-                    EnteredAtNanos: s.EnteredAtNanos));
+                    EnteredAtNanos: s.EnteredAtNanos)
+                { Memo = s.Memo });
             }
         }
         // Issue #322: capture per-instrument administrative halts so the
@@ -292,6 +294,7 @@ public sealed class MatchingEngine
                     EnteringFirm = s.EnteringFirm,
                     EnteredAtNanos = s.EnteredAtNanos,
                     SecurityId = s.SecurityId,
+                    Memo = s.Memo,
                 };
                 bucket.Add(stop);
                 _stopById.Add(s.OrderId, stop);
@@ -763,6 +766,7 @@ public sealed class MatchingEngine
 
     private void SubmitImpl(NewOrderCommand cmd, bool emitUnmatchedIocClose)
     {
+        _currentMemo = cmd.Memo;
         EnterDispatch();
         try
         {
@@ -948,6 +952,7 @@ public sealed class MatchingEngine
 
     public void Cancel(CancelOrderCommand cmd)
     {
+        _currentMemo = cmd.Memo;
         EnterDispatch();
         try
         {
@@ -968,14 +973,15 @@ public sealed class MatchingEngine
                     StopPxMantissa: stop.StopPxMantissa,
                     RemainingQuantityAtCancel: stop.Quantity,
                     TransactTimeNanos: cmd.EnteredAtNanos,
-                    RptSeq: NextRptSeq()));
+                    RptSeq: NextRptSeq(),
+                    Memo: cmd.Memo));
                 return;
             }
 
             if (!book.TryGet(cmd.OrderId, out var resting))
             { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnknownOrderId, cmd.EnteredAtNanos); return; }
 
-            EmitCanceled(book, resting, cmd.EnteredAtNanos, CancelReason.Client);
+            EmitCanceled(book, resting, cmd.EnteredAtNanos, CancelReason.Client, cmd.Memo);
             RecomputeAuctionTopIfApplicable(cmd.SecurityId, cmd.EnteredAtNanos);
         }
         finally { ExitDispatch(); }
@@ -1073,6 +1079,7 @@ public sealed class MatchingEngine
 
     public void Replace(ReplaceOrderCommand cmd)
     {
+        _currentMemo = cmd.Memo;
         EnterDispatch();
         try
         {
@@ -1156,7 +1163,8 @@ public sealed class MatchingEngine
                     NewRemainingQuantity: cmd.NewQuantity,
                     InsertTimestampNanos: resting.InsertTimestampNanos,
                     TransactTimeNanos: cmd.EnteredAtNanos,
-                    RptSeq: rptSeq));
+                    RptSeq: rptSeq,
+                    Memo: cmd.Memo));
                 // Issue #251: priority-kept Replace must also surface as
                 // an ExecutionReport_Modify on the requesting session.
                 // The book mutation is announced via the UMDF UPDATE
@@ -1171,7 +1179,8 @@ public sealed class MatchingEngine
                     NewPriceMantissa: resting.PriceMantissa,
                     NewRemainingQuantity: cmd.NewQuantity,
                     TransactTimeNanos: cmd.EnteredAtNanos,
-                    RptSeq: rptSeq));
+                    RptSeq: rptSeq,
+                    Memo: cmd.Memo));
                 RecomputeAuctionTopIfApplicable(cmd.SecurityId, cmd.EnteredAtNanos);
                 return;
             }
@@ -1179,7 +1188,7 @@ public sealed class MatchingEngine
             // Priority lost: emit DEL of the resting order, then submit the
             // replacement as a fresh aggressor (which may cross or rest).
             var side = resting.Side;
-            EmitCanceled(book, resting, cmd.EnteredAtNanos, CancelReason.ReplaceLostPriority);
+            EmitCanceled(book, resting, cmd.EnteredAtNanos, CancelReason.ReplaceLostPriority, cmd.Memo);
 
             // Build a synthetic NewOrderCommand for the replacement and process
             // it through the normal aggressor path. Type/TIF come from the
@@ -1200,6 +1209,7 @@ public sealed class MatchingEngine
                 OrdTagId = resting.OrdTagId,
                 Asset = resting.Asset,
                 InvestorId = resting.InvestorId,
+                Memo = cmd.Memo,
             };
 
             // Issue #228 / #229 (Onda M): in auction phases the replacement
@@ -1523,7 +1533,9 @@ public sealed class MatchingEngine
                         RestingOrderId: maker.OrderId,
                         RestingFirm: maker.EnteringFirm,
                         TransactTimeNanos: cmd.EnteredAtNanos,
-                        RptSeq: NextRptSeq()));
+                        RptSeq: NextRptSeq(),
+                        AggressorMemo: cmd.Memo,
+                        RestingMemo: maker.Memo));
 
                     aggressorRemaining -= tradeQty;
                     maker.RemainingQuantity -= tradeQty;
@@ -1677,7 +1689,8 @@ public sealed class MatchingEngine
                         RemainingQuantityAtCancel: aggressorRemaining,
                         TransactTimeNanos: cmd.EnteredAtNanos,
                         Reason: CancelReason.IocUnmatched,
-                        RptSeq: NextRptSeq()));
+                        RptSeq: NextRptSeq(),
+                        Memo: cmd.Memo));
                 }
                 return;
             }
@@ -1708,6 +1721,7 @@ public sealed class MatchingEngine
                 Tif = cmd.Tif,
                 MaxFloor = (long)cmd.MaxFloor,
                 HiddenQuantity = hidden,
+                Memo = cmd.Memo,
             };
             book.Insert(resting);
             _sink.OnOrderAccepted(new OrderAcceptedEvent(
@@ -1719,7 +1733,8 @@ public sealed class MatchingEngine
                 RemainingQuantity: resting.RemainingQuantity,
                 EnteringFirm: resting.EnteringFirm,
                 InsertTimestampNanos: resting.InsertTimestampNanos,
-                RptSeq: NextRptSeq()));
+                RptSeq: NextRptSeq(),
+                Memo: resting.Memo));
         }
         finally
         {
@@ -1734,12 +1749,13 @@ public sealed class MatchingEngine
         }
     }
 
-    private void EmitCanceled(LimitOrderBook book, RestingOrder o, ulong txn, CancelReason reason)
+    private void EmitCanceled(LimitOrderBook book, RestingOrder o, ulong txn, CancelReason reason, byte[]? requestMemo = null)
     {
         var side = o.Side;
         long px = o.PriceMantissa;
         long qty = o.RemainingQuantity;
         long oid = o.OrderId;
+        var memo = requestMemo ?? o.Memo;
         book.Remove(o);
         _sink.OnOrderCanceled(new OrderCanceledEvent(
             SecurityId: book.SecurityId,
@@ -1749,7 +1765,8 @@ public sealed class MatchingEngine
             RemainingQuantityAtCancel: qty,
             TransactTimeNanos: txn,
             Reason: reason,
-            RptSeq: NextRptSeq()));
+            RptSeq: NextRptSeq(),
+            Memo: memo));
         // #200: when this cancel emptied the side, publish EmptyBook_9 so
         // recovery consumers can drop their per-side state without waiting
         // for the next snapshot rotation.
@@ -1788,6 +1805,7 @@ public sealed class MatchingEngine
         public uint EnteringFirm { get; init; }
         public ulong EnteredAtNanos { get; init; }
         public long SecurityId { get; init; }
+        public byte[] Memo { get; init; } = [];
     }
 
     private void SubmitStop(NewOrderCommand cmd, InstrumentTradingRules rules)
@@ -1841,6 +1859,7 @@ public sealed class MatchingEngine
             EnteringFirm = cmd.EnteringFirm,
             EnteredAtNanos = cmd.EnteredAtNanos,
             SecurityId = cmd.SecurityId,
+            Memo = cmd.Memo,
         };
         _stopsBySymbol[cmd.SecurityId].Add(stop);
         _stopById.Add(oid, stop);
@@ -1856,7 +1875,8 @@ public sealed class MatchingEngine
             Quantity: cmd.Quantity,
             EnteringFirm: cmd.EnteringFirm,
             InsertTimestampNanos: cmd.EnteredAtNanos,
-            RptSeq: NextRptSeq()));
+            RptSeq: NextRptSeq(),
+            Memo: cmd.Memo));
     }
 
     /// <summary>
@@ -1933,7 +1953,8 @@ public sealed class MatchingEngine
             PriceMantissa: s.StopType == OrderType.StopLoss ? 0L : s.LimitPriceMantissa,
             Quantity: s.Quantity,
             EnteringFirm: s.EnteringFirm,
-            EnteredAtNanos: txnNanos);
+            EnteredAtNanos: txnNanos)
+        { Memo = s.Memo };
 
         // Triggered StopLoss sees an empty opposite side → no fills,
         // silently dropped. We do NOT emit MarketNoLiquidity reject
@@ -1947,7 +1968,7 @@ public sealed class MatchingEngine
     }
 
     private void Reject(string clOrdId, long securityId, long orderId, RejectReason r, ulong txn)
-        => _sink.OnReject(new RejectEvent(clOrdId, securityId, orderId, r, txn));
+        => _sink.OnReject(new RejectEvent(clOrdId, securityId, orderId, r, txn, _currentMemo));
 
     private uint NextRptSeq() => ++_rptSeq;
 

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -153,6 +153,41 @@ public partial class ChannelDispatcherTests
         Assert.Equal(415UL, Assert.Single(reply.RejectClOrdIds));
     }
 
+
+    [Fact]
+    public void NewOrder_WithMemo_ExecReportNewCarriesMemo()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+        byte[] memo = System.Text.Encoding.ASCII.GetBytes("ABC123");
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL)
+        {
+            Memo = memo,
+        }, reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        Assert.Single(reply.News);
+        Assert.True(reply.News[0].Memo!.SequenceEqual(memo));
+    }
+
+    [Fact]
+    public void RejectedOrder_WithMemo_ExecReportRejectCarriesMemo()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+        byte[] memo = System.Text.Encoding.ASCII.GetBytes("ABC123");
+
+        disp.EnqueueNewOrder(new NewOrderCommand("1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 0, 7, 1_000UL)
+        {
+            Memo = memo,
+        }, reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        Assert.Single(reply.Rejects);
+        Assert.True(reply.Rejects[0].Memo!.SequenceEqual(memo));
+    }
+
     [Fact]
     public void Crossing_AggressorAndResting_BothGetTradeReportsAndDeleteFrames()
     {

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -47,6 +47,26 @@ public class ExecutionReportEncoderTests
         Assert.Equal(long.MinValue, MemoryMarshal.Read<long>(body.Slice(112, 8))); // StopPx null
     }
 
+
+    [Fact]
+    public void EncodeNew_WritesMemoVarData()
+    {
+        byte[] memo = System.Text.Encoding.ASCII.GetBytes("ABC123");
+        var buf = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportNewBlock, memo.Length)];
+
+        int n = ExecutionReportEncoder.EncodeExecReportNew(buf,
+            sessionId: 42, msgSeqNum: 1, sendingTimeNanos: 1_000_000_000UL,
+            side: Side.Buy, clOrdIdValue: 99, secondaryOrderId: 555,
+            securityId: 1122, orderId: 7777, execId: 100UL, transactTimeNanos: 1_000_000_001UL,
+            ordType: OrderType.Limit, tif: TimeInForce.Day,
+            orderQty: 10, priceMantissa: 12_3450L, memo: memo);
+
+        Assert.Equal(buf.Length, n);
+        var trailer = buf.AsSpan(EntryPointFrameReader.WireHeaderSize + ExecutionReportEncoder.ExecReportNewBlock);
+        Assert.Equal((byte)memo.Length, trailer[0]);
+        Assert.True(trailer.Slice(1, memo.Length).SequenceEqual(memo));
+    }
+
     [Fact]
     public void EncodeTrade_WritesCoreFields()
     {

--- a/tests/B3.Exchange.Gateway.Tests/RejectEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/RejectEncoderTests.cs
@@ -40,16 +40,17 @@ public class RejectEncoderTests
     [Fact]
     public void EncodeBusinessMessageReject_WritesHeaderBlockAndVarData()
     {
-        var buf = new byte[BusinessMessageRejectEncoder.TotalSize(12)];
+        byte[] memoBytes = System.Text.Encoding.ASCII.GetBytes("ABC123");
+        var buf = new byte[BusinessMessageRejectEncoder.TotalSize(memoBytes.Length, 12)];
         int n = BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(buf,
             sessionId: 7u, msgSeqNum: 99u, sendingTimeNanos: 1_700_000_000_000_000_000UL,
             refMsgType: BusinessMessageRejectEncoder.MapRefMsgTypeFromTemplateId(EntryPointFrameReader.TidSimpleNewOrder),
             refSeqNum: 42u,
             businessRejectRefId: 12345UL,
             businessRejectReason: BusinessMessageRejectEncoder.Reason.InvalidField,
-            text: "invalid Side");
+            text: "invalid Side", memo: memoBytes);
 
-        Assert.Equal(BusinessMessageRejectEncoder.TotalSize(12), n);
+        Assert.Equal(BusinessMessageRejectEncoder.TotalSize(memoBytes.Length, 12), n);
 
         // SOFH
         Assert.Equal((ushort)n, BinaryPrimitives.ReadUInt16LittleEndian(buf.AsSpan(0, 2)));
@@ -79,9 +80,11 @@ public class RejectEncoderTests
 
         // VarData: memo (length 0) then text ("invalid Side", 11 ASCII bytes)
         var trailer = buf.AsSpan(EntryPointFrameReader.WireHeaderSize + BusinessMessageRejectEncoder.BusinessRejectBlock);
-        Assert.Equal((byte)0, trailer[0]);          // memo length
-        Assert.Equal((byte)12, trailer[1]);         // text length
-        var text = System.Text.Encoding.ASCII.GetString(trailer.Slice(2, 12));
+        Assert.Equal((byte)memoBytes.Length, trailer[0]);
+        Assert.True(trailer.Slice(1, memoBytes.Length).SequenceEqual(memoBytes));
+        int textLenOffset = 1 + memoBytes.Length;
+        Assert.Equal((byte)12, trailer[textLenOffset]);
+        var text = System.Text.Encoding.ASCII.GetString(trailer.Slice(textLenOffset + 1, 12));
         Assert.Equal("invalid Side", text);
     }
 


### PR DESCRIPTION
## Summary
- Echo inbound memo varData on ExecutionReport and BusinessMessageReject frames.
- Thread memo through inbound decode, matching commands/events, resting orders, and outbound gateway encoding.
- Add encoder and dispatcher roundtrip coverage.

Fixes #411

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release --verbosity minimal
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn --verbosity minimal