### PR TITLE
Pre-trade fat-finger validation: qty, price, price-band (#433, #436)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -12,7 +12,12 @@
     "heartbeatIntervalMs": 30000,
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000,
-    "sendingTimeSkewToleranceMs": 5000
+    "sendingTimeSkewToleranceMs": 5000,
+    // Decode-time fat-finger guardrails. Price is the EntryPoint /10000
+    // mantissa; priceBandPercent null disables the last-trade-relative band.
+    "maxOrderQty": 1000000000,
+    "maxPrice": 1000000000000000,
+    "priceBandPercent": null
   },
   // Authentication. devMode=true bypasses access-key validation during
   // FIXP Negotiate (#42) — useful for local dev / tests. Production

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -77,7 +77,10 @@ Exposes:
     "heartbeatIntervalMs": 30000,
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000,
-    "sendingTimeSkewToleranceMs": 5000
+    "sendingTimeSkewToleranceMs": 5000,
+    "maxOrderQty": 1000000000,
+    "maxPrice": 1000000000000000,
+    "priceBandPercent": null
   },
   "auth": { "devMode": true },
   "firms": [
@@ -147,6 +150,18 @@ Exposes:
 * `tcp.sendingTimeSkewToleranceMs` — maximum absolute skew tolerated between
   the server clock and an inbound application message's
   `InboundBusinessHeader.sendingTime`. Default `5000`; set `0` to disable.
+* `tcp.maxOrderQty` — decode-time upper bound for `OrderQty` /
+  `NewQuantity`. Default `1000000000`; larger values are rejected with
+  `ER_Reject(OrdRejReason=99 Other)`.
+* `tcp.maxPrice` — decode-time upper bound for EntryPoint `Price` mantissa
+  (`/10000`). Default `1000000000000000` (decimal
+  `100,000,000,000.0000`), deliberately far above normal B3 cash-equity and
+  listed-derivative prices while still catching corrupted 64-bit payloads.
+* `tcp.priceBandPercent` — optional dynamic price-band check relative to the
+  instrument's last trade price. `null` disables it; when enabled but no last
+  trade reference exists yet, the decoder accepts and leaves downstream
+  validation unchanged. Breaches produce
+  `ER_Reject(OrdRejReason=16 Price exceeds current price band)`.
 * `http` — **optional** Kestrel-hosted operability endpoint exposing
   `/health/live`, `/health/ready`, and `/metrics`. Omit the entire block to
   disable HTTP.

--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -145,6 +145,11 @@ public sealed partial class ChannelDispatcher
         /// </summary>
         public void DrainInbound()
         {
+            if (_disp._loopTask is null)
+            {
+                _disp._writerGuard.RebindForReplay();
+                _disp._engine.RebindOwnerForTesting();
+            }
             var reader = _disp._inbound.Reader;
             while (reader.TryRead(out var item))
             {

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -242,6 +242,19 @@ public sealed partial class ChannelDispatcher
                         var otherLeg = buyFirst ? cross.Sell : cross.Buy;
                         ulong otherClOrd = buyFirst ? cross.SellClOrdIdValue : cross.BuyClOrdIdValue;
 
+                        if (prioLeg.PreTradeRejectReason is not null || otherLeg.PreTradeRejectReason is not null)
+                        {
+                            _metrics?.IncOrdersIn();
+                            _currentClOrdId = prioClOrd;
+                            BeginAggressor(prioLeg.Quantity);
+                            _engine.Submit(prioLeg);
+                            _metrics?.IncOrdersIn();
+                            _currentClOrdId = otherClOrd;
+                            BeginAggressor(otherLeg.Quantity);
+                            _engine.Submit(otherLeg);
+                            break;
+                        }
+
                         if (cross.CrossType == CrossType.AgainstBook && cross.MaxSweepQty > 0)
                         {
                             // Phase 1: prioritized leg sweeps the opposing

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -278,6 +278,7 @@ public sealed partial class ChannelDispatcher
     public void OnTrade(in TradeEvent e)
     {
         AssertOnLoopThread();
+        _lastTradePriceBySecurity[e.SecurityId] = e.PriceMantissa;
         // Issue #218 (Onda L · L5): when a cross sweep phase is active,
         // accumulate the aggressor's filled qty so the loop can decide how
         // much of the prioritized leg remains for the internal print.

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -173,6 +173,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// wire and no ExecutionReport is sent to a (potentially long-gone)
     /// session.</summary>
     private bool _replayMode;
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<long, long> _lastTradePriceBySecurity = new();
 
     /// <summary>
     /// Issue #329 PR-5: snapshot of the audit sink's persisted durability
@@ -276,6 +277,11 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// <c>receivedTime</c> field nulled.
     /// </summary>
     private ulong _currentReceivedTimeNanos = ulong.MaxValue;
+
+    public long? LastTradePriceMantissa(long securityId)
+        => _lastTradePriceBySecurity.TryGetValue(securityId, out var price) && price > 0
+            ? price
+            : null;
 
     /// <summary>
     /// When non-null, the dispatcher is processing the sweep phase of a

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -243,6 +243,8 @@ internal sealed class FixpOutboundEncoder
     ///   5  = Unknown order
     ///   11 = Unsupported order characteristic (used for invalid quantity and
     ///        Market/IOC-only constraints not satisfied by the inbound order)
+    ///   16 = Price exceeds current price band
+    ///   99 = Other
     /// Engine reasons that have no direct FIX peer (e.g. <see cref="RejectReason.MarketNoLiquidity"/>,
     /// <see cref="RejectReason.FokUnfillable"/>, <see cref="RejectReason.SelfTradePrevention"/>)
     /// fall through to 0 (Broker/exchange option) — context is conveyed via the
@@ -271,6 +273,8 @@ internal sealed class FixpOutboundEncoder
         RejectReason.InstrumentHalted => 13u,
         RejectReason.TimeInForceNotSupported => 11u,
         RejectReason.UnsupportedOrderCharacteristic => 11u,
+        RejectReason.QuantityExceedsLimit => 99u,
+        RejectReason.PriceExceedsCurrentPriceBand => 16u,
         RejectReason.MinQtyNotMet => 0u,
         RejectReason.InvalidField => 11u,
         _ => 0u,

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -272,7 +272,8 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidNewOrderSingle:
                 {
                     var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
-                        fixedBlock, EnteringFirm, now, out var nos, out var nosClOrd, out var nosMsg);
+                        fixedBlock, EnteringFirm, now, out var nos, out var nosClOrd, out var nosMsg,
+                        _options.FatFinger);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
                         nos = nos with { Memo = inboundMemo };
@@ -301,7 +302,8 @@ public sealed partial class FixpSession
             case EntryPointFrameReader.TidOrderCancelReplaceRequest:
                 {
                     var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
-                        fixedBlock, now, out var ocr, out var ocrClOrd, out var ocrOrigClOrd, out var ocrMsg);
+                        fixedBlock, now, out var ocr, out var ocrClOrd, out var ocrOrigClOrd, out var ocrMsg,
+                        _options.FatFinger);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
                         ocr = ocr with { Memo = inboundMemo };

--- a/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Dispatch.cs
@@ -248,7 +248,7 @@ public sealed partial class FixpSession
                     return false;
                 }
             case EntryPointFrameReader.TidSimpleNewOrder:
-                if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr))
+                if (InboundMessageDecoder.TryDecodeNewOrder(fixedBlock, EnteringFirm, now, out var no, out var noClOrd, out var noErr, _options.FatFinger))
                 {
                     no = no with { Memo = inboundMemo };
                     if (!_sink.EnqueueNewOrder(no, Identity, EnteringFirm, noClOrd))
@@ -259,7 +259,7 @@ public sealed partial class FixpSession
                 await TerminateAndCloseAsync(SessionRejectEncoder.TerminationCode.DecodingError, "decode-error:SimpleNewOrder").ConfigureAwait(false);
                 return false;
             case EntryPointFrameReader.TidSimpleModifyOrder:
-                if (InboundMessageDecoder.TryDecodeReplace(fixedBlock, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr))
+                if (InboundMessageDecoder.TryDecodeReplace(fixedBlock, now, out var rp, out var rpClOrd, out var rpOrigClOrd, out var rpErr, _options.FatFinger))
                 {
                     rp = rp with { Memo = inboundMemo };
                     if (!_sink.EnqueueReplace(rp, Identity, EnteringFirm, rpClOrd, rpOrigClOrd))
@@ -336,7 +336,7 @@ public sealed partial class FixpSession
                     // decoder can walk past the SBE group header.
                     var fullBodySpan = fullBody.Span;
                     var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
-                        fullBodySpan, EnteringFirm, now, out var cross, out var crossId, out var crossMsg);
+                        fullBodySpan, EnteringFirm, now, out var cross, out var crossId, out var crossMsg, _options.FatFinger);
                     if (outcome == InboundMessageDecoder.InboundDecodeOutcome.Success)
                     {
                         if (!_sink.EnqueueCross(cross, Identity, EnteringFirm))

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -109,6 +109,13 @@ public sealed record FixpSessionOptions
 
     public B3.Exchange.Contracts.ThrottleMetrics? ThrottleMetrics { get; init; }
 
+    /// <summary>
+    /// Decode-time pre-trade fat-finger guardrails for OrderQty/NewQuantity
+    /// and Price. Defaults are intentionally loose and preserve legacy
+    /// behaviour except for absurd values.
+    /// </summary>
+    public InboundFatFingerOptions FatFinger { get; init; } = InboundFatFingerOptions.Default;
+
     public static FixpSessionOptions Default { get; } = new();
 
     internal void Validate()
@@ -122,5 +129,6 @@ public sealed record FixpSessionOptions
         if (ThrottleTimeWindowMs < 0) throw new ArgumentOutOfRangeException(nameof(ThrottleTimeWindowMs));
         if (ThrottleMaxMessages < 0) throw new ArgumentOutOfRangeException(nameof(ThrottleMaxMessages));
         if (MaxOrderRatePerSecond < 0) throw new ArgumentOutOfRangeException(nameof(MaxOrderRatePerSecond));
+        FatFinger.Validate();
     }
 }

