### PR TITLE
Migrate audit checkpoint to SingleWriterGuard

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Lifecycle.cs
@@ -36,20 +36,25 @@ public sealed partial class ChannelDispatcher
         var heartbeatMs = (int)Math.Max(1, HeartbeatInterval.TotalMilliseconds);
         try
         {
-            while (!ct.IsCancellationRequested)
+            while (true)
             {
                 RecordHeartbeat();
-                var waitTask = reader.WaitToReadAsync(ct).AsTask();
+                var drainingShutdown = ct.IsCancellationRequested
+                    && Volatile.Read(ref _drainOnCancellation) != 0;
+                if (ct.IsCancellationRequested && !drainingShutdown) return;
+                var waitTask = drainingShutdown
+                    ? reader.WaitToReadAsync().AsTask()
+                    : reader.WaitToReadAsync(ct).AsTask();
                 bool signaled;
-                try { signaled = waitTask.Wait(heartbeatMs, ct); }
-                catch (OperationCanceledException) { return; /* expected: dispatch loop cancelled during shutdown */ }
-                catch (AggregateException ae) when (ae.InnerException is OperationCanceledException) { return; /* same: wrapped in Task.Wait */ }
+                try { signaled = waitTask.Wait(heartbeatMs); }
+                catch (OperationCanceledException) { if (Volatile.Read(ref _drainOnCancellation) == 0) return; else continue; }
+                catch (AggregateException ae) when (ae.InnerException is OperationCanceledException) { if (Volatile.Read(ref _drainOnCancellation) == 0) return; else continue; }
                 if (!signaled) continue; // heartbeat timeout — re-record and loop
 
                 bool more;
                 try { more = waitTask.GetAwaiter().GetResult(); }
-                catch (OperationCanceledException) { return; /* expected: dispatch loop cancelled during shutdown */ }
-                if (!more) return; // channel completed
+                catch (OperationCanceledException) { if (Volatile.Read(ref _drainOnCancellation) == 0) return; else continue; }
+                if (!more) return; // channel completed after all queued work drained
 
                 while (reader.TryRead(out var item))
                 {
@@ -69,20 +74,34 @@ public sealed partial class ChannelDispatcher
                 }
             }
         }
-        catch (OperationCanceledException) { /* expected: dispatch loop cancelled during shutdown */ }
         catch (Exception ex)
         {
             _logger.LogError(ex, "channel {ChannelNumber} dispatch loop terminated unexpectedly", ChannelNumber);
         }
         finally
         {
-            try { FlushPendingSnapshotOnShutdown(); }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex,
-                    "channel {ChannelNumber}: final shutdown snapshot flush failed",
-                    ChannelNumber);
-            }
+            FlushPendingSnapshotOnShutdownSafely();
+        }
+    }
+
+    private async Task DrainInboundBeforeStoppingSnapshotWriterAsync()
+    {
+        if (_loopTask is null) return;
+        var drained = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var item = new WorkItem(WorkKind.ShutdownBarrier, default, 0, false,
+            0, 0, null, null, null, null, ShutdownBarrier: drained);
+        await _inbound.Writer.WriteAsync(item).AsTask().WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+        await drained.Task.WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+    }
+
+    private void FlushPendingSnapshotOnShutdownSafely()
+    {
+        try { FlushPendingSnapshotOnShutdown(); }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: final shutdown snapshot flush failed",
+                ChannelNumber);
         }
     }
 
@@ -177,12 +196,22 @@ public sealed partial class ChannelDispatcher
     {
         _logger.LogInformation("channel {ChannelNumber} dispatcher stopping (sequenceNumber={SequenceNumber})",
             ChannelNumber, SequenceNumber);
-        _inbound.Writer.TryComplete();
+        Volatile.Write(ref _drainOnCancellation, 1);
         try { _cts.Cancel(); } catch { }
-        if (_loopTask != null) { try { await _loopTask.ConfigureAwait(false); } catch { } }
-        // Issue #268: ensure any in-flight async snapshot is durable
-        // before tearing down. The writer drains its pending mailbox
-        // inside StopAsync.
+        try { await DrainInboundBeforeStoppingSnapshotWriterAsync().ConfigureAwait(false); }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: shutdown inbox drain failed before snapshot writer stop",
+                ChannelNumber);
+        }
+        // Issue #445 review: keep the inbox open while the async snapshot
+        // writer drains. Its final onSaved callback enqueues an AuditCheckpoint
+        // work item; the dispatch loop remains alive after cancellation until
+        // the channel is completed below, so the prepare half runs on the
+        // dispatch thread and the writer-thread fsync completes before this
+        // method returns. BackgroundSnapshotWriter only enqueues that
+        // AuditCheckpoint callback during drain.
         if (_asyncSnapshotWriter is { } writer)
         {
             try { await writer.DisposeAsync().ConfigureAwait(false); }
@@ -193,6 +222,8 @@ public sealed partial class ChannelDispatcher
                     ChannelNumber);
             }
         }
+        _inbound.Writer.TryComplete();
+        if (_loopTask != null) { try { await _loopTask.ConfigureAwait(false); } catch { } }
         // Issue #269: release the WAL file handle so the underlying
         // file can be deleted by tests / operator tooling. The
         // dispatcher loop has already flushed its final snapshot

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -41,6 +41,12 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.AuditCheckpoint)
+        {
+            ProcessAuditCheckpoint(item.AuditCheckpoint!);
+            return;
+        }
+
         // Issue #286 follow-up: producer-side gates (RejectIfWalHalted)
         // catch most halts, but a work item already in the channel when
         // the WAL flips to halted would still reach here and mutate the

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -47,6 +47,13 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.ShutdownBarrier)
+        {
+            FlushPendingSnapshotOnShutdownSafely();
+            item.ShutdownBarrier!.TrySetResult(true);
+            return;
+        }
+
         // Issue #286 follow-up: producer-side gates (RejectIfWalHalted)
         // catch most halts, but a work item already in the channel when
         // the WAL flips to halted would still reach here and mutate the

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -1,5 +1,6 @@
 using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
 using Microsoft.Extensions.Logging;
 using MatchingRejectEvent = B3.Exchange.Matching.RejectEvent;
 using MatchingSide = B3.Exchange.Matching.Side;
@@ -175,21 +176,26 @@ public sealed partial class ChannelDispatcher
 
     /// <summary>
     /// Post-save callback invoked by <see cref="BackgroundSnapshotWriter"/>
-    /// on the writer thread when async-writer mode is enabled. Truncates
-    /// the WAL on that thread so the on-disk WAL only loses records that
-    /// the matching snapshot has already absorbed.
+    /// on the writer thread when async-writer mode is enabled. It requests
+    /// the audit checkpoint prepare from the dispatch thread, performs the
+    /// slow audit fsync on this writer thread, then truncates the WAL on this
+    /// writer thread so the on-disk WAL only loses records that the matching
+    /// snapshot has already absorbed.
     ///
-    /// <para>Issue #329 PR-4: gated on the audit watermark (see
-    /// <see cref="TruncateWalAfterSyncSave(long)"/>). The audit sink's
-    /// Checkpoint is safe to call cross-thread.</para>
+    /// <para>Issue #396: FileAuditLogWriter state is dispatch-thread owned;
+    /// this callback never calls Checkpoint directly.</para>
     /// </summary>
     private void OnAsyncSnapshotSaved(ChannelStateSnapshot snap)
     {
+        if (_wal is null && ReferenceEquals(_postTradeSink, NullPostTradeSink.Instance))
+            return;
+
         // Issue #329 PR-4 / #352 follow-up: Checkpoint the audit sink
         // even when no WAL is configured (see TruncateWalAfterSyncSave
-        // above for the same rationale). The audit sink's Checkpoint
-        // is safe to call cross-thread.
-        bool watermarkOk = CheckpointAndGateAuditWatermark(snap.LastAppliedSeq, async: true);
+        // above for the same rationale). Issue #396 marshals the prepare
+        // half through the dispatch inbox; this writer thread performs the
+        // returned operation's fsync and sidecar write.
+        bool watermarkOk = EnqueueAndRunAsyncAuditCheckpoint(snap.LastAppliedSeq);
         if (_wal is null) return;
         if (!watermarkOk) return;
         try
@@ -243,6 +249,80 @@ public sealed partial class ChannelDispatcher
             return false;
         }
         return true;
