### PR TITLE
fix(matching): triggered StopLimit residual preserves OrdTagID/InvestorID (#453)

### DIFF
--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -53,7 +53,7 @@ public sealed record ChannelStateSnapshot(
     EngineStateSnapshot Engine,
     IReadOnlyList<OrderOwnerSnapshot> Owners)
 {
-    public const int CurrentVersion = 3;
+    public const int CurrentVersion = 4;
 
     /// <summary>
     /// Issue #269: monotonic counter of commands the dispatcher has

--- a/src/B3.Exchange.Core/SnapshotMigrations.cs
+++ b/src/B3.Exchange.Core/SnapshotMigrations.cs
@@ -75,6 +75,11 @@ public sealed class SnapshotMigrationSet
         // STJ's missing-property tolerance leaves Halts at the default
         // (null) on deserialise.
         set.Register(2, MigrateV2ToV3);
+        // Issue #453: v4 only adds optional OrdTagId / InvestorId fields
+        // on each RestingStopRecord. v3 trees upgrade by stamping the
+        // version; STJ's missing-property tolerance leaves the new
+        // fields at their record defaults (0 / null) on deserialise.
+        set.Register(3, MigrateV3ToV4);
         return set;
     }
 
@@ -89,6 +94,13 @@ public sealed class SnapshotMigrationSet
     {
         if (previous is JsonObject obj)
             obj["Version"] = 3;
+        return previous;
+    }
+
+    private static JsonNode MigrateV3ToV4(JsonNode previous)
+    {
+        if (previous is JsonObject obj)
+            obj["Version"] = 4;
         return previous;
     }
 

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -85,7 +85,9 @@ public sealed record RestingStopRecord(
     long LimitPriceMantissa,
     long Quantity,
     uint EnteringFirm,
-    ulong EnteredAtNanos)
+    ulong EnteredAtNanos,
+    byte OrdTagId = 0,
+    InvestorId? InvestorId = null)
 {
     public byte[] Memo { get; init; } = [];
 }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -197,7 +197,9 @@ public sealed class MatchingEngine
                     LimitPriceMantissa: s.LimitPriceMantissa,
                     Quantity: s.Quantity,
                     EnteringFirm: s.EnteringFirm,
-                    EnteredAtNanos: s.EnteredAtNanos)
+                    EnteredAtNanos: s.EnteredAtNanos,
+                    OrdTagId: s.OrdTagId,
+                    InvestorId: s.InvestorId)
                 { Memo = s.Memo });
             }
         }
@@ -295,6 +297,8 @@ public sealed class MatchingEngine
                     EnteredAtNanos = s.EnteredAtNanos,
                     SecurityId = s.SecurityId,
                     Memo = s.Memo,
+                    OrdTagId = s.OrdTagId,
+                    InvestorId = s.InvestorId,
                 };
                 bucket.Add(stop);
                 _stopById.Add(s.OrderId, stop);
@@ -1824,6 +1828,13 @@ public sealed class MatchingEngine
         public ulong EnteredAtNanos { get; init; }
         public long SecurityId { get; init; }
         public byte[] Memo { get; init; } = [];
+
+        // Issue #453: on-behalf-of identifiers must survive both the
+        // park-then-trigger transition (so the triggered residual
+        // remains mass-cancellable by OrdTagID/InvestorID) and a
+        // snapshot+restore round-trip.
+        public byte OrdTagId { get; init; }
+        public InvestorId? InvestorId { get; init; }
     }
 
     private void SubmitStop(NewOrderCommand cmd, InstrumentTradingRules rules)
@@ -1878,6 +1889,8 @@ public sealed class MatchingEngine
             EnteredAtNanos = cmd.EnteredAtNanos,
             SecurityId = cmd.SecurityId,
             Memo = cmd.Memo,
+            OrdTagId = cmd.OrdTagId,
+            InvestorId = cmd.InvestorId,
         };
         _stopsBySymbol[cmd.SecurityId].Add(stop);
         _stopById.Add(oid, stop);
@@ -1972,7 +1985,7 @@ public sealed class MatchingEngine
             Quantity: s.Quantity,
             EnteringFirm: s.EnteringFirm,
             EnteredAtNanos: txnNanos)
