### PR TITLE
Pre-OOM observability gauges: book size, WAL bytes, retransmit util% (#432)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -347,6 +347,7 @@ public sealed partial class ChannelDispatcher
             // partial state would corrupt downstream consumers.
             if (succeeded)
             {
+                RecordBookCountsAfterWorkItem(in item);
                 long flushStart = engineEnd;
                 // Fast path: skip the virtual StartActivity call when no
                 // listeners are attached (round-2 perf #11).
@@ -404,6 +405,46 @@ public sealed partial class ChannelDispatcher
     {
         _aggressorOrigQty = originalQty;
         _aggressorCumQty = 0;
+    }
+
+    private void RecordBookCountsAfterWorkItem(in WorkItem item)
+    {
+        if (_metrics is null) return;
+        switch (item.Kind)
+        {
+            case WorkKind.New when item.NewOrder is not null:
+                RecordBookCount(item.NewOrder.SecurityId);
+                break;
+            case WorkKind.Cancel when item.Cancel is not null:
+                RecordBookCount(item.Cancel.SecurityId);
+                break;
+            case WorkKind.Replace when item.Replace is not null:
+                RecordBookCount(item.Replace.SecurityId);
+                break;
+            case WorkKind.Cross when item.Cross is not null:
+                RecordBookCount(item.Cross.Buy.SecurityId);
+                break;
+            case WorkKind.MassCancel when item.MassCancel is not null && item.MassCancel.Command.SecurityId != 0:
+                RecordBookCount(item.MassCancel.Command.SecurityId);
+                break;
+            case WorkKind.MassCancel:
+                RecordAllBookCounts();
+                break;
+        }
+    }
+
+    private void RecordBookCount(long securityId)
+    {
+        if (_metrics is null) return;
+        try { _metrics.SetBookLiveOrders(securityId, _engine.OrderCount(securityId)); }
+        catch (KeyNotFoundException) { }
+    }
+
+    private void RecordAllBookCounts()
+    {
+        if (_metrics is null) return;
+        foreach (var sample in _engine.OrderCountsSnapshot())
+            _metrics.SetBookLiveOrders(sample.SecurityId, sample.Count);
     }
 
     private void EmitUnknownOrderIdReject(string clOrdId, long securityId, ulong nowNanos)

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -29,6 +29,7 @@ public sealed partial class ChannelDispatcher
         AssertOnLoopThread();
         _engine.ResetForChannelReset();
         _orders.Clear();
+        RecordAllBookCounts();
         Volatile.Write(ref _sequenceVersion, (ushort)(_sequenceVersion + 1));
         Volatile.Write(ref _sequenceNumber, 0u);
         _snapshotRotator?.BumpSequenceVersion();

--- a/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Persistence.cs
@@ -210,6 +210,7 @@ public sealed partial class ChannelDispatcher
                 originalQty: origQty, cumQty: o.CumQty);
         }
         if (droppedOrphans > 0) _metrics?.AddOwnerOrphansDropped(droppedOrphans);
+        RecordAllBookCounts();
 
         _logger.LogInformation(
             "channel {ChannelNumber}: restored snapshot — seq={SequenceNumber}/{SequenceVersion} owners={OwnerCount} orphansDropped={OrphansDropped}",

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -78,6 +78,8 @@ public sealed partial class ChannelDispatcher
             // we return the on-disk bytes from this single call.
             long approxBytes = _wal.Append(rec);
             _metrics?.IncWalAppend(approxBytes);
+            if (approxBytes > 0)
+                _metrics?.SetWalLastWriteUnixMs(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
             _metrics?.SetWalSizeBytes(_wal.CurrentSizeBytes);
             _metrics?.SetWalDropsOnFull(_wal.DropsOnFullCount);
             return true;
@@ -379,6 +381,7 @@ public sealed partial class ChannelDispatcher
         // and migration progress immediately after boot.
         _metrics?.AddWalRecordCorruptions(_wal.LastReadCorruptCount);
         _metrics?.AddWalRecordsLegacy(_wal.LastReadLegacyCount);
+        RecordAllBookCounts();
         _logger.LogInformation(
             "channel {ChannelNumber}: WAL replay complete — replayed={Replayed} skipped={Skipped} corrupt={Corrupt} legacy={Legacy} (snapshotLastAppliedSeq={SnapshotSeq})",
             ChannelNumber, replayed, skipped, _wal.LastReadCorruptCount, _wal.LastReadLegacyCount, snapshotLastAppliedSeq);

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -448,6 +448,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
             {
                 try { _phaseSnapshot[secId] = _engine.GetTradingPhase(secId); }
                 catch (KeyNotFoundException) { /* engine doesn't know this id; skip */ }
+                _metrics?.SetBookLiveOrders(secId, 0);
             }
         }
     }

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Text;
+using System.Collections.Concurrent;
 using B3.Exchange.Contracts;
 
 namespace B3.Exchange.Core;