+    }
+
+    private void ProcessAuditCheckpoint(AuditCheckpointRequest request)
+    {
+        AssertOnLoopThread();
+        try
+        {
+            if (_postTradeSink is IDispatchThreadCheckpointSink splitSink)
+            {
+                request.Prepared.TrySetResult(splitSink.BeginCheckpointOnDispatchThread());
+                return;
+            }
+
+            _postTradeSink.Checkpoint();
+            request.Prepared.TrySetResult(CompletedAuditCheckpointOperation.Instance);
+        }
+        catch (Exception ex)
+        {
+            request.Prepared.TrySetException(ex);
+        }
+    }
+
+    private bool EnqueueAndRunAsyncAuditCheckpoint(long snapshotLastAppliedSeq)
+    {
+        var prepared = new TaskCompletionSource<IAuditCheckpointOperation>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var request = new AuditCheckpointRequest(snapshotLastAppliedSeq, prepared);
+        var item = new WorkItem(WorkKind.AuditCheckpoint, default, 0, false,
+            0, 0, null, null, null, null, AuditCheckpoint: request);
+
+        if (!_inbound.Writer.TryWrite(item))
+        {
+            _metrics?.IncAuditWalTruncateDeferred();
+            _logger.LogWarning(
+                "channel {ChannelNumber}: audit checkpoint enqueue failed; WAL truncation deferred (snapshotSeq={SnapshotSeq})",
+                ChannelNumber, snapshotLastAppliedSeq);
+            return false;
+        }
+
+        try
+        {
+            if (!prepared.Task.Wait(TimeSpan.FromSeconds(30)))
+                throw new TimeoutException("timed out waiting for dispatch-thread audit checkpoint prepare");
+            using var checkpoint = prepared.Task.GetAwaiter().GetResult();
+            checkpoint.FlushToDiskAndCommit();
+        }
+        catch (Exception ex)
+        {
+            _metrics?.IncAuditWalTruncateDeferred();
+            _logger.LogError(ex,
+                "channel {ChannelNumber}: audit log async Checkpoint failed; WAL truncation deferred (snapshotSeq={SnapshotSeq})",
+                ChannelNumber, snapshotLastAppliedSeq);
+            return false;
+        }
+
+        long durable = _postTradeSink.DurableThroughCommandSeq;
+        if (durable < snapshotLastAppliedSeq)
+        {
+            _metrics?.IncAuditWalTruncateDeferred();
+            _logger.LogWarning(
+                "channel {ChannelNumber}: WAL truncation deferred — audit watermark behind snapshot (durable={Durable}, snapshotSeq={SnapshotSeq}, path=async)",
+                ChannelNumber, durable, snapshotLastAppliedSeq);
+            return false;
+        }
+
+        return true;
+    }
+
+    private sealed class CompletedAuditCheckpointOperation : IAuditCheckpointOperation
+    {
+        public static readonly CompletedAuditCheckpointOperation Instance = new();
+        private CompletedAuditCheckpointOperation() { }
+        public void FlushToDiskAndCommit() { }
+        public void Dispose() { }
     }
 
     /// <summary>

--- a/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Wal.cs
@@ -279,17 +279,16 @@ public sealed partial class ChannelDispatcher
         var item = new WorkItem(WorkKind.AuditCheckpoint, default, 0, false,
             0, 0, null, null, null, null, AuditCheckpoint: request);
 
-        if (!_inbound.Writer.TryWrite(item))
-        {
-            _metrics?.IncAuditWalTruncateDeferred();
-            _logger.LogWarning(
-                "channel {ChannelNumber}: audit checkpoint enqueue failed; WAL truncation deferred (snapshotSeq={SnapshotSeq})",
-                ChannelNumber, snapshotLastAppliedSeq);
-            return false;
-        }
-
         try
         {
+            if (!_inbound.Writer.TryWrite(item))
+            {
+                var writeTask = _inbound.Writer.WriteAsync(item).AsTask();
+                if (!writeTask.Wait(TimeSpan.FromSeconds(30)))
+                    throw new TimeoutException("timed out waiting to enqueue dispatch-thread audit checkpoint prepare");
+                writeTask.GetAwaiter().GetResult();
+            }
+
             if (!prepared.Task.Wait(TimeSpan.FromSeconds(30)))
                 throw new TimeoutException("timed out waiting for dispatch-thread audit checkpoint prepare");
             using var checkpoint = prepared.Task.GetAwaiter().GetResult();

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -1,5 +1,6 @@
 using B3.Exchange.Contracts;
 using B3.Exchange.Matching;
+using B3.Exchange.PostTrade;
 using Microsoft.Extensions.Logging;
 
 namespace B3.Exchange.Core;
@@ -10,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2 }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -37,6 +38,7 @@ public sealed partial class ChannelDispatcher
         "OperatorHaltInstrument",
         "OperatorResumeInstrument",
         "OperatorBustV2",
+        "AuditCheckpoint",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -66,6 +68,7 @@ public sealed partial class ChannelDispatcher
         TaskCompletionSource<HaltOutcome>? HaltCompletion = null,
         OperatorBustV2? BustV2 = null,
         TaskCompletionSource<OperatorBustV2Outcome>? BustCompletion = null,
+        AuditCheckpointRequest? AuditCheckpoint = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -139,6 +142,15 @@ public sealed partial class ChannelDispatcher
     public readonly record struct OperatorBustV2Outcome(
         B3.Exchange.PostTrade.BustValidationKind Kind,
         ulong ExistingCorrelationId);
+
+    /// <summary>
+    /// Cross-thread handshake payload for issue #396: snapshot writer requests
+    /// a dispatch-thread audit checkpoint prepare, then performs the returned
+    /// durable flush off the dispatch loop.
+    /// </summary>
+    internal sealed record AuditCheckpointRequest(
+        long SnapshotLastAppliedSeq,
+        TaskCompletionSource<IAuditCheckpointOperation> Prepared);
 
     // ====== high-frequency log messages (LoggerMessage source-gen) ======
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -11,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -39,6 +39,7 @@ public sealed partial class ChannelDispatcher
         "OperatorResumeInstrument",
         "OperatorBustV2",
         "AuditCheckpoint",
+        "ShutdownBarrier",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -69,6 +70,7 @@ public sealed partial class ChannelDispatcher
         OperatorBustV2? BustV2 = null,
         TaskCompletionSource<OperatorBustV2Outcome>? BustCompletion = null,
         AuditCheckpointRequest? AuditCheckpoint = null,
+        TaskCompletionSource<bool>? ShutdownBarrier = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -430,13 +430,14 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
         // Issue #268: opt-in async snapshot writer. Off by default so
         // pre-existing deployments keep the synchronous in-loop persist
         // (zero-RPO). Enabled per channel via host config.
