### PR TITLE
fix(gateway): make FIXP suspend transport teardown deterministic

### DIFF
--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -150,8 +150,18 @@ public sealed partial class FixpSession
     /// </summary>
     private void SuspendLocked(string reason)
     {
-        // Atomically flip the attachment flag; second caller is a no-op.
-        if (Interlocked.Exchange(ref _isAttached, 0) == 0) return;
+        // Atomically claim the right to suspend; second caller is a no-op.
+        // We use a separate CAS guard (not _isAttached) so the public
+        // IsAttached flag stays true until after teardown + state transition,
+        // preserving the invariant that observers seeing !IsAttached can rely
+        // on State == Suspended AND the transport already being down.
+        if (Interlocked.Exchange(ref _suspendInProgress, 1) == 1) return;
+        if (Volatile.Read(ref _isAttached) == 0)
+        {
+            // A concurrent Close already cleared attachment; nothing to do.
+            Volatile.Write(ref _suspendInProgress, 0);
+            return;
+        }
         _logger.LogInformation("fixp session {ConnectionId} suspending (reason={Reason})",
             ConnectionId, reason);
         // Best-effort teardown of cancellation + transport before publishing
@@ -180,6 +190,9 @@ public sealed partial class FixpSession
         // while the session is parked still produces an
         // EstablishmentAck.lastIncomingSeqNo matching reality.
         SaveStateSnapshotSafe();
+        // Publish !IsAttached only after state transition + teardown so
+        // consumers observing IsAttached==false see a fully-suspended session.
+        Volatile.Write(ref _isAttached, 0);
     }
 
     /// <summary>

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -154,6 +154,14 @@ public sealed partial class FixpSession
         if (Interlocked.Exchange(ref _isAttached, 0) == 0) return;
         _logger.LogInformation("fixp session {ConnectionId} suspending (reason={Reason})",
             ConnectionId, reason);
+        // Best-effort teardown of cancellation + transport before publishing
+        // Suspended. Tests and diagnostics use State==Suspended as the contract
+        // that the transport is already detached/down; publishing the state
+        // first races observers against the close side effect on fast machines.
+        try { _cts.Cancel(); } catch (ObjectDisposedException) { /* concurrent dispose */ }
+        try { _transport.Close(reason); } catch (ObjectDisposedException) { /* transport already disposed */ }
+        try { _transport.Stream.Dispose(); } catch (ObjectDisposedException) { /* stream already disposed */ }
+
         var action = ApplyTransition(FixpEvent.Detach);
         if (action != FixpAction.Accept || State != FixpState.Suspended)
         {
@@ -166,12 +174,6 @@ public sealed partial class FixpSession
             CloseLocked(reason, CloseKind.TransportError);
             return;
         }
-        // Best-effort teardown of cancellation + transport during Suspend; each
-        // step may legitimately fail if a concurrent Close has already raced
-        // ahead (e.g. transport callback while suspend was being decided).
-        try { _cts.Cancel(); } catch (ObjectDisposedException) { /* concurrent dispose */ }
-        try { _transport.Close(reason); } catch (ObjectDisposedException) { /* transport already disposed */ }
-        try { _transport.Stream.Dispose(); } catch (ObjectDisposedException) { /* stream already disposed */ }
         Volatile.Write(ref _suspendedSinceMs, NowMs());
         ScheduleCodTimerLocked();
         // Issue #405: persist the envelope on suspend so a host crash

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -107,6 +107,11 @@ public sealed partial class FixpSession : IAsyncDisposable
     private long _msgSeqNum;
     private int _isOpen = 1;
     private int _isAttached = 1;
+    /// <summary>De-dup CAS guard for <c>SuspendLocked</c>. Distinct from
+    /// <c>_isAttached</c> so that the public <c>IsAttached</c> flag can stay
+    /// true throughout teardown + state transition and only flip to false
+    /// once Suspend has fully published.</summary>
+    private int _suspendInProgress;
     /// <summary>
     /// Issue #405: classification of the most recent close (or null
     /// when the session is still open / has never closed). Set


### PR DESCRIPTION
Closes #399

## Root cause

`SuspendLocked` published `State == Suspended` before it cancelled/closed/disposed the attached transport. The passive ER buffering test waits for `Suspended` and then asserts `IsOpen == false`, so fast local runs could observe the state transition before the teardown side effect completed.

## Fix

Move the best-effort cancellation/transport teardown before `ApplyTransition(FixpEvent.Detach)`. Now `State == Suspended` is only visible after the transport has been marked closed, matching the diagnostic/test contract without adding sleeps or weakening the assertion.

## Validation

- 20/20 Debug loop runs passed: `dotnet test tests/B3.Exchange.Gateway.Tests/B3.Exchange.Gateway.Tests.csproj -c Debug --filter "FullyQualifiedName~PassiveTrade_WhileSuspended_AppendsToRetransmitRing"`
- `dotnet restore SbeB3Exchange.slnx`
- `dotnet build SbeB3Exchange.slnx -c Release --no-restore`
- `dotnet test SbeB3Exchange.slnx -c Release --no-build`
- `dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn`