### PR TITLE
FIXP retransmit journal rotation by bytes+age (#431)

### DIFF
--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -132,6 +132,9 @@ public sealed class FixpJournalMetrics
             Interlocked.Increment(ref s.RotationsAge);
     }
 
+    public void Reset(uint sessionId)
+        => _sessions.TryRemove(SessionKey(sessionId), out _);
+
     public IReadOnlyList<FixpJournalMetricsSnapshot> Snapshot()
         => _sessions
             .Select(kv => new FixpJournalMetricsSnapshot(
@@ -144,8 +147,11 @@ public sealed class FixpJournalMetrics
             .ToArray();
 
     private SessionJournalMetrics Get(uint sessionId)
-        => _sessions.GetOrAdd("0x" + sessionId.ToString("x8", System.Globalization.CultureInfo.InvariantCulture),
+        => _sessions.GetOrAdd(SessionKey(sessionId),
             static _ => new SessionJournalMetrics());
+
+    private static string SessionKey(uint sessionId)
+        => "0x" + sessionId.ToString("x8", System.Globalization.CultureInfo.InvariantCulture);
 
     private sealed class SessionJournalMetrics
     {

--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -106,3 +106,59 @@ public sealed class RetransmitMetrics
     public void IncBufferEvictions() => Interlocked.Increment(ref _bufferEvictions);
     public void IncPassiveErBuffered() => Interlocked.Increment(ref _passiveErBuffered);
 }
+
+/// <summary>
+/// Process-wide gauges/counters for the durable FIXP outbound retransmit
+/// journal. Lives in Contracts so Gateway can update it without referencing
+/// Core.
+/// </summary>
+public sealed class FixpJournalMetrics
+{
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, SessionJournalMetrics> _sessions = new();
+
+    public void Observe(uint sessionId, long bytes, long oldestAgeSeconds)
+    {
+        var s = Get(sessionId);
+        Interlocked.Exchange(ref s.Bytes, bytes);
+        Interlocked.Exchange(ref s.OldestAgeSeconds, oldestAgeSeconds);
+    }
+
+    public void IncRotation(uint sessionId, string reason)
+    {
+        var s = Get(sessionId);
+        if (string.Equals(reason, "bytes", StringComparison.Ordinal))
+            Interlocked.Increment(ref s.RotationsBytes);
+        else if (string.Equals(reason, "age", StringComparison.Ordinal))
+            Interlocked.Increment(ref s.RotationsAge);
+    }
+
+    public IReadOnlyList<FixpJournalMetricsSnapshot> Snapshot()
+        => _sessions
+            .Select(kv => new FixpJournalMetricsSnapshot(
+                kv.Key,
+                Interlocked.Read(ref kv.Value.Bytes),
+                Interlocked.Read(ref kv.Value.OldestAgeSeconds),
+                Interlocked.Read(ref kv.Value.RotationsBytes),
+                Interlocked.Read(ref kv.Value.RotationsAge)))
+            .OrderBy(s => s.Session, StringComparer.Ordinal)
+            .ToArray();
+
+    private SessionJournalMetrics Get(uint sessionId)
+        => _sessions.GetOrAdd("0x" + sessionId.ToString("x8", System.Globalization.CultureInfo.InvariantCulture),
+            static _ => new SessionJournalMetrics());
+
+    private sealed class SessionJournalMetrics
+    {
+        public long Bytes;
+        public long OldestAgeSeconds;
+        public long RotationsBytes;
+        public long RotationsAge;
+    }
+}
+
+public readonly record struct FixpJournalMetricsSnapshot(
+    string Session,
+    long Bytes,
+    long OldestAgeSeconds,
+    long RotationsBytes,
+    long RotationsAge);

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -403,11 +403,13 @@ public sealed class MetricsRegistry
     private readonly ThrottleMetrics _throttle = new();
     private readonly TransportMetrics _transport = new();
     private readonly RetransmitMetrics _retransmit = new();
+    private readonly FixpJournalMetrics _journal = new();
     private readonly BoundedSessionFirmCounters _sessionFirmMessages = new();
 
     public SessionLifecycleMetrics Sessions => _sessionLifecycle;
     public ThrottleMetrics Throttle => _throttle;
     public TransportMetrics Transport => _transport;
+    public FixpJournalMetrics Journal => _journal;
 
     /// <summary>
     /// Issue #288: process-wide RetransmitBuffer counters
@@ -665,6 +667,8 @@ public sealed class MetricsRegistry
             }
         }
 
+        EmitFixpJournalMetrics(sb);
+
         // Issue #173: latency histograms. Per-channel buckets in seconds;
         // observed via Stopwatch.GetTimestamp() at the dispatcher
         // boundaries (decode→enqueue, enqueue→pickup, engine entry→exit,
@@ -819,6 +823,50 @@ public sealed class MetricsRegistry
               .Append(EscapeLabel(trigger))
               .Append("\"} ")
               .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+    }
