### PR TITLE
fix(persistence): RestingOrderRecord codec preserves OrdTagID/Asset/InvestorID (#455)

### DIFF
--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -53,7 +53,7 @@ public sealed record ChannelStateSnapshot(
     EngineStateSnapshot Engine,
     IReadOnlyList<OrderOwnerSnapshot> Owners)
 {
-    public const int CurrentVersion = 4;
+    public const int CurrentVersion = 5;
 
     /// <summary>
     /// Issue #269: monotonic counter of commands the dispatcher has

--- a/src/B3.Exchange.Core/SnapshotMigrations.cs
+++ b/src/B3.Exchange.Core/SnapshotMigrations.cs
@@ -80,6 +80,12 @@ public sealed class SnapshotMigrationSet
         // version; STJ's missing-property tolerance leaves the new
         // fields at their record defaults (0 / null) on deserialise.
         set.Register(3, MigrateV3ToV4);
+        // Issue #455: v5 only adds optional OrdTagId / Asset / InvestorId
+        // fields on each RestingOrderRecord. v4 trees upgrade by
+        // stamping the version; STJ's missing-property tolerance leaves
+        // the new fields at their record defaults (0 / null / null) on
+        // deserialise.
+        set.Register(4, MigrateV4ToV5);
         return set;
     }
 
@@ -101,6 +107,13 @@ public sealed class SnapshotMigrationSet
     {
         if (previous is JsonObject obj)
             obj["Version"] = 4;
+        return previous;
+    }
+
+    private static JsonNode MigrateV4ToV5(JsonNode previous)
+    {
+        if (previous is JsonObject obj)
+            obj["Version"] = 5;
         return previous;
     }
 

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -36,7 +36,11 @@ namespace B3.Exchange.Persistence;
 /// <para><b>Resting order record:</b> int64 OrderId, len-prefixed UTF-8
 /// ClOrdId, byte Side, int64 PriceMantissa, int64 RemainingQuantity,
 /// uint32 EnteringFirm, uint64 InsertTimestampNanos, byte Tif, int64
-/// MaxFloor, int64 HiddenQuantity.</para>
+/// MaxFloor, int64 HiddenQuantity. Issue #455 (codec v5) appends a
+/// trailer: byte OrdTagId, len-prefixed UTF-8 Asset (empty = null),
+/// byte InvestorPresence (0=null, 1=present), and when present uint16
+/// Prefix + uint32 Document. Older versions omit the trailer and decode
+/// with OrdTagId=0 / Asset=null / InvestorId=null.</para>
 ///
 /// <para><b>Resting stop record:</b> int64 OrderId, len-prefixed UTF-8
 /// ClOrdId, int64 SecurityId, byte Side, byte StopType, byte Tif, int64
@@ -108,7 +112,7 @@ public static class BinaryChannelStateSnapshotCodec
         {
             w.WriteInt64(b.SecurityId);
             w.WriteUVarInt((ulong)b.Orders.Count);
-            foreach (var o in b.Orders) WriteRestingOrder(w, o);
+            foreach (var o in b.Orders) WriteRestingOrder(w, o, snapshot.Version);
         }
 
         // null and empty stops are operationally identical to the
@@ -231,7 +235,7 @@ public static class BinaryChannelStateSnapshotCodec
             long securityId = r.ReadInt64();
             ulong orderCount = ReadBoundedCount(ref r, bytes.Length, "order");
             var orders = new RestingOrderRecord[orderCount];
-            for (ulong j = 0; j < orderCount; j++) orders[j] = ReadRestingOrder(ref r);
+            for (ulong j = 0; j < orderCount; j++) orders[j] = ReadRestingOrder(ref r, version);
             books[i] = new EngineStateSnapshot.BookSnapshot(securityId, orders);
         }
 
@@ -338,14 +342,18 @@ public static class BinaryChannelStateSnapshotCodec
         // Issue #453: v3 → v4 is also a clean migration — v3 files have
         // no per-stop OrdTagId/InvestorId trailer, and ReadRestingStop
         // defaults them to 0/null for older versions.
-        int effectiveVersion = (version == 1 || version == 2 || version == 3) ? ChannelStateSnapshot.CurrentVersion : version;
+        // Issue #455: v4 → v5 is also a clean migration — v4 files have
+        // no per-resting-order OrdTagId/Asset/InvestorId trailer, and
+        // ReadRestingOrder defaults them to 0/null/null for older
+        // versions.
+        int effectiveVersion = (version == 1 || version == 2 || version == 3 || version == 4) ? ChannelStateSnapshot.CurrentVersion : version;
         return new ChannelStateSnapshot(effectiveVersion, channelNumber, sequenceNumber, sequenceVersion, engine, owners)
         {
             LastAppliedSeq = lastAppliedSeq,
         };
     }
 