@@ -266,6 +267,28 @@ public sealed class ChannelMetrics
     /// (or the audit Checkpoint threw). See <see cref="_auditWalTruncateDeferred"/>.</summary>
     public void IncAuditWalTruncateDeferred() => Interlocked.Increment(ref _auditWalTruncateDeferred);
 
+    private sealed class LiveOrderGauge
+    {
+        public long Value;
+    }
+
+    private readonly ConcurrentDictionary<long, LiveOrderGauge> _liveOrdersBySecurityId = new();
+
+    public void SetBookLiveOrders(long securityId, long count)
+    {
+        var gauge = _liveOrdersBySecurityId.GetOrAdd(securityId, static _ => new LiveOrderGauge());
+        Interlocked.Exchange(ref gauge.Value, count);
+    }
+
+    internal IReadOnlyList<(long SecurityId, long Count)> BookLiveOrdersSnapshot()
+    {
+        var result = new List<(long SecurityId, long Count)>(_liveOrdersBySecurityId.Count);
+        foreach (var kv in _liveOrdersBySecurityId)
+            result.Add((kv.Key, Interlocked.Read(ref kv.Value.Value)));
+        result.Sort(static (a, b) => a.SecurityId.CompareTo(b.SecurityId));
+        return result;
+    }
+
     /// <summary>Issue #291: current on-disk WAL size in bytes
     /// (gauge). Updated by the dispatcher after every successful
     /// Append/Truncate so the alert can fire well before
@@ -273,6 +296,10 @@ public sealed class ChannelMetrics
     private long _walSizeBytes;
     public long WalSizeBytes => Interlocked.Read(ref _walSizeBytes);
     public void SetWalSizeBytes(long bytes) => Interlocked.Exchange(ref _walSizeBytes, bytes);
+
+    private long _walLastWriteUnixMs;
+    public long WalLastWriteUnixMs => Interlocked.Read(ref _walLastWriteUnixMs);
+    public void SetWalLastWriteUnixMs(long unixMs) => Interlocked.Exchange(ref _walLastWriteUnixMs, unixMs);
 
     /// <summary>Issue #291: cumulative count of WAL appends silently
     /// skipped because <c>maxBytes</c> was reached and the resolved
@@ -534,6 +561,7 @@ public sealed class MetricsRegistry
         EmitGauge(sb, "exch_dispatch_loop_last_tick_unixms",
             "Unix time (milliseconds) of the dispatcher loop's last heartbeat.",
             channels, c => c.LastTickUnixMs);
+        EmitBookLiveOrders(sb, channels);
         EmitCounter(sb, "umdf_chaos_dropped_total",
             "Total UMDF packets dropped by the chaos decorator (issue #119). 0 unless chaos is enabled in HostConfig.",
             channels, c => c.ChaosDropped);
@@ -598,6 +626,7 @@ public sealed class MetricsRegistry
         EmitSessionGauge(sb, sessionSnap, "fixp_session_retx_buffer_depth",
             "Number of business frames buffered for replay on this session.",
             withFirmLabel: false, s => s.RetxBufferDepth);
+        EmitSessionRetransmitUtilizationPercent(sb, sessionSnap);
         EmitSessionGauge(sb, sessionSnap, "fixp_session_attached_transports",
             "1 if a TCP transport is currently attached, 0 if Suspended.",
             withFirmLabel: false, s => s.AttachedTransportId is null ? 0 : 1);
@@ -745,6 +774,12 @@ public sealed class MetricsRegistry
         EmitGauge(sb, "exch_wal_size_bytes",
             "Issue #291: current on-disk size of the channel's WAL file in bytes. Compare against persistence.wal.maxBytes to alert before the cap is reached. A flat-line at the cap under onFull=halt indicates a halted channel; a flat-line under onFull=drop indicates silent data loss.",
             channels, c => c.WalSizeBytes);