+
+    private void EmitFixpJournalMetrics(StringBuilder sb)
+    {
+        var snap = _journal.Snapshot();
+        if (snap.Count == 0) return;
+
+        sb.Append("# HELP fixp_journal_bytes Current on-disk FIXP outbound retransmit journal bytes per session.\n");
+        sb.Append("# TYPE fixp_journal_bytes gauge\n");
+        foreach (var s in snap)
+        {
+            sb.Append("fixp_journal_bytes{session=\"")
+              .Append(EscapeLabel(s.Session))
+              .Append("\"} ")
+              .Append(s.Bytes.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+
+        sb.Append("# HELP fixp_journal_oldest_age_seconds Age in seconds of the oldest retained FIXP outbound retransmit journal entry per session.\n");
+        sb.Append("# TYPE fixp_journal_oldest_age_seconds gauge\n");
+        foreach (var s in snap)
+        {
+            sb.Append("fixp_journal_oldest_age_seconds{session=\"")
+              .Append(EscapeLabel(s.Session))
+              .Append("\"} ")
+              .Append(s.OldestAgeSeconds.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+
+        sb.Append("# HELP fixp_journal_rotation_total Total FIXP retransmit journal segment rotations by trigger reason.\n");
+        sb.Append("# TYPE fixp_journal_rotation_total counter\n");
+        foreach (var s in snap)
+        {
+            sb.Append("fixp_journal_rotation_total{session=\"")
+              .Append(EscapeLabel(s.Session))
+              .Append("\",reason=\"bytes\"} ")
+              .Append(s.RotationsBytes.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+            sb.Append("fixp_journal_rotation_total{session=\"")
+              .Append(EscapeLabel(s.Session))
+              .Append("\",reason=\"age\"} ")
+              .Append(s.RotationsAge.ToString(CultureInfo.InvariantCulture))
               .Append('\n');
         }
     }

--- a/src/B3.Exchange.Gateway/FixpRetransmitController.cs
+++ b/src/B3.Exchange.Gateway/FixpRetransmitController.cs
@@ -28,6 +28,7 @@ internal sealed class FixpRetransmitController
     private readonly Func<uint> _peekNextMsgSeqNum;
     private readonly Func<FixpEvent, FixpAction> _applyTransition;
     private readonly Func<FixpState> _getState;
+    private readonly Action<uint>? _confirmPeerAck;
     private readonly ILogger _logger;
     private readonly long _connectionId;
 
@@ -46,6 +47,7 @@ internal sealed class FixpRetransmitController
         Func<uint> peekNextMsgSeqNum,
         Func<FixpEvent, FixpAction> applyTransition,
         Func<FixpState> getState,
+        Action<uint>? confirmPeerAck,
         ILogger logger,
         long connectionId)
     {
@@ -58,6 +60,7 @@ internal sealed class FixpRetransmitController
         _peekNextMsgSeqNum = peekNextMsgSeqNum;
         _applyTransition = applyTransition;
         _getState = getState;
+        _confirmPeerAck = confirmPeerAck;
         _logger = logger;
         _connectionId = connectionId;
     }
@@ -163,6 +166,8 @@ internal sealed class FixpRetransmitController
                 EnqueueRetransmitReject(reqTimestamp, code);
                 return;
             }
+            if (fromSeq > 1)
+                _confirmPeerAck?.Invoke(fromSeq - 1);
 
             // Hold the outbound lock for the entire block so (a) no live
             // business frame interleaves on the wire and (b) the

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -418,6 +418,7 @@ public sealed partial class FixpSession : IAsyncDisposable
             peekNextMsgSeqNum: PeekNextMsgSeqNum,
             applyTransition: ApplyTransition,
             getState: () => State,
+            confirmPeerAck: ack => _outboundJournal?.ConfirmPeerAck(SessionId, ack),
             logger: _logger,
             connectionId: ConnectionId);
         if (_options.ThrottleMaxMessages > 0 && _options.ThrottleTimeWindowMs > 0)

--- a/src/B3.Exchange.Gateway/Persistence/FileFixpOutboundJournal.cs
+++ b/src/B3.Exchange.Gateway/Persistence/FileFixpOutboundJournal.cs
@@ -1,5 +1,6 @@
 using System.Buffers.Binary;
 using System.Globalization;
+using B3.Exchange.Contracts;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Exchange.Gateway.Persistence;
@@ -33,14 +34,12 @@ namespace B3.Exchange.Gateway.Persistence;
 /// straddle the watermark are kept intact (conservative — never
 /// drop a record we cannot prove is acked).</para>
 ///
-/// <para><b>Per-session cap</b>: when
-/// <see cref="MaxBytesPerSession"/> is non-zero and an
-/// <see cref="Append"/> would push the on-disk size for the session
-/// above the cap, the implementation throws
-/// <see cref="JournalCapacityExceededException"/> (fail-stop policy
-/// — the producer is expected to surface this as a
-/// <c>Terminate(Unspecified)</c> on the session rather than silently
-/// lose history).</para>
+/// <para><b>Quota/retention</b>: when <see cref="MaxBytesPerSession"/>
+/// or <see cref="MaxRetention"/> is exceeded during <see cref="Append"/>,
+/// whole old segments are deleted only if their last seq is at or below
+/// the last peer-confirmed ACK watermark. If no segment is safe, the
+/// append succeeds, a warning is logged, and metrics show the over-budget
+/// journal.</para>
 /// </summary>
 public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
 {
@@ -56,22 +55,30 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
     private readonly string _journalDir;
     private readonly ILogger<FileFixpOutboundJournal> _logger;
     private readonly int _segmentMaxBytes;
+    private readonly TimeSpan _maxRetention;
+    private readonly FixpJournalMetrics? _metrics;
     private readonly object _lock = new();
     private readonly Dictionary<uint, ActiveSegment> _active = new();
+    private readonly Dictionary<uint, uint> _confirmedPeerAck = new();
     private bool _disposed;
 
     /// <summary>
     /// Per-session on-disk byte budget. When non-zero an
     /// <see cref="Append"/> that would push the session above this
-    /// value throws <see cref="JournalCapacityExceededException"/>.
+    /// value triggers ACK-watermark-gated rotation.
     /// Zero (default) disables the cap.
     /// </summary>
     public long MaxBytesPerSession { get; }
 
+    /// <summary>Maximum retained age for the oldest journal entry. Zero disables age rotation.</summary>
+    public TimeSpan MaxRetention => _maxRetention;
+
     public FileFixpOutboundJournal(string dataDir,
         ILogger<FileFixpOutboundJournal> logger,
         int segmentMaxBytes = DefaultSegmentMaxBytes,
-        long maxBytesPerSession = 0)
+        long maxBytesPerSession = 0,
+        TimeSpan? maxRetention = null,
+        FixpJournalMetrics? metrics = null)
     {
         ArgumentNullException.ThrowIfNull(dataDir);
         ArgumentNullException.ThrowIfNull(logger);
@@ -81,10 +88,15 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
         if (maxBytesPerSession < 0)
             throw new ArgumentOutOfRangeException(nameof(maxBytesPerSession),
                 "must be >= 0 (0 disables the cap)");
+        if (maxRetention < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(maxRetention),
+                "must be >= TimeSpan.Zero (zero disables retention)");
         _journalDir = Path.Combine(dataDir, JournalSubdir);
         _logger = logger;
         _segmentMaxBytes = segmentMaxBytes;
         MaxBytesPerSession = maxBytesPerSession;
+        _maxRetention = maxRetention ?? TimeSpan.Zero;
+        _metrics = metrics;
         Directory.CreateDirectory(_journalDir);
     }
 
@@ -116,19 +128,14 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
                 throw new InvalidOperationException(
                     $"journal append for session 0x{sessionId:x8} seq={seq} is not strictly greater than last persisted seq {segment.LastSeq}");
 
-            if (MaxBytesPerSession > 0)
-            {
-                long projected = CurrentSessionBytesLocked(sessionId, segment) + recordBytes;
-                if (projected > MaxBytesPerSession)
-                    throw new JournalCapacityExceededException(sessionId, projected, MaxBytesPerSession);
-            }
-
             if (segment.Stream.Length + recordBytes > _segmentMaxBytes && segment.LastSeq != 0)
             {
                 segment.Dispose();
                 segment = CreateNewActiveSegment(sessionId, seq);
                 _active[sessionId] = segment;
             }
+
+            EnforceQuotasBeforeAppendLocked(sessionId, segment, recordBytes, timestampNanos);
         }
 
         Span<byte> header = stackalloc byte[16];
@@ -148,6 +155,11 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
             segment.LastSeq = seq;
             segment.EntryCount++;
         }