-    private static void WriteRestingOrder(BinaryBufferWriter w, RestingOrderRecord o)
+    private static void WriteRestingOrder(BinaryBufferWriter w, RestingOrderRecord o, int version)
     {
         w.WriteInt64(o.OrderId);
         w.WriteString(o.ClOrdId);
@@ -357,9 +365,29 @@ public static class BinaryChannelStateSnapshotCodec
         w.WriteByte((byte)o.Tif);
         w.WriteInt64(o.MaxFloor);
         w.WriteInt64(o.HiddenQuantity);
+        // Issue #455 (codec v5): on-behalf-of identifiers tail so the
+        // restored resting order remains mass-cancellable by OrdTagID /
+        // Asset / InvestorID across a snapshot+restore round-trip.
+        // Older versions wrote nothing here; ReadRestingOrder defaults
+        // to 0 / null / null when the trailer is absent.
+        if (version >= 5)
+        {
+            w.WriteByte(o.OrdTagId);
+            w.WriteString(o.Asset);
+            if (o.InvestorId is { } iid)
+            {
+                w.WriteByte(1);
+                w.WriteUInt16(iid.Prefix);
+                w.WriteUInt32(iid.Document);
+            }
+            else
+            {
+                w.WriteByte(0);
+            }
+        }
     }
 
-    private static RestingOrderRecord ReadRestingOrder(ref BinaryBufferReader r)
+    private static RestingOrderRecord ReadRestingOrder(ref BinaryBufferReader r, int version)
     {
         long orderId = r.ReadInt64();
         string clOrdId = r.ReadString();
@@ -371,8 +399,24 @@ public static class BinaryChannelStateSnapshotCodec
         byte tif = r.ReadByte();
         long maxFloor = r.ReadInt64();
         long hidden = r.ReadInt64();
+        byte ordTagId = 0;
+        string? asset = null;
+        InvestorId? investor = null;
+        if (version >= 5)
+        {
+            ordTagId = r.ReadByte();
+            string assetField = r.ReadString();
+            asset = string.IsNullOrEmpty(assetField) ? null : assetField;
+            byte hasInvestor = r.ReadByte();
+            if (hasInvestor != 0)
+            {
+                ushort prefix = r.ReadUInt16();
+                uint document = r.ReadUInt32();
+                investor = new InvestorId(prefix, document);
+            }
+        }
         return new RestingOrderRecord(orderId, clOrdId, (Side)side, price, qty, firm, ts,
-            (TimeInForce)tif, maxFloor, hidden);
+            (TimeInForce)tif, maxFloor, hidden, ordTagId, asset, investor);
     }
 
     private static void WriteRestingStop(BinaryBufferWriter w, RestingStopRecord s, int version)

--- a/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
@@ -20,10 +20,16 @@ public class BinaryChannelStateSnapshotCodecTests
                 PriceMantissa: 250000, RemainingQuantity: 100,
                 EnteringFirm: 7, InsertTimestampNanos: 123456789UL,
                 Tif: TimeInForce.Day, MaxFloor: 100, HiddenQuantity: 0),
+            // Issue #455: exercise the new OrdTagId/Asset/InvestorId
+            // trailer so AssertEqual catches any regression in the codec
+            // round-trip (record equality covers them).
             new RestingOrderRecord(102, "iceberg-Ω-✓", Side.Sell,
                 PriceMantissa: 250100, RemainingQuantity: 50_000,
                 EnteringFirm: 9, InsertTimestampNanos: 987654321UL,
-                Tif: TimeInForce.Gtc, MaxFloor: 1000, HiddenQuantity: 49_000),
+                Tif: TimeInForce.Gtc, MaxFloor: 1000, HiddenQuantity: 49_000,
+                OrdTagId: 77,
+                Asset: "PETR",
+                InvestorId: new InvestorId(0xABCD, 1_234_567u)),
         };
         var stops = new[]
         {
@@ -122,6 +128,50 @@ public class BinaryChannelStateSnapshotCodecTests
         var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
         var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
         Assert.Null(decoded.Engine.Stops);
+    }
+
+    [Fact]
+    public void Encode_AtV4_OmitsRestingOrderTrailer_AndV4DecodeFillsDefaults()
+    {
+        // Issue #455 backward-compat: a snapshot stamped at Version=4
+        // (the codec's pre-#455 schema) MUST round-trip without the
+        // OrdTagId/Asset/InvestorId per-resting-order trailer. Re-
+        // decoded fields default to 0 / null / null and the codec re-
+        // stamps the loaded snapshot at CurrentVersion so
+        // RestoreChannelState's strict version check accepts it.
+        var orders = new[]
+        {
+            new RestingOrderRecord(101, "CLI-A", Side.Buy,
+                PriceMantissa: 250000, RemainingQuantity: 100,
+                EnteringFirm: 7, InsertTimestampNanos: 123456789UL,
+                Tif: TimeInForce.Day, MaxFloor: 100, HiddenQuantity: 0,
+                // These would be written under v5 but MUST NOT be on
+                // the wire when Version=4.
+                OrdTagId: 77,
+                Asset: "PETR",
+                InvestorId: new InvestorId(0xABCD, 1_234_567u)),
+        };
+        var books = new[]
+        {
+            new EngineStateSnapshot.BookSnapshot(999_001, orders),
+        };
+        var engine = new EngineStateSnapshot(
+            NextOrderId: 102, NextTradeId: 1, RptSeq: 0,
+            Phases: Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+            Books: books,
+            Stops: null);
+        var snap = new ChannelStateSnapshot(
+            Version: 4, ChannelNumber: 1, SequenceNumber: 0, SequenceVersion: 0,
+            Engine: engine, Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
+
+        Assert.Equal(ChannelStateSnapshot.CurrentVersion, decoded.Version);
+        var roundTripped = Assert.Single(decoded.Engine.Books[0].Orders);
+        Assert.Equal((byte)0, roundTripped.OrdTagId);
+        Assert.Null(roundTripped.Asset);
+        Assert.Null(roundTripped.InvestorId);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
@@ -49,9 +49,9 @@ public class SnapshotMigrationTests
             var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #453: chain now upgrades to v4, the new
-            // CurrentVersion (was v3 in #322).
-            Assert.Equal(4, loaded!.Version);
+            // Issue #455: chain now upgrades to v5, the new
+            // CurrentVersion (was v4 in #453).
+            Assert.Equal(5, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }
@@ -82,10 +82,10 @@ public class SnapshotMigrationTests
                 migrations: migrations);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #453: chain is 0→1 (registered here) followed by
-            // 1→2, 2→3, and 3→4 (registered by BuildDefault), so the
-            // loaded version reflects CurrentVersion = 4.
-            Assert.Equal(4, loaded!.Version);
+            // Issue #455: chain is 0→1 (registered here) followed by
+            // 1→2, 2→3, 3→4, and 4→5 (registered by BuildDefault), so
+            // the loaded version reflects CurrentVersion = 5.
+            Assert.Equal(5, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }


### PR DESCRIPTION
Closes #455.

Sibling bug of #453: snapshot binary codec was dropping `OrdTagId`, `Asset`, `InvestorId` on every live resting order. After a snapshot+restart, mass-cancel by OrdTagID/InvestorID and post-trade allocation by Asset would silently miss those orders.

## Scope

Engine path was already correct (`LimitOrderBook.EnumerateAllOrdersForSnapshot` + `RestoreOrder` copy the three fields). JSON codec round-trips via record properties. Only the hand-rolled binary codec needed a fix.

## Wire format (codec v4 → v5)

Per-resting-order trailer appended when `version >= 5`:
- `byte` OrdTagId
- len-prefixed UTF-8 Asset (empty → null on read)
- InvestorId presence byte; when present, `uint16` Prefix + `uint32` Document

`v4` added to the re-stamp set so existing binary snapshots load with defaults and stamp at CurrentVersion. JSON `MigrateV4ToV5` is a no-op (STJ tolerates missing optional fields).

## Tests
- `Encode_AtV4_OmitsRestingOrderTrailer_AndV4DecodeFillsDefaults` (new) — backward compat.
- `BuildRichSnapshot` now sets non-zero OrdTagId/Asset/InvestorId on a resting order so existing round-trip equality covers the trailer.
- Empty-snapshot byte count unchanged (45 B).

## Validation
- `dotnet build -c Debug` / `-c Release`: clean.
- `dotnet test SbeB3Exchange.slnx -c Release`: all suites green.
- `dotnet format --verify-no-changes`: clean.