+        EmitProcessGauge(sb, "exch_wal_total_size_bytes",
+            "Total on-disk size in bytes of all channel WAL files. Alert before this approaches the persistence volume capacity.",
+            channels.Sum(static c => c.WalSizeBytes));
+        EmitGauge(sb, "exch_wal_last_write_unixms",
+            "Unix time (milliseconds) of the most recent successful WAL append per channel; 0 if no record has been written.",
+            channels, c => c.WalLastWriteUnixMs);
         EmitCounter(sb, "exch_wal_drops_on_full_total",
             "Issue #291: WAL Append() calls silently skipped because persistence.wal.maxBytes was reached and persistence.wal.onFull=drop. Distinct from exch_wal_append_failures_total so on-call can route a capacity-exhaustion alert separately from a generic IO-fault alert. Non-zero means the durability contract has been silently relaxed on this channel.",
             channels, c => c.WalDropsOnFull);
@@ -1009,6 +1044,13 @@ public sealed class MetricsRegistry
         sb.Append(name).Append(' ').Append(value.ToString("0.######", CultureInfo.InvariantCulture)).Append('\n');
     }
 
+    private static void EmitProcessGauge(StringBuilder sb, string name, string help, long value)
+    {
+        sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
+        sb.Append("# TYPE ").Append(name).Append(" gauge\n");
+        sb.Append(name).Append(' ').Append(value.ToString(CultureInfo.InvariantCulture)).Append('\n');
+    }
+
     private static void EmitProcessCounter(StringBuilder sb, string name, string help, long value)
     {
         sb.Append("# HELP ").Append(name).Append(' ').Append(help).Append('\n');
@@ -1078,6 +1120,43 @@ public sealed class MetricsRegistry
               .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
               .Append("\"} ")
               .Append(selector(c).ToString(CultureInfo.InvariantCulture))
+              .Append('\n');
+        }
+    }
+
+    private static void EmitBookLiveOrders(StringBuilder sb, ChannelMetrics[] channels)
+    {
+        sb.Append("# HELP exch_book_live_orders Current resting order count per SecurityId. Updated on the channel dispatch thread after each command.\n");
+        sb.Append("# TYPE exch_book_live_orders gauge\n");
+        foreach (var c in channels)
+        {
+            foreach (var sample in c.BookLiveOrdersSnapshot())
+            {
+                sb.Append("exch_book_live_orders{channel=\"")
+                  .Append(c.ChannelNumber.ToString(CultureInfo.InvariantCulture))
+                  .Append("\",security_id=\"")
+                  .Append(sample.SecurityId.ToString(CultureInfo.InvariantCulture))
+                  .Append("\"} ")
+                  .Append(sample.Count.ToString(CultureInfo.InvariantCulture))
+                  .Append('\n');
+            }
+        }
+    }
+
+    private static void EmitSessionRetransmitUtilizationPercent(StringBuilder sb, SessionDiagnostics[] sessions)
+    {
+        sb.Append("# HELP exch_fixp_retransmit_buffer_full_percent Per-session FIXP retransmit ring fill level as a percentage of RetransmitBufferCapacity (0..100).\n");
+        sb.Append("# TYPE exch_fixp_retransmit_buffer_full_percent gauge\n");
+        foreach (var s in sessions)
+        {
+            if (s.RetxBufferCapacity <= 0) continue;
+            double percent = 100.0 * s.RetxBufferDepth / s.RetxBufferCapacity;
+            sb.Append("exch_fixp_retransmit_buffer_full_percent{session=\"")
+              .Append(EscapeLabel(s.SessionId))
+              .Append("\",firm=\"")
+              .Append(EscapeLabel(s.FirmId))
+              .Append("\"} ")
+              .Append(percent.ToString("0.######", CultureInfo.InvariantCulture))
               .Append('\n');
         }
     }

--- a/src/B3.Exchange.Core/MetricsRegistry.cs
+++ b/src/B3.Exchange.Core/MetricsRegistry.cs
@@ -439,15 +439,16 @@ public sealed class MetricsRegistry
     /// <summary>
     /// Issue #288: process-wide RetransmitBuffer counters
     /// (per-session-ring evictions and Suspended-state appends). The
-    /// per-session utilization gauge is rendered separately, gated by
+    /// per-session fill-level gauges are rendered separately, gated by
     /// <see cref="EmitFixpSessionLabels"/>.
     /// </summary>
     public RetransmitMetrics Retransmit => _retransmit;
 
     /// <summary>
     /// Issue #288: when <c>true</c>, the Prometheus renderer emits
