### PR TITLE
Pool outbound FIXP encoder buffer to remove per-frame allocations (#434)

### DIFF
--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -73,17 +73,24 @@ internal sealed class FixpOutboundEncoder
         // fall back to TryParse only when callers don't supply it
         // (legacy tests). Avoids a ~50–100 ns parse on every ER hot path.
         ulong clOrd = clOrdIdValue != 0 ? clOrdIdValue : (ulong.TryParse(e.ClOrdId, out var v) ? v : 0);
-        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportNewBlock, memo.Length)];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportNewBlock, memo.Length));
+        try
         {
-            ExecutionReportEncoder.EncodeExecReportNew(exact,
-                _sessionId(), _nextMsgSeqNum(), e.InsertTimestampNanos,
-                e.Side, clOrd, e.OrderId, e.SecurityId, e.OrderId,
-                (ulong)e.RptSeq, e.InsertTimestampNanos,
-                OrderType.Limit, TimeInForce.Day,
-                e.RemainingQuantity, e.PriceMantissa,
-                memo.Span, receivedTimeNanos);
-            return AppendAndEnqueueLocked(exact, durability);
+            lock (_outboundLock)
+            {
+                ExecutionReportEncoder.EncodeExecReportNew(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), e.InsertTimestampNanos,
+                    e.Side, clOrd, e.OrderId, e.SecurityId, e.OrderId,
+                    (ulong)e.RptSeq, e.InsertTimestampNanos,
+                    OrderType.Limit, TimeInForce.Day,
+                    e.RemainingQuantity, e.PriceMantissa,
+                    memo.Span, receivedTimeNanos);
+                return AppendAndEnqueueLocked(exact, durability);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
@@ -92,19 +99,26 @@ internal sealed class FixpOutboundEncoder
     {
         if (!_isOpen()) return false;
         var side = isAggressor ? e.AggressorSide : (e.AggressorSide == Side.Buy ? Side.Sell : Side.Buy);
-        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportTradeBlock, memo.Length)];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportTradeBlock, memo.Length));
+        try
         {
-            ExecutionReportEncoder.EncodeExecReportTrade(exact,
-                _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
-                side, clOrdIdValue, ownerOrderId, e.SecurityId, ownerOrderId,
-                e.Quantity, e.PriceMantissa,
-                (ulong)e.RptSeq, e.TransactTimeNanos, leavesQty, cumQty,
-                isAggressor, e.TradeId,
-                isAggressor ? e.RestingFirm : e.AggressorFirm,
-                tradeDate: 0,
-                orderQty: leavesQty + cumQty, memo.Span);
-            return AppendAndEnqueueLocked(exact, durability);
+            lock (_outboundLock)
+            {
+                ExecutionReportEncoder.EncodeExecReportTrade(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
+                    side, clOrdIdValue, ownerOrderId, e.SecurityId, ownerOrderId,
+                    e.Quantity, e.PriceMantissa,
+                    (ulong)e.RptSeq, e.TransactTimeNanos, leavesQty, cumQty,
+                    isAggressor, e.TradeId,
+                    isAggressor ? e.RestingFirm : e.AggressorFirm,
+                    tradeDate: 0,
+                    orderQty: leavesQty + cumQty, memo.Span);
+                return AppendAndEnqueueLocked(exact, durability);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
@@ -113,17 +127,24 @@ internal sealed class FixpOutboundEncoder
         DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
-        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportCancelBlock, memo.Length)];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportCancelBlock, memo.Length));
+        try
         {
-            ExecutionReportEncoder.EncodeExecReportCancel(exact,
-                _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
-                e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
-                e.SecurityId, e.OrderId,
-                (ulong)e.RptSeq, e.TransactTimeNanos,
-                cumQty: 0, orderQty: e.RemainingQuantityAtCancel, priceMantissa: e.PriceMantissa,
-                memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
-            return AppendAndEnqueueLocked(exact, durability);
+            lock (_outboundLock)
+            {
+                ExecutionReportEncoder.EncodeExecReportCancel(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
+                    e.Side, clOrdIdValue, origClOrdIdValue, e.OrderId,
+                    e.SecurityId, e.OrderId,
+                    (ulong)e.RptSeq, e.TransactTimeNanos,
+                    cumQty: 0, orderQty: e.RemainingQuantityAtCancel, priceMantissa: e.PriceMantissa,
+                    memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
+                return AppendAndEnqueueLocked(exact, durability);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
@@ -133,16 +154,23 @@ internal sealed class FixpOutboundEncoder
         DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
     {
         if (!_isOpen()) return false;
-        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportModifyBlock, memo.Length)];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportModifyBlock, memo.Length));
+        try
         {
-            ExecutionReportEncoder.EncodeExecReportModify(exact,
-                _sessionId(), _nextMsgSeqNum(), transactTimeNanos,
-                side, clOrdIdValue, origClOrdIdValue, orderId,
-                securityId, orderId, (ulong)rptSeq, transactTimeNanos,
-                leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa,
-                memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
-            return AppendAndEnqueueLocked(exact, durability);
+            lock (_outboundLock)
+            {
+                ExecutionReportEncoder.EncodeExecReportModify(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), transactTimeNanos,
+                    side, clOrdIdValue, origClOrdIdValue, orderId,
+                    securityId, orderId, (ulong)rptSeq, transactTimeNanos,
+                    leavesQty: newRemainingQty, cumQty: 0, orderQty: newRemainingQty, priceMantissa: newPriceMantissa,
+                    memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
+                return AppendAndEnqueueLocked(exact, durability);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
@@ -158,14 +186,21 @@ internal sealed class FixpOutboundEncoder
         if (!_isOpen()) return false;
         ulong reportId = (ulong)Interlocked.Increment(ref _massActionReportSeq);
         int textLen = string.IsNullOrEmpty(text) ? 0 : Math.Min(text!.Length, OrderMassActionReportEncoder.MaxTextLength);
-        var exact = new byte[OrderMassActionReportEncoder.TotalSize(textLen)];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(OrderMassActionReportEncoder.TotalSize(textLen));
+        try
         {
-            OrderMassActionReportEncoder.EncodeOrderMassActionReportWithText(exact,
-                _sessionId(), _nextMsgSeqNum(), transactTimeNanos,
-                clOrdIdValue, reportId, transactTimeNanos,
-                massActionResponse, massActionRejectReason, side, securityId, text);
-            return AppendAndEnqueueLocked(exact);
+            lock (_outboundLock)
+            {
+                OrderMassActionReportEncoder.EncodeOrderMassActionReportWithText(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), transactTimeNanos,
+                    clOrdIdValue, reportId, transactTimeNanos,
+                    massActionResponse, massActionRejectReason, side, securityId, text);
+                return AppendAndEnqueueLocked(exact);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
@@ -174,25 +209,39 @@ internal sealed class FixpOutboundEncoder
     {
         if (!_isOpen()) return false;
         uint rej = MapRejectReason(e.Reason);
-        var exact = new byte[ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportRejectBlock, memo.Length)];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportRejectBlock, memo.Length));
+        try
         {
-            ExecutionReportEncoder.EncodeExecReportReject(exact,
-                _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
-                clOrdIdValue, origClOrdIdValue: 0, e.SecurityId, e.OrderIdOrZero,
-                rej, e.TransactTimeNanos, memo.Span);
-            return AppendAndEnqueueLocked(exact, durability);
+            lock (_outboundLock)
+            {
+                ExecutionReportEncoder.EncodeExecReportReject(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
+                    clOrdIdValue, origClOrdIdValue: 0, e.SecurityId, e.OrderIdOrZero,
+                    rej, e.TransactTimeNanos, memo.Span);
+                return AppendAndEnqueueLocked(exact, durability);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
     public bool WriteSessionReject(byte terminationCode)
     {
         if (!_isOpen()) return false;
-        var exact = new byte[SessionRejectEncoder.TerminateTotal];
-        SessionRejectEncoder.EncodeTerminate(exact, _sessionId(), _sessionVerId(), terminationCode);
-        bool result = _transport().TryEnqueueFrame(exact);
-        _close();
-        return result;
+        var exact = PooledOutboundFrame.Rent(SessionRejectEncoder.TerminateTotal);
+        try
+        {
+            SessionRejectEncoder.EncodeTerminate(exact.Span, _sessionId(), _sessionVerId(), terminationCode);
+            bool result = _transport().TryEnqueueFrame(exact);
+            _close();
+            return result;
+        }
+        finally
+        {
+            exact.Release();
+        }
     }
 
     public bool WriteBusinessMessageReject(byte refMsgType, uint refSeqNum, ulong businessRejectRefId,
@@ -201,13 +250,20 @@ internal sealed class FixpOutboundEncoder
         if (!_isOpen()) return false;
         int textLen = string.IsNullOrEmpty(text) ? 0 : Math.Min(text.Length, BusinessMessageRejectEncoder.MaxTextLength);
         int total = BusinessMessageRejectEncoder.TotalSize(memo.Length, textLen);
-        var exact = new byte[total];
-        lock (_outboundLock)
+        var exact = PooledOutboundFrame.Rent(total);
+        try
         {
-            BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(
-                exact, _sessionId(), _nextMsgSeqNum(), _timeSource.NowNanos(),
-                refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text, memo.Span);
-            return AppendAndEnqueueLocked(exact);
+            lock (_outboundLock)
+            {
+                BusinessMessageRejectEncoder.EncodeBusinessMessageRejectWithText(
+                    exact.Span, _sessionId(), _nextMsgSeqNum(), _timeSource.NowNanos(),
+                    refMsgType, refSeqNum, businessRejectRefId, businessRejectReason, text, memo.Span);
+                return AppendAndEnqueueLocked(exact);
+            }
+        }
+        finally
+        {
+            exact.Release();
         }
     }
 
@@ -218,14 +274,14 @@ internal sealed class FixpOutboundEncoder
     /// transport. Centralizes the two-step "buffer + enqueue" so every
     /// business-frame write site has identical semantics.
     /// </summary>
-    private bool AppendAndEnqueueLocked(byte[] exact, DurabilityHandle durability = default)
+    private bool AppendAndEnqueueLocked(PooledOutboundFrame exact, DurabilityHandle durability = default)
     {
         // OutboundBusinessHeader.MsgSeqNum sits at body offset 4
         // (SessionID(4) | MsgSeqNum(4) | …) → absolute offset
         // WireHeaderSize + 4 = 16. Read it back so the buffer key
         // exactly matches what's on the wire.
         uint seq = BinaryPrimitives.ReadUInt32LittleEndian(
-            exact.AsSpan(EntryPointFrameReader.WireHeaderSize + 4, 4));
+            exact.Buffer.AsSpan(EntryPointFrameReader.WireHeaderSize + 4, 4));
         // Append BEFORE enqueue: per spec recovery semantics, any seq
         // that has been allocated MUST be replayable, even if the local
         // send queue rejects the frame (gpt-5.5 critique #9).

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -335,6 +335,7 @@ public sealed partial class FixpSession
             || kind == CloseKind.DailyReset;
         if (removePersistence)
         {
+            _retxBuffer.Dispose();
             if (_outboundJournal is not null && SessionId != 0)
             {
                 try { _outboundJournal.Remove(SessionId); }
@@ -516,6 +517,7 @@ public sealed partial class FixpSession
                 ConnectionId);
         }
         await _transport.DisposeAsync().ConfigureAwait(false);
+        _retxBuffer.Dispose();
         _cts.Dispose();
     }
 }

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -382,7 +382,7 @@ public sealed partial class FixpSession : IAsyncDisposable
         // after a host restart can replay any business frame from
         // disk. When no journal is wired (tests / standalone), the
         // ring degrades to a pure in-memory cache.
-        Action<uint, byte[]>? onAppendPersist = null;
+        RetxAppendPersistCallback? onAppendPersist = null;
         Func<uint, int, IReadOnlyList<B3.Exchange.Gateway.Persistence.OutboundJournalEntry>>? coldRead = null;
         if (outboundJournal is not null)
         {

--- a/src/B3.Exchange.Gateway/PooledOutboundFrame.cs
+++ b/src/B3.Exchange.Gateway/PooledOutboundFrame.cs
@@ -1,0 +1,68 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+
+namespace B3.Exchange.Gateway;
+
+/// <summary>
+/// Reference-counted, ArrayPool-backed outbound frame. The encoder, transport
+/// queue, and retransmit ring can share the same bytes and only return them to
+/// the pool after the last asynchronous consumer releases its reference.
+/// </summary>
+internal sealed class PooledOutboundFrame
+{
+    private static readonly ConcurrentStack<PooledOutboundFrame> s_framePool = new();
+
+    private int _refCount;
+
+    private PooledOutboundFrame()
+    {
+        Buffer = Array.Empty<byte>();
+    }
+
+    public byte[] Buffer { get; private set; }
+
+    public int Length { get; private set; }
+
+    public Span<byte> Span => Buffer.AsSpan(0, Length);
+
+    public ReadOnlyMemory<byte> Memory => Buffer.AsMemory(0, Length);
+
+    public static PooledOutboundFrame Rent(int length)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(length);
+        if (!s_framePool.TryPop(out var frame))
+        {
+            frame = new PooledOutboundFrame();
+        }
+
+        frame.Buffer = ArrayPool<byte>.Shared.Rent(length);
+        frame.Length = length;
+        Volatile.Write(ref frame._refCount, 1);
+        return frame;
+    }
+
+    public void AddRef()
+    {
+        int refs = Interlocked.Increment(ref _refCount);
+        if (refs <= 1)
+        {
+            throw new InvalidOperationException("Cannot retain a released outbound frame.");
+        }
+    }
+
+    public void Release()
+    {
+        int refs = Interlocked.Decrement(ref _refCount);
+        if (refs > 0) return;
+        if (refs < 0)
+        {
+            throw new InvalidOperationException("Outbound frame released too many times.");
+        }
+
+        byte[] buffer = Buffer;
+        Buffer = Array.Empty<byte>();
+        Length = 0;
+        ArrayPool<byte>.Shared.Return(buffer);
+        s_framePool.Push(this);
+    }
+}

--- a/src/B3.Exchange.Gateway/RetransmitBuffer.cs
+++ b/src/B3.Exchange.Gateway/RetransmitBuffer.cs
@@ -1,6 +1,8 @@
 using B3.EntryPoint.Wire;
 namespace B3.Exchange.Gateway;
 
+internal delegate void RetxAppendPersistCallback(uint seq, ReadOnlySpan<byte> frame);
+
 /// <summary>
 /// Per-session bounded ring buffer of recently-emitted business frames,
 /// keyed by FIXP <c>MsgSeqNum</c>. Used by issue #46 to satisfy
@@ -26,7 +28,7 @@ namespace B3.Exchange.Gateway;
 /// caller distinguish <c>OUT_OF_RANGE</c> (below window) from
 /// <c>INVALID_FROMSEQNO</c> (above window) per #46 acceptance criteria.</para>
 /// </summary>
-internal sealed class RetransmitBuffer
+internal sealed class RetransmitBuffer : IDisposable
 {
     /// <summary>Absolute byte offset of the
     /// <c>OutboundBusinessHeader.EventIndicator</c> within a wire frame
@@ -45,10 +47,11 @@ internal sealed class RetransmitBuffer
 
     private readonly object _lock = new();
     private readonly byte[]?[] _frames;
+    private readonly PooledOutboundFrame?[] _pooledFrames;
     private readonly uint[] _seqs;
     private readonly B3.Exchange.Contracts.RetransmitMetrics? _metrics;
     private readonly Func<bool>? _isSuspended;
-    private readonly Action<uint, byte[]>? _onAppendPersist;
+    private readonly RetxAppendPersistCallback? _onAppendPersist;
     /// <summary>
     /// Issue #405: cold-read callback into the persistent outbound
     /// journal, invoked when a <c>RetransmitRequest.fromSeqNo</c>
@@ -105,12 +108,13 @@ internal sealed class RetransmitBuffer
     public RetransmitBuffer(int capacity,
         B3.Exchange.Contracts.RetransmitMetrics? metrics,
         Func<bool>? isSuspended,
-        Action<uint, byte[]>? onAppendPersist,
+        RetxAppendPersistCallback? onAppendPersist,
         Func<uint, int, IReadOnlyList<B3.Exchange.Gateway.Persistence.OutboundJournalEntry>>? coldRead)
     {
         if (capacity <= 0) throw new ArgumentOutOfRangeException(nameof(capacity));
         Capacity = capacity;
         _frames = new byte[]?[capacity];
+        _pooledFrames = new PooledOutboundFrame?[capacity];
         _seqs = new uint[capacity];
         _metrics = metrics;
         _isSuspended = isSuspended;
@@ -133,7 +137,9 @@ internal sealed class RetransmitBuffer
         lock (_lock)
         {
             evicted = _count == Capacity;
+            ReleasePooledAt(_head);
             _frames[_head] = frame;
+            _pooledFrames[_head] = null;
             _seqs[_head] = seq;
             _head = (_head + 1) % Capacity;
             if (_count < Capacity) _count++;
@@ -147,6 +153,27 @@ internal sealed class RetransmitBuffer
         // Issue #288: surface eviction + suspended-write counters outside
         // the lock so a slow metrics consumer cannot back-pressure the
         // outbound encoder. Both checks are best-effort.
+        if (evicted) _metrics?.IncBufferEvictions();
+        if (_isSuspended is { } cb && cb()) _metrics?.IncPassiveErBuffered();
+    }
+
+    internal void Append(uint seq, PooledOutboundFrame frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        bool evicted;
+        lock (_lock)
+        {
+            evicted = _count == Capacity;
+            ReleasePooledAt(_head);
+            frame.AddRef();
+            _frames[_head] = null;
+            _pooledFrames[_head] = frame;
+            _seqs[_head] = seq;
+            _head = (_head + 1) % Capacity;
+            if (_count < Capacity) _count++;
+            _lastSeq = seq;
+            _onAppendPersist?.Invoke(seq, frame.Buffer.AsSpan(0, frame.Length));
+        }
         if (evicted) _metrics?.IncBufferEvictions();
         if (_isSuspended is { } cb && cb()) _metrics?.IncPassiveErBuffered();
     }
@@ -174,6 +201,21 @@ internal sealed class RetransmitBuffer
     }
 
     public int Count { get { lock (_lock) { return _count; } } }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            for (int i = 0; i < Capacity; i++)
+            {
+                ReleasePooledAt(i);
+                _seqs[i] = 0;
+            }
+            _head = 0;
+            _count = 0;
+            _lastSeq = 0;
+        }
+    }
 
     /// <summary>
     /// Outcome of <see cref="TryGet"/>. On success <see cref="Frames"/>
@@ -301,18 +343,38 @@ internal sealed class RetransmitBuffer
         for (uint i = 0; i < actual; i++)
         {
             int idx = (firstIndex + offsetFromFirst + (int)i) % Capacity;
-            clones[i] = CloneWithPossResend(_frames[idx]!);
+            clones[i] = CloneWithPossResend(FrameSpanAt(idx));
         }
         return clones;
     }
 
     private static byte[] CloneWithPossResend(byte[] src)
+        => CloneWithPossResend(src.AsSpan());
+
+    private static byte[] CloneWithPossResend(ReadOnlySpan<byte> src)
     {
         var clone = new byte[src.Length];
-        Buffer.BlockCopy(src, 0, clone, 0, src.Length);
+        src.CopyTo(clone);
         if (clone.Length > EventIndicatorAbsoluteOffset)
             clone[EventIndicatorAbsoluteOffset] |= PossResendBit;
         return clone;
+    }
+
+    private ReadOnlySpan<byte> FrameSpanAt(int idx)
+    {
+        if (_pooledFrames[idx] is { } pooled)
+            return pooled.Buffer.AsSpan(0, pooled.Length);
+        return _frames[idx]!;
+    }
+
+    private void ReleasePooledAt(int idx)
+    {
+        if (_pooledFrames[idx] is { } pooled)
+        {
+            pooled.Release();
+            _pooledFrames[idx] = null;
+        }
+        _frames[idx] = null;
     }
 
     private IReadOnlyList<B3.Exchange.Gateway.Persistence.OutboundJournalEntry> SafeColdRead(uint fromSeq, int count)

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -18,8 +18,8 @@ namespace B3.Exchange.Gateway;
 /// liveness watchdog without crossing a callback boundary on every
 /// frame.</para>
 ///
-/// <para>Backpressure: the send queue is bounded with
-/// <c>FullMode = DropWrite</c>. On overflow the transport closes the
+/// <para>Backpressure: the send queue is bounded and uses non-blocking
+/// <c>TryWrite</c> calls. On overflow the transport closes the
 /// connection rather than ballooning memory under a stuck peer; the
 /// session is notified via the <c>onClose</c> delegate.</para>
 /// </summary>
@@ -92,7 +92,7 @@ public sealed class TcpTransport : IAsyncDisposable
         {
             SingleReader = true,
             SingleWriter = false,
-            FullMode = BoundedChannelFullMode.DropWrite,
+            FullMode = BoundedChannelFullMode.Wait,
         });
         Volatile.Write(ref _lastOutboundTickMs, Environment.TickCount64);
     }

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -43,7 +43,15 @@ public sealed class TcpTransport : IAsyncDisposable
     /// (the default for non-ER frames such as keep-alive,
     /// SessionReject, BusinessMessageReject) skips the wait.
     /// </summary>