--- a/src/B3.Exchange.Gateway/InboundFatFingerOptions.cs
+++ b/src/B3.Exchange.Gateway/InboundFatFingerOptions.cs
@@ -1,0 +1,32 @@
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Decode-time pre-trade guardrails applied before commands enter Core.
+/// Prices use the EntryPoint implicit /10000 mantissa representation.
+/// </summary>
+public sealed record InboundFatFingerOptions
+{
+    public const long DefaultMaxOrderQty = 1_000_000_000L;
+
+    /// <summary>
+    /// Extremely loose default: 100 billion in decimal price terms
+    /// (1e15 mantissa). B3 securities generally trade many orders of
+    /// magnitude below this; keeping the default wide preserves simulator
+    /// flexibility while rejecting corrupted 64-bit payloads.
+    /// </summary>
+    public const long DefaultMaxPriceMantissa = 1_000_000_000_000_000L;
+
+    public long MaxOrderQty { get; init; } = DefaultMaxOrderQty;
+    public long MaxPriceMantissa { get; init; } = DefaultMaxPriceMantissa;
+    public decimal? PriceBandPercent { get; init; }
+    public Func<long, long?>? LastTradePriceProvider { get; init; }
+
+    public static InboundFatFingerOptions Default { get; } = new();
+
+    public void Validate()
+    {
+        if (MaxOrderQty <= 0) throw new ArgumentOutOfRangeException(nameof(MaxOrderQty));
+        if (MaxPriceMantissa <= 0) throw new ArgumentOutOfRangeException(nameof(MaxPriceMantissa));
+        if (PriceBandPercent is <= 0m) throw new ArgumentOutOfRangeException(nameof(PriceBandPercent));
+    }
+}

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderCross.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderCross.cs
@@ -54,7 +54,8 @@ internal static partial class InboundMessageDecoder
     /// </summary>
     public static InboundDecodeOutcome TryDecodeNewOrderCross(
         ReadOnlySpan<byte> body, uint sessionFirm, ulong enteredAtNanos,
-        out CrossOrderCommand cross, out ulong crossId, out string? message)
+        out CrossOrderCommand cross, out ulong crossId, out string? message,
+        InboundFatFingerOptions? fatFingerOptions = null)
     {
         cross = null!;
         crossId = 0;
@@ -96,6 +97,11 @@ internal static partial class InboundMessageDecoder
             message = "NewOrderCross requires positive OrderQty";
             return InboundDecodeOutcome.UnsupportedFeature;
         }