+        lock (_lock)
+        {
+            if (_active.TryGetValue(sessionId, out var active))
+                ObserveSessionLocked(sessionId, active, timestampNanos);
+        }
     }
 
     private long CurrentSessionBytesLocked(uint sessionId, ActiveSegment active)
@@ -162,6 +174,126 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
             catch (FileNotFoundException) { /* concurrent prune race; ignore */ }
         }
         return total;
+    }
+
+    private void EnforceQuotasBeforeAppendLocked(uint sessionId, ActiveSegment active,
+        int recordBytes, long nowNanos)
+    {
+        bool overBytes = MaxBytesPerSession > 0
+            && CurrentSessionBytesLocked(sessionId, active) + recordBytes > MaxBytesPerSession;
+        bool overAge = IsRetentionExceededLocked(sessionId, nowNanos);
+
+        if (!overBytes && !overAge)
+        {
+            ObserveSessionLocked(sessionId, active, nowNanos);
+            return;
+        }
+
+        if (overBytes)
+            RotateSafeSegmentsLocked(sessionId, active, nowNanos, "bytes");
+        if (overAge)
+            RotateSafeSegmentsLocked(sessionId, active, nowNanos, "age");
+
+        ObserveSessionLocked(sessionId, active, nowNanos);
+    }
+
+    private bool IsRetentionExceededLocked(uint sessionId, long nowNanos)
+    {
+        if (_maxRetention <= TimeSpan.Zero) return false;
+        var dir = SessionDir(sessionId);
+        if (!Directory.Exists(dir)) return false;
+        long oldest = 0;
+        foreach (var (_, path) in EnumerateSegmentsOrdered(dir))
+        {
+            var info = ScanSegment(path);
+            if (info.EntryCount == 0) continue;
+            oldest = info.FirstTimestampNanos;
+            break;
+        }
+        if (oldest == 0) return false;
+        return AgeSeconds(nowNanos, oldest) > _maxRetention.TotalSeconds;
+    }
+
+    private void RotateSafeSegmentsLocked(uint sessionId, ActiveSegment active,
+        long nowNanos, string reason)
+    {
+        uint watermark = _confirmedPeerAck.TryGetValue(sessionId, out var ack) ? ack : 0u;
+        if (watermark == 0)
+        {
+            LogRotationBlocked(sessionId, reason, watermark, active, nowNanos);
+            return;
+        }
+
+        var dir = SessionDir(sessionId);
+        if (!Directory.Exists(dir)) return;
+        var segments = EnumerateSegmentsOrdered(dir);
+        int deleted = 0;
+        for (int i = 0; i < segments.Count; i++)
+        {
+            var (firstSeq, path) = segments[i];
+            uint nextFirst = i + 1 < segments.Count ? segments[i + 1].firstSeq : uint.MaxValue;
+            uint segmentLastSeq = nextFirst == uint.MaxValue
+                ? ScanSegment(path).LastSeq
+                : nextFirst - 1;
+            if (segmentLastSeq == 0) continue;
+            if (segmentLastSeq > watermark) break;
+            if (string.Equals(path, active.Path, StringComparison.Ordinal)) continue;
+            try
+            {
+                File.Delete(path);
+                deleted++;
+                _metrics?.IncRotation(sessionId, reason);
+                _logger.LogInformation(
+                    "fixp outbound journal: rotated segment {Path} (session=0x{SessionId:x8}, reason={Reason}, firstSeq={FirstSeq}, lastSeq={LastSeq}, peerAck={PeerAck})",
+                    path, sessionId, reason, firstSeq, segmentLastSeq, watermark);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "fixp outbound journal: failed to rotate segment {Path} (session=0x{SessionId:x8}, reason={Reason})",
+                    path, sessionId, reason);
+            }
+        }
+
+        bool stillOver = reason == "bytes"
+            ? MaxBytesPerSession > 0 && CurrentSessionBytesLocked(sessionId, active) > MaxBytesPerSession
+            : IsRetentionExceededLocked(sessionId, nowNanos);
+        if (deleted == 0 || stillOver)
+            LogRotationBlocked(sessionId, reason, watermark, active, nowNanos);
+    }
+
+    private void LogRotationBlocked(uint sessionId, string reason, uint watermark,
+        ActiveSegment active, long nowNanos)
+    {
+        long bytes = CurrentSessionBytesLocked(sessionId, active);
+        long oldestAge = OldestAgeSecondsLocked(sessionId, nowNanos);
+        _metrics?.Observe(sessionId, bytes, oldestAge);
+        _logger.LogWarning(
+            "fixp outbound journal: {Reason} quota reached for session 0x{SessionId:x8}, but no segment is safe to delete (peerAck={PeerAck}, bytes={Bytes}, oldestAgeSeconds={OldestAgeSeconds}); allowing journal to grow",
+            reason, sessionId, watermark, bytes, oldestAge);
+    }
+
+    private void ObserveSessionLocked(uint sessionId, ActiveSegment active, long nowNanos)
+        => _metrics?.Observe(sessionId, CurrentSessionBytesLocked(sessionId, active),
+            OldestAgeSecondsLocked(sessionId, nowNanos));
+
+    private long OldestAgeSecondsLocked(uint sessionId, long nowNanos)
+    {
+        var dir = SessionDir(sessionId);
+        if (!Directory.Exists(dir)) return 0;
+        foreach (var (_, path) in EnumerateSegmentsOrdered(dir))
+        {
+            var info = ScanSegment(path);
+            if (info.EntryCount == 0) continue;
+            return AgeSeconds(nowNanos, info.FirstTimestampNanos);
+        }
+        return 0;
+    }
+
+    private static long AgeSeconds(long nowNanos, long timestampNanos)
+    {
+        if (nowNanos <= timestampNanos) return 0;
+        return (nowNanos - timestampNanos) / 1_000_000_000L;
     }
 
     private static uint ComputeRecordCrc(ReadOnlySpan<byte> header, ReadOnlySpan<byte> frame)