-        // Issue #269: when WAL is also enabled, the writer notifies us
-        // via the post-save callback so we can truncate the WAL on the
-        // writer thread — guaranteeing the WAL is only ever truncated
-        // after the matching snapshot has reached the disk.
+        // Issue #269/#396: the writer notifies us via the post-save
+        // callback so we can checkpoint audit durability and, when WAL is
+        // configured, truncate on the writer thread — guaranteeing the WAL
+        // is only ever truncated after the matching snapshot and audit
+        // checkpoint are durable.
         _asyncSnapshotWriter = (options.UseAsyncSnapshotWriter && options.Persister is not null)
             ? new BackgroundSnapshotWriter(channelNumber, options.Persister, options.Logger, options.Metrics,
-                onSaved: _wal is null ? null : OnAsyncSnapshotSaved)
+                onSaved: OnAsyncSnapshotSaved)
             : null;
         // Direct field writes are safe here: ctor runs on the constructing
         // thread before Start() and before any other thread can observe the

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -344,6 +344,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private AuctionPrintInfo? _pendingAuctionPrint;
 
     private readonly CancellationTokenSource _cts = new();
+    private int _drainOnCancellation;
     private Task? _loopTask;
     // Single-thread invariant (ADR 0009 / issues #138, #169, #384).
     // Captured on entry to RunLoop; used by AssertOnLoopThread() to enforce

--- a/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
+++ b/src/B3.Exchange.PostTrade/FileAuditLogWriter.cs
@@ -1,3 +1,4 @@
+using B3.Exchange.Matching.Threading;
 using Microsoft.Win32.SafeHandles;
 
 namespace B3.Exchange.PostTrade;
@@ -11,14 +12,11 @@ namespace B3.Exchange.PostTrade;
 /// rather than wall-clock so the rollover is deterministic across replay
 /// and across time-warped scenario tests.
 ///
-/// Threading model: OnTrade and OnCommandBoundary are called exclusively on
-/// the <c>ChannelDispatcher</c>'s dispatch thread. Checkpoint MAY be called
-/// from another thread (the async snapshot writer's onSaved callback runs on
-/// the writer thread). A single private state lock serializes mutations of
-/// the FileStream / counters; the slow <c>fsync</c> portion of Checkpoint is
-/// executed OUTSIDE the lock against the underlying <see cref="SafeFileHandle"/>
-/// via <see cref="RandomAccess.FlushToDisk(SafeFileHandle)"/> so the
-/// dispatch thread's next OnTrade does not have to wait for storage
+/// Threading model: mutable file/index/counter state is owned by the
+/// <c>ChannelDispatcher</c>'s dispatch thread and guarded by
+/// <see cref="SingleWriterGuard"/> (ADR 0009). Async snapshot callbacks
+/// marshal checkpoint preparation back to the dispatcher; the returned
+/// operation performs slow <c>fsync</c> on the snapshot writer thread
 /// (issue #349).
 ///
 /// Durability watermark (issue #329 PR-4): each <see cref="OnCommandBoundary"/>
@@ -27,14 +25,14 @@ namespace B3.Exchange.PostTrade;
 /// promotes that pending value into <see cref="DurableThroughCommandSeq"/>,
 /// which the WAL truncation gate reads before dropping WAL records.
 /// </summary>