+
+        var guardrails = NormalizeFatFingerOptions(fatFingerOptions);
+        RejectReason? preTradeRejectReason = ValidateFatFinger(secId, qty, priceMantissa, guardrails);
+        if (preTradeRejectReason is not null)
+            message = FatFingerRejectMessage(preTradeRejectReason.Value, "OrderQty", guardrails);
 
         // CrossType: null/255 → AllOrNone (default). Wire values 1
         // (AllOrNone) and 4 (AgainstBook) accepted; 7/8 (VWAP /
@@ -246,7 +252,10 @@ internal static partial class InboundMessageDecoder
             PriceMantissa: priceMantissa,
             Quantity: qty,
             EnteringFirm: sessionFirm,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            PreTradeRejectReason = preTradeRejectReason,
+        };
         var sell = new NewOrderCommand(
             ClOrdId: sellClOrd.ToString(),
             SecurityId: secId,
@@ -256,7 +265,10 @@ internal static partial class InboundMessageDecoder
             PriceMantissa: priceMantissa,
             Quantity: qty,
             EnteringFirm: sessionFirm,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            PreTradeRejectReason = preTradeRejectReason,
+        };
         cross = new CrossOrderCommand(buy, sell, buyClOrd, sellClOrd, crossId)
         {
             CrossType = crossTypeEnum,

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -61,8 +61,10 @@ internal static partial class InboundMessageDecoder
     /// </summary>
     public static InboundDecodeOutcome TryDecodeNewOrderSingle(
         ReadOnlySpan<byte> body, uint enteringFirm, ulong enteredAtNanos,
-        out NewOrderCommand cmd, out ulong clOrdIdValue, out string? message)
+        out NewOrderCommand cmd, out ulong clOrdIdValue, out string? message,
+        InboundFatFingerOptions? fatFingerOptions = null)
     {
+        var guardrails = NormalizeFatFingerOptions(fatFingerOptions);
         cmd = null!;
         clOrdIdValue = 0;
         message = null;
@@ -73,7 +75,8 @@ internal static partial class InboundMessageDecoder
         byte ordTypeByte = body[NewOrderSingleOffsets.OrdType];
         byte tifByte = body[NewOrderSingleOffsets.TimeInForce];
         byte routing = body[NewOrderSingleOffsets.RoutingInstruction];
-        long qty = (long)MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.OrderQty, 8));
+        ulong qtyRaw = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.OrderQty, 8));
+        long qty = qtyRaw > long.MaxValue ? long.MaxValue : (long)qtyRaw;
         long priceMantissa = MemoryMarshal.Read<long>(body.Slice(NewOrderSingleOffsets.PriceMantissa, 8));
         long stopPx = MemoryMarshal.Read<long>(body.Slice(NewOrderSingleOffsets.StopPxMantissa, 8));
         ulong minQty = MemoryMarshal.Read<ulong>(body.Slice(NewOrderSingleOffsets.MinQty, 8));
@@ -204,6 +207,32 @@ internal static partial class InboundMessageDecoder
             ? 0L
             : (priceMantissa == PriceNull ? 0L : priceMantissa);
         long engineStopPx = isStop ? stopPx : 0L;
+
+        if (ValidateFatFinger(secId, qty, enginePrice, guardrails) is { } preTradeRejectReason)
+        {
+            message = preTradeRejectReason == RejectReason.QuantityExceedsLimit
+                ? $"OrderQty exceeds maxOrderQty={guardrails.MaxOrderQty}"
+                : "Price exceeds configured fat-finger limit or current price band";
+            cmd = new NewOrderCommand(
+                ClOrdId: clOrdId.ToString(),
+                SecurityId: secId,
+                Side: side,
+                Type: ordType,
+                Tif: tif,
+                PriceMantissa: enginePrice,
+                Quantity: qty,
+                EnteringFirm: enteringFirm,
+                EnteredAtNanos: enteredAtNanos)
+            {
+                MinQty = minQty,
+                MaxFloor = maxFloor,
+                StopPxMantissa = engineStopPx,
+                OrdTagId = ordTagId,
+                InvestorId = investorId,
+                PreTradeRejectReason = preTradeRejectReason,
+            };
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
 
         cmd = new NewOrderCommand(
             ClOrdId: clOrdId.ToString(),

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -210,9 +210,7 @@ internal static partial class InboundMessageDecoder
 
         if (ValidateFatFinger(secId, qty, enginePrice, guardrails) is { } preTradeRejectReason)
         {
-            message = preTradeRejectReason == RejectReason.QuantityExceedsLimit
-                ? $"OrderQty exceeds maxOrderQty={guardrails.MaxOrderQty}"
-                : "Price exceeds configured fat-finger limit or current price band";
+            message = FatFingerRejectMessage(preTradeRejectReason, "OrderQty", guardrails);
             cmd = new NewOrderCommand(
                 ClOrdId: clOrdId.ToString(),
                 SecurityId: secId,

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -198,9 +198,7 @@ internal static partial class InboundMessageDecoder
 
         if (ValidateFatFinger(secId, qty, enginePrice, guardrails) is { } preTradeRejectReason)
         {
-            message = preTradeRejectReason == RejectReason.QuantityExceedsLimit
-                ? $"NewQuantity exceeds maxOrderQty={guardrails.MaxOrderQty}"
-                : "Price exceeds configured fat-finger limit or current price band";
+            message = FatFingerRejectMessage(preTradeRejectReason, "NewQuantity", guardrails);
             cmd = new ReplaceOrderCommand(
                 ClOrdId: clOrdId.ToString(),
                 SecurityId: secId,

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -42,8 +42,10 @@ internal static partial class InboundMessageDecoder
     /// </summary>
     public static InboundDecodeOutcome TryDecodeOrderCancelReplace(
         ReadOnlySpan<byte> body, ulong enteredAtNanos,
-        out ReplaceOrderCommand cmd, out ulong clOrdIdValue, out ulong origClOrdIdValue, out string? message)
+        out ReplaceOrderCommand cmd, out ulong clOrdIdValue, out ulong origClOrdIdValue, out string? message,
+        InboundFatFingerOptions? fatFingerOptions = null)
     {
+        var guardrails = NormalizeFatFingerOptions(fatFingerOptions);
         cmd = null!;
         clOrdIdValue = 0;
         origClOrdIdValue = 0;
@@ -55,7 +57,8 @@ internal static partial class InboundMessageDecoder
         byte ordTypeByte = body[OrderCancelReplaceOffsets.OrdType];
         byte tifByte = body[OrderCancelReplaceOffsets.TimeInForce];
         byte routing = body[OrderCancelReplaceOffsets.RoutingInstruction];
-        long qty = (long)MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrderQty, 8));
+        ulong qtyRaw = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrderQty, 8));
+        long qty = qtyRaw > long.MaxValue ? long.MaxValue : (long)qtyRaw;
         long priceMantissa = MemoryMarshal.Read<long>(body.Slice(OrderCancelReplaceOffsets.PriceMantissa, 8));
         ulong orderId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrderID, 8));
         ulong origClOrdId = MemoryMarshal.Read<ulong>(body.Slice(OrderCancelReplaceOffsets.OrigClOrdID, 8));
