### PR TITLE
Ignore Copilot CLI scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ BenchmarkDotNet.Artifacts/
 
 # dotnet-trace / speedscope captures
 .profile/
+
+## Copilot CLI scratch / fleet build artifacts
+.copilot-temp/
+artifacts/verify/
+.copilot-worktrees/


### PR DESCRIPTION
Adds `.copilot-temp/`, `artifacts/verify/`, and `.copilot-worktrees/` to `.gitignore`.

These directories are produced by the Copilot CLI agent during `dotnet build/test/restore` cycles and worktree-based fleet runs. They leaked into recent rebase resolutions for the spec-compliance fleet (PRs #422, #424, #425, #427) and required manual `git rm --cached` cleanup.

Pre-PR checklist: gitignore only — no code changes, build/test/format unaffected.