-public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
+public sealed class FileAuditLogWriter : IDispatchThreadCheckpointSink, IDisposable
 {
     private readonly string _rootDir;
     private readonly byte _channelNumber;
     private readonly int _indexBlockRecords;
     private readonly byte[] _scratch;
     private readonly byte[] _indexScratch;
-    private readonly object _stateLock = new();
+    private readonly SingleWriterGuard _writerGuard;
 
     private FileStream? _stream;
     private FileStream? _indexStream;
@@ -58,7 +56,7 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     // on-disk WAL. Mirrors the WalAppendFailurePolicy.Halt model in
     // ChannelDispatcher (issue #286). Sticky for the lifetime of this
     // writer instance — only a restart/rebuild clears it.
-    private bool _writeFault;
+    private int _writeFault;
 
     // Current in-progress index block. _blockFirmIds is kept sorted+distinct
     // (linear insertion — typical session has well below 64 firms per block,
@@ -74,6 +72,7 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
             throw new ArgumentOutOfRangeException(nameof(indexBlockRecords), "block size must be in [1, 65535]");
         _rootDir = rootDir;
         _channelNumber = channelNumber;
+        _writerGuard = new SingleWriterGuard($"FileAuditLogWriter[channel={channelNumber}]");
         _indexBlockRecords = indexBlockRecords;
         _scratch = new byte[Math.Max(AuditRecordCodec.RecordSize, AuditRecordCodec.FileHeaderSize)];
         // Worst-case index entry: prefix + indexBlockRecords distinct firm IDs
@@ -142,63 +141,61 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// no record has been written yet.</summary>
     public DateOnly? CurrentTradeDate => _stream is null ? null : _currentDate;
 
+    public SingleWriterGuard Guard => _writerGuard;
+
     public void OnTrade(in PostTradeRecord record)
     {
-        lock (_stateLock)
+        _writerGuard.AssertOwnedByCurrentThread();
+        // If a prior write already failed, refuse silently — the audit
+        // log is in a known-broken state and further writes would only
+        // deepen the hole. ChannelDispatcher's OnTrade catches and
+        // swallows post-trade sink exceptions, so throwing here would
+        // not even reach the operator; the deferred-truncate metric
+        // (bumped on every Checkpoint attempt below) is the alert path.
+        if (Volatile.Read(ref _writeFault) != 0) return;
+        try
         {
-            // If a prior write already failed, refuse silently — the audit
-            // log is in a known-broken state and further writes would only
-            // deepen the hole. ChannelDispatcher's OnTrade catches and
-            // swallows post-trade sink exceptions, so throwing here would
-            // not even reach the operator; the deferred-truncate metric
-            // (bumped on every Checkpoint attempt below) is the alert path.
-            if (_writeFault) return;
-            try
+            var recordDate = ToUtcDate(record.TransactTimeNanos);
+            if (_stream is null || recordDate != _currentDate)
             {
-                var recordDate = ToUtcDate(record.TransactTimeNanos);
-                if (_stream is null || recordDate != _currentDate)
-                {
-                    RotateTo(recordDate);
-                }
-                if (_blockRecordCount == 0)
-                    _blockStartOffset = _stream!.Position;
-
-                int n = AuditRecordCodec.Encode(_scratch, in record);
-                _stream!.Write(_scratch, 0, n);
-                _stream.Flush(flushToDisk: false);
-                _recordsWritten++;
-
-                TrackFirm(record.BuyFirm);
-                TrackFirm(record.SellFirm);
-                _blockRecordCount++;
-                if (_blockRecordCount >= _indexBlockRecords)
-                    FlushCurrentBlock();
+                RotateTo(recordDate);
             }
-            catch
-            {
-                // Poison the watermark for the rest of this writer's life.
-                // Any subsequent OnCommandBoundary/Checkpoint will refuse to
-                // advance _durableCommandSeq, keeping the WAL truncation
-                // gate permanently closed until the operator restarts.
-                _writeFault = true;
-                throw;
-            }
+            if (_blockRecordCount == 0)
+                _blockStartOffset = _stream!.Position;
+
+            int n = AuditRecordCodec.Encode(_scratch, in record);
+            _stream!.Write(_scratch, 0, n);
+            _stream.Flush(flushToDisk: false);
+            _recordsWritten++;
+
+            TrackFirm(record.BuyFirm);
+            TrackFirm(record.SellFirm);
+            _blockRecordCount++;
+            if (_blockRecordCount >= _indexBlockRecords)
+                FlushCurrentBlock();
+        }
+        catch
+        {
+            // Poison the watermark for the rest of this writer's life.
+            // Any subsequent OnCommandBoundary/Checkpoint will refuse to
+            // advance _durableCommandSeq, keeping the WAL truncation
+            // gate permanently closed until the operator restarts.
+            Volatile.Write(ref _writeFault, 1);
+            throw;
         }
     }
 
     /// <summary>Tags every record OnTrade'd since the previous boundary as
     /// "produced by <paramref name="commandSeq"/>". The watermark advances
     /// from pending to durable on the next <see cref="Checkpoint"/> call.
-    /// Dispatch-thread-only; cheap (single store under the shared lock).
+    /// Dispatch-thread-only; cheap (single monotonic store).
     /// No-op when the writer is in write-fault state.</summary>
     public void OnCommandBoundary(long commandSeq)
     {
-        lock (_stateLock)
-        {
-            if (_writeFault) return;
-            // Monotonic: tolerate replay paths that resubmit lower seqs.
-            if (commandSeq > _pendingCommandSeq) _pendingCommandSeq = commandSeq;
-        }
+        _writerGuard.AssertOwnedByCurrentThread();
+        if (Volatile.Read(ref _writeFault) != 0) return;
+        // Monotonic: tolerate replay paths that resubmit lower seqs.
+        if (commandSeq > _pendingCommandSeq) _pendingCommandSeq = commandSeq;
     }
 
     /// <summary>ADR 0008 PR-2: appends a bust audit record. When
@@ -210,31 +207,29 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// busts are queried via the v2 ReadAllEntries path).</summary>
     public void OnBust(in BustRecord record, DateOnly tradeDate)
     {
-        lock (_stateLock)
+        _writerGuard.AssertOwnedByCurrentThread();
+        if (Volatile.Read(ref _writeFault) != 0) return;
+        try
         {
-            if (_writeFault) return;
-            try
+            Span<byte> buf = stackalloc byte[AuditRecordCodec.BustRecordSize];
+            int n = AuditRecordCodec.EncodeBust(buf, in record);
+            if (_stream is not null && tradeDate == _currentDate)
             {
-                Span<byte> buf = stackalloc byte[AuditRecordCodec.BustRecordSize];
-                int n = AuditRecordCodec.EncodeBust(buf, in record);
-                if (_stream is not null && tradeDate == _currentDate)
-                {
-                    // Same-day inline: end any open fill block first so the
-                    // .idx invariant ("entries cover contiguous fill runs")
-                    // is preserved across the non-fill insertion.
-                    FlushCurrentBlock();
-                    _stream.Write(buf.Slice(0, n));
-                    _stream.Flush(flushToDisk: false);
-                    return;
-                }
-                // Cross-day write: open/create, fsync, close.
-                AppendNonFillToOtherDay(tradeDate, buf.Slice(0, n));
+                // Same-day inline: end any open fill block first so the
+                // .idx invariant ("entries cover contiguous fill runs")
+                // is preserved across the non-fill insertion.
+                FlushCurrentBlock();
+                _stream.Write(buf.Slice(0, n));
+                _stream.Flush(flushToDisk: false);
+                return;
             }
-            catch
-            {
-                _writeFault = true;
-                throw;
-            }
+            // Cross-day write: open/create, fsync, close.
+            AppendNonFillToOtherDay(tradeDate, buf.Slice(0, n));
+        }
+        catch
+        {
+            Volatile.Write(ref _writeFault, 1);
+            throw;
         }
     }
 
@@ -244,31 +239,29 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// </summary>
     public void OnRejectAttempt(in RejectAttemptRecord record)
     {
-        lock (_stateLock)
+        _writerGuard.AssertOwnedByCurrentThread();
+        if (Volatile.Read(ref _writeFault) != 0) return;
+        try
         {
-            if (_writeFault) return;
-            try
+            var recordDate = ToUtcDate(record.AttemptTransactTimeNanos);
+            Span<byte> buf = stackalloc byte[AuditRecordCodec.RejectAttemptRecordSize];
+            int n = AuditRecordCodec.EncodeRejectAttempt(buf, in record);
+            if (_stream is null || recordDate != _currentDate)
             {
-                var recordDate = ToUtcDate(record.AttemptTransactTimeNanos);
-                Span<byte> buf = stackalloc byte[AuditRecordCodec.RejectAttemptRecordSize];
-                int n = AuditRecordCodec.EncodeRejectAttempt(buf, in record);
-                if (_stream is null || recordDate != _currentDate)
-                {
-                    // OnRejectAttempt is dispatched on the dispatch thread,
-                    // so a rotation to today's log is the natural action:
-                    // future fills land on the same day. Mirrors OnTrade's
-                    // RotateTo path.
-                    RotateTo(recordDate);
-                }
-                FlushCurrentBlock();
-                _stream!.Write(buf.Slice(0, n));
-                _stream.Flush(flushToDisk: false);
+                // OnRejectAttempt is dispatched on the dispatch thread,
+                // so a rotation to today's log is the natural action:
+                // future fills land on the same day. Mirrors OnTrade's
+                // RotateTo path.
+                RotateTo(recordDate);
             }
-            catch
-            {
-                _writeFault = true;
-                throw;
-            }
+            FlushCurrentBlock();
+            _stream!.Write(buf.Slice(0, n));
+            _stream.Flush(flushToDisk: false);
+        }
+        catch
+        {
+            Volatile.Write(ref _writeFault, 1);
+            throw;
         }
     }
 
@@ -294,92 +287,52 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         fs.Flush(flushToDisk: true);
     }
 