@@ -192,6 +195,26 @@ internal static partial class InboundMessageDecoder
         long enginePrice = ordType == OrderType.Market
             ? 0L
             : priceMantissa;
+
+        if (ValidateFatFinger(secId, qty, enginePrice, guardrails) is { } preTradeRejectReason)
+        {
+            message = preTradeRejectReason == RejectReason.QuantityExceedsLimit
+                ? $"NewQuantity exceeds maxOrderQty={guardrails.MaxOrderQty}"
+                : "Price exceeds configured fat-finger limit or current price band";
+            cmd = new ReplaceOrderCommand(
+                ClOrdId: clOrdId.ToString(),
+                SecurityId: secId,
+                OrderId: (long)orderId,
+                NewPriceMantissa: enginePrice,
+                NewQuantity: qty,
+                EnteredAtNanos: enteredAtNanos)
+            {
+                NewOrdType = ordType,
+                NewTif = newTif,
+                PreTradeRejectReason = preTradeRejectReason,
+            };
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
 
         cmd = new ReplaceOrderCommand(
             ClOrdId: clOrdId.ToString(),

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleNewOrder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleNewOrder.cs
@@ -20,7 +20,8 @@ internal static partial class InboundMessageDecoder
     }
 
     public static bool TryDecodeNewOrder(ReadOnlySpan<byte> body, uint enteringFirm, ulong enteredAtNanos,
-        out NewOrderCommand cmd, out ulong clOrdIdValue, out string? error)
+        out NewOrderCommand cmd, out ulong clOrdIdValue, out string? error,
+        InboundFatFingerOptions? fatFingerOptions = null)
     {
         cmd = null!;
         clOrdIdValue = 0;
@@ -38,8 +39,13 @@ internal static partial class InboundMessageDecoder
         if (!TryMapOrdType(ordTypeByte, out var ordType)) { error = $"invalid OrdType={ordTypeByte}"; return false; }
         if (!TryMapTif(tifByte, out var tif)) { error = $"invalid TimeInForce={tifByte}"; return false; }
 
+        var guardrails = NormalizeFatFingerOptions(fatFingerOptions);
+
         // Market orders never carry a meaningful price; engine ignores it.
         long enginePrice = ordType == OrderType.Market ? 0L : (priceMantissa == PriceNull ? 0L : priceMantissa);
+        RejectReason? preTradeRejectReason = ValidateFatFinger(secId, qty, enginePrice, guardrails);
+        if (preTradeRejectReason is not null)
+            error = FatFingerRejectMessage(preTradeRejectReason.Value, "OrderQty", guardrails);
 
         clOrdIdValue = clOrdId;
         cmd = new NewOrderCommand(
@@ -51,7 +57,10 @@ internal static partial class InboundMessageDecoder
             PriceMantissa: enginePrice,
             Quantity: qty,
             EnteringFirm: enteringFirm,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            PreTradeRejectReason = preTradeRejectReason,
+        };
         return true;
     }
 }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleReplace.cs
@@ -20,7 +20,8 @@ internal static partial class InboundMessageDecoder
     }
 
     public static bool TryDecodeReplace(ReadOnlySpan<byte> body, ulong enteredAtNanos,
-        out ReplaceOrderCommand cmd, out ulong clOrdIdValue, out ulong origClOrdIdValue, out string? error)
+        out ReplaceOrderCommand cmd, out ulong clOrdIdValue, out ulong origClOrdIdValue, out string? error,
+        InboundFatFingerOptions? fatFingerOptions = null)
     {
         cmd = null!;
         clOrdIdValue = 0;
@@ -45,6 +46,11 @@ internal static partial class InboundMessageDecoder
             return false;
         }
 
+        var guardrails = NormalizeFatFingerOptions(fatFingerOptions);
+        RejectReason? preTradeRejectReason = ValidateFatFinger(secId, qty, priceMantissa, guardrails);
+        if (preTradeRejectReason is not null)
+            error = FatFingerRejectMessage(preTradeRejectReason.Value, "NewQuantity", guardrails);
+
         clOrdIdValue = clOrdId;
         origClOrdIdValue = origClOrdId;
         cmd = new ReplaceOrderCommand(
@@ -53,7 +59,10 @@ internal static partial class InboundMessageDecoder
             OrderId: (long)orderId,
             NewPriceMantissa: priceMantissa,
             NewQuantity: qty,
-            EnteredAtNanos: enteredAtNanos);
+            EnteredAtNanos: enteredAtNanos)
+        {
+            PreTradeRejectReason = preTradeRejectReason,
+        };
         return true;
     }
 }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -65,6 +65,14 @@ internal static partial class InboundMessageDecoder
             : null;
     }
 