@@ -286,6 +418,17 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
             return 0;
         }
         return candidate;
+    }
+
+    public void ConfirmPeerAck(uint sessionId, uint uptoSeq)
+    {
+        if (uptoSeq == 0) return;
+        lock (_lock)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_confirmedPeerAck.TryGetValue(sessionId, out var existing) || uptoSeq > existing)
+                _confirmedPeerAck[sessionId] = uptoSeq;
+        }
     }
 
     private void FlushActiveLocked(uint sessionId)
@@ -437,17 +580,20 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
 
     private readonly struct SegmentInfo
     {
-        public SegmentInfo(uint lastSeq, long entryCount, long validBytes, bool corrupt)
+        public SegmentInfo(uint lastSeq, long entryCount, long validBytes, bool corrupt,
+            long firstTimestampNanos)
         {
             LastSeq = lastSeq;
             EntryCount = entryCount;
             ValidBytes = validBytes;
             IsCorrupt = corrupt;
+            FirstTimestampNanos = firstTimestampNanos;
         }
         public uint LastSeq { get; }
         public long EntryCount { get; }
         public long ValidBytes { get; }
         public bool IsCorrupt { get; }
+        public long FirstTimestampNanos { get; }
     }
 
     private SegmentInfo ScanSegment(string path)
@@ -459,24 +605,26 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
             _logger.LogCritical(ex,
                 "fixp outbound journal: failed to read segment {Path}; treating as empty",
                 path);