-    /// <summary>Flushes OS buffers, forces <c>fsync</c> on both files, and
-    /// advances <see cref="DurableThroughCommandSeq"/> to the most recent
-    /// <see cref="OnCommandBoundary"/> value. Safe to call from any thread
-    /// (the lock serializes against OnTrade/OnCommandBoundary on the
-    /// dispatch thread). If the fsync throws the watermark is NOT advanced
-    /// — callers must treat that as "audit not durable; defer truncation".
-    /// Throws when the writer is in write-fault state so the WAL truncation
-    /// gate stays closed.</summary>
-    /// <summary>Flushes OS buffers, forces <c>fsync</c> on both files, and
-    /// advances <see cref="DurableThroughCommandSeq"/> to the most recent
-    /// <see cref="OnCommandBoundary"/> value. Safe to call from any thread
-    /// (the lock serializes against OnTrade/OnCommandBoundary on the
-    /// dispatch thread). If the fsync throws the watermark is NOT advanced
-    /// — callers must treat that as "audit not durable; defer truncation".
-    /// Throws when the writer is in write-fault state so the WAL truncation
-    /// gate stays closed.
-    ///
-    /// <para>Issue #349: the slow <c>fsync</c> syscalls run OUTSIDE the
-    /// state lock against pinned <see cref="SafeFileHandle"/> refs (via
-    /// <see cref="RandomAccess.FlushToDisk(SafeFileHandle)"/>). The state
-    /// lock is held only for: bail-on-fault check, FlushCurrentBlock,
-    /// user-space buffer flush, snapshot pending, AddRef the handles —
-    /// all O(1) memcpy/syscall work. The dispatch thread can keep
-    /// OnTrade-ing during the storage fsync without being stalled.
-    /// Handle lifetime is anchored by <see cref="SafeHandle.DangerousAddRef"/>
-    /// so a concurrent rotation/dispose can't pull the fd from under us.</para></summary>
-    public void Checkpoint()
+    /// <summary>Dispatch-thread prepare half of an audit checkpoint. It
+    /// snapshots the pending boundary, flushes user-space buffers, and pins
+    /// any open file handles. The returned operation owns the slow durable
+    /// flush and watermark promotion.</summary>
+    public IAuditCheckpointOperation BeginCheckpointOnDispatchThread()
     {
-        long pending;
-        SafeFileHandle? streamHandle = null;
-        SafeFileHandle? indexHandle = null;
+        _writerGuard.AssertOwnedByCurrentThread();
+        if (Volatile.Read(ref _writeFault) != 0)
+        {
+            throw new IOException(
+                "audit log writer in write-fault state — refusing to advance durability watermark; restart the host after investigating the prior OnTrade failure");
+        }
+
+        long pending = _pendingCommandSeq;
+        FlushCurrentBlock();
+        _stream?.Flush(flushToDisk: false);
+        _indexStream?.Flush(flushToDisk: false);
+
+        SafeFileHandle? streamHandle = _streamHandle;
+        SafeFileHandle? indexHandle = _indexStreamHandle;
         bool streamRef = false;
         bool indexRef = false;
-        lock (_stateLock)
-        {
-            if (_writeFault)
-            {
-                throw new IOException(
-                    "audit log writer in write-fault state — refusing to advance durability watermark; restart the host after investigating the prior OnTrade failure");
-            }
-            // Snapshot the pending boundary BEFORE the fsync — any
-            // concurrent OnCommandBoundary call would have to acquire
-            // this lock so the value is stable while we fsync.
-            pending = _pendingCommandSeq;
-            FlushCurrentBlock();
-            // Push FileStream user-space buffer down to the OS while we
-            // hold the lock; the slow disk fsync happens below outside
-            // the lock against the SafeFileHandle directly.
-            _stream?.Flush(flushToDisk: false);
-            _indexStream?.Flush(flushToDisk: false);
-            streamHandle = _streamHandle;
-            indexHandle = _indexStreamHandle;
-            // Anchor the handles for the duration of the fsync so a
-            // concurrent OnTrade-triggered RotateTo (or Dispose) can't
-            // close the underlying fd while we're flushing it.
-            if (streamHandle is not null) streamHandle.DangerousAddRef(ref streamRef);
-            if (indexHandle is not null) indexHandle.DangerousAddRef(ref indexRef);
-        }
         try
         {
-            if (streamRef) RandomAccess.FlushToDisk(streamHandle!);
-            if (indexRef) RandomAccess.FlushToDisk(indexHandle!);
-            // Issue #329 PR-5: persist the watermark sidecar so a post-crash
-            // boot can recover it and gate replay-mode OnTrade emissions.
-            // Order matters: sidecar update happens AFTER the .log/.idx
-            // fsyncs so the sidecar can never claim durability the underlying
-            // files don't already have. If the sidecar write itself throws
-            // we propagate without advancing _durableCommandSeq so the gate
-            // stays closed and the next Checkpoint retries.
-            WriteWatermarkSidecar(pending);
+            if (streamHandle is not null) streamHandle.DangerousAddRef(ref streamRef);
+            if (indexHandle is not null) indexHandle.DangerousAddRef(ref indexRef);
+            return new CheckpointOperation(this, pending, streamHandle, indexHandle, streamRef, indexRef);
         }
-        finally
+        catch
         {
             if (streamRef) streamHandle!.DangerousRelease();
             if (indexRef) indexHandle!.DangerousRelease();
+            throw;
         }
-        // Advance only on success; if any Flush/sidecar threw we
-        // propagated above without touching _durableCommandSeq so the
-        // WAL truncation gate stays closed. Re-check _writeFault — a
-        // concurrent OnTrade may have failed during the unlocked fsync
-        // window; if so do not promote the watermark.
-        lock (_stateLock)
-        {
-            if (_writeFault) return;
-            Volatile.Write(ref _durableCommandSeq, pending);
-        }
+    }
+
+    /// <summary>Flushes OS buffers, forces <c>fsync</c> on both files, and
+    /// advances <see cref="DurableThroughCommandSeq"/> to the most recent
+    /// <see cref="OnCommandBoundary"/> value. Must be entered from the
+    /// dispatch thread; async snapshot mode calls
+    /// <see cref="BeginCheckpointOnDispatchThread"/> on the dispatcher and
+    /// runs the returned operation on the snapshot writer thread.</summary>
+    public void Checkpoint()
+    {
+        using var checkpoint = BeginCheckpointOnDispatchThread();
+        checkpoint.FlushToDiskAndCommit();
     }
 
     /// <summary>Highest commandSeq whose OnTrade records are guaranteed
@@ -390,12 +343,68 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// <summary>True once an OnTrade write has thrown; the writer is
     /// permanently broken and the watermark will not advance. Exposed
     /// for regression tests of the issue #329 PR-4 write-fault contract.</summary>
-    internal bool WriteFault => _writeFault;
+    internal bool WriteFault => Volatile.Read(ref _writeFault) != 0;
 
     /// <summary>Test-only hook to force the writer into write-fault state
     /// without engineering a real I/O failure. Exercises the watermark
     /// poisoning contract.</summary>