+    private static string FatFingerRejectMessage(
+        RejectReason reason,
+        string quantityFieldName,
+        InboundFatFingerOptions options)
+        => reason == RejectReason.QuantityExceedsLimit
+            ? $"{quantityFieldName} exceeds maxOrderQty={options.MaxOrderQty}"
+            : "Price exceeds configured fat-finger limit or current price band";
+
     /// <summary>
     /// Three-valued outcome for the full NewOrderSingle (102) and
     /// OrderCancelReplaceRequest (104) decoders. Distinguishes

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.cs
@@ -29,6 +29,42 @@ internal static partial class InboundMessageDecoder
 
     private const long PriceNull = long.MinValue;
 
+    private static InboundFatFingerOptions NormalizeFatFingerOptions(InboundFatFingerOptions? options)
+        => options ?? InboundFatFingerOptions.Default;
+
+    private static RejectReason? ValidateFatFinger(
+        long securityId,
+        long qty,
+        long enginePrice,
+        InboundFatFingerOptions options)
+    {
+        if (qty <= 0)
+            return null;
+
+        if (qty > options.MaxOrderQty)
+            return RejectReason.QuantityExceedsLimit;
+
+        if (enginePrice <= 0)
+            return null;
+
+        if (enginePrice > options.MaxPriceMantissa)
+            return RejectReason.PriceExceedsCurrentPriceBand;
+
+        if (options.PriceBandPercent is not { } bandPercent)
+            return null;
+
+        long? reference = options.LastTradePriceProvider?.Invoke(securityId);
+        if (reference is not > 0)
+            return null;
+
+        decimal price = enginePrice;
+        decimal refPrice = reference.Value;
+        decimal deviationPercent = Math.Abs(price - refPrice) * 100m / refPrice;
+        return deviationPercent > bandPercent
+            ? RejectReason.PriceExceedsCurrentPriceBand
+            : null;
+    }
+
     /// <summary>
     /// Three-valued outcome for the full NewOrderSingle (102) and
     /// OrderCancelReplaceRequest (104) decoders. Distinguishes

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -472,6 +472,13 @@ public sealed class ExchangeHost : IAsyncDisposable
             MaxOrderRatePerSecond = 200,
             ThrottleMetrics = _metrics.Throttle,
             OnTransportSendQueueFull = _metrics.Transport.IncSendQueueFull,
+            FatFinger = new InboundFatFingerOptions
+            {
+                MaxOrderQty = _config.Tcp.MaxOrderQty,
+                MaxPriceMantissa = _config.Tcp.MaxPrice,
+                PriceBandPercent = _config.Tcp.PriceBandPercent,
+                LastTradePriceProvider = _router.LastTradePriceMantissa,
+            },
         };
         // Phase 2 (#42): real Negotiate handshake. The validator is pure
         // (no IO); the claim ledger lives for the host process lifetime

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using B3.Exchange.Gateway;
 
 namespace B3.Exchange.Host;
 
@@ -91,6 +92,22 @@ public sealed class TcpConfig
     /// InboundBusinessHeader.sendingTime. Default: 5 s. Set to 0 to disable.
     /// </summary>
     [JsonPropertyName("sendingTimeSkewToleranceMs")] public int SendingTimeSkewToleranceMs { get; set; } = 5_000;
+
+    /// <summary>Decode-time maximum accepted OrderQty/NewQuantity. Larger
+    /// values are rejected with ER_Reject OrdRejReason=99 (Other).</summary>
+    [JsonPropertyName("maxOrderQty")] public long MaxOrderQty { get; set; } = InboundFatFingerOptions.DefaultMaxOrderQty;
+
+    /// <summary>Decode-time maximum accepted limit price mantissa (/10000).
+    /// Default 1e15 = 100,000,000,000.0000, intentionally far above normal B3
+    /// cash-equity and listed-derivative price ranges while still catching
+    /// corrupted 64-bit payloads.</summary>
+    [JsonPropertyName("maxPrice")] public long MaxPrice { get; set; } = InboundFatFingerOptions.DefaultMaxPriceMantissa;
+
+    /// <summary>Optional dynamic price band in percent, relative to the last
+    /// trade price for the instrument. Null disables the band; with no last
+    /// trade reference the decoder accepts and leaves downstream validation
+    /// unchanged.</summary>
+    [JsonPropertyName("priceBandPercent")] public decimal? PriceBandPercent { get; set; }
 
     /// <summary>
     /// Per-session inbound sliding-window throttle (issue #56 / GAP-20,

--- a/src/B3.Exchange.Host/HostRouter.cs
+++ b/src/B3.Exchange.Host/HostRouter.cs
@@ -157,6 +157,11 @@ public sealed class HostRouter : IInboundCommandSink
             _logger.LogDebug("session {Session} closed; evicted {Count} ownership entries", session, total);
     }
 
+    public long? LastTradePriceMantissa(long securityId)
+        => _bySecId.TryGetValue(securityId, out var disp)
+            ? disp.LastTradePriceMantissa(securityId)
+            : null;
+
     private CancelOrderCommand ResolveOrderIdIfNeeded(in CancelOrderCommand cmd, uint firm, ulong origClOrdId, out bool ok)
     {
         if (cmd.OrderId != 0) { ok = true; return cmd; }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -97,6 +97,16 @@ public enum RejectReason : byte
     /// client receives an <c>ExecutionReport_Reject</c> with FIX
     /// OrdRejReason=11 instead of a <c>BusinessMessageReject</c>.</summary>
     UnsupportedOrderCharacteristic,
+    /// <summary>The order quantity breached the gateway's pre-trade
+    /// fat-finger ceiling. B3's public SBE schema delegates concrete
+    /// reject domains to the external error-code document; this maps to
+    /// OrdRejReason=99 (Other) rather than a session-level reject.</summary>
+    QuantityExceedsLimit,
+    /// <summary>The order price breached the gateway's absolute fat-finger
+    /// ceiling or optional dynamic price band. Maps to OrdRejReason=16
+    /// (Price exceeds current price band) per the B3/FIX reject-domain
+    /// convention used by EntryPoint clients.</summary>
+    PriceExceedsCurrentPriceBand,
 }
 
 /// <summary>
