### PR TITLE
Per-session Max Order Rate throttle per B3 spec (#435)

### DIFF
--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading;
 
 namespace B3.Exchange.Contracts;
@@ -45,6 +46,7 @@ public sealed class SessionLifecycleMetrics
 /// </summary>
 public sealed class ThrottleMetrics
 {
+    private readonly ConcurrentDictionary<string, long[]> _rateLimitedBySession = new();
     private long _accepted;
     private long _rejected;
 
@@ -52,7 +54,20 @@ public sealed class ThrottleMetrics
     public long Rejected => Interlocked.Read(ref _rejected);
 
     public void IncAccepted() => Interlocked.Increment(ref _accepted);
-    public void IncRejected() => Interlocked.Increment(ref _rejected);
+    public void IncRejected() => IncRejected(sessionId: null);
+    public void IncRejected(string? sessionId)
+    {
+        Interlocked.Increment(ref _rejected);
+        if (string.IsNullOrEmpty(sessionId))
+            return;
+        var box = _rateLimitedBySession.GetOrAdd(sessionId, static _ => new long[1]);
+        Interlocked.Increment(ref box[0]);
+    }
+
+    public KeyValuePair<string, long>[] RateLimitedBySessionSnapshot()
+        => _rateLimitedBySession.ToArray()
+            .Select(kv => new KeyValuePair<string, long>(kv.Key, Volatile.Read(ref kv.Value[0])))
+            .ToArray();
 }
 
 /// <summary>

--- a/src/B3.Exchange.Contracts/Metrics.cs
+++ b/src/B3.Exchange.Contracts/Metrics.cs
@@ -46,7 +46,8 @@ public sealed class SessionLifecycleMetrics
 /// </summary>
 public sealed class ThrottleMetrics
 {
-    private readonly ConcurrentDictionary<string, long[]> _rateLimitedBySession = new();
+    private readonly ConcurrentDictionary<uint, long[]> _rateLimitedBySession = new();
+    private readonly ConcurrentDictionary<string, long[]> _rateLimitedBySessionLabels = new();
     private long _accepted;
     private long _rejected;
 
@@ -57,8 +58,24 @@ public sealed class ThrottleMetrics
     public void IncRejected() => IncRejected(sessionId: null);
     public void IncRejected(string? sessionId)
     {
+        if (uint.TryParse(sessionId, System.Globalization.NumberStyles.None,
+            System.Globalization.CultureInfo.InvariantCulture, out var numericSessionId))
+        {
+            IncRejected(numericSessionId);
+            return;
+        }
+
         Interlocked.Increment(ref _rejected);
         if (string.IsNullOrEmpty(sessionId))
+            return;
+        var box = _rateLimitedBySessionLabels.GetOrAdd(sessionId, static _ => new long[1]);
+        Interlocked.Increment(ref box[0]);
+    }
+
+    public void IncRejected(uint sessionId)
+    {
+        Interlocked.Increment(ref _rejected);
+        if (sessionId == 0)
             return;
         var box = _rateLimitedBySession.GetOrAdd(sessionId, static _ => new long[1]);
         Interlocked.Increment(ref box[0]);
@@ -66,7 +83,11 @@ public sealed class ThrottleMetrics
 
     public KeyValuePair<string, long>[] RateLimitedBySessionSnapshot()
         => _rateLimitedBySession.ToArray()
-            .Select(kv => new KeyValuePair<string, long>(kv.Key, Volatile.Read(ref kv.Value[0])))
+            .Select(kv => new KeyValuePair<string, long>(
+                kv.Key.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                Volatile.Read(ref kv.Value[0])))
+            .Concat(_rateLimitedBySessionLabels.ToArray()
+                .Select(kv => new KeyValuePair<string, long>(kv.Key, Volatile.Read(ref kv.Value[0]))))
             .ToArray();
 }
 

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -632,6 +632,7 @@ public sealed class MetricsRegistry
         EmitProcessCounter(sb, "exch_throttle_rejected_total",
             "Total inbound application messages rejected with BusinessMessageReject(\"Throttle limit exceeded\") by the per-session sliding-window throttle (issue #56 / GAP-20).",
             _throttle.Rejected);
+        EmitRateLimitedBySession(sb);
         EmitProcessCounter(sb, "exch_transport_send_queue_full_total",
             "Total times the gateway's TcpTransport closed a session because its bounded outbound send queue overflowed (issue #155). A non-zero value means a stuck/slow consumer is causing teardowns — alert.",
             _transport.SendQueueFull);
@@ -920,6 +921,22 @@ public sealed class MetricsRegistry
           .Append("\"} ")
           .Append(_sessionFirmMessages.SessionOverflowCount.ToString(CultureInfo.InvariantCulture))
           .Append('\n');
+    }
+
+    private void EmitRateLimitedBySession(StringBuilder sb)
+    {
+        sb.Append("# HELP rate_limited_total Total order messages rejected with BusinessMessageReject(\"Throttle limit exceeded\") by the per-session Max Order Rate throttle (issue #435 / GAP-20).\n");
+        sb.Append("# TYPE rate_limited_total counter\n");
+        var sessions = _throttle.RateLimitedBySessionSnapshot();
+        Array.Sort(sessions, (a, b) => StringComparer.Ordinal.Compare(a.Key, b.Key));
+        foreach (var kv in sessions)
+        {
+            sb.Append("rate_limited_total{session=\"")
+              .Append(EscapeLabel(kv.Key))
+              .Append("\"} ")
+              .Append(kv.Value.ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
     }
 
     private static void EmitRuntimeMetrics(StringBuilder sb)

--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -32,6 +32,7 @@ public sealed class EntryPointListener : IAsyncDisposable
     private readonly B3.Exchange.Gateway.Persistence.IFixpOutboundJournal? _outboundJournal;
     private readonly B3.Exchange.Gateway.Persistence.IFixpSessionStatePersister? _statePersister;
     private readonly IDictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>? _persistedSessionStates;
+    private readonly Func<uint, int?>? _persistedMaxOrderRateResolver;
     private readonly CancellationTokenSource _cts = new();
     private TcpListener? _listener;
     private Task? _acceptTask;
@@ -70,7 +71,8 @@ public sealed class EntryPointListener : IAsyncDisposable
         B3.Exchange.Contracts.RetransmitMetrics? retransmitMetrics = null,
         B3.Exchange.Gateway.Persistence.IFixpOutboundJournal? outboundJournal = null,
         B3.Exchange.Gateway.Persistence.IFixpSessionStatePersister? statePersister = null,
-        IReadOnlyDictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>? persistedSessionStates = null)
+        IReadOnlyDictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>? persistedSessionStates = null,
+        Func<uint, int?>? persistedMaxOrderRateResolver = null)
     {
         ArgumentNullException.ThrowIfNull(loggerFactory);
         ArgumentNullException.ThrowIfNull(registry);
@@ -92,6 +94,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         _persistedSessionStates = persistedSessionStates is null
             ? null
             : new Dictionary<uint, B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot>(persistedSessionStates);
+        _persistedMaxOrderRateResolver = persistedMaxOrderRateResolver;
         if ((_negotiationValidator is null) ^ (_sessionClaims is null))
         {
             throw new ArgumentException(
@@ -442,6 +445,7 @@ public sealed class EntryPointListener : IAsyncDisposable
         // hot path (same-process Suspended session); this block handles
         // the cold path where the prior incarnation died.
         B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot? rehydrateState = null;
+        int? persistedMaxOrderRatePerSecond = null;
         bool resumeAsNegotiated = false;
         if (_persistedSessionStates is not null
             && firstFrame.Length >= EntryPointFrameReader.WireHeaderSize)
@@ -478,6 +482,7 @@ public sealed class EntryPointListener : IAsyncDisposable
             if (decoded && _persistedSessionStates.TryGetValue(sessionIdFromFrame, out var snap))
             {
                 rehydrateState = snap;
+                persistedMaxOrderRatePerSecond = _persistedMaxOrderRateResolver?.Invoke(snap.SessionId);
                 // Only the Establish-with-matching-SessionVerId shape
                 // should resume in Negotiated state. A Negotiate frame
                 // (any SessionVerId) and an Establish with a different
@@ -493,12 +498,15 @@ public sealed class EntryPointListener : IAsyncDisposable
             }
         }
 
-        ConstructAndStartSession(stream, sock, firstFrame, persistedState: rehydrateState, resumeAsNegotiated: resumeAsNegotiated);
+        ConstructAndStartSession(stream, sock, firstFrame, persistedState: rehydrateState,
+            resumeAsNegotiated: resumeAsNegotiated,
+            persistedMaxOrderRatePerSecond: persistedMaxOrderRatePerSecond);
     }
 
     private void ConstructAndStartSession(NetworkStream stream, Socket sock, byte[]? firstFrame,
         B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot? persistedState,
-        bool resumeAsNegotiated = false)
+        bool resumeAsNegotiated = false,
+        int? persistedMaxOrderRatePerSecond = null)
     {
         var identity = _identityFactory(SafeRemote(sock));
         _logger.LogInformation("accepted connection {ConnectionId} from {Remote} sessionId={SessionId}",
@@ -522,7 +530,8 @@ public sealed class EntryPointListener : IAsyncDisposable
             outboundJournal: _outboundJournal,
             statePersister: _statePersister,
             persistedState: persistedState,
-            resumeAsNegotiated: resumeAsNegotiated);
+            resumeAsNegotiated: resumeAsNegotiated,
+            persistedMaxOrderRatePerSecond: persistedMaxOrderRatePerSecond);
         _registry.Register(session);
         lock (_lock) _sessions.Add(session);
         session.Start();

--- a/src/B3.Exchange.Gateway/Firm.cs
+++ b/src/B3.Exchange.Gateway/Firm.cs
@@ -19,7 +19,7 @@ public sealed record Firm(string Id, string Name, uint EnteringFirmCode);
 /// global TCP defaults for backwards-compatibility.
 /// </summary>
 public sealed record SessionPolicy(
-    int ThrottleMessagesPerSecond = 0,
+    int MaxOrderRatePerSecond = 200,
     int KeepAliveIntervalMs = 30_000,
     int IdleTimeoutMs = 30_000,
     int TestRequestGraceMs = 5_000,
@@ -37,8 +37,8 @@ public sealed record SessionPolicy(
             throw new InvalidOperationException("SessionPolicy.TestRequestGraceMs must be > 0");
         if (RetransmitBufferSize <= 0)
             throw new InvalidOperationException("SessionPolicy.RetransmitBufferSize must be > 0");
-        if (ThrottleMessagesPerSecond < 0)
-            throw new InvalidOperationException("SessionPolicy.ThrottleMessagesPerSecond must be >= 0 (0 disables)");
+        if (MaxOrderRatePerSecond < 0)
+            throw new InvalidOperationException("SessionPolicy.MaxOrderRatePerSecond must be >= 0 (0 disables)");
     }
 }
 

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -50,10 +50,10 @@ public sealed partial class FixpSession
         var fixedBlock = fullBody.Slice(0, info.BlockLength).Span;
         var varData = fullBody.Slice(info.BlockLength).Span;
 
-        // Per-session inbound sliding-window throttle (issue #56 / GAP-20,
-        // guidelines §4.9). Only application templates count toward the
+        // Per-session Max Order Rate throttle (issue #435 / GAP-20,
+        // guidelines §4.9). Only order-entry templates count toward the
         // budget — FIXP session-layer messages (Negotiate, Establish,
-        // Sequence, RetransmitRequest) bypass it. On violation we emit
+        // Sequence, RetransmitRequest, NotApplied) bypass it. On violation we emit
         // BusinessMessageReject with text "Throttle limit exceeded" and
         // KEEP the session open; the offending frame does not consume a
         // slot (so a sustained burst keeps getting rejected, not slowly
@@ -437,6 +437,9 @@ public sealed partial class FixpSession
         || templateId == EntryPointFrameReader.TidOrderCancelRequest
         || templateId == EntryPointFrameReader.TidNewOrderCross
         || templateId == EntryPointFrameReader.TidOrderMassActionRequest;
+
+    private static bool IsOrderRateLimitedTemplate(ushort templateId)
+        => IsApplicationTemplate(templateId);
     private static byte[] ExtractInboundMemo(ushort templateId, ReadOnlySpan<byte> varData)
     {
         if (varData.IsEmpty) return [];

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -16,12 +16,12 @@ namespace B3.Exchange.Gateway;
 public sealed partial class FixpSession
 {
     /// <summary>
-    /// Per-session inbound sliding-window throttle gate (issue #56 /
-    /// GAP-20). Returns <c>true</c> if the inbound frame is admitted
+    /// Per-session Max Order Rate gate (issue #435 / GAP-20). Returns
+    /// <c>true</c> if the inbound order frame is admitted
     /// (the slot is consumed), or <c>false</c> after emitting
     /// <c>BusinessMessageReject(text="Throttle limit exceeded")</c> for
     /// the rejected frame. Session-layer FIXP messages (anything that
-    /// is not an <see cref="IsApplicationTemplate"/> template) and
+    /// is not an <see cref="IsOrderRateLimitedTemplate"/> template) and
     /// sessions configured without a throttle (<c>_throttle == null</c>)
     /// always return <c>true</c>. Exposed as <c>internal</c> so tests can
     /// drive the throttle directly without constructing a fully-decodable
@@ -29,7 +29,7 @@ public sealed partial class FixpSession
     /// </summary>
     internal bool TryAcceptInboundThrottle(ushort templateId, ReadOnlySpan<byte> fixedBlock)
     {
-        if (_throttle is null || !IsApplicationTemplate(templateId))
+        if (_throttle is null || !IsOrderRateLimitedTemplate(templateId))
             return true;
         if (_throttle.TryAccept())
         {
@@ -48,7 +48,7 @@ public sealed partial class FixpSession
             businessRejectRefId: refClOrdId,
             businessRejectReason: BusinessMessageRejectEncoder.Reason.Other,
             text: "Throttle limit exceeded");
-        _options.ThrottleMetrics?.IncRejected();
+        _options.ThrottleMetrics?.IncRejected(SessionId.ToString(System.Globalization.CultureInfo.InvariantCulture));
         _logger.LogWarning(
             "fixp session {ConnectionId} throttle reject template={Template} (max={Max}/{WindowMs}ms)",
             ConnectionId, templateId, _throttle.MaxMessages, _throttle.TimeWindowMs);

--- a/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.HeaderValidation.cs
@@ -48,7 +48,7 @@ public sealed partial class FixpSession
             businessRejectRefId: refClOrdId,
             businessRejectReason: BusinessMessageRejectEncoder.Reason.Other,
             text: "Throttle limit exceeded");
-        _options.ThrottleMetrics?.IncRejected(SessionId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        _options.ThrottleMetrics?.IncRejected(SessionId);
         _logger.LogWarning(
             "fixp session {ConnectionId} throttle reject template={Template} (max={Max}/{WindowMs}ms)",
             ConnectionId, templateId, _throttle.MaxMessages, _throttle.TimeWindowMs);

--- a/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
@@ -146,6 +146,7 @@ public sealed partial class FixpSession
         SessionId = req.SessionId;
         EnteringFirm = outcome.Firm!.EnteringFirmCode;
         SessionVerId = req.SessionVerId;
+        ConfigureOrderRateLimit(outcome.Credential!.Policy.MaxOrderRatePerSecond);
         // Issue #405 (review finding): commit the new SessionVerID to
         // disk BEFORE acking the Negotiate. If persistence fails, abort
         // the handshake — without this, a transient disk error would

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -314,7 +314,8 @@ public sealed partial class FixpSession : IAsyncDisposable
         B3.Exchange.Gateway.Persistence.IFixpOutboundJournal? outboundJournal = null,
         B3.Exchange.Gateway.Persistence.IFixpSessionStatePersister? statePersister = null,
         B3.Exchange.Gateway.Persistence.FixpSessionStateSnapshot? persistedState = null,
-        bool resumeAsNegotiated = false)
+        bool resumeAsNegotiated = false,
+        int? persistedMaxOrderRatePerSecond = null)
     {
         ArgumentNullException.ThrowIfNull(logger);
         ConnectionId = connectionId;
@@ -329,6 +330,8 @@ public sealed partial class FixpSession : IAsyncDisposable
         _nowMs = nowMs ?? (() => Environment.TickCount64);
         _options = options ?? FixpSessionOptions.Default;
         _options.Validate();
+        if (persistedMaxOrderRatePerSecond is < 0)
+            throw new ArgumentOutOfRangeException(nameof(persistedMaxOrderRatePerSecond));
         _outboundJournal = outboundJournal;
         _statePersister = statePersister;
         // Issue #405 rehydration: when a state snapshot survives a
@@ -421,7 +424,8 @@ public sealed partial class FixpSession : IAsyncDisposable
             logger: _logger,
             connectionId: ConnectionId);
         ConfigureOrderRateLimit(
-            _options.ThrottleMaxMessages > 0 ? _options.ThrottleMaxMessages : _options.MaxOrderRatePerSecond,
+            persistedMaxOrderRatePerSecond
+                ?? (_options.ThrottleMaxMessages > 0 ? _options.ThrottleMaxMessages : _options.MaxOrderRatePerSecond),
             _options.ThrottleTimeWindowMs > 0 ? _options.ThrottleTimeWindowMs : 1_000);
         _onClosed = onClosed;
         _validator = negotiationValidator;

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -129,7 +129,7 @@ public sealed partial class FixpSession : IAsyncDisposable
     /// and <see cref="FixpSessionOptions.ThrottleMaxMessages"/> are 0
     /// (throttling disabled). Mutated only on the receive thread.
     /// </summary>
-    private readonly InboundThrottle? _throttle;
+    private InboundThrottle? _throttle;
 
     public long ConnectionId { get; }
 
@@ -420,13 +420,9 @@ public sealed partial class FixpSession : IAsyncDisposable
             getState: () => State,
             logger: _logger,
             connectionId: ConnectionId);
-        if (_options.ThrottleMaxMessages > 0 && _options.ThrottleTimeWindowMs > 0)
-        {
-            _throttle = new InboundThrottle(
-                _options.ThrottleMaxMessages,
-                _options.ThrottleTimeWindowMs,
-                _nowMs);
-        }
+        ConfigureOrderRateLimit(
+            _options.ThrottleMaxMessages > 0 ? _options.ThrottleMaxMessages : _options.MaxOrderRatePerSecond,
+            _options.ThrottleTimeWindowMs > 0 ? _options.ThrottleTimeWindowMs : 1_000);
         _onClosed = onClosed;
         _validator = negotiationValidator;
         _establishValidator = establishValidator;
@@ -492,6 +488,12 @@ public sealed partial class FixpSession : IAsyncDisposable
 
     private static long NowMs() => Environment.TickCount64;
 
+    private void ConfigureOrderRateLimit(int maxOrderRatePerSecond, int timeWindowMs = 1_000)
+    {
+        _throttle = maxOrderRatePerSecond > 0
+            ? new InboundThrottle(maxOrderRatePerSecond, timeWindowMs, _nowMs)
+            : null;
+    }
 
     private uint NextMsgSeqNum() => (uint)Interlocked.Increment(ref _msgSeqNum);
 

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -73,9 +73,8 @@ public sealed record FixpSessionOptions
     public B3.Exchange.Contracts.SessionLifecycleMetrics? LifecycleMetrics { get; init; }
 
     /// <summary>
-    /// Per-session inbound rate cap (issue #56 / GAP-20, guidelines §4.9):
-    /// at most <see cref="ThrottleMaxMessages"/> application messages
-    /// per <see cref="ThrottleTimeWindowMs"/>-millisecond sliding window.
+    /// Per-session Max Order Rate (issue #435 / GAP-20, guidelines §4.9):
+    /// at most <see cref="MaxOrderRatePerSecond"/> order messages per second.
     /// On violation the session emits
     /// <c>BusinessMessageReject("Throttle limit exceeded")</c> and stays
     /// open (the offending frame is dropped and does NOT consume budget).
@@ -87,6 +86,12 @@ public sealed record FixpSessionOptions
 
     /// <summary>See <see cref="ThrottleTimeWindowMs"/>.</summary>
     public int ThrottleMaxMessages { get; init; }
+
+    /// <summary>
+    /// Preferred per-session order-message cap. Defaults to 200 msg/s.
+    /// Set to <c>0</c> to disable the limiter.
+    /// </summary>
+    public int MaxOrderRatePerSecond { get; init; } = 200;
 
     /// <summary>
     /// Optional process-wide throttle counters. When non-null the session
@@ -116,5 +121,6 @@ public sealed record FixpSessionOptions
         if (RetransmitBufferCapacity <= 0) throw new ArgumentOutOfRangeException(nameof(RetransmitBufferCapacity));
         if (ThrottleTimeWindowMs < 0) throw new ArgumentOutOfRangeException(nameof(ThrottleTimeWindowMs));
         if (ThrottleMaxMessages < 0) throw new ArgumentOutOfRangeException(nameof(ThrottleMaxMessages));
+        if (MaxOrderRatePerSecond < 0) throw new ArgumentOutOfRangeException(nameof(MaxOrderRatePerSecond));
     }
 }

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -469,7 +469,8 @@ public sealed class ExchangeHost : IAsyncDisposable
             LifecycleMetrics = _metrics.Sessions,
             ThrottleTimeWindowMs = _config.Tcp.Throttle?.TimeWindowMs ?? 0,
             ThrottleMaxMessages = _config.Tcp.Throttle?.MaxMessages ?? 0,