-    internal void ForceWriteFaultForTests() { lock (_stateLock) { _writeFault = true; } }
+    internal void ForceWriteFaultForTests()
+    {
+        _writerGuard.AssertOwnedByCurrentThread();
+        Volatile.Write(ref _writeFault, 1);
+    }
+
+    private sealed class CheckpointOperation : IAuditCheckpointOperation
+    {
+        private readonly FileAuditLogWriter _owner;
+        private readonly long _pending;
+        private readonly SafeFileHandle? _streamHandle;
+        private readonly SafeFileHandle? _indexHandle;
+        private readonly bool _streamRef;
+        private readonly bool _indexRef;
+        private int _disposed;
+
+        public CheckpointOperation(
+            FileAuditLogWriter owner,
+            long pending,
+            SafeFileHandle? streamHandle,
+            SafeFileHandle? indexHandle,
+            bool streamRef,
+            bool indexRef)
+        {
+            _owner = owner;
+            _pending = pending;
+            _streamHandle = streamHandle;
+            _indexHandle = indexHandle;
+            _streamRef = streamRef;
+            _indexRef = indexRef;
+        }
+
+        public void FlushToDiskAndCommit()
+        {
+            try
+            {
+                if (_streamRef) RandomAccess.FlushToDisk(_streamHandle!);
+                if (_indexRef) RandomAccess.FlushToDisk(_indexHandle!);
+                // Issue #329 PR-5: persist the watermark sidecar after the
+                // .log/.idx fsyncs, never before.
+                _owner.WriteWatermarkSidecar(_pending);
+                if (Volatile.Read(ref _owner._writeFault) == 0)
+                    Volatile.Write(ref _owner._durableCommandSeq, _pending);
+            }
+            finally
+            {
+                Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            if (_streamRef) _streamHandle!.DangerousRelease();
+            if (_indexRef) _indexHandle!.DangerousRelease();
+        }
+    }
 
     private void TrackFirm(uint firmId)
     {
@@ -455,8 +464,8 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         }
         fs.Seek(0, SeekOrigin.End);
         _stream = fs;
-        // Cache the underlying SafeFileHandle so Checkpoint can call
-        // RandomAccess.FlushToDisk outside the state lock (issue #349).
+        // Cache the underlying SafeFileHandle so checkpoint operations can
+        // call RandomAccess.FlushToDisk off the dispatch thread (issue #349).
         // The handle is owned by the FileStream; Dispose releases it.
         _streamHandle = fs.SafeFileHandle;
         _currentDate = newDate;
@@ -657,10 +666,9 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
     /// (.log, .idx) pairs deleted; partial pairs (an orphan .log or
     /// .idx) are still counted toward the deletion total per file.</para>
     ///
-    /// <para>Safe to call from any thread: the method acquires the same
-    /// <c>_stateLock</c> as <see cref="Checkpoint"/> / <see cref="Dispose"/>
-    /// so it never races the active stream. The active day is identified
-    /// by <c>_currentDate</c> under the lock to avoid a TOCTOU window.</para>
+    /// <para>Best-effort operator maintenance hook. It does not mutate the
+    /// active stream; it snapshots the currently-open day and never prunes
+    /// that day.</para>
     /// </summary>
     public int PruneOldDays(DateOnly todayUtc, int retentionDays)
     {
@@ -670,32 +678,30 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
         if (!Directory.Exists(channelDir)) return 0;
         var cutoff = todayUtc.AddDays(-retentionDays);
         int deleted = 0;
-        lock (_stateLock)
+        DateOnly? activeDate = _stream is null ? null : _currentDate;
+        foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.*"))
         {
-            foreach (var path in Directory.EnumerateFiles(channelDir, "fills-*.*"))
+            var name = Path.GetFileName(path);
+            if (!TryParseFillsDate(name, out var date, out var ext)) continue;
+            if (ext != ".log" && ext != ".idx") continue;
+            // Never delete the currently-open day even if it falls
+            // before the cutoff (e.g. a clock skew or aggressive
+            // retentionDays=1 during development).
+            if (activeDate is { } current && date == current) continue;
+            if (date >= cutoff) continue;
+            try
             {
-                var name = Path.GetFileName(path);
-                if (!TryParseFillsDate(name, out var date, out var ext)) continue;
-                if (ext != ".log" && ext != ".idx") continue;
-                // Never delete the currently-open day even if it falls
-                // before the cutoff (e.g. a clock skew or aggressive
-                // retentionDays=1 during development).
-                if (_stream is not null && date == _currentDate) continue;
-                if (date >= cutoff) continue;
-                try
-                {
-                    File.Delete(path);
-                    deleted++;
-                }
-                catch (IOException)
-                {
-                    // Best-effort: file in use or transient FS error;
-                    // the next prune pass will retry.
-                }
-                catch (UnauthorizedAccessException)
-                {
-                    // Permissions issue — leave for the operator.
-                }
+                File.Delete(path);
+                deleted++;
+            }
+            catch (IOException)
+            {
+                // Best-effort: file in use or transient FS error;
+                // the next prune pass will retry.
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // Permissions issue — leave for the operator.
             }
         }
         return deleted;
@@ -720,23 +726,20 @@ public sealed class FileAuditLogWriter : IPostTradeSink, IDisposable
 
     public void Dispose()
     {
-        lock (_stateLock)
+        if (_stream is not null)
         {
-            if (_stream is not null)
-            {
-                FlushCurrentBlock();
-                _stream.Flush(flushToDisk: true);
-                _stream.Dispose();
-                _stream = null;
-                _streamHandle = null;
-            }
-            if (_indexStream is not null)
-            {
-                _indexStream.Flush(flushToDisk: true);
-                _indexStream.Dispose();
-                _indexStream = null;
-                _indexStreamHandle = null;
-            }
+            FlushCurrentBlock();
+            _stream.Flush(flushToDisk: true);
+            _stream.Dispose();
+            _stream = null;
+            _streamHandle = null;
+        }
+        if (_indexStream is not null)
+        {
+            _indexStream.Flush(flushToDisk: true);
+            _indexStream.Dispose();
+            _indexStream = null;
+            _indexStreamHandle = null;
         }
     }
 }

--- a/src/B3.Exchange.PostTrade/IPostTradeSink.cs
+++ b/src/B3.Exchange.PostTrade/IPostTradeSink.cs
@@ -3,6 +3,28 @@ using B3.Exchange.Matching;
 namespace B3.Exchange.PostTrade;
 
 /// <summary>
+/// Prepared audit checkpoint whose dispatch-thread portion has already
+/// snapshotted writer state. The slow durable flush may be executed by a
+/// background writer thread; <see cref="FlushToDiskAndCommit"/> advances the
+/// durability watermark only after every durable write succeeds.
+/// </summary>
+public interface IAuditCheckpointOperation : IDisposable
+{
+    void FlushToDiskAndCommit();
+}
+
+/// <summary>
+/// Optional split-checkpoint contract for ADR 0009 single-writer audit sinks.
+/// The dispatcher calls <see cref="BeginCheckpointOnDispatchThread"/> on the
+/// dispatch thread; the returned operation is then flushed off-thread by the
+/// snapshot writer in async snapshot mode.
+/// </summary>
+public interface IDispatchThreadCheckpointSink : IPostTradeSink
+{
+    IAuditCheckpointOperation BeginCheckpointOnDispatchThread();
+}
+
+/// <summary>
 /// Self-contained, per-trade audit record. One <see cref="PostTradeRecord"/>
 /// is emitted on the dispatch thread for every <see cref="TradeEvent"/> the
 /// engine produces, immediately after the matching ER_Trade / UMDF
@@ -74,12 +96,9 @@ public interface IPostTradeSink
     /// On exception the watermark is NOT advanced — callers (the WAL
     /// truncation gate) must treat that as "audit not durable; defer".
     ///
-    /// <para>Implementations MUST be safe to call from a thread other than
-    /// the dispatch thread (the async snapshot writer invokes it from its
-    /// dedicated writer thread). The expected concurrency cost is a brief
-    /// lock acquisition; the fsync itself runs under the lock so the
-    /// dispatch hot path stalls only for the fsync duration when both
-    /// happen to overlap.</para>
+    /// <para>Implementations that also implement
+    /// <see cref="IDispatchThreadCheckpointSink"/> may split this into a
+    /// dispatch-thread prepare step and an off-thread durable flush.</para>
     /// </summary>
     void Checkpoint();
 

--- a/tests/B3.Exchange.Persistence.Tests/B3.Exchange.Persistence.Tests.csproj
+++ b/tests/B3.Exchange.Persistence.Tests/B3.Exchange.Persistence.Tests.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\src\B3.Exchange.Instruments\B3.Exchange.Instruments.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Matching\B3.Exchange.Matching.csproj" />
     <ProjectReference Include="..\..\src\B3.Exchange.Persistence\B3.Exchange.Persistence.csproj" />
+    <ProjectReference Include="..\..\src\B3.Exchange.PostTrade\B3.Exchange.PostTrade.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs
@@ -92,6 +92,55 @@ public class ChannelDispatcherAuditWatermarkTests
             => DurableOverride >= 0 ? DurableOverride : _pending;
     }
 
+    private sealed class ThreadRecordingPostTradeSink : IDispatchThreadCheckpointSink
+    {
+        private long _pending;
+        private long _durable;
+        public int PrepareThreadId;
+        public int FlushThreadId;
+        public int PrepareCount;
+        public int FlushCount;
+
+        public void OnTrade(in PostTradeRecord record) { }
+        public void OnCommandBoundary(long commandSeq)
+        {
+            if (commandSeq > _pending) _pending = commandSeq;
+        }
+        public void Checkpoint()
+        {
+            using var op = BeginCheckpointOnDispatchThread();
+            op.FlushToDiskAndCommit();
+        }
+        public void OnBust(in BustRecord record, DateOnly tradeDate) { }
+        public void OnRejectAttempt(in RejectAttemptRecord record) { }
+        public long DurableThroughCommandSeq => Volatile.Read(ref _durable);
+
+        public IAuditCheckpointOperation BeginCheckpointOnDispatchThread()
+        {
+            PrepareThreadId = Environment.CurrentManagedThreadId;
+            PrepareCount++;
+            return new Operation(this, _pending);
+        }
+
+        private sealed class Operation : IAuditCheckpointOperation
+        {
+            private readonly ThreadRecordingPostTradeSink _owner;
+            private readonly long _pending;
+            public Operation(ThreadRecordingPostTradeSink owner, long pending)
+            {
+                _owner = owner;
+                _pending = pending;
+            }
+            public void FlushToDiskAndCommit()
+            {
+                _owner.FlushThreadId = Environment.CurrentManagedThreadId;
+                _owner.FlushCount++;
+                Volatile.Write(ref _owner._durable, _pending);
+            }
+            public void Dispose() { }
+        }
+    }
+
     private sealed class TempDir : IDisposable
     {
         public string Path { get; }
@@ -253,6 +302,44 @@ public class ChannelDispatcherAuditWatermarkTests
             $"expected audit Checkpoint to run, got CheckpointCount={sink.CheckpointCount}");
         Assert.Equal(0, metrics.WalTruncations);
         Assert.Equal(0, metrics.AuditWalTruncateDeferred);