@@ -237,6 +247,8 @@ public sealed record NewOrderCommand(
 
     public bool UnsupportedOrderCharacteristic { get; init; }
 
+    public RejectReason? PreTradeRejectReason { get; init; }
+
     public byte[] Memo { get; init; } = [];
 }
 
@@ -285,6 +297,8 @@ public sealed record ReplaceOrderCommand(
     public TimeInForce? NewTif { get; init; }
 
     public bool UnsupportedOrderCharacteristic { get; init; }
+
+    public RejectReason? PreTradeRejectReason { get; init; }
 
     public byte[] Memo { get; init; } = [];
 }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -770,6 +770,12 @@ public sealed class MatchingEngine
         EnterDispatch();
         try
         {
+            if (cmd.PreTradeRejectReason is { } preTradeRejectReason)
+            {
+                Reject(cmd.ClOrdId, cmd.SecurityId, 0, preTradeRejectReason, cmd.EnteredAtNanos);
+                return;
+            }
+
             if (cmd.UnsupportedOrderCharacteristic)
             {
                 Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.UnsupportedOrderCharacteristic, cmd.EnteredAtNanos);
@@ -1083,6 +1089,9 @@ public sealed class MatchingEngine
         EnterDispatch();
         try
         {
+            if (cmd.PreTradeRejectReason is { } preTradeRejectReason)
+            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, preTradeRejectReason, cmd.EnteredAtNanos); return; }
+
             if (cmd.UnsupportedOrderCharacteristic)
             { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnsupportedOrderCharacteristic, cmd.EnteredAtNanos); return; }
 
@@ -2006,6 +2015,14 @@ public sealed class MatchingEngine
             + $"actual={Thread.CurrentThread.ManagedThreadId})");
         _writerGuard.BindToCurrentThread();
     }
+
+    /// <summary>
+    /// Test-only seam for direct-drive dispatcher probes that intentionally
+    /// process queued work on xUnit continuation threads rather than a live
+    /// dispatcher loop. Production dispatchers must bind once via
+    /// <see cref="BindToDispatchThread"/>.
+    /// </summary>
+    public void RebindOwnerForTesting() => _writerGuard.RebindForReplay();
 
     /// <summary>
     /// Asserts the calling thread owns the engine. Latches the owner