-            ThrottleMetrics = _config.Tcp.Throttle is not null ? _metrics.Throttle : null,
+            MaxOrderRatePerSecond = 200,
+            ThrottleMetrics = _metrics.Throttle,
             OnTransportSendQueueFull = _metrics.Transport.IncSendQueueFull,
         };
         // Phase 2 (#42): real Negotiate handshake. The validator is pure
@@ -955,7 +956,7 @@ public sealed class ExchangeHost : IAsyncDisposable
             var policy = sc.Policy is null
                 ? SessionPolicy.Default
                 : new SessionPolicy(
-                    ThrottleMessagesPerSecond: sc.Policy.ThrottleMessagesPerSecond,
+                    MaxOrderRatePerSecond: sc.Policy.MaxOrderRatePerSecond,
                     KeepAliveIntervalMs: sc.Policy.KeepAliveIntervalMs,
                     IdleTimeoutMs: sc.Policy.IdleTimeoutMs,
                     TestRequestGraceMs: sc.Policy.TestRequestGraceMs,

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -539,7 +539,9 @@ public sealed class ExchangeHost : IAsyncDisposable
             retransmitMetrics: _metrics.Retransmit,
             outboundJournal: _outboundJournal,
             statePersister: _statePersister,
-            persistedSessionStates: persistedSessionStates);
+            persistedSessionStates: persistedSessionStates,
+            persistedMaxOrderRateResolver: sessionId =>
+                firmRegistry.FindSessionByWire(sessionId)?.Policy.MaxOrderRatePerSecond);
         _listener.Start();
         _logger.LogInformation("entrypoint listening on {Endpoint}", _listener.LocalEndpoint);
 

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -180,7 +180,22 @@ public sealed class SessionConfig
 
 public sealed class SessionPolicyConfig
 {
-    [JsonPropertyName("throttleMessagesPerSecond")] public int ThrottleMessagesPerSecond { get; set; }
+    private int _maxOrderRatePerSecond = 200;
+
+    [JsonPropertyName("maxOrderRatePerSecond")]
+    public int MaxOrderRatePerSecond
+    {
+        get => _maxOrderRatePerSecond;
+        set => _maxOrderRatePerSecond = value;
+    }
+
+    [JsonPropertyName("throttleMessagesPerSecond")]
+    public int ThrottleMessagesPerSecond
+    {
+        get => _maxOrderRatePerSecond;
+        set => _maxOrderRatePerSecond = value;
+    }
+
     [JsonPropertyName("keepAliveIntervalMs")] public int KeepAliveIntervalMs { get; set; } = 30_000;
     [JsonPropertyName("idleTimeoutMs")] public int IdleTimeoutMs { get; set; } = 30_000;
     [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -150,6 +150,21 @@ public class MetricsRegistryTests
     }
 
     [Fact]
+    public void RateLimitedCounter_IsRenderedPerSession()
+    {
+        var reg = new MetricsRegistry();
+        reg.Throttle.IncRejected("123");
+        reg.Throttle.IncRejected("123");
+        reg.Throttle.IncRejected("456");
+
+        var text = reg.RenderProm();
+
+        Assert.Contains("# TYPE rate_limited_total counter\n", text);
+        Assert.Contains("rate_limited_total{session=\"123\"} 2\n", text);
+        Assert.Contains("rate_limited_total{session=\"456\"} 1\n", text);
+    }
+
+    [Fact]
     public void Render_EmitsRuntimeMetrics_Issue177()
     {
         var reg = new MetricsRegistry();

--- a/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FirmRegistryTests.cs
@@ -167,7 +167,7 @@ public class FirmRegistryTests
     [Fact]
     public void SessionPolicy_rejects_negative_throttle()
     {
-        var p = new SessionPolicy(ThrottleMessagesPerSecond: -1);
+        var p = new SessionPolicy(MaxOrderRatePerSecond: -1);
         Assert.Throws<InvalidOperationException>(p.Validate);
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionResyncBootRehydrationTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionResyncBootRehydrationTests.cs
@@ -4,6 +4,7 @@ using B3.Exchange.Gateway;
 using B3.Exchange.Gateway.Persistence;
 using B3.Exchange.Matching;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Buffers.Binary;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -33,6 +34,15 @@ public class FixpSessionResyncBootRehydrationTests
         public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) => true;
         public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
         public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static byte[] BuildFixedBlock(uint sessionId, uint msgSeqNum, ulong clOrdId)
+    {
+        var fb = new byte[82];
+        BinaryPrimitives.WriteUInt32LittleEndian(fb.AsSpan(0, 4), sessionId);
+        BinaryPrimitives.WriteUInt32LittleEndian(fb.AsSpan(4, 4), msgSeqNum);
+        BinaryPrimitives.WriteUInt64LittleEndian(fb.AsSpan(20, 8), clOrdId);
+        return fb;
     }
 
     [Fact]
@@ -308,6 +318,99 @@ public class FixpSessionResyncBootRehydrationTests
         {
             try { Directory.Delete(dir, recursive: true); } catch { }
         }
+    }
+
+    [Theory]
+    [InlineData(50, 51, 50, 50, 1)]
+    [InlineData(0, 250, 250, 0, 0)]
+    public async Task ReconnectingEstablish_WithSamePersistedSessionVerId_AppliesCredentialRateLimit(
+        int configuredMaxOrderRatePerSecond,
+        int attemptedOrders,
+        int expectedAccepted,
+        int expectedMetricAccepted,
+        int expectedRejected)
+    {
+        var persistedStates = new Dictionary<uint, FixpSessionStateSnapshot>
+        {
+            [1] = new(
+                SessionId: 1,
+                SessionVerId: 100UL,
+                OutboundMsgSeqNum: 3u,
+                LastIncomingSeqNo: 2u,
+                EnteringFirm: 42u,
+                UpdatedAtNanos: 1_000_000L),
+        };
+        var firms = new FirmRegistry(
+            new[] { new Firm(Id: "F1", Name: "Firm 1", EnteringFirmCode: 42u) },
+            new[]
+            {
+                new SessionCredential(
+                    SessionId: "1",
+                    FirmId: "F1",
+                    AccessKey: "",
+                    AllowedSourceCidrs: null,
+                    Policy: new SessionPolicy(MaxOrderRatePerSecond: configuredMaxOrderRatePerSecond)),
+            });
+        var claims = new SessionClaimRegistry();
+        foreach (var s in persistedStates.Values)
+            claims.SeedLastVersion(s.SessionId, s.SessionVerId);
+
+        var metrics = new ThrottleMetrics();
+        var negValidator = new NegotiationValidator(firms, claims, devMode: true, timestampSkewToleranceNs: 0);
+        var estValidator = new EstablishValidator(timestampSkewToleranceNs: 0);
+
+        await using var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            new SessionRegistry(),
+            NullLoggerFactory.Instance,
+            sessionOptions: new FixpSessionOptions
+            {
+                HeartbeatIntervalMs = 60_000,
+                IdleTimeoutMs = 60_000,
+                TestRequestGraceMs = 60_000,
+                SuspendedTimeoutMs = 0,
+                FirstFrameTimeoutMs = 5_000,
+                MaxOrderRatePerSecond = 200,
+                ThrottleMetrics = metrics,
+            },
+            negotiationValidator: negValidator,
+            sessionClaims: claims,
+            establishValidator: estValidator,
+            persistedSessionStates: persistedStates,
+            persistedMaxOrderRateResolver: sessionId =>
+                firms.FindSessionByWire(sessionId)?.Policy.MaxOrderRatePerSecond);
+        listener.Start();
+
+        using var client = new TcpClient();
+        await client.ConnectAsync(IPAddress.Loopback, listener.LocalEndpoint!.Port);
+        var buf = new byte[256];
+        int len = EntryPointFixpFrameCodec.EncodeEstablish(buf,
+            sessionId: 1, sessionVerId: 100UL,
+            timestampNanos: 0UL, keepAliveIntervalMillis: 60_000UL,
+            nextSeqNo: 3u,
+            cancelOnDisconnectType: 0, codTimeoutWindowMillis: 0UL,
+            credentials: ReadOnlySpan<byte>.Empty);
+        await client.GetStream().WriteAsync(buf.AsMemory(0, len));
+
+        var establishedSession = await TestUtil.WaitUntilAsync(() =>
+        {
+            var s = listener.ActiveSessions.FirstOrDefault(x => x.SessionId == 1);
+            return s is not null && s.State == FixpState.Established;
+        }, TimeSpan.FromSeconds(5));
+        Assert.True(establishedSession);
+
+        var session = listener.ActiveSessions.Single(s => s.SessionId == 1);
+        for (int i = 0; i < attemptedOrders; i++)
+        {
+            var accepted = session.TryAcceptInboundThrottle(
+                EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(1, (uint)(i + 1), (ulong)(10_000 + i)));
+            Assert.Equal(i < expectedAccepted, accepted);
+        }
+
+        Assert.Equal(expectedMetricAccepted, metrics.Accepted);
+        Assert.Equal(expectedRejected, metrics.Rejected);
     }
 
     private sealed class FaultingStatePersister : IFixpSessionStatePersister

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -253,6 +253,45 @@ public class FixpSessionThrottleTests
     }
 
     [Fact]
