### PR TITLE
Fix or quarantine WalAsyncSnapshot prefix-truncate flake (#429)

### DIFF
--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
@@ -55,14 +55,24 @@ public class ChannelDispatcherWalTests
 
     private sealed class InMemoryPersister : IChannelStatePersister
     {
+        private int _saveCount;
+
         public Dictionary<byte, ChannelStateSnapshot> Last { get; } = new();
-        public int SaveCount { get; private set; }
+        public int SaveCount => Volatile.Read(ref _saveCount);
         public ChannelStateSnapshot? TryLoad(byte n)
-            => Last.TryGetValue(n, out var s) ? s : null;
+        {
+            lock (Last)
+            {
+                return Last.TryGetValue(n, out var s) ? s : null;
+            }
+        }
         public long Save(ChannelStateSnapshot s)
         {
-            SaveCount++;
-            Last[s.ChannelNumber] = s;
+            Interlocked.Increment(ref _saveCount);
+            lock (Last)
+            {
+                Last[s.ChannelNumber] = s;
+            }
             return 1;
         }
     }
@@ -118,6 +128,17 @@ public class ChannelDispatcherWalTests
             new NewOrderCommand(clOrdId, Sec, Side.Buy, OrderType.Limit,
                 TimeInForce.Day, Px(10.00m), 100, 100, nanos),
             session, enteringFirm: 700, clOrdIdValue: clOrdIdValue);
+
+    private static async Task<bool> WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition()) return true;
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+        return condition();
+    }
 
     [Fact]
     public void FileWal_Append_ReadAll_RoundTrip()
@@ -236,13 +257,10 @@ public class ChannelDispatcherWalTests
         var dispB = BuildDispatcher(persister, wal2, out var sinkB, out var outB,
             metrics: metricsB, throttle: throttle);
         // Drive RunLoopAsync's initial LoadPersistedStateOnLoopThread by
-        // starting the dispatcher. Use Start + a brief settle window.
+        // starting the dispatcher and waiting for the replayed registry state.
         dispB.Start();
-        // Wait until the loop has applied the replay (looking at
-        // OrderRegistryCount).
-        var deadline = DateTime.UtcNow.AddSeconds(5);
-        while (dispB.OrderRegistryCount < 3 && DateTime.UtcNow < deadline)
-            Thread.Sleep(20);
+        Assert.True(await WaitForAsync(() => dispB.OrderRegistryCount >= 3,
+            TimeSpan.FromSeconds(5)), "dispatcher did not replay WAL tail before timeout");
 
         Assert.Equal(3, dispB.OrderRegistryCount);
         // Replay must NOT publish on the wire or send ERs.
@@ -286,12 +304,11 @@ public class ChannelDispatcherWalTests
         Assert.True(EnqueueOrder(disp, session, "CL-1", 0x1, 1UL));
         probe.DrainInbound();
 
-        // Async writer is on a background thread; allow it a brief
-        // window to drain + truncate.
-        var deadline = DateTime.UtcNow.AddSeconds(5);
-        while ((persister.SaveCount == 0 || metrics.WalTruncations == 0)
-            && DateTime.UtcNow < deadline)
-            Thread.Sleep(20);
+        // Async writer is on a background thread; wait until it has
+        // drained and truncated instead of sleeping a fixed interval.
+        Assert.True(await WaitForAsync(
+            () => persister.SaveCount >= 1 && metrics.WalTruncations >= 1,
+            TimeSpan.FromSeconds(5)), "async snapshot writer did not save and truncate before timeout");
 
         Assert.True(persister.SaveCount >= 1);
         Assert.True(metrics.WalTruncations >= 1);
@@ -350,9 +367,8 @@ public class ChannelDispatcherWalTests
             metrics: metricsB);
         dispB.Start();
 
-        var deadline = DateTime.UtcNow.AddSeconds(5);
-        while (dispB.IsWalHealthy && DateTime.UtcNow < deadline)
-            Thread.Sleep(20);
+        Assert.True(await WaitForAsync(() => !dispB.IsWalHealthy,
+            TimeSpan.FromSeconds(5)), "dispatcher did not halt on the snapshot/WAL boundary gap before timeout");
 
         Assert.False(dispB.IsWalHealthy);
         // Engine must remain at the snapshot baseline (2 resting orders);