-    /// <c>exch_fixp_retransmit_buffer_utilization</c> with a per-session
-    /// label. Default <c>false</c> so deployments with many short-lived
+    /// <c>exch_fixp_retransmit_buffer_utilization</c> and
+    /// <c>exch_fixp_retransmit_buffer_full_percent</c> with per-session
+    /// labels. Default <c>false</c> so deployments with many short-lived
     /// sessions do not blow up scrape cardinality. The aggregate counters
     /// (<c>exch_fixp_retransmit_buffer_evictions_total</c>,
     /// <c>exch_fixp_passive_er_buffered_total</c>) are always emitted.
@@ -626,7 +627,6 @@ public sealed class MetricsRegistry
         EmitSessionGauge(sb, sessionSnap, "fixp_session_retx_buffer_depth",
             "Number of business frames buffered for replay on this session.",
             withFirmLabel: false, s => s.RetxBufferDepth);
-        EmitSessionRetransmitUtilizationPercent(sb, sessionSnap);
         EmitSessionGauge(sb, sessionSnap, "fixp_session_attached_transports",
             "1 if a TCP transport is currently attached, 0 if Suspended.",
             withFirmLabel: false, s => s.AttachedTransportId is null ? 0 : 1);
@@ -667,7 +667,7 @@ public sealed class MetricsRegistry
 
         // Issue #288: FIXP RetransmitBuffer dimensioning observability.
         // Aggregate counters are always emitted; the per-session
-        // utilization gauge below is gated by EmitFixpSessionLabels to
+        // fill-level gauges below are gated by EmitFixpSessionLabels to
         // protect scrape cardinality on deployments with many short-lived
         // sessions.
         EmitProcessCounter(sb, "exch_fixp_retransmit_buffer_evictions_total",
@@ -678,6 +678,7 @@ public sealed class MetricsRegistry
             _retransmit.PassiveErBuffered);
         if (EmitFixpSessionLabels && sessionSnap.Length > 0)
         {
+            EmitSessionRetransmitUtilizationPercent(sb, sessionSnap);
             sb.Append("# HELP exch_fixp_retransmit_buffer_utilization Per-session ratio of buffered frames to RetransmitBufferCapacity (0.0..1.0). Combined with exch_fixp_retransmit_buffer_evictions_total this is the dimensioning signal for issue #288. Per-session labels are opt-in; enable via metrics.fixpSessionLabelsEnabled.\n");
             sb.Append("# TYPE exch_fixp_retransmit_buffer_utilization gauge\n");
             foreach (var s in sessionSnap)

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -273,7 +273,12 @@ public sealed class ExchangeHost : IAsyncDisposable
             var wal = BuildWal(ch);
             var auditWriter = BuildPostTradeAuditWriter(ch);
             if (persister != null) _persistersByChannel[ch.ChannelNumber] = persister;
-            if (wal != null) _walsByChannel[ch.ChannelNumber] = wal;
+            if (wal != null)
+            {
+                _walsByChannel[ch.ChannelNumber] = wal;
+                channelMetrics.SetWalSizeBytes(wal.CurrentSizeBytes);
+                channelMetrics.SetWalDropsOnFull(wal.DropsOnFullCount);
+            }
             if (auditWriter != null) _auditWriters.Add(auditWriter);
             // Issue #270: cross-channel consistency check on restore.
             // Resolve the policy here so the dispatcher can stay

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -38,8 +38,9 @@ public sealed class MetricsConfig
 {
     /// <summary>
     /// When <c>true</c>, the Prometheus renderer emits the
-    /// <c>exch_fixp_retransmit_buffer_utilization</c> gauge with a
-    /// per-session label. Default <c>false</c>; the aggregate counters
+    /// <c>exch_fixp_retransmit_buffer_utilization</c> and
+    /// <c>exch_fixp_retransmit_buffer_full_percent</c> gauges with
+    /// per-session labels. Default <c>false</c>; the aggregate counters
     /// (<c>exch_fixp_retransmit_buffer_evictions_total</c>,
     /// <c>exch_fixp_passive_er_buffered_total</c>) are always emitted.
     /// </summary>

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -369,6 +369,15 @@ public sealed class MatchingEngine
 
     public int OrderCount(long securityId) => _booksById[securityId].OrderCount;
 
+    public IReadOnlyList<(long SecurityId, int Count)> OrderCountsSnapshot()
+    {
+        AssertOnOwnerThread();
+        var result = new List<(long SecurityId, int Count)>(_booksById.Count);
+        foreach (var kv in _booksById)
+            result.Add((kv.Key, kv.Value.OrderCount));
+        return result;
+    }
+
     /// <summary>
     /// Total number of untriggered stop orders parked across every
     /// instrument. Issue #262 — exposes a counter the persistence tests

--- a/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
+++ b/tests/B3.Exchange.Core.Tests/MetricsRegistryTests.cs
@@ -423,6 +423,7 @@ public class MetricsRegistryTests
         }));
         var text = reg.RenderProm();
         Assert.DoesNotContain("exch_fixp_retransmit_buffer_utilization", text);