+    public async Task Max_order_rate_plus_one_within_one_second_rejects_exactly_one_with_BMR_other()
+    {
+        var (server, client) = await ConnectPairAsync();
+        try
+        {
+            long now = 1_000_000;
+            var metrics = new B3.Exchange.Contracts.ThrottleMetrics();
+            var session = NewSession(server,
+                new FixpSessionOptions { MaxOrderRatePerSecond = 2, ThrottleMetrics = metrics },
+                () => now);
+
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidNewOrderSingle,
+                BuildFixedBlock(100, 1, 9000)));
+            Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidOrderCancelReplaceRequest,
+                BuildFixedBlock(100, 2, 9001)));
+            Assert.False(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidOrderCancelRequest,
+                BuildFixedBlock(100, 3, 9002)));
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var (tid, body) = await ReadOneFrameAsync(client.GetStream(), cts.Token);
+            Assert.Equal(EntryPointFrameReader.TidBusinessMessageReject, tid);
+            Assert.Equal((byte)19, body[18]);
+            Assert.Equal(3u, BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(20, 4)));
+            Assert.Equal(9002UL, BinaryPrimitives.ReadUInt64LittleEndian(body.AsSpan(24, 8)));
+            Assert.Equal(BusinessMessageRejectEncoder.Reason.Other,
+                BinaryPrimitives.ReadUInt32LittleEndian(body.AsSpan(32, 4)));
+            Assert.Equal(2, metrics.Accepted);
+            Assert.Equal(1, metrics.Rejected);
+            Assert.True(session.IsOpen);
+            session.Close("test");
+        }
+        finally
+        {
+            client.Close();
+            server.Dispose();
+        }
+    }
+
+    [Fact]
     public async Task Window_slides_forward_so_more_messages_admitted_after_time_passes()
     {
         var (server, client) = await ConnectPairAsync();
@@ -302,6 +341,8 @@ public class FixpSessionThrottleTests
             {
                 Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidSequence,
                     BuildFixedBlock(100, (uint)(i + 1), 0)));
