### PR TITLE
fix(gateway): SimpleNewOrder decodes ordTagID/investorID (#449)

### DIFF
--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleNewOrder.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleNewOrder.cs
@@ -10,6 +10,7 @@ internal static partial class InboundMessageDecoder
     /// </summary>
     private static class SimpleNewOrderOffsets
     {
+        public const int OrdTagID = 18;       // byte (0 == null)
         public const int ClOrdID = 20;        // ulong
         public const int SecurityID = 48;     // ulong
         public const int Side = 56;           // byte (overlaps SecurityExchange constant)
@@ -17,6 +18,7 @@ internal static partial class InboundMessageDecoder
         public const int TimeInForce = 58;    // byte
         public const int OrderQty = 60;       // ulong
         public const int PriceMantissa = 68;  // long (PriceOptional, MinValue == NULL)
+        public const int InvestorID = 76;     // Prefix(2) + Document(4), all-zero == null
     }
 
     public static bool TryDecodeNewOrder(ReadOnlySpan<byte> body, uint enteringFirm, ulong enteredAtNanos,
@@ -34,6 +36,10 @@ internal static partial class InboundMessageDecoder
         byte tifByte = body[SimpleNewOrderOffsets.TimeInForce];
         long qty = (long)MemoryMarshal.Read<ulong>(body.Slice(SimpleNewOrderOffsets.OrderQty, 8));
         long priceMantissa = MemoryMarshal.Read<long>(body.Slice(SimpleNewOrderOffsets.PriceMantissa, 8));
+        byte ordTagId = body[SimpleNewOrderOffsets.OrdTagID];
+
+        var investorSpan = body.Slice(SimpleNewOrderOffsets.InvestorID, 6);
+        InvestorId? investorId = IsAllZero(investorSpan) ? null : DecodeInvestorId(investorSpan);
 
         if (!TryMapSide(sideByte, out var side)) { error = $"invalid Side={sideByte}"; return false; }
         if (!TryMapOrdType(ordTypeByte, out var ordType)) { error = $"invalid OrdType={ordTypeByte}"; return false; }
@@ -59,6 +65,8 @@ internal static partial class InboundMessageDecoder
             EnteringFirm: enteringFirm,
             EnteredAtNanos: enteredAtNanos)
         {
+            OrdTagId = ordTagId,
+            InvestorId = investorId,
             PreTradeRejectReason = preTradeRejectReason,
         };
         return true;

--- a/tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs
@@ -16,10 +16,14 @@ public class InboundMessageDecoderTests
         ulong clOrdId = 12345UL,
         long secId = 99887766L,
         long qty = 100L,
-        long price = 12_3450L)
+        long price = 12_3450L,
+        byte ordTagId = 0,
+        ushort investorPrefix = 0,
+        uint investorDocument = 0)
     {
         var body = new byte[82];
         Span<byte> s = body;
+        s[18] = ordTagId;
         MemoryMarshal.Write(s.Slice(20, 8), in clOrdId);
         MemoryMarshal.Write(s.Slice(48, 8), in secId);
         s[56] = (byte)'1';
@@ -27,6 +31,8 @@ public class InboundMessageDecoderTests
         s[58] = (byte)'0';
         MemoryMarshal.Write(s.Slice(60, 8), in qty);
         MemoryMarshal.Write(s.Slice(68, 8), in price);
+        MemoryMarshal.Write(s.Slice(76, 2), in investorPrefix);
+        MemoryMarshal.Write(s.Slice(78, 4), in investorDocument);
         return body;
     }
 
@@ -71,6 +77,38 @@ public class InboundMessageDecoderTests
         Assert.Equal(qty, cmd.Quantity);
         Assert.Equal(price, cmd.PriceMantissa);
         Assert.Equal(7u, cmd.EnteringFirm);