--- a/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
@@ -71,16 +71,19 @@ public class WalAsyncSnapshotTruncateRaceTests
     private sealed class BlockingPersister : IChannelStatePersister
     {
         private readonly SemaphoreSlim _gate = new(0, int.MaxValue);
-        public int SaveCount { get; private set; }
-        public int SaveEnteredCount;
-        public ChannelStateSnapshot? Last { get; private set; }
+        private readonly TaskCompletionSource _firstSaveEntered =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _saveEnteredCount;
+
+        public Task FirstSaveEntered => _firstSaveEntered.Task;
         public ChannelStateSnapshot? TryLoad(byte channelNumber) => null;
         public long Save(ChannelStateSnapshot snapshot)
         {
-            Interlocked.Increment(ref SaveEnteredCount);
+            if (Interlocked.Increment(ref _saveEnteredCount) == 1)
+            {
+                _firstSaveEntered.TrySetResult();
+            }
             _gate.Wait();
-            SaveCount++;
-            Last = snapshot;
             return 0;
         }
         public void ReleaseOne() => _gate.Release();
@@ -104,11 +107,18 @@ public class WalAsyncSnapshotTruncateRaceTests
         return condition();
     }
 
+    private static async Task<bool> WaitForTaskAsync(Task task, TimeSpan timeout)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+        return completed == task;
+    }
+
     [Fact]
     public async Task AsyncSnapshotSaved_PrefixTruncatesWal_KeepsRecordsBeyondSnapshotSeq()
     {
         using var dir = new TempDir();
         var blocking = new BlockingPersister();
+        var metrics = new ChannelMetrics(84);
         var wal = new FileChannelWriteAheadLog(dir.Path, channelNumber: 84,
             NullLogger<FileChannelWriteAheadLog>.Instance, fsyncPerWrite: false);
         var disp = new ChannelDispatcher(
@@ -119,6 +129,7 @@ public class WalAsyncSnapshotTruncateRaceTests
                 PacketSink = new NoOpPacketSink(),
                 Outbound = new NoOpOutbound(),
                 Logger = NullLogger<ChannelDispatcher>.Instance,
+                Metrics = metrics,
                 Persister = blocking,
                 SnapshotThrottle = null,
                 UseAsyncSnapshotWriter = true,
@@ -136,9 +147,7 @@ public class WalAsyncSnapshotTruncateRaceTests
         Assert.True(EnqueueOrder(disp, session, "CL-1", 0x1, 1UL));
         probe.DrainInbound();
         Assert.Single(wal.ReadAll());
-        Assert.True(await WaitForAsync(
-            () => Volatile.Read(ref blocking.SaveEnteredCount) >= 1,
-            TimeSpan.FromSeconds(5)),
+        Assert.True(await WaitForTaskAsync(blocking.FirstSaveEntered, TimeSpan.FromSeconds(5)),
             "writer thread never entered Save(snap@1) — async writer may not be running");
 
         // Cmd 2 → WAL seq=2 appended while the writer is parked inside
@@ -156,16 +165,13 @@ public class WalAsyncSnapshotTruncateRaceTests
         // release a second time), giving us a stable window to assert
         // the WAL state after the first prefix truncate.
         blocking.ReleaseOne();
-
         // Pre-fix (full Truncate): WAL ends up empty → seq=2 is lost.
         // Post-fix (TruncateThrough): seq=2 survives.
-        Assert.True(await WaitForAsync(() => blocking.SaveCount >= 1, TimeSpan.FromSeconds(2)));
-        Assert.True(await WaitForAsync(() =>
-        {
-            var recs = wal.ReadAll();
-            return recs.Count == 1 && recs[0].Seq == 2;
-        }, TimeSpan.FromSeconds(2)),
-            $"expected WAL to contain only seq=2 after prefix truncate, got [{string.Join(",", wal.ReadAll().Select(r => r.Seq))}]");
+        Assert.True(await WaitForAsync(() => metrics.WalTruncations >= 1,
+            TimeSpan.FromSeconds(2)), "async snapshot writer did not truncate WAL before timeout");
+        var kept = wal.ReadAll();
+        Assert.True(kept.Count == 1 && kept[0].Seq == 2,
+            $"expected WAL to contain only seq=2 after prefix truncate, got [{string.Join(",", kept.Select(r => r.Seq))}]");
 
         // Drain the writer cleanly before disposing.
         blocking.ReleaseOne();

--- a/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
@@ -62,6 +62,67 @@ public class WalAsyncSnapshotTruncateRaceTests
         public void Dispose() { try { Directory.Delete(Path, recursive: true); } catch { } }
     }
 
+    private sealed class DispatcherDriver : IDisposable
+    {
+        private readonly ChannelDispatcher.TestProbe _probe;
+        private readonly System.Collections.Concurrent.BlockingCollection<DrainRequest> _requests = new();
+        private readonly Thread _thread;
+
+        public DispatcherDriver(ChannelDispatcher.TestProbe probe)
+        {
+            _probe = probe;
+            _thread = new Thread(Run)
+            {
+                IsBackground = true,
+                Name = "wal-race-dispatcher-test-driver",
+            };
+            _thread.Start();
+        }
+
+        public void DrainInbound()
+        {
+            var request = new DrainRequest();
+            _requests.Add(request);
+            request.Done.Wait();
+            if (request.Error is { } error)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(error).Throw();
+            }
+        }
+
+        public void Dispose()
+        {
+            _requests.CompleteAdding();
+            _thread.Join();
+            _requests.Dispose();
+        }
+
+        private void Run()
+        {
+            foreach (var request in _requests.GetConsumingEnumerable())
+            {
+                try
+                {
+                    _probe.DrainInbound();
+                }
+                catch (Exception ex)
+                {
+                    request.Error = ex;
+                }
+                finally
+                {
+                    request.Done.Set();
+                }
+            }
+        }
+
+        private sealed class DrainRequest
+        {
+            public ManualResetEventSlim Done { get; } = new();
+            public Exception? Error { get; set; }
+        }
+    }
+
     /// <summary>
     /// Persister whose <c>Save</c> blocks on a counting gate. The test
     /// releases one save at a time so it can observe the post-fix WAL
@@ -136,6 +197,7 @@ public class WalAsyncSnapshotTruncateRaceTests
                 Wal = wal,
             });
         var probe = disp.CreateTestProbe();