-            return new SegmentInfo(0, 0, 0, corrupt: true);
+            return new SegmentInfo(0, 0, 0, corrupt: true, firstTimestampNanos: 0);
         }
         int offset = 0;
         int recIdx = 0;
         long entryCount = 0;
         uint lastSeq = 0;
+        long firstTimestampNanos = 0;
         while (offset < raw.Length)
         {
             recIdx++;
             if (!TryDecodeRecord(raw, offset, path, recIdx, out var entry, out int recordLength))
             {
-                return new SegmentInfo(lastSeq, entryCount, offset, corrupt: true);
+                return new SegmentInfo(lastSeq, entryCount, offset, corrupt: true, firstTimestampNanos);
             }
             offset += recordLength;
             entryCount++;
+            if (firstTimestampNanos == 0) firstTimestampNanos = entry.TimestampNanos;
             lastSeq = entry.Seq;
         }
-        return new SegmentInfo(lastSeq, entryCount, offset, corrupt: false);
+        return new SegmentInfo(lastSeq, entryCount, offset, corrupt: false, firstTimestampNanos);
     }
 
     private bool TryDecodeRecord(byte[] raw, int offset, string path, int recIdx,
@@ -573,28 +721,5 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
         {
             try { Stream.Dispose(); } catch { }
         }
-    }
-}
-
-/// <summary>
-/// Thrown by <see cref="FileFixpOutboundJournal.Append"/> when a
-/// per-session byte cap is configured and a new append would push
-/// the on-disk size above it. The producer (<c>FixpSession</c>) is
-/// expected to surface this as a session-level terminate rather than
-/// silently lose business-frame history.
-/// </summary>
-public sealed class JournalCapacityExceededException : Exception
-{
-    public uint SessionId { get; }
-    public long ProjectedBytes { get; }
-    public long CapBytes { get; }
-
-    public JournalCapacityExceededException(uint sessionId, long projectedBytes, long capBytes)
-        : base($"FIXP outbound journal cap exceeded for session 0x{sessionId:x8}: " +
-            $"projected={projectedBytes} bytes > cap={capBytes} bytes")
-    {
-        SessionId = sessionId;
-        ProjectedBytes = projectedBytes;
-        CapBytes = capBytes;
     }
 }

--- a/src/B3.Exchange.Gateway/Persistence/FileFixpOutboundJournal.cs
+++ b/src/B3.Exchange.Gateway/Persistence/FileFixpOutboundJournal.cs
@@ -516,14 +516,29 @@ public sealed class FileFixpOutboundJournal : IFixpOutboundJournal
             }
         }
         var dir = SessionDir(sessionId);
-        if (!Directory.Exists(dir)) return;
-        try { Directory.Delete(dir, recursive: true); }
-        catch (Exception ex)
+        bool removed = !Directory.Exists(dir);
+        if (!removed)
         {
-            _logger.LogWarning(ex,
-                "fixp outbound journal: failed to delete session directory {Dir}",
-                dir);
+            try
+            {
+                Directory.Delete(dir, recursive: true);
+                removed = true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "fixp outbound journal: failed to delete session directory {Dir}",
+                    dir);
+            }
         }
+
+        if (!removed) return;
+
+        lock (_lock)
+        {
+            _confirmedPeerAck.Remove(sessionId);
+        }
+        _metrics?.Reset(sessionId);
     }
 
     public IReadOnlyCollection<uint> ListSessions()

--- a/src/B3.Exchange.Gateway/Persistence/IFixpOutboundJournal.cs
+++ b/src/B3.Exchange.Gateway/Persistence/IFixpOutboundJournal.cs
@@ -79,6 +79,14 @@ public interface IFixpOutboundJournal : IDisposable
     void Append(uint sessionId, uint seq, long timestampNanos, ReadOnlySpan<byte> frame);
 
     /// <summary>
+    /// Records the highest outbound <c>MsgSeqNum</c> the peer has proven it
+    /// no longer needs for retransmit. Implementations may use this as the
+    /// safe lower bound for quota/retention pruning; they must never delete
+    /// entries above this watermark.
+    /// </summary>
+    void ConfirmPeerAck(uint sessionId, uint uptoSeq);
+
+    /// <summary>
     /// Returns up to <paramref name="count"/> consecutive entries
     /// from <paramref name="sessionId"/>'s journal starting at
     /// <paramref name="fromSeq"/> (inclusive). Returns an empty list

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -485,9 +485,9 @@ public sealed class ExchangeHost : IAsyncDisposable
         // prior Negotiate/Establish — used by the synthetic trader and
         // pre-#42 integration tests until they learn the handshake.
         bool requireHandshake = _config.Auth.RequireFixpHandshake;