+        Assert.Equal((byte)0, cmd.OrdTagId);
+        Assert.Null(cmd.InvestorId);
+    }
+
+    [Fact]
+    public void SimpleNewOrder_PopulatesOrdTagIdAndInvestorId()
+    {
+        // #449 — SimpleNewOrder must propagate ordTagID (id 35505) and
+        // investorID (id 35508) so mass-cancel-on-behalf filters work.
+        var body = BuildSimpleNewOrder(ordTagId: 99, investorPrefix: 7, investorDocument: 123456789);
+
+        var ok = InboundMessageDecoder.TryDecodeNewOrder(body, enteringFirm: 7, enteredAtNanos: 1_000_000UL,
+            out var cmd, out _, out var err);
+
+        Assert.True(ok, err);
+        Assert.Equal((byte)99, cmd.OrdTagId);
+        Assert.NotNull(cmd.InvestorId);
+        Assert.Equal((ushort)7, cmd.InvestorId!.Value.Prefix);
+        Assert.Equal(123456789u, cmd.InvestorId!.Value.Document);
+    }
+
+    [Fact]
+    public void SimpleNewOrder_AllZeroInvestorIdDecodesAsNull()
+    {
+        var body = BuildSimpleNewOrder(ordTagId: 0, investorPrefix: 0, investorDocument: 0);
+
+        var ok = InboundMessageDecoder.TryDecodeNewOrder(body, enteringFirm: 7, enteredAtNanos: 1_000_000UL,
+            out var cmd, out _, out var err);
+
+        Assert.True(ok, err);
+        Assert.Equal((byte)0, cmd.OrdTagId);
+        Assert.Null(cmd.InvestorId);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #449.

`InboundMessageDecoder.SimpleNewOrder` was not reading two fields declared on `SimpleNewOrder` (template 100):

| Field | id | Offset | Wire |
|---|---|---|---|
| `ordTagID` | 35505 | 18 | byte (0 == null) |
| `investorID` | 35508 | 76 | Prefix(2) + Document(4), all-zero == null |

Offsets verified against the generated codec `SimpleNewOrderV2.cs` (`[FieldOffset(18)]` / `[FieldOffset(76)]`, `BLOCK_LENGTH = 82`). The result was that resting orders entered via the simple path silently missed `OrdTagID` / `InvestorID` mass-cancel filters in `MatchingEngine.MatchesMassCancelFilter` — GAP-19 residual from PR #448 review.

## Changes

- `src/B3.Exchange.Gateway/InboundMessageDecoder.SimpleNewOrder.cs` — adds the two offsets to `SimpleNewOrderOffsets`, reads the bytes, and propagates `OrdTagId` + `InvestorId` on `NewOrderCommand`. Uses the shared `DecodeInvestorId` / `IsAllZero` helpers already used by `NewOrderSingle` (102) and `OrderMassActionRequest` (701) — same on-wire layout, same null sentinel rule.
- `tests/B3.Exchange.Gateway.Tests/InboundMessageDecoderTests.cs`:
  - Extended `BuildSimpleNewOrder` with optional `ordTagId` / `investorPrefix` / `investorDocument` parameters (defaults preserve existing call sites).
  - Existing `DecodesSimpleNewOrderLimitDay` test asserts new fields default to `0` / `null`.
  - New `SimpleNewOrder_PopulatesOrdTagIdAndInvestorId` round-trips non-zero values.
  - New `SimpleNewOrder_AllZeroInvestorIdDecodesAsNull` exercises the SBE null sentinel.

## Out of scope

- `SimpleModifyOrder` (template 101) declares the same two fields and has the same omission. Filing as separate issue post-merge — `SimpleModifyOrder` modify-flow is fundamentally different (looks up existing order) so the impact is smaller; keeping the scope tight per AGENTS.md §3.

## Compliance doc

After this lands, the GAP-19 row in `docs/B3-ENTRYPOINT-COMPLIANCE.md` can be flipped from `partial` back to `done` (folded into the next compliance audit, not in this PR — keeps the code change reviewable in isolation).

## Verification

- `dotnet build -c Release` — 0 warnings, 0 errors.
- `dotnet test -c Release` — 531 / 531 in Gateway.Tests; full slnx run all green.
- `dotnet format --verify-no-changes` — clean.

Per AGENTS.md §1, will run gpt-5.5 review before flipping to ready.