--- a/tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs
@@ -6,24 +6,57 @@ namespace B3.Exchange.Gateway.Tests;
 
 public class InboundMessageDecoderTests
 {
+    private static readonly InboundFatFingerOptions TightGuardrails = new()
+    {
+        MaxOrderQty = 1_000,
+        MaxPriceMantissa = 1_000_000,
+    };
+
+    private static byte[] BuildSimpleNewOrder(
+        ulong clOrdId = 12345UL,
+        long secId = 99887766L,
+        long qty = 100L,
+        long price = 12_3450L)
+    {
+        var body = new byte[82];
+        Span<byte> s = body;
+        MemoryMarshal.Write(s.Slice(20, 8), in clOrdId);
+        MemoryMarshal.Write(s.Slice(48, 8), in secId);
+        s[56] = (byte)'1';
+        s[57] = (byte)'2';
+        s[58] = (byte)'0';
+        MemoryMarshal.Write(s.Slice(60, 8), in qty);
+        MemoryMarshal.Write(s.Slice(68, 8), in price);
+        return body;
+    }
+
+    private static byte[] BuildSimpleModifyOrder(
+        ulong clOrdId = 99UL,
+        long secId = 555L,
+        long qty = 200L,
+        long price = 100_000L,
+        ulong orderId = 42UL,
+        ulong origClOrdId = 7UL)
+    {
+        var body = new byte[98];
+        Span<byte> s = body;
+        MemoryMarshal.Write(s.Slice(20, 8), in clOrdId);
+        MemoryMarshal.Write(s.Slice(48, 8), in secId);
+        MemoryMarshal.Write(s.Slice(60, 8), in qty);
+        MemoryMarshal.Write(s.Slice(68, 8), in price);
+        MemoryMarshal.Write(s.Slice(76, 8), in orderId);
+        MemoryMarshal.Write(s.Slice(84, 8), in origClOrdId);
+        return body;
+    }
+
     [Fact]
     public void DecodesSimpleNewOrderLimitDay()
     {
-        Span<byte> body = stackalloc byte[82];
-        body.Clear();
-
         ulong clOrdId = 12345UL;
         long secId = 99887766L;
         long qty = 100L;
         long price = 12_3450L;
-
-        MemoryMarshal.Write(body.Slice(20, 8), in clOrdId);
-        MemoryMarshal.Write(body.Slice(48, 8), in secId);
-        body[56] = (byte)'1';     // Side = Buy
-        body[57] = (byte)'2';     // OrdType = Limit
-        body[58] = (byte)'0';     // TimeInForce = Day
-        MemoryMarshal.Write(body.Slice(60, 8), in qty);
-        MemoryMarshal.Write(body.Slice(68, 8), in price);
+        var body = BuildSimpleNewOrder(clOrdId, secId, qty, price);
 
         var ok = InboundMessageDecoder.TryDecodeNewOrder(body, enteringFirm: 7, enteredAtNanos: 1_000_000UL,
             out var cmd, out var clOrdValue, out var err);
@@ -38,6 +71,34 @@ public class InboundMessageDecoderTests
         Assert.Equal(qty, cmd.Quantity);
         Assert.Equal(price, cmd.PriceMantissa);
         Assert.Equal(7u, cmd.EnteringFirm);
+    }
+
+    [Fact]
+    public void SimpleNewOrder_QtyOverLimitReturnsErRejectCommand()
+    {
+        var body = BuildSimpleNewOrder(qty: 1_001);
+
+        var ok = InboundMessageDecoder.TryDecodeNewOrder(body, 7, 1_000_000UL,
+            out var cmd, out _, out var msg, TightGuardrails);
+
+        Assert.True(ok);
+        Assert.Equal(RejectReason.QuantityExceedsLimit, cmd.PreTradeRejectReason);
+        Assert.Equal(99u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("OrderQty", msg);
+    }
+
+    [Fact]
+    public void SimpleNewOrder_PriceOverAbsoluteMaxReturnsErRejectCommand()
+    {
+        var body = BuildSimpleNewOrder(price: 1_000_001);
+
+        var ok = InboundMessageDecoder.TryDecodeNewOrder(body, 7, 1_000_000UL,
+            out var cmd, out _, out var msg, TightGuardrails);
+
+        Assert.True(ok);
+        Assert.Equal(RejectReason.PriceExceedsCurrentPriceBand, cmd.PreTradeRejectReason);
+        Assert.Equal(16u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("Price", msg);
     }
 
     [Fact]
@@ -90,20 +151,12 @@ public class InboundMessageDecoderTests
     [Fact]
     public void DecodesReplaceByOrigClOrdIdOnly()
     {
-        Span<byte> body = stackalloc byte[98];
-        body.Clear();
         ulong clOrdId = 99UL;
         long secId = 555L;
         long qty = 200L;
         long price = 100_000L;
-        ulong orderId = 0UL;
         ulong origClOrdId = 42UL;
-        MemoryMarshal.Write(body.Slice(20, 8), in clOrdId);
-        MemoryMarshal.Write(body.Slice(48, 8), in secId);
-        MemoryMarshal.Write(body.Slice(60, 8), in qty);
-        MemoryMarshal.Write(body.Slice(68, 8), in price);
-        MemoryMarshal.Write(body.Slice(76, 8), in orderId);
-        MemoryMarshal.Write(body.Slice(84, 8), in origClOrdId);
+        var body = BuildSimpleModifyOrder(clOrdId, secId, qty, price, orderId: 0UL, origClOrdId: origClOrdId);
 
         var ok = InboundMessageDecoder.TryDecodeReplace(body, 9_000UL,
             out var cmd, out var clOrd, out var origClOrd, out var err);
@@ -114,5 +167,19 @@ public class InboundMessageDecoderTests
         Assert.Equal(0L, cmd.OrderId);
         Assert.Equal(qty, cmd.NewQuantity);
         Assert.Equal(price, cmd.NewPriceMantissa);
+    }
+
+    [Fact]
+    public void SimpleModifyOrder_QtyOverLimitReturnsErRejectCommand()
+    {
+        var body = BuildSimpleModifyOrder(qty: 1_001);
+
+        var ok = InboundMessageDecoder.TryDecodeReplace(body, 9_000UL,
+            out var cmd, out _, out _, out var msg, TightGuardrails);
+
+        Assert.True(ok);
+        Assert.Equal(RejectReason.QuantityExceedsLimit, cmd.PreTradeRejectReason);
+        Assert.Equal(99u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("NewQuantity", msg);
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/MapRejectReasonTests.cs
@@ -11,6 +11,8 @@ namespace B3.Exchange.Gateway.Tests;
 ///   3  = Order exceeds limit
 ///   5  = Unknown order
 ///   11 = Unsupported order characteristic
+///   16 = Price exceeds current price band
+///   99 = Other
 /// </summary>
 public class MapRejectReasonTests
 {
@@ -30,6 +32,8 @@ public class MapRejectReasonTests
     [InlineData(RejectReason.MinQtyNotMet, 0u)]
     [InlineData(RejectReason.InvalidField, 11u)]
     [InlineData(RejectReason.UnsupportedOrderCharacteristic, 11u)]
+    [InlineData(RejectReason.QuantityExceedsLimit, 99u)]
+    [InlineData(RejectReason.PriceExceedsCurrentPriceBand, 16u)]
     public void MapRejectReason_ProducesExpectedWireCode(RejectReason reason, uint expected)
     {
         Assert.Equal(expected, FixpSession.MapRejectReason(reason));
@@ -45,7 +49,7 @@ public class MapRejectReasonTests
         {
             // Should not throw and must return one of the documented wire codes.
             uint code = FixpSession.MapRejectReason(r);
-            Assert.Contains(code, new uint[] { 0u, 1u, 3u, 5u, 11u, 13u });
+            Assert.Contains(code, new uint[] { 0u, 1u, 3u, 5u, 11u, 13u, 16u, 99u });
         }
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderCrossDecoderTests.cs
@@ -17,6 +17,11 @@ public class NewOrderCrossDecoderTests
     private const long PriceNull = long.MinValue;
     private const uint FirmNull = 0xFFFFFFFFu;
     private const uint SessionFirm = 4242u;
+    private static readonly InboundFatFingerOptions TightGuardrails = new()
+    {
+        MaxOrderQty = 1_000,
+        MaxPriceMantissa = 1_000_000,
+    };
 
     /// <summary>
     /// Builds a NewOrderCross body (root 84B + NoSides group + DeskID + Memo)
@@ -135,6 +140,23 @@ public class NewOrderCrossDecoderTests
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
         Assert.Equal(9002UL, cross.BuyClOrdIdValue);
         Assert.Equal(9001UL, cross.SellClOrdIdValue);
+    }
+
+    [Fact]
+    public void QtyOverLimitReturnsErRejectCommandsForBothLegs()
+    {
+        // NewOrderCross carries shared OrderQty/Price in the root block, so
+        // a fat-finger violation applies to both emitted NewOrderCommand legs.
+        var body = BuildCross(qty: 1_001);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderCross(
+            body, SessionFirm, 1UL, out var cross, out _, out var msg, TightGuardrails);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(RejectReason.QuantityExceedsLimit, cross.Buy.PreTradeRejectReason);
+        Assert.Equal(RejectReason.QuantityExceedsLimit, cross.Sell.PreTradeRejectReason);
+        Assert.Equal(99u, FixpSession.MapRejectReason(cross.Buy.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("OrderQty", msg);
     }
 
     [Theory]

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -14,6 +14,11 @@ public class NewOrderSingleAndReplaceDecoderTests
 {
     private const long PriceNull = long.MinValue;
     private const byte RoutingNull = 255;
+    private static readonly InboundFatFingerOptions TightGuardrails = new()
+    {
+        MaxOrderQty = 1_000,
+        MaxPriceMantissa = 1_000_000,
+    };
 
     private static byte[] BuildNewOrderSingleV2(
         ulong clOrdId = 99UL,
@@ -226,6 +231,98 @@ public class NewOrderSingleAndReplaceDecoderTests
     }
 
     [Fact]
+    public void NewOrderSingle_QtyOverLimitReturnsErRejectCommand()
+    {
+        var body = BuildNewOrderSingleV2(qty: 1_001);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out var msg, TightGuardrails);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal(RejectReason.QuantityExceedsLimit, cmd.PreTradeRejectReason);
+        Assert.Equal(99u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("OrderQty", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_PriceOverAbsoluteMaxReturnsErRejectCommand()
+    {
+        var body = BuildNewOrderSingleV2(price: 1_000_001);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out var msg, TightGuardrails);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal(RejectReason.PriceExceedsCurrentPriceBand, cmd.PreTradeRejectReason);
+        Assert.Equal(16u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("Price", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_BoundaryValuesAtLimitsAreAccepted()
+    {
+        var body = BuildNewOrderSingleV2(qty: 1_000, price: 1_000_000);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out var msg, TightGuardrails);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(1_000, cmd.Quantity);
+        Assert.Equal(1_000_000, cmd.PriceMantissa);
+    }
+
+    [Fact]
+    public void NewOrderSingle_PriceBandEnabledInBandPassesOutOfBandRejects()
+    {
+        var options = TightGuardrails with
+        {
+            MaxPriceMantissa = 2_000_000,
+            PriceBandPercent = 10m,
+            LastTradePriceProvider = _ => 1_000_000,
+        };
+
+        var inBand = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            BuildNewOrderSingleV2(price: 1_100_000), 1, 0, out var accepted, out _, out var inBandMsg, options);
+        var outOfBand = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            BuildNewOrderSingleV2(price: 1_100_001), 1, 0, out var rejected, out _, out var outOfBandMsg, options);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, inBand);
+        Assert.Null(inBandMsg);
+        Assert.Equal(1_100_000, accepted.PriceMantissa);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outOfBand);
+        Assert.Equal(RejectReason.PriceExceedsCurrentPriceBand, rejected.PreTradeRejectReason);
+        Assert.Contains("Price", outOfBandMsg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_PriceBandDisabledOrNoReferencePasses()
+    {
+        var disabled = TightGuardrails with
+        {
+            MaxPriceMantissa = 2_000_000,
+            PriceBandPercent = null,
+            LastTradePriceProvider = _ => 1_000_000,
+        };
+        var noReference = TightGuardrails with
+        {
+            MaxPriceMantissa = 2_000_000,
+            PriceBandPercent = 10m,
+            LastTradePriceProvider = _ => null,
+        };
+
+        var disabledOutcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            BuildNewOrderSingleV2(price: 1_500_000), 1, 0, out _, out _, out var disabledMsg, disabled);
+        var noReferenceOutcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            BuildNewOrderSingleV2(price: 1_500_000), 1, 0, out _, out _, out var noReferenceMsg, noReference);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, disabledOutcome);
+        Assert.Null(disabledMsg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, noReferenceOutcome);
+        Assert.Null(noReferenceMsg);
+    }
+
+    [Fact]
     public void NewOrderSingle_RoutingInstructionRejectsAsUnsupported()
     {
         var body = BuildNewOrderSingleV2(routing: 1);
@@ -275,6 +372,34 @@ public class NewOrderSingleAndReplaceDecoderTests
 
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
         Assert.Null(msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_QtyOverLimitReturnsErRejectCommand()
+    {
+        var body = BuildOrderCancelReplaceV2(qty: 1_001);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 1, out var cmd, out _, out _, out var msg, TightGuardrails);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal(RejectReason.QuantityExceedsLimit, cmd.PreTradeRejectReason);
+        Assert.Equal(99u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("NewQuantity", msg);
+    }
+
+    [Fact]
+    public void OrderCancelReplace_PriceOverAbsoluteMaxReturnsErRejectCommand()
+    {
+        var body = BuildOrderCancelReplaceV2(price: 1_000_001);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 1, out var cmd, out _, out _, out var msg, TightGuardrails);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Equal(RejectReason.PriceExceedsCurrentPriceBand, cmd.PreTradeRejectReason);
+        Assert.Equal(16u, FixpSession.MapRejectReason(cmd.PreTradeRejectReason.GetValueOrDefault()));
+        Assert.Contains("Price", msg);
     }
 
     [Theory]


### PR DESCRIPTION
Closes #433 and #436.

Adds decode-time guardrails for full NewOrderSingle and OrderCancelReplace before commands enter Core/Matching:
- maxOrderQty rejects as ER_Reject OrdRejReason=99 (Other) for quantity fat-finger payloads.
- maxPrice and optional last-trade-relative priceBandPercent reject as ER_Reject OrdRejReason=16 (Price exceeds current price band).
- priceBandPercent remains disabled by default; if enabled with no last-trade reference, the decoder accepts and downstream validation still applies.

Defaults are intentionally loose: maxOrderQty=1,000,000,000 and maxPrice=1,000,000,000,000,000 mantissa (100,000,000,000.0000) to preserve simulator flexibility while catching corrupted 64-bit inputs.

Validation:
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>