-        { Memo = s.Memo };
+        { Memo = s.Memo, OrdTagId = s.OrdTagId, InvestorId = s.InvestorId };
 
         // Triggered StopLoss sees an empty opposite side → no fills,
         // silently dropped. We do NOT emit MarketNoLiquidity reject

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -41,7 +41,10 @@ namespace B3.Exchange.Persistence;
 /// <para><b>Resting stop record:</b> int64 OrderId, len-prefixed UTF-8
 /// ClOrdId, int64 SecurityId, byte Side, byte StopType, byte Tif, int64
 /// StopPxMantissa, int64 LimitPriceMantissa, int64 Quantity, uint32
-/// EnteringFirm, uint64 EnteredAtNanos.</para>
+/// EnteringFirm, uint64 EnteredAtNanos. Issue #453 (codec v4) appends
+/// a trailer: byte OrdTagId, byte InvestorPresence (0=null, 1=present),
+/// and when present uint16 Prefix + uint32 Document. Older versions omit
+/// the trailer and decode with OrdTagId=0 / InvestorId=null.</para>
 ///
 /// <para><b>Owner record:</b> int64 OrderId, len-prefixed UTF-8
 /// SessionValue, uint32 Firm, uint64 ClOrdId, byte Side, int64 SecurityId.</para>
@@ -118,7 +121,7 @@ public static class BinaryChannelStateSnapshotCodec
         else
         {
             w.WriteUVarInt((ulong)stops.Count);
-            foreach (var s in stops) WriteRestingStop(w, s);
+            foreach (var s in stops) WriteRestingStop(w, s, snapshot.Version);
         }
 
         w.WriteUVarInt((ulong)snapshot.Owners.Count);
@@ -245,7 +248,7 @@ public static class BinaryChannelStateSnapshotCodec
         else
         {
             var arr = new RestingStopRecord[stopCount];
-            for (ulong i = 0; i < stopCount; i++) arr[i] = ReadRestingStop(ref r);
+            for (ulong i = 0; i < stopCount; i++) arr[i] = ReadRestingStop(ref r, version);
             stops = arr;
         }
 
@@ -332,7 +335,10 @@ public static class BinaryChannelStateSnapshotCodec
         // Issue #322: v2 → v3 is also a clean migration — v2 files have no
         // halts section, and the decoder above leaves <c>halts</c> null,
         // so re-stamping here is safe.
-        int effectiveVersion = (version == 1 || version == 2) ? ChannelStateSnapshot.CurrentVersion : version;
+        // Issue #453: v3 → v4 is also a clean migration — v3 files have
+        // no per-stop OrdTagId/InvestorId trailer, and ReadRestingStop
+        // defaults them to 0/null for older versions.
+        int effectiveVersion = (version == 1 || version == 2 || version == 3) ? ChannelStateSnapshot.CurrentVersion : version;
         return new ChannelStateSnapshot(effectiveVersion, channelNumber, sequenceNumber, sequenceVersion, engine, owners)
         {
             LastAppliedSeq = lastAppliedSeq,
@@ -369,7 +375,7 @@ public static class BinaryChannelStateSnapshotCodec
             (TimeInForce)tif, maxFloor, hidden);
     }
 
-    private static void WriteRestingStop(BinaryBufferWriter w, RestingStopRecord s)
+    private static void WriteRestingStop(BinaryBufferWriter w, RestingStopRecord s, int version)
     {
         w.WriteInt64(s.OrderId);
         w.WriteString(s.ClOrdId);
@@ -382,9 +388,28 @@ public static class BinaryChannelStateSnapshotCodec
         w.WriteInt64(s.Quantity);
         w.WriteUInt32(s.EnteringFirm);
         w.WriteUInt64(s.EnteredAtNanos);
+        // Issue #453 (codec v4): on-behalf-of identifiers tail so the
+        // triggered residual remains mass-cancellable by OrdTagID /
+        // InvestorID across a snapshot+restore round-trip. Older
+        // versions wrote nothing here; ReadRestingStop defaults to 0/
+        // null when the trailer is absent.
+        if (version >= 4)
+        {
+            w.WriteByte(s.OrdTagId);
+            if (s.InvestorId is { } iid)
+            {
+                w.WriteByte(1);
+                w.WriteUInt16(iid.Prefix);
+                w.WriteUInt32(iid.Document);
+            }
+            else
+            {
+                w.WriteByte(0);
+            }
+        }
     }
 