+        Assert.DoesNotContain("exch_fixp_retransmit_buffer_full_percent", text);
     }
 
     [Fact]
@@ -443,6 +444,8 @@ public class MetricsRegistryTests
                 SendQueueDepth: 0, AttachedTransportId: null, LastActivityAtMs: 0),
         }));
         var text = reg.RenderProm();
+        Assert.Contains("# TYPE exch_fixp_retransmit_buffer_full_percent gauge\n", text);
+        Assert.Contains("exch_fixp_retransmit_buffer_full_percent{session=\"conn-1\",firm=\"F1\"} 75\n", text);
         Assert.Contains("# TYPE exch_fixp_retransmit_buffer_utilization gauge\n", text);
         Assert.Contains("exch_fixp_retransmit_buffer_utilization{session=\"conn-1\",firm=\"F1\"} 0.75\n", text);
         Assert.DoesNotContain("session=\"conn-2\"", text.Substring(text.IndexOf("exch_fixp_retransmit_buffer_utilization", StringComparison.Ordinal)));

--- a/tests/B3.Exchange.Host.Tests/PreOomMetricsTests.cs
+++ b/tests/B3.Exchange.Host.Tests/PreOomMetricsTests.cs
@@ -1,0 +1,143 @@
+using System.Buffers.Binary;
+using System.Globalization;
+using System.Net.Sockets;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
+
+namespace B3.Exchange.Host.Tests;
+
+public class PreOomMetricsTests
+{
+    private const long Petr = 900_000_000_001L;
+
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    [Fact]
+    public async Task MetricsExposePreOomGauges_AfterRestingOrders()
+    {
+        var dataDir = Path.Combine(AppContext.BaseDirectory,
+            "wal-metrics-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+        try
+        {
+            var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 60000 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 84,
+                        IncrementalGroup = "239.255.42.84",
+                        IncrementalPort = 30184,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                        Persistence = new PersistenceConfig
+                        {
+                            DataDir = dataDir,
+                            Throttle = new SnapshotThrottleConfig { EveryNCommands = 1000 },
+                            Wal = new WalConfig { Enabled = true, FsyncPerWrite = false },
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(host.TcpEndpoint!.Address, host.TcpEndpoint.Port);
+            var stream = tcp.GetStream();
+
+            await stream.WriteAsync(BuildSimpleNewOrder(1001, Petr, '1', '2', '0', 100, 123_400));
+            await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            await stream.WriteAsync(BuildSimpleNewOrder(1002, Petr, '1', '2', '0', 200, 123_300));
+            await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+
+            using var http = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+            string body = "";
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+            while (DateTime.UtcNow < deadline)
+            {
+                body = await http.GetStringAsync("/metrics");
+                if (body.Contains($"exch_book_live_orders{{channel=\"84\",security_id=\"{Petr}\"}} 2", StringComparison.Ordinal)
+                    && MetricValue(body, "exch_wal_total_size_bytes") > 0)
+                    break;
+                await Task.Delay(25);
+            }
+
+            Assert.Contains($"exch_book_live_orders{{channel=\"84\",security_id=\"{Petr}\"}} 2", body);
+            Assert.True(MetricValue(body, "exch_wal_size_bytes", "channel=\"84\"") > 0, body);
+            Assert.True(MetricValue(body, "exch_wal_total_size_bytes") > 0, body);
+            Assert.True(MetricValue(body, "exch_wal_last_write_unixms", "channel=\"84\"") > 0, body);
+            Assert.True(MetricValue(body, "exch_fixp_retransmit_buffer_full_percent", "firm=\"unknown\"") > 0, body);
+            Assert.DoesNotContain("fixp_journal_", body);
+        }
+        finally
+        {
+            TempDirs.TryDelete(dataDir);
+        }
+    }
+
+    private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
+        char tif, long qty, long priceMantissa)
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)ordType;
+        body[58] = (byte)tif;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        return frame;
+    }
+
+    private static async Task ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+
+    private static double MetricValue(string body, string name, string? requiredLabel = null)
+    {
+        foreach (var rawLine in body.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (!line.StartsWith(name, StringComparison.Ordinal)) continue;
+            if (requiredLabel is not null && !line.Contains(requiredLabel, StringComparison.Ordinal)) continue;
+            int space = line.LastIndexOf(' ');
+            if (space < 0) continue;
+            return double.Parse(line[(space + 1)..], CultureInfo.InvariantCulture);
+        }
+        return 0;
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/PreOomMetricsTests.cs
+++ b/tests/B3.Exchange.Host.Tests/PreOomMetricsTests.cs
@@ -30,6 +30,7 @@ public class PreOomMetricsTests
                 Auth = new AuthConfig { RequireFixpHandshake = false },
                 Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
                 Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 60000 },