+                Assert.True(session.TryAcceptInboundThrottle(EntryPointFrameReader.TidNotApplied,
+                    BuildFixedBlock(100, (uint)(i + 100), 0)));
             }
             // No application templates were sent, so neither counter moves.
             Assert.Equal(0, metrics.Accepted);
@@ -312,6 +353,46 @@ public class FixpSessionThrottleTests
         {
             client.Close();
             server.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task Rate_limit_is_isolated_per_session()
+    {
+        var (server1, client1) = await ConnectPairAsync();
+        var (server2, client2) = await ConnectPairAsync();
+        try
+        {
+            long now = 1_000_000;
+            var session1 = NewSession(server1,
+                new FixpSessionOptions { MaxOrderRatePerSecond = 1 },
+                () => now);
+            var session2 = new FixpSession(
+                connectionId: 2, enteringFirm: 7, sessionId: 200,
+                stream: server2, sink: new NoOpEngineSink(),
+                logger: NullLogger<FixpSession>.Instance,
+                options: new FixpSessionOptions { MaxOrderRatePerSecond = 1 },
+                nowMs: () => now);
+            session2.Start();
+            session2.ApplyTransition(FixpEvent.Negotiate);
+            session2.ApplyTransition(FixpEvent.Establish);
+
+            Assert.True(session1.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 1, 1)));
+            Assert.False(session1.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(100, 2, 2)));
+            Assert.True(session2.TryAcceptInboundThrottle(EntryPointFrameReader.TidSimpleNewOrder,
+                BuildFixedBlock(200, 1, 3)));
+
+            session1.Close("test");
+            session2.Close("test");
+        }
+        finally
+        {
+            client1.Close();
+            server1.Dispose();
+            client2.Close();
+            server2.Dispose();
         }
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionThrottleTests.cs
@@ -292,6 +292,21 @@ public class FixpSessionThrottleTests
     }
 
     [Fact]