-    private readonly record struct OutboundFrame(byte[] Bytes, DurabilityHandle Durability);
+    private readonly record struct OutboundFrame(byte[]? Bytes, PooledOutboundFrame? PooledFrame, DurabilityHandle Durability)
+    {
+        public ReadOnlyMemory<byte> Memory => PooledFrame is { } pooled ? pooled.Memory : Bytes!;
+
+        public void Release()
+        {
+            PooledFrame?.Release();
+        }
+    }
 
     /// <summary>
     /// Underlying stream. Exposed for the session-level receive loop —
@@ -115,7 +123,19 @@ public sealed class TcpTransport : IAsyncDisposable
     public bool TryEnqueueFrame(byte[] frame, DurabilityHandle durability = default)
     {
         if (!IsOpen) return false;
-        if (_sendQueue.Writer.TryWrite(new OutboundFrame(frame, durability))) return true;
+        if (_sendQueue.Writer.TryWrite(new OutboundFrame(frame, null, durability))) return true;
+        try { _onSendQueueFull?.Invoke(); } catch { }
+        Close("send-queue-full");
+        return false;
+    }
+
+    internal bool TryEnqueueFrame(PooledOutboundFrame frame, DurabilityHandle durability = default)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        if (!IsOpen) return false;
+        frame.AddRef();
+        if (_sendQueue.Writer.TryWrite(new OutboundFrame(null, frame, durability))) return true;
+        frame.Release();
         try { _onSendQueueFull?.Invoke(); } catch { }
         Close("send-queue-full");
         return false;