-        // Issue #405: optional FIXP session-resync persistence. When
-        // configured, every outbound business frame is appended to an
-        // unbounded per-session journal and the FIXP envelope state
+        // Issue #405/#431: optional FIXP session-resync persistence. When
+        // configured, every outbound business frame is appended to a
+        // quota/retention-managed per-session journal and the FIXP envelope state
         // (SessionVerId, LastIncomingSeqNo, OutboundMsgSeqNum) is
         // snapshotted on every Negotiate/Suspend/non-terminal Close.
         // On boot we load whatever state survived a crash + seed the
@@ -501,7 +501,10 @@ public sealed class ExchangeHost : IAsyncDisposable
         {
             _outboundJournal = new B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal(
                 _config.Tcp.RetransmitPersistenceDir!,
-                _loggerFactory.CreateLogger<B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal>());
+                _loggerFactory.CreateLogger<B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal>(),
+                maxBytesPerSession: _config.Tcp.MaxJournalBytes,
+                maxRetention: TimeSpan.FromHours(_config.Tcp.MaxJournalRetentionHours),
+                metrics: _metrics.Journal);
             _statePersister = new B3.Exchange.Gateway.Persistence.FileFixpSessionStatePersister(
                 _config.Tcp.RetransmitPersistenceDir!,
                 _loggerFactory.CreateLogger<B3.Exchange.Gateway.Persistence.FileFixpSessionStatePersister>());

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -103,7 +103,7 @@ public sealed class TcpConfig
     /// <summary>
     /// Issue #405: per-FIXP-session resync persistence directory.
     /// When non-empty, two artifacts are written under this directory:
-    /// (a) an unbounded append-only journal of every outbound business
+    /// (a) an append-only journal of every outbound business
     /// frame at <c>{dir}/journal/session-{sessionId:x8}/segment-*.log</c>,
     /// and (b) a periodically-rewritten envelope-state snapshot
     /// (SessionVerId, LastIncomingSeqNo, outbound MsgSeqNum, CoD
@@ -121,6 +121,21 @@ public sealed class TcpConfig
     /// back-compat; semantics widened by #405.
     /// </summary>
     [JsonPropertyName("retransmitPersistenceDir")] public string? RetransmitPersistenceDir { get; set; }
+
+    /// <summary>
+    /// Maximum on-disk bytes retained per FIXP retransmit journal session.
+    /// Default 256 MiB. When exceeded, only segments at or below the last
+    /// peer-confirmed ACK watermark may be deleted; otherwise the journal is
+    /// allowed to grow and metrics/logs alert the operator.
+    /// </summary>
+    [JsonPropertyName("maxJournalBytes")] public long MaxJournalBytes { get; set; } = 256L * 1024L * 1024L;
+
+    /// <summary>
+    /// Maximum age, in hours, of the oldest retained FIXP retransmit journal
+    /// entry. Default 24h. Rotation is conservative and never deletes entries
+    /// the peer may need on reconnect.
+    /// </summary>
+    [JsonPropertyName("maxJournalRetentionHours")] public double MaxJournalRetentionHours { get; set; } = 24.0;
 }
 
 /// <summary>

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -448,6 +448,22 @@ public class MetricsRegistryTests
         Assert.DoesNotContain("session=\"conn-2\"", text.Substring(text.IndexOf("exch_fixp_retransmit_buffer_utilization", StringComparison.Ordinal)));
     }
 
+    [Fact]
+    public void Issue431_FixpJournalMetrics_RenderGaugesAndRotationCounters()
+    {
+        var reg = new MetricsRegistry();
+        reg.Journal.Observe(0x431u, bytes: 1234, oldestAgeSeconds: 3600);
+        reg.Journal.IncRotation(0x431u, "bytes");
+        reg.Journal.IncRotation(0x431u, "age");
+
+        var text = reg.RenderProm();
+
+        Assert.Contains("fixp_journal_bytes{session=\"0x00000431\"} 1234\n", text);
+        Assert.Contains("fixp_journal_oldest_age_seconds{session=\"0x00000431\"} 3600\n", text);
+        Assert.Contains("fixp_journal_rotation_total{session=\"0x00000431\",reason=\"bytes\"} 1\n", text);
+        Assert.Contains("fixp_journal_rotation_total{session=\"0x00000431\",reason=\"age\"} 1\n", text);
+    }
+
     private sealed class CapturingSink : IUmdfPacketSink
     {
         public int PublishCount;

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -464,6 +464,23 @@ public class MetricsRegistryTests
         Assert.Contains("fixp_journal_rotation_total{session=\"0x00000431\",reason=\"age\"} 1\n", text);
     }
 