+    }
+
+    [Fact]
+    public async Task AsyncSnapshot_AuditCheckpoint_PreparesOnDispatcher_AndFlushesOnWriterThread()
+    {
+        var persister = new InMemoryPersister();
+        var sink = new ThreadRecordingPostTradeSink();
+        var disp = new ChannelDispatcher(
+            channelNumber: 84,
+            engineFactory: s => new MatchingEngine(new[] { Petr4 }, s, NullLogger<MatchingEngine>.Instance),
+            options: new ChannelDispatcherOptions
+            {
+                PacketSink = new NoOpPacketSink(),
+                Outbound = new NoOpOutbound(),
+                Logger = NullLogger<ChannelDispatcher>.Instance,
+                Metrics = new ChannelMetrics(84),
+                Persister = persister,
+                SnapshotThrottle = null,
+                UseAsyncSnapshotWriter = true,
+                Wal = null,
+                PostTradeSink = sink,
+            });
+
+        disp.Start();
+        Assert.True(EnqueueOrder(disp, "CL-ASYNC", 0xA1, 1UL));
+
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while ((Volatile.Read(ref sink.FlushCount) == 0 || persister.SaveCount == 0) && DateTime.UtcNow < deadline)
+            Thread.Sleep(10);
+
+        Assert.True(sink.PrepareCount >= 1);
+        Assert.True(sink.FlushCount >= 1);
+        Assert.NotEqual(0, sink.PrepareThreadId);
+        Assert.NotEqual(0, sink.FlushThreadId);
+        Assert.NotEqual(sink.PrepareThreadId, sink.FlushThreadId);
+        Assert.True(sink.DurableThroughCommandSeq >= 1);
+
+        await disp.DisposeAsync();
     }
 
 

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -3,6 +3,7 @@ using B3.Exchange.Core;
 using B3.Exchange.Instruments;
 using B3.Exchange.Matching;
 using B3.Exchange.Persistence;
+using B3.Exchange.PostTrade;
 using Microsoft.Extensions.Logging.Abstractions;
 using RejectEvent = B3.Exchange.Matching.RejectEvent;
 using Side = B3.Exchange.Matching.Side;
@@ -77,7 +78,9 @@ public class ChannelDispatcherPersistenceTests
         out NoOpOutbound outbound,
         ChannelMetrics? metrics = null,
         SnapshotThrottlePolicy? throttle = null,
-        bool useAsyncSnapshotWriter = false)
+        bool useAsyncSnapshotWriter = false,
+        IChannelWriteAheadLog? wal = null,
+        B3.Exchange.PostTrade.IPostTradeSink? postTradeSink = null)
     {
         outbound = new NoOpOutbound();
         var localOutbound = outbound;
@@ -94,6 +97,8 @@ public class ChannelDispatcherPersistenceTests
                 Persister = persister,
                 SnapshotThrottle = throttle,
                 UseAsyncSnapshotWriter = useAsyncSnapshotWriter,
+                Wal = wal,
+                PostTradeSink = postTradeSink,
             });
     }
 
@@ -791,6 +796,77 @@ public class ChannelDispatcherPersistenceTests
         await disp.DisposeAsync();
         Assert.True(persister.SaveCount >= 1);
         Assert.NotNull(persister.TryLoad(84));