+        using var driver = new DispatcherDriver(probe);
         var session = new SessionId("80801");
 
         // Cmd 1 → WAL seq=1 → submits snap@1 to the writer thread.
@@ -145,7 +207,7 @@ public class WalAsyncSnapshotTruncateRaceTests
         // runners, causing both snapshots to coalesce into snap@2 →
         // TruncateThrough(2) → empty WAL → wrong race exercised.
         Assert.True(EnqueueOrder(disp, session, "CL-1", 0x1, 1UL));
-        probe.DrainInbound();
+        driver.DrainInbound();
         Assert.Single(wal.ReadAll());
         Assert.True(await WaitForTaskAsync(blocking.FirstSaveEntered, TimeSpan.FromSeconds(5)),
             "writer thread never entered Save(snap@1) — async writer may not be running");
@@ -155,7 +217,7 @@ public class WalAsyncSnapshotTruncateRaceTests
         // the single-slot mailbox; the writer will drain it after we
         // release the first save.
         Assert.True(EnqueueOrder(disp, session, "CL-2", 0x2, 2UL));
-        probe.DrainInbound();
+        driver.DrainInbound();
         Assert.Equal(2, wal.ReadAll().Count);
 
         // Release ONLY the first blocked Save. The writer completes


### PR DESCRIPTION
Closes #429.

This PR fixes the Debug-only WalAsyncSnapshot prefix-truncate flake instead of quarantining it. The race test now synchronizes with the async snapshot writer using a TaskCompletionSource when Save is entered, then waits for the WAL truncation metric before asserting that seq=2 survived the prefix truncate. The sibling ChannelDispatcher WAL recovery tests now use timeout-based async waits and thread-safe in-memory persister counters instead of unsynchronized Thread.Sleep polling.

No tests were marked Category=Flaky and CI filters were not changed.

Validation:
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
- WalAsyncSnapshotTruncateRaceTests ran 5x in Debug

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>