@@ -151,25 +171,32 @@ public sealed class TcpTransport : IAsyncDisposable
             {
                 try
                 {
-                    // Issue #312: never let an ER (or any frame tagged
-                    // with a durability handle) hit the wire before its
-                    // covering WAL record is fsynced. Synchronous wait
-                    // is fine here — the send loop is the only consumer
-                    // of the queue and we WANT it to back-pressure on
-                    // un-durable frames; that's the whole point of the
-                    // gating contract.
-                    if (frame.Durability.IsActive)
-                    {
-                        frame.Durability.Barrier!.WaitForDurable(frame.Durability.Seq, ct);
-                    }
-                    await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
                     try
                     {
-                        await _stream.WriteAsync(frame.Bytes, ct).ConfigureAwait(false);
+                        // Issue #312: never let an ER (or any frame tagged
+                        // with a durability handle) hit the wire before its
+                        // covering WAL record is fsynced. Synchronous wait
+                        // is fine here — the send loop is the only consumer
+                        // of the queue and we WANT it to back-pressure on
+                        // un-durable frames; that's the whole point of the
+                        // gating contract.
+                        if (frame.Durability.IsActive)
+                        {
+                            frame.Durability.Barrier!.WaitForDurable(frame.Durability.Seq, ct);
+                        }
+                        await _streamWriteLock.WaitAsync(ct).ConfigureAwait(false);
+                        try
+                        {
+                            await _stream.WriteAsync(frame.Memory, ct).ConfigureAwait(false);
+                        }
+                        finally
+                        {
+                            _streamWriteLock.Release();
+                        }
                     }
                     finally
                     {
-                        _streamWriteLock.Release();
+                        frame.Release();
                     }
                     Volatile.Write(ref _lastOutboundTickMs, Environment.TickCount64);
                 }
@@ -185,6 +212,15 @@ public sealed class TcpTransport : IAsyncDisposable
         finally
         {
             Close("send-loop-exit");
+            ReleaseQueuedFrames();
+        }
+    }
+
+    private void ReleaseQueuedFrames()
+    {
+        while (_sendQueue.Reader.TryRead(out var frame))
+        {
+            frame.Release();
         }
     }
 