+                Metrics = new MetricsConfig { FixpSessionLabelsEnabled = true },
                 Channels =
                 {
                     new ChannelConfig
@@ -79,6 +80,61 @@ public class PreOomMetricsTests
             Assert.True(MetricValue(body, "exch_wal_last_write_unixms", "channel=\"84\"") > 0, body);
             Assert.True(MetricValue(body, "exch_fixp_retransmit_buffer_full_percent", "firm=\"unknown\"") > 0, body);
             Assert.DoesNotContain("fixp_journal_", body);
+        }
+        finally
+        {
+            TempDirs.TryDelete(dataDir);
+        }
+    }
+
+    [Fact]
+    public async Task MetricsFixpSessionLabelsDisabled_DoesNotEmitRetransmitFullPercent()
+    {
+        var dataDir = Path.Combine(AppContext.BaseDirectory,
+            "wal-metrics-disabled-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dataDir);
+        try
+        {
+            var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Http = new HttpConfig { Listen = "127.0.0.1:0", LivenessStaleMs = 60000 },
+                Metrics = new MetricsConfig { FixpSessionLabelsEnabled = false },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 84,
+                        IncrementalGroup = "239.255.42.84",
+                        IncrementalPort = 30184,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                        Persistence = new PersistenceConfig
+                        {
+                            DataDir = dataDir,
+                            Throttle = new SnapshotThrottleConfig { EveryNCommands = 1000 },
+                            Wal = new WalConfig { Enabled = true, FsyncPerWrite = false },
+                        },
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            await host.StartAsync();
+
+            using var tcp = new TcpClient();
+            await tcp.ConnectAsync(host.TcpEndpoint!.Address, host.TcpEndpoint.Port);
+            var stream = tcp.GetStream();
+
+            await stream.WriteAsync(BuildSimpleNewOrder(2001, Petr, '1', '2', '0', 100, 123_400));
+            await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+
+            using var http = new HttpClient { BaseAddress = new Uri($"http://{host.HttpEndpoint!}") };
+            string body = await http.GetStringAsync("/metrics");
+
+            Assert.DoesNotContain("exch_fixp_retransmit_buffer_full_percent", body);
         }
         finally
         {


### PR DESCRIPTION
Closes #432.

Adds pre-OOM gauges via the existing MetricsRegistry / /metrics path:
- exch_book_live_orders{channel,security_id}: current resting order count per book.
- exch_wal_size_bytes{channel}: existing per-channel WAL bytes-on-disk, now paired with exch_wal_total_size_bytes process total.
- exch_wal_last_write_unixms{channel}: last successful WAL append timestamp for write-age alerts.
- exch_fixp_retransmit_buffer_full_percent{session,firm}: per-session FIXP retransmit ring percent full.

Suggested runbook alerts:
- Book live orders: warn on fast growth vs baseline; page near capacity/load-test envelope for a symbol.
- WAL total size: warn at 70% of persistence volume or maxBytes aggregate, page at 85-90%.
- WAL last write age: alert if appends are expected but timestamp is stale while orders_in is increasing; separately alert if WAL bytes grow without truncation.
- Retransmit buffer full percent: warn >70% for 5m, page >85% or any evictions.

Validation:
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn

Note: did not add any fixp_journal_* metrics to avoid overlapping #431.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>