+    }
+
+
+    [Fact]
+    public async Task Issue445_DisposeAsync_DrainsAsyncSnapshotAuditCheckpointBeforeClosingInbox()
+    {
+        var root = Path.Combine(AppContext.BaseDirectory, "test-artifacts",
+            $"issue445-{Guid.NewGuid():N}");
+        var snapshotDir = Path.Combine(root, "snapshots");
+        var walDir = Path.Combine(root, "wal");
+        var auditDir = Path.Combine(root, "audit");
+        Directory.CreateDirectory(root);
+        try
+        {
+            var persister = new FileChannelStatePersister(snapshotDir,
+                NullLogger<FileChannelStatePersister>.Instance);
+            long snapshotLastApplied;
+            long durableBeforeRestart;
+            using (var audit = new FileAuditLogWriter(auditDir, channelNumber: 84))
+            {
+                var wal = new FileChannelWriteAheadLog(walDir, channelNumber: 84,
+                    NullLogger<FileChannelWriteAheadLog>.Instance);
+                var disp = BuildDispatcher(persister, out _,
+                    useAsyncSnapshotWriter: true, wal: wal, postTradeSink: audit);
+                var session = new SessionId("80805");
+                disp.Start();
+
+                Assert.True(disp.EnqueueNewOrder(
+                    new NewOrderCommand("CL-SELL", Sec, Side.Sell, OrderType.Limit,
+                        TimeInForce.Day, Px(10.00m), 100, 100, 9000UL),
+                    session, enteringFirm: 801, clOrdIdValue: 0xE44501));
+                Assert.True(disp.EnqueueNewOrder(
+                    new NewOrderCommand("CL-BUY", Sec, Side.Buy, OrderType.Limit,
+                        TimeInForce.Day, Px(10.00m), 100, 100, 9001UL),
+                    session, enteringFirm: 802, clOrdIdValue: 0xE44502));
+
+                await disp.DisposeAsync();
+
+                var snapshot = persister.TryLoad(84);
+                Assert.NotNull(snapshot);
+                snapshotLastApplied = snapshot!.LastAppliedSeq;
+                durableBeforeRestart = audit.DurableThroughCommandSeq;
+                Assert.True(snapshotLastApplied >= 2);
+                Assert.True(durableBeforeRestart >= snapshotLastApplied,
+                    $"audit durable watermark {durableBeforeRestart} must cover snapshot {snapshotLastApplied} before DisposeAsync returns");
+                Assert.Equal(1, audit.RecordsWritten);
+            }
+
+            using (var recoveredAudit = new FileAuditLogWriter(auditDir, channelNumber: 84))
+            {
+                Assert.Equal(durableBeforeRestart, recoveredAudit.DurableThroughCommandSeq);
+                Assert.True(recoveredAudit.DurableThroughCommandSeq >= snapshotLastApplied);
+
+                var restartWal = new FileChannelWriteAheadLog(walDir, channelNumber: 84,
+                    NullLogger<FileChannelWriteAheadLog>.Instance);
+                var restarted = BuildDispatcher(persister, out _,
+                    useAsyncSnapshotWriter: true, wal: restartWal, postTradeSink: recoveredAudit);
+                restarted.Start();
+                await restarted.DisposeAsync();
+            }
+
+            var auditFiles = Directory.GetFiles(Path.Combine(auditDir, "84"), "fills-*.log");
+            Assert.Single(auditFiles);
+            Assert.Single(AuditLogReader.ReadAll(auditFiles[0]));
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
@@ -306,8 +306,14 @@ public class ChannelDispatcherWalTests
 
         // Async writer is on a background thread; wait until it has
         // drained and truncated instead of sleeping a fixed interval.
+        // Issue #396: onSaved enqueues an AuditCheckpoint work item before
+        // truncation, so TestProbe-driven tests must pump the inbox.
         Assert.True(await WaitForAsync(
-            () => persister.SaveCount >= 1 && metrics.WalTruncations >= 1,
+            () =>
+            {
+                probe.DrainInbound();
+                return persister.SaveCount >= 1 && metrics.WalTruncations >= 1;
+            },
             TimeSpan.FromSeconds(5)), "async snapshot writer did not save and truncate before timeout");
 
         Assert.True(persister.SaveCount >= 1);

--- a/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs
@@ -227,9 +227,16 @@ public class WalAsyncSnapshotTruncateRaceTests
         // release a second time), giving us a stable window to assert
         // the WAL state after the first prefix truncate.
         blocking.ReleaseOne();
+        // Issue #396: async onSaved now marshals audit-checkpoint prepare
+        // through the dispatch inbox before truncating. This test drives the
+        // dispatcher via TestProbe, so pump that work item while waiting.
         // Pre-fix (full Truncate): WAL ends up empty → seq=2 is lost.
         // Post-fix (TruncateThrough): seq=2 survives.
-        Assert.True(await WaitForAsync(() => metrics.WalTruncations >= 1,
+        Assert.True(await WaitForAsync(() =>
+        {
+            driver.DrainInbound();
+            return metrics.WalTruncations >= 1;
+        },
             TimeSpan.FromSeconds(2)), "async snapshot writer did not truncate WAL before timeout");
         var kept = wal.ReadAll();
         Assert.True(kept.Count == 1 && kept[0].Seq == 2,
@@ -237,6 +244,7 @@ public class WalAsyncSnapshotTruncateRaceTests
 
         // Drain the writer cleanly before disposing.
         blocking.ReleaseOne();
+        driver.DrainInbound();
         await disp.DisposeAsync();
         wal.Dispose();
     }

--- a/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs
+++ b/tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs
@@ -120,35 +120,24 @@ public class FileAuditLogWriterWatermarkTests : IDisposable
     }
 
     [Fact]
-    public void Checkpoint_FromAnotherThread_IsSafeAgainstOnTrade()
+    public void CheckpointOperation_CanFlushOffOwnerThread()
     {
-        // The async-snapshot-writer path calls Checkpoint from its writer
-        // thread while OnTrade keeps running on the dispatch thread.
-        // The internal lock must keep both honest. We don't assert
-        // performance here — just that no exception or corruption arises
-        // and the watermark advances at least to the last observed boundary.
+        // Issue #396: the dispatch thread prepares the checkpoint under the
+        // SingleWriterGuard, then the background snapshot writer performs the
+        // slow fsync/watermark sidecar write off the owner thread.
         using var w = new FileAuditLogWriter(_root, channelNumber: 1);
-        var stop = false;
-        var producer = new System.Threading.Thread(() =>
+        for (uint i = 1; i <= 20; i++)
         {
-            for (uint i = 1; i <= 200 && !stop; i++)
-            {
-                w.OnTrade(Make(i, Day0Nanos));
-                w.OnCommandBoundary(i);
-                System.Threading.Thread.Yield();
-            }
-        });
-        producer.Start();
-        for (int i = 0; i < 20; i++)
-        {
-            w.Checkpoint();
-            System.Threading.Thread.Sleep(1);
+            w.OnTrade(Make(i, Day0Nanos));
+            w.OnCommandBoundary(i);
         }
-        stop = true;
-        producer.Join(TimeSpan.FromSeconds(5));
-        w.Checkpoint();
-        Assert.True(w.DurableThroughCommandSeq > 0);
-        Assert.True(w.DurableThroughCommandSeq <= 200);
+
+        using var checkpoint = w.BeginCheckpointOnDispatchThread();
+        var flushThread = new System.Threading.Thread(checkpoint.FlushToDiskAndCommit);
+        flushThread.Start();
+        Assert.True(flushThread.Join(TimeSpan.FromSeconds(5)));
+
+        Assert.Equal(20, w.DurableThroughCommandSeq);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #396

## Refactor plan as implemented

```
BackgroundSnapshotWriter thread
  onSaved(snapshot seq=N)
    └─ enqueue WorkKind.AuditCheckpoint(N, TCS) to ChannelDispatcher inbox

ChannelDispatcher dispatch thread
  ProcessAuditCheckpoint
    └─ FileAuditLogWriter.BeginCheckpointOnDispatchThread()
         - SingleWriterGuard assert
         - snapshot pending command seq
         - flush user-space buffers
         - DangerousAddRef current .log/.idx handles
         - complete TCS with checkpoint operation

BackgroundSnapshotWriter thread
  await prepared operation
    └─ FlushToDiskAndCommit()
         - RandomAccess.FlushToDisk(.log/.idx)
         - write/fsync watermark sidecar
         - Volatile.Write DurableThroughCommandSeq
    └─ if DurableThroughCommandSeq >= snapshot seq: WAL TruncateThrough(N)
```

## fsync stays off dispatch thread

- Dispatch thread only prepares/pins handles in `FileAuditLogWriter.BeginCheckpointOnDispatchThread` (`src/B3.Exchange.PostTrade/FileAuditLogWriter.cs:294-316`).
- The slow fsync calls are in `CheckpointOperation.FlushToDiskAndCommit` (`src/B3.Exchange.PostTrade/FileAuditLogWriter.cs:383-393`).
- Async snapshot `onSaved` runs `checkpoint.FlushToDiskAndCommit()` on the snapshot writer thread after the dispatch thread returns the prepared operation (`src/B3.Exchange.Core/ChannelDispatcher.Wal.cs:188-198`, `274-307`).

## Files touched

- `src/B3.Exchange.PostTrade/FileAuditLogWriter.cs` — replace `_stateLock` with `SingleWriterGuard`, split checkpoint prepare from off-thread fsync/commit, keep `Volatile` durable watermark.
- `src/B3.Exchange.PostTrade/IPostTradeSink.cs` — add split checkpoint operation interfaces.
- `src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs` — add `WorkKind.AuditCheckpoint` and request payload.
- `src/B3.Exchange.Core/ChannelDispatcher.Loop.cs` — dispatch audit checkpoint work before WAL-halt filtering.
- `src/B3.Exchange.Core/ChannelDispatcher.Wal.cs` — enqueue/execute async audit checkpoint handshake before WAL truncation.
- `src/B3.Exchange.Core/ChannelDispatcher.cs` — wire async snapshot `onSaved` for audit-enabled no-WAL channels too.
- `tests/B3.Exchange.PostTrade.Tests/FileAuditLogWriterWatermarkTests.cs` — cover off-owner checkpoint operation flush.
- `tests/B3.Exchange.Persistence.Tests/ChannelDispatcherAuditWatermarkTests.cs` — verify async checkpoint prepare and flush occur on different threads.
- `tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs` — pump AuditCheckpoint in TestProbe async-writer test.
- `tests/B3.Exchange.Persistence.Tests/WalAsyncSnapshotTruncateRaceTests.cs` — pump AuditCheckpoint in prefix-truncation race test.

## Pre-PR checklist

- [x] `dotnet restore SbeB3Exchange.slnx`
- [x] `dotnet build SbeB3Exchange.slnx --no-restore -c Release`
- [x] `dotnet test SbeB3Exchange.slnx --no-build -c Release`
- [x] `dotnet build SbeB3Exchange.slnx --no-restore -c Debug`
- [x] `dotnet test SbeB3Exchange.slnx --no-build -c Debug`
- [x] audit-related Debug test loop 5x (`FileAuditLogWriter`/`AuditWatermark`/async checkpoint race filters)
- [x] `dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn`

Note: local full-solution test runs used `--tl:off` to avoid terminal logger stalls in this non-interactive shell; commands otherwise match CI configurations.