-    private static RestingStopRecord ReadRestingStop(ref BinaryBufferReader r)
+    private static RestingStopRecord ReadRestingStop(ref BinaryBufferReader r, int version)
     {
         long orderId = r.ReadInt64();
         string clOrdId = r.ReadString();
@@ -397,8 +422,22 @@ public static class BinaryChannelStateSnapshotCodec
         long qty = r.ReadInt64();
         uint firm = r.ReadUInt32();
         ulong enteredAt = r.ReadUInt64();
+        byte ordTagId = 0;
+        InvestorId? investor = null;
+        if (version >= 4)
+        {
+            ordTagId = r.ReadByte();
+            byte hasInvestor = r.ReadByte();
+            if (hasInvestor != 0)
+            {
+                ushort prefix = r.ReadUInt16();
+                uint document = r.ReadUInt32();
+                investor = new InvestorId(prefix, document);
+            }
+        }
         return new RestingStopRecord(orderId, clOrdId, securityId, (Side)side,
-            (OrderType)stopType, (TimeInForce)tif, stopPx, limit, qty, firm, enteredAt);
+            (OrderType)stopType, (TimeInForce)tif, stopPx, limit, qty, firm, enteredAt,
+            ordTagId, investor);
     }
 
     private static void WriteOwner(BinaryBufferWriter w, OrderOwnerSnapshot o)

--- a/tests/B3.Exchange.Matching.Tests/StopOrderTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/StopOrderTests.cs
@@ -221,4 +221,78 @@ public class StopOrderTests
         var r = Assert.Single(sink.Rejects);
         Assert.Equal(RejectReason.InvalidField, r.Reason);
     }
+
+    // Issue #453: a StopLimit whose triggered residual ends up resting
+    // on the book must keep the parked stop's OrdTagID / InvestorID so
+    // a later OrderMassActionRequest filtered by those identifiers
+    // still cancels it. Before #453 the triggered NewOrderCommand
+    // dropped both fields and the residual was silently exempt.
+    [Fact]
+    public void Triggered_stoplimit_residual_preserves_ordtagid_and_investorid()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        var investor = new InvestorId(0x1234, 999_000_111u);
+
+        // Seller sits at 10@100. Park a BuyStopLimit at stop=10 limit=10
+        // for 200 with OrdTagId=99 + InvestorId set. A second buyer
+        // (AGG) trades 10@100 — the resulting print arms the stop. The
+        // triggered limit-buy then sees an empty book (AGG already
+        // consumed the offer) and the full 200 rests on the bid.
+        engine.Submit(Limit("S1", Side.Sell, 10m, 100, firm: 9));
+        engine.Submit(new NewOrderCommand("STP", TestFactory.PetrSecId, Side.Buy,
+            OrderType.StopLimit, TimeInForce.Day,
+            PriceMantissa: TestFactory.Px(10m), Quantity: 200, EnteringFirm: 1, EnteredAtNanos: 0)
+        {
+            StopPxMantissa = TestFactory.Px(10m),
+            OrdTagId = 99,
+            InvestorId = investor,
+        });
+        var parkedStopId = sink.StopAccepted.Single().OrderId;
+        sink.Clear();
+        engine.Submit(Limit("AGG", Side.Buy, 10m, 100, firm: 8));
+
+        // The triggered residual rests under the parked stop's OrderId.
+        Assert.Single(sink.StopTriggered);
+        var residual = sink.Accepted.Single(a => a.OrderId == parkedStopId);
+        Assert.Equal(200, residual.RemainingQuantity);
+
+        // Mass-cancel by OrdTagID=99 ONLY (no firm / no side / no
+        // SecurityId) must reach the residual.
+        sink.Clear();
+        int cancelled = engine.MassCancel(
+            new[] { parkedStopId },
+            new MassCancelCommand(SecurityId: 0, SideFilter: null, EnteredAtNanos: 1)
+            { OrdTagIdFilter = 99 });
+        Assert.Equal(1, cancelled);
+        var c = Assert.Single(sink.Canceled);
+        Assert.Equal(parkedStopId, c.OrderId);
+        Assert.Equal(CancelReason.MassCancel, c.Reason);
+    }
+
+    [Fact]
+    public void Triggered_stoplimit_residual_matches_investorid_filter()
+    {
+        var engine = TestFactory.NewEngine(out var sink);
+        var investor = new InvestorId(0x1234, 999_000_111u);
+
+        engine.Submit(Limit("S1", Side.Sell, 10m, 100, firm: 9));
+        engine.Submit(new NewOrderCommand("STP", TestFactory.PetrSecId, Side.Buy,
+            OrderType.StopLimit, TimeInForce.Day,
+            PriceMantissa: TestFactory.Px(10m), Quantity: 200, EnteringFirm: 1, EnteredAtNanos: 0)
+        {
+            StopPxMantissa = TestFactory.Px(10m),
+            OrdTagId = 99,
+            InvestorId = investor,
+        });
+        var parkedStopId = sink.StopAccepted.Single().OrderId;
+        engine.Submit(Limit("AGG", Side.Buy, 10m, 100, firm: 8));
+        sink.Clear();
+
+        int cancelled = engine.MassCancel(
+            new[] { parkedStopId },
+            new MassCancelCommand(SecurityId: 0, SideFilter: null, EnteredAtNanos: 1)
+            { InvestorIdFilter = investor });
+        Assert.Equal(1, cancelled);
+        Assert.Equal(parkedStopId, sink.Canceled.Single().OrderId);
+    }
 }