+    [Fact]
+    public void Issue437_FixpJournalMetrics_ResetRemovesScrapedSessionGauges()
+    {
+        var reg = new MetricsRegistry();
+        reg.Journal.Observe(0x437u, bytes: 1234, oldestAgeSeconds: 3600);
+
+        var before = reg.RenderProm();
+        Assert.Contains("fixp_journal_bytes{session=\"0x00000437\"} 1234\n", before);
+        Assert.Contains("fixp_journal_oldest_age_seconds{session=\"0x00000437\"} 3600\n", before);
+
+        reg.Journal.Reset(0x437u);
+
+        var after = reg.RenderProm();
+        Assert.DoesNotContain("fixp_journal_bytes{session=\"0x00000437\"}", after);
+        Assert.DoesNotContain("fixp_journal_oldest_age_seconds{session=\"0x00000437\"}", after);
+    }
+
     private sealed class CapturingSink : IUmdfPacketSink
     {
         public int PublishCount;

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionPersistenceWiringTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionPersistenceWiringTests.cs
@@ -58,6 +58,7 @@ public sealed class FixpSessionPersistenceWiringTests
             }
             return list;
         }
+        public void ConfirmPeerAck(uint sessionId, uint uptoSeq) { }
         public void PruneUpTo(uint sessionId, uint uptoSeq) { }
         public uint MaxSeq(uint sessionId)
             => _data.TryGetValue(sessionId, out var s) && s.Count > 0 ? s.Keys.Max() : 0u;

--- a/tests/B3.Exchange.Gateway.Tests/Persistence/FileFixpOutboundJournalTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/Persistence/FileFixpOutboundJournalTests.cs
@@ -1,4 +1,5 @@
 using System.Buffers.Binary;
+using B3.Exchange.Contracts;
 using B3.Exchange.Gateway.Persistence;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -24,10 +25,14 @@ public sealed class FileFixpOutboundJournalTests : IDisposable
 
     private FileFixpOutboundJournal NewJournal(
         int segmentMaxBytes = FileFixpOutboundJournal.DefaultSegmentMaxBytes,
-        long maxBytesPerSession = 0)
+        long maxBytesPerSession = 0,
+        TimeSpan? maxRetention = null,
+        FixpJournalMetrics? metrics = null)
         => new(_root, NullLogger<FileFixpOutboundJournal>.Instance,
             segmentMaxBytes: segmentMaxBytes,
-            maxBytesPerSession: maxBytesPerSession);
+            maxBytesPerSession: maxBytesPerSession,
+            maxRetention: maxRetention,
+            metrics: metrics);
 
     private static byte[] Frame(uint seq, int extraBytes = 0)
     {
@@ -251,18 +256,86 @@ public sealed class FileFixpOutboundJournalTests : IDisposable
     }
 
     [Fact]
-    public void Cap_overflow_fails_stop_when_configured()
+    public void Bytes_quota_without_peer_ack_warns_and_allows_growth()
     {
         // record overhead 20 + frame 100 = 120 bytes per record.
-        // cap = 250 => after 2 records the 3rd is rejected.
-        using var j = NewJournal(maxBytesPerSession: 250);
+        // cap = 250 => after 2 records the 3rd is over budget, but no
+        // peer ACK watermark means nothing is safe to delete.
+        var metrics = new FixpJournalMetrics();
+        using var j = NewJournal(maxBytesPerSession: 250, metrics: metrics);
         const uint sid = 1u;
         j.Append(sid, 1, 0, Frame(1, extraBytes: 96));
         j.Append(sid, 2, 0, Frame(2, extraBytes: 96));
-        var ex = Assert.Throws<JournalCapacityExceededException>(
-            () => j.Append(sid, 3, 0, Frame(3, extraBytes: 96)));
-        Assert.Equal(sid, ex.SessionId);
-        Assert.True(ex.CapBytes == 250);
+        j.Append(sid, 3, 0, Frame(3, extraBytes: 96));
+
+        Assert.Equal(new uint[] { 1, 2, 3 }, j.ReadRange(sid, 1, 10).Select(e => e.Seq));
+        Assert.True(Assert.Single(metrics.Snapshot()).Bytes > 250);
+    }
+
+    [Fact]
+    public void Bytes_quota_triggers_rotation_below_peer_ack_watermark()
+    {
+        var metrics = new FixpJournalMetrics();
+        using var j = NewJournal(segmentMaxBytes: 250, maxBytesPerSession: 500, metrics: metrics);
+        const uint sid = 0x431u;
+        for (uint s = 1; s <= 4; s++) j.Append(sid, s, s, Frame(s, extraBytes: 96));
+        j.ConfirmPeerAck(sid, 4);
+        j.Append(sid, 5, 5, Frame(5, extraBytes: 96));
+        j.Append(sid, 6, 6, Frame(6, extraBytes: 96));
+
+        Assert.Empty(j.ReadRange(sid, 1, 2));
+        Assert.Equal(new uint[] { 5, 6 }, j.ReadRange(sid, 5, 10).Select(e => e.Seq));
+        var snap = Assert.Single(metrics.Snapshot());
+        Assert.True(snap.RotationsBytes >= 1);
+    }
+
+    [Fact]
+    public void Age_quota_triggers_rotation_below_peer_ack_watermark()
+    {
+        var metrics = new FixpJournalMetrics();
+        using var j = NewJournal(segmentMaxBytes: 250,
+            maxRetention: TimeSpan.FromHours(1),
+            metrics: metrics);
+        const uint sid = 0x432u;
+        j.Append(sid, 1, 1_000_000_000L, Frame(1, extraBytes: 96));
+        j.Append(sid, 2, 2_000_000_000L, Frame(2, extraBytes: 96));
+        j.ConfirmPeerAck(sid, 2);
+        j.Append(sid, 3, 8_000_000_000_000L, Frame(3, extraBytes: 96));
+
+        Assert.Empty(j.ReadRange(sid, 1, 2));
+        Assert.Equal(new uint[] { 3 }, j.ReadRange(sid, 3, 10).Select(e => e.Seq));
+        var snap = Assert.Single(metrics.Snapshot());
+        Assert.True(snap.RotationsAge >= 1);
+    }
+
+    [Fact]
+    public void Rotation_never_drops_entries_above_peer_confirmed_sequence()
+    {
+        using var j = NewJournal(segmentMaxBytes: 250, maxBytesPerSession: 500);
+        const uint sid = 0x433u;
+        for (uint s = 1; s <= 4; s++) j.Append(sid, s, s, Frame(s, extraBytes: 96));
+        j.ConfirmPeerAck(sid, 2);
+        j.Append(sid, 5, 5, Frame(5, extraBytes: 96));
+        j.Append(sid, 6, 6, Frame(6, extraBytes: 96));
+
+        Assert.Equal(new uint[] { 3, 4, 5, 6 }, j.ReadRange(sid, 3, 10).Select(e => e.Seq));
+    }
+
+    [Fact]
+    public void Reconnect_after_rotation_serves_retained_sequence_range()
+    {
+        const uint sid = 0x434u;
+        using (var j = NewJournal(segmentMaxBytes: 250, maxBytesPerSession: 500))
+        {
+            for (uint s = 1; s <= 4; s++) j.Append(sid, s, s, Frame(s, extraBytes: 96));
+            j.ConfirmPeerAck(sid, 4);
+            j.Append(sid, 5, 5, Frame(5, extraBytes: 96));
+            j.Append(sid, 6, 6, Frame(6, extraBytes: 96));
+        }
+
+        using var reopened = NewJournal(segmentMaxBytes: 250, maxBytesPerSession: 500);
+        Assert.Equal(6u, reopened.MaxSeq(sid));
+        Assert.Equal(new uint[] { 5, 6 }, reopened.ReadRange(sid, 5, 10).Select(e => e.Seq));
     }
 
     [Fact]