+    public void Rejected_metric_numeric_session_id_has_zero_steady_state_allocation()
+    {
+        var metrics = new B3.Exchange.Contracts.ThrottleMetrics();
+        metrics.IncRejected(100u);
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        for (int i = 0; i < 10_000; i++)
+            metrics.IncRejected(100u);
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(0, after - before);
+        Assert.Equal(10_001, metrics.Rejected);
+    }
+
+    [Fact]
     public async Task Window_slides_forward_so_more_messages_admitted_after_time_passes()
     {
         var (server, client) = await ConnectPairAsync();


### PR DESCRIPTION
Closes #435.

## Summary
- Adds sessions[].policy.maxOrderRatePerSecond (default 200 msg/s; legacy throttleMessagesPerSecond remains an alias).
- Applies an exact per-FIXP-session sliding-window limiter at inbound order dispatch. The window is 1 second and rejected messages do not consume quota.
- Limits order-entry templates only (Simple/New/Replace/Cancel/Cross/MassAction); FIXP session-level messages such as Sequence/NotApplied bypass the limiter.
- Emits rate_limited_total{session="..."} plus existing aggregate throttle counters.

## BMR reason / spec note
B3 compliance docs cite guidelines §4.9/GAP-20: sliding window of N messages / M ms per session, reject violations with BusinessMessageReject text "Throttle limit exceeded". The vendored SBE schema exposes BusinessMessageReject.businessRejectReason as generic RejReason (schemas/b3-entrypoint-messages-8.4.2.xml:1264-1266) and does not include a named throttle-specific enum value, so this PR uses BusinessRejectReason=0 (Other) with text "Throttle limit exceeded".

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>