@@ -206,6 +242,7 @@ public sealed class TcpTransport : IAsyncDisposable
     {
         Close("dispose");
         try { if (_sendTask != null) await _sendTask.ConfigureAwait(false); } catch { }
+        ReleaseQueuedFrames();
         _streamWriteLock.Dispose();
     }
 }

--- a/tests/B3.Exchange.Gateway.Tests/TcpTransportOverflowTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/TcpTransportOverflowTests.cs
@@ -1,0 +1,32 @@
+using B3.Exchange.Gateway;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Gateway.Tests;
+
+public class TcpTransportOverflowTests
+{
+    [Fact]
+    public async Task TryEnqueueFrame_WhenQueueIsFull_ReturnsFalseClosesTransportAndReleasesPooledReference()
+    {
+        string? closeReason = null;
+        await using var transport = new TcpTransport(
+            connectionId: 1,
+            stream: new MemoryStream(),
+            logger: NullLogger<TcpTransport>.Instance,
+            sendQueueCapacity: 1,
+            onClose: reason => closeReason = reason);
+
+        Assert.True(transport.TryEnqueueFrame(new byte[] { 1 }));
+
+        var pooled = PooledOutboundFrame.Rent(4);
+        pooled.Span.Fill(0x42);
+
+        Assert.False(transport.TryEnqueueFrame(pooled));
+        Assert.False(transport.IsOpen);
+        Assert.Equal("send-queue-full", closeReason);
+
+        pooled.Release();
+        Assert.Equal(0, pooled.Length);
+        Assert.Empty(pooled.Buffer);
+    }
+}


### PR DESCRIPTION
Closes #434.

## Approach
- Uses ArrayPool-backed `PooledOutboundFrame` instances rather than a single reusable encoder buffer because outbound bytes are consumed asynchronously by `TcpTransport` and retained by `RetransmitBuffer` for replay.
- `FixpOutboundEncoder` now rents one frame, encodes into its span, then shares it with the retransmit ring and transport send queue.
- The pooled frame object is reference-counted and itself pooled, so steady-state allocations grow only to the concurrent/high-water mark.

## Buffer lifetime safety
- Encoder releases its temporary owner reference in `finally`.
- `RetransmitBuffer` retains a reference on append and releases it on eviction, terminal session close, or session disposal.
- `TcpTransport` retains only after a successful queue write and releases after async write completion, cancellation, IO failure, or queued-frame drain during shutdown.
- Persistent outbound journal append receives a synchronous `ReadOnlySpan<byte>`, avoiding an extra byte-array copy.

## Allocation verification
- Static byte allocation sites in `FixpOutboundEncoder`: 8 before, 0 after (`grep -c "new byte\["`).
- Full pre-PR checklist passed locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>