--- a/tests/B3.Exchange.Gateway.Tests/Persistence/FileFixpOutboundJournalTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/Persistence/FileFixpOutboundJournalTests.cs
@@ -242,6 +242,40 @@ public sealed class FileFixpOutboundJournalTests : IDisposable
     }
 
     [Fact]
+    public void Remove_clears_peer_ack_watermark_before_session_id_reuse()
+    {
+        using var j = NewJournal(segmentMaxBytes: 250, maxBytesPerSession: 350);
+        const uint sid = 0x437u;
+        for (uint s = 1; s <= 4; s++) j.Append(sid, s, s, Frame(s, extraBytes: 96));
+        j.ConfirmPeerAck(sid, 4);
+
+        j.Remove(sid);
+
+        j.Append(sid, 1, 1, Frame(1, extraBytes: 96));
+        j.Append(sid, 2, 2, Frame(2, extraBytes: 96));
+        j.Append(sid, 3, 3, Frame(3, extraBytes: 96));
+
+        Assert.Equal(new uint[] { 1, 2, 3 }, j.ReadRange(sid, 1, 10).Select(e => e.Seq));
+    }
+
+    [Fact]
+    public void Remove_resets_journal_metrics_for_session()
+    {
+        var metrics = new FixpJournalMetrics();
+        using var j = NewJournal(metrics: metrics);
+        const uint sid = 0x438u;
+        j.Append(sid, 1, 1_000_000_000L, Frame(1, extraBytes: 96));
+
+        var before = Assert.Single(metrics.Snapshot());
+        Assert.Equal("0x00000438", before.Session);
+        Assert.True(before.Bytes > 0);
+
+        j.Remove(sid);
+
+        Assert.Empty(metrics.Snapshot());
+    }
+
+    [Fact]
     public void ListSessions_enumerates_persisted_sessions()
     {
         using (var j = NewJournal())


### PR DESCRIPTION
Closes #431.

## Rotation policy
- Adds tcp.maxJournalBytes (default 256 MiB/session) and tcp.maxJournalRetentionHours (default 24h).
- On append, byte or age pressure rotates whole oldest journal segments only when segmentLastSeq <= the peer-confirmed retransmit ACK watermark. The watermark is advanced from accepted RetransmitRequest.fromSeqNo - 1.
- If no segment is below that safe watermark (or only the active segment qualifies), the append succeeds, a warning is logged, and fixp_journal_bytes / fixp_journal_oldest_age_seconds expose the over-budget condition.

## Metrics
- fixp_journal_bytes{session=...}
- fixp_journal_oldest_age_seconds{session=...}
- fixp_journal_rotation_total{session=...,reason=bytes|age}

## Trade-offs
- Rotation is conservative: disk can temporarily exceed limits rather than risk deleting frames a reconnecting peer may request.
- Whole-segment deletion avoids rewriting/truncating active journal files, so retention precision depends on segment boundaries and message rate.

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>