--- a/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
@@ -31,10 +31,15 @@ public class BinaryChannelStateSnapshotCodecTests
                 StopType: OrderType.StopLoss, Tif: TimeInForce.Day,
                 StopPxMantissa: 245000, LimitPriceMantissa: 0,
                 Quantity: 200, EnteringFirm: 7, EnteredAtNanos: 111UL),
+            // Issue #453: exercise the new OrdTagId/InvestorId trailer
+            // so AssertEqual catches any regression in the codec
+            // round-trip (record equality covers them).
             new RestingStopRecord(202, "S-2", SecurityId: 999_001, Side.Sell,
                 StopType: OrderType.StopLimit, Tif: TimeInForce.Gtc,
                 StopPxMantissa: 255000, LimitPriceMantissa: 256000,
-                Quantity: 300, EnteringFirm: 9, EnteredAtNanos: 222UL),
+                Quantity: 300, EnteringFirm: 9, EnteredAtNanos: 222UL,
+                OrdTagId: 99,
+                InvestorId: new InvestorId(0x4321, 7_654_321u)),
         };
         var phases = new[]
         {
@@ -117,6 +122,44 @@ public class BinaryChannelStateSnapshotCodecTests
         var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
         var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
         Assert.Null(decoded.Engine.Stops);
+    }
+
+    [Fact]
+    public void Encode_AtV3_OmitsRestingStopTrailer_AndV3DecodeFillsDefaults()
+    {
+        // Issue #453 backward-compat: a snapshot stamped at Version=3
+        // (the codec's pre-#453 schema) MUST round-trip without the
+        // OrdTagId/InvestorId trailer. Re-decoded fields default to
+        // 0 / null and the codec re-stamps the loaded snapshot at
+        // CurrentVersion so RestoreChannelState's strict version check
+        // accepts it.
+        var stops = new[]
+        {
+            new RestingStopRecord(201, "S-1", SecurityId: 999_001, Side.Buy,
+                StopType: OrderType.StopLoss, Tif: TimeInForce.Day,
+                StopPxMantissa: 245000, LimitPriceMantissa: 0,
+                Quantity: 200, EnteringFirm: 7, EnteredAtNanos: 111UL,
+                // These would be written under v4 but MUST NOT be on
+                // the wire when Version=3.
+                OrdTagId: 99,
+                InvestorId: new InvestorId(0x1234, 567u)),
+        };
+        var engine = new EngineStateSnapshot(
+            NextOrderId: 1, NextTradeId: 1, RptSeq: 0,
+            Phases: Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+            Books: Array.Empty<EngineStateSnapshot.BookSnapshot>(),
+            Stops: stops);
+        var snap = new ChannelStateSnapshot(
+            Version: 3, ChannelNumber: 1, SequenceNumber: 0, SequenceVersion: 0,
+            Engine: engine, Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
+
+        Assert.Equal(ChannelStateSnapshot.CurrentVersion, decoded.Version);
+        var roundTripped = Assert.Single(decoded.Engine.Stops!);
+        Assert.Equal((byte)0, roundTripped.OrdTagId);
+        Assert.Null(roundTripped.InvestorId);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
@@ -49,9 +49,9 @@ public class SnapshotMigrationTests
             var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #322: chain now upgrades to v3, the new
-            // CurrentVersion (was v2 in #319).
-            Assert.Equal(3, loaded!.Version);
+            // Issue #453: chain now upgrades to v4, the new
+            // CurrentVersion (was v3 in #322).
+            Assert.Equal(4, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }
@@ -82,10 +82,10 @@ public class SnapshotMigrationTests
                 migrations: migrations);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #322: chain is 0→1 (registered here) followed by
-            // 1→2 and 2→3 (registered by BuildDefault), so the loaded
-            // version reflects CurrentVersion = 3.
-            Assert.Equal(3, loaded!.Version);
+            // Issue #453: chain is 0→1 (registered here) followed by
+            // 1→2, 2→3, and 3→4 (registered by BuildDefault), so the
+            // loaded version reflects CurrentVersion = 4.
+            Assert.Equal(4, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }


### PR DESCRIPTION
Closes #453.

Sibling-of-#449 fix on the matching engine side: a parked Stop / StopLimit whose limit-side residual ends up resting on the book after trigger now carries the on-behalf-of identifiers from the original `SimpleNewOrder` / `NewOrderSingle`. Before this PR `ExecuteTriggeredStop` rebuilt the triggered `NewOrderCommand` with only `Memo` preserved, so `OrdTagID` / `InvestorID` were silently dropped — and a subsequent `OrderMassActionRequest` filtered by those fields silently missed the residual.

## Surface

- `RestingStop` (engine-private) and `RestingStopRecord` (snapshot DTO) gain `OrdTagId` + `InvestorId`, defaulted to `0` / `null` so positional constructors in tests keep compiling.
- `SubmitStop` populates both from the inbound `NewOrderCommand`.
- `ExecuteTriggeredStop` propagates both to the triggered `NewOrderCommand` so the residual that rests after the aggressor finishes carries the parked stop's identifiers.
- `CaptureState` / `RestoreState` round-trip the fields so a restart preserves them for a still-parked stop.

## Wire-format bump (codec v3 → v4)

- `WriteRestingStop` / `ReadRestingStop` now version-gate a per-stop trailer: `byte OrdTagId` + presence-byte `InvestorId` + `uint16 Prefix` + `uint32 Document` when present.
- v3 binary files (no trailer) decode with defaults and are re-stamped to `CurrentVersion`, matching the existing v1/v2 → CurrentVersion re-stamp behaviour.
- JSON migration chain gains a no-op `MigrateV3ToV4` shim so JSON-format snapshots upgrade the same way.

## Tests

- `Triggered_stoplimit_residual_preserves_ordtagid_and_investorid` (end-to-end: park → trade arms stop → residual rests → MassCancel by OrdTagID cancels it)
- `Triggered_stoplimit_residual_matches_investorid_filter` (same flow, InvestorID filter)
- `Encode_AtV3_OmitsRestingStopTrailer_AndV3DecodeFillsDefaults` (backward-compat: v3-stamped snapshot omits the trailer on the wire, decodes with defaults, re-stamps to CurrentVersion)
- `BuildRichSnapshot` now sets non-zero `OrdTagId`/`InvestorId` on one stop so the round-trip equality check exercises the trailer
- `SnapshotMigrationTests` version expectations bumped to 4

## Pre-PR checklist

- `dotnet build -c Release` — clean (warnings-as-errors)
- `dotnet test -c Release` — full slnx green
- `dotnet format --verify-no-changes` — clean

## Follow-ups not in scope

While auditing the codec I noticed `RestingOrderRecord` already carries `OrdTagId` / `Asset` / `InvestorId` fields (added with `= 0` / `= null` defaults) but `WriteRestingOrder` / `ReadRestingOrder` do NOT serialize them — so live resting orders that survive a snapshot+restore also lose their mass-cancel filter identifiers. Same shape of bug as #453, applied to non-Stop orders. I'll file a follow-up issue separately rather than expand scope here.