### PR TITLE
feat(matching): OCRR may mutate InvestorID per B3 spec §7.4 (#451)

### DIFF
--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -26,6 +26,10 @@ internal static partial class InboundMessageDecoder
         public const int MinQty = 100;            // ulong (0 == null)
         public const int MaxFloor = 108;          // ulong (0 == null)
         public const int ExpireDate = 122;        // ushort (0 == null)
+        // Issue #451: spec §7.4 allows InvestorID mutation via OCRR
+        // (Add ✓, Change ✓). Composite (Prefix uint16 + Document uint32),
+        // all-zero == null sentinel == "preserve original".
+        public const int InvestorID = 136;        // Prefix(2) + Document(4), all-zero == null
         // V6 trailer (BlockLength=150). Same semantics as
         // NewOrderSingle's trailer — see issue #238.
         public const int StrategyID = 142;        // int32 (0 == null)
@@ -68,6 +72,8 @@ internal static partial class InboundMessageDecoder
         byte mmpReset = body[OrderCancelReplaceOffsets.MmProtectionReset];
         byte stp = body[OrderCancelReplaceOffsets.Stp];
         ushort expireDate = MemoryMarshal.Read<ushort>(body.Slice(OrderCancelReplaceOffsets.ExpireDate, 2));
+        var investorSpan = body.Slice(OrderCancelReplaceOffsets.InvestorID, 6);
+        InvestorId? investorId = IsAllZero(investorSpan) ? null : DecodeInvestorId(investorSpan);
 
         clOrdIdValue = clOrdId;
         origClOrdIdValue = origClOrdId;
@@ -210,6 +216,7 @@ internal static partial class InboundMessageDecoder
                 NewOrdType = ordType,
                 NewTif = newTif,
                 PreTradeRejectReason = preTradeRejectReason,
+                NewInvestorId = investorId,
             };
             return InboundDecodeOutcome.UnsupportedFeature;
         }
@@ -224,6 +231,7 @@ internal static partial class InboundMessageDecoder
         {
             NewOrdType = ordType,
             NewTif = newTif,
+            NewInvestorId = investorId,
         };
         return InboundDecodeOutcome.Success;
     }

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -300,6 +300,17 @@ public sealed record ReplaceOrderCommand(
     /// </summary>
     public TimeInForce? NewTif { get; init; }
 
+    /// <summary>
+    /// Optional new <see cref="Matching.InvestorId"/> for the working order.
+    /// Mutable per B3 Binary EntryPoint Messaging Guidelines §7.4 (Add ✓,
+    /// Change ✓ for InvestorID). <c>null</c> means "preserve the resting
+    /// order's existing InvestorId" (spec §7.4: "Fields that are not sent
+    /// will be considered the same as the original order"). The spec table
+    /// does not include InvestorID in the Remove column, so explicit
+    /// clearing is intentionally not supported. Issue #451.
+    /// </summary>
+    public InvestorId? NewInvestorId { get; init; }
+
     public bool UnsupportedOrderCharacteristic { get; init; }
 
     public RejectReason? PreTradeRejectReason { get; init; }

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -14,7 +14,7 @@ internal sealed class RestingOrder
     public required uint EnteringFirm { get; init; }
     public byte OrdTagId { get; init; }
     public string? Asset { get; init; }
-    public InvestorId? InvestorId { get; init; }
+    public InvestorId? InvestorId { get; set; }
     public byte[] Memo { get; init; } = [];
 
     /// <summary>

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -1176,6 +1176,14 @@ public sealed class MatchingEngine
                 long delta = resting.RemainingQuantity - cmd.NewQuantity;
                 resting.RemainingQuantity = cmd.NewQuantity;
                 resting.Level!.TotalQuantity -= delta;
+                // Issue #451: spec §7.4 allows InvestorID mutation via OCRR
+                // (Add ✓, Change ✓). Apply before emitting events so the
+                // resting order — and subsequent MassCancel filtering — see
+                // the new identifier. Null means preserve.
+                if (cmd.NewInvestorId is { } newInvestorKept)
+                {
+                    resting.InvestorId = newInvestorKept;
+                }
                 uint rptSeq = NextRptSeq();
                 _sink.OnOrderQuantityReduced(new OrderQuantityReducedEvent(
                     SecurityId: book.SecurityId,
@@ -1230,7 +1238,7 @@ public sealed class MatchingEngine
                 MaxFloor = resting.MaxFloor > 0 ? (ulong)resting.MaxFloor : 0UL,
                 OrdTagId = resting.OrdTagId,
                 Asset = resting.Asset,
-                InvestorId = resting.InvestorId,
+                InvestorId = cmd.NewInvestorId ?? resting.InvestorId,
                 Memo = cmd.Memo,
             };
 

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -62,7 +62,9 @@ public class NewOrderSingleAndReplaceDecoderTests
         ulong origClOrdId = 99UL,
         long stopPx = PriceNull,
         ulong minQty = 0UL,
-        ulong maxFloor = 0UL)
+        ulong maxFloor = 0UL,
+        ushort investorPrefix = 0,
+        uint investorDocument = 0)
     {
         var body = new byte[142];
         Span<byte> s = body;
@@ -79,6 +81,8 @@ public class NewOrderSingleAndReplaceDecoderTests
         MemoryMarshal.Write(s.Slice(92, 8), in stopPx);
         MemoryMarshal.Write(s.Slice(100, 8), in minQty);
         MemoryMarshal.Write(s.Slice(108, 8), in maxFloor);
+        MemoryMarshal.Write(s.Slice(136, 2), in investorPrefix);
+        MemoryMarshal.Write(s.Slice(138, 4), in investorDocument);
         return body;
     }
 
@@ -521,6 +525,39 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Equal(42L, cmd.OrderId);
         Assert.Equal(25L, cmd.NewQuantity);
         Assert.Equal(50_0000L, cmd.NewPriceMantissa);
+    }
+
+    // Issue #451: B3 Binary EntryPoint Messaging Guidelines §7.4 allows
+    // InvestorID mutation via OCRR (Add ✓, Change ✓). A non-zero composite
+    // on the OCRR body must surface on ReplaceOrderCommand.NewInvestorId so
+    // the engine can apply it to the resting order.
+    [Fact]
+    public void OrderCancelReplace_InvestorIdNonZero_PopulatesNewInvestorId()
+    {
+        var body = BuildOrderCancelReplaceV2(investorPrefix: 7, investorDocument: 123_456);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out var cmd, out _, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.NotNull(cmd.NewInvestorId);
+        Assert.Equal((ushort)7, cmd.NewInvestorId!.Value.Prefix);
+        Assert.Equal(123_456u, cmd.NewInvestorId.Value.Document);
+    }
+
+    // Spec §7.4 footer: "Fields that are not sent will be considered the
+    // same as the original order." An all-zero composite is the wire NULL
+    // sentinel → command carries null → engine preserves resting value.
+    [Fact]
+    public void OrderCancelReplace_InvestorIdAllZero_LeavesNewInvestorIdNull()
+    {
+        var body = BuildOrderCancelReplaceV2(); // defaults leave composite all-zero
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out var cmd, out _, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(cmd.NewInvestorId);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
@@ -135,6 +135,112 @@ public class CancelReplaceTests
         eng.Replace(new ReplaceOrderCommand("c1", PetrSecId, 999L, Px(10m), 100, 2000));
         Assert.Equal(RejectReason.UnknownOrderId, sink.Rejects[0].Reason);
     }
+
+    // Issue #451: B3 Binary EntryPoint Messaging Guidelines §7.4 lists
+    // InvestorID with Add ✓ Change ✓ — clients must be able to mutate the
+    // resting order's InvestorId via OCRR. Verified via MassCancel filter
+    // (the only externally observable view on the resting order's
+    // InvestorId), which must match the NEW value, not the original.
+    [Fact]
+    public void Replace_PriorityKept_WithNewInvestorId_AppliesToRestingOrder()
+    {
+        var eng = NewEngine(out var sink);
+        var orig = new InvestorId(1, 100);
+        var changed = new InvestorId(2, 200);
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 500, 11, 1000)
+        {
+            InvestorId = orig,
+        });
+        var oid = sink.Accepted[0].OrderId;
+        sink.Clear();
+
+        // Qty decrease at same price → priority kept (in-place mutation path).
+        eng.Replace(new ReplaceOrderCommand("c1", PetrSecId, oid, Px(10m), 300, 2000)
+        {
+            NewInvestorId = changed,
+        });
+        Assert.Single(sink.QtyReduced);
+        sink.Clear();
+
+        // MassCancel filtered by the ORIGINAL InvestorId must NOT match
+        // (proves the mutation happened); filtered by the NEW value MUST.
+        int byOriginal = eng.MassCancel(new[] { oid }, new MassCancelCommand(0, null, 9_000)
+        {
+            InvestorIdFilter = orig,
+        });
+        Assert.Equal(0, byOriginal);
+        Assert.Empty(sink.Canceled);
+
+        int byChanged = eng.MassCancel(new[] { oid }, new MassCancelCommand(0, null, 9_001)
+        {
+            InvestorIdFilter = changed,
+        });
+        Assert.Equal(1, byChanged);
+        Assert.Equal(oid, Assert.Single(sink.Canceled).OrderId);
+    }
+
+    // Issue #451: spec §7.4 "Fields that are not sent will be considered
+    // the same as the original order." → null NewInvestorId must preserve
+    // the resting order's existing InvestorId (backward-compat with
+    // pre-#451 callers and with InvestorID-less OCRRs).
+    [Fact]
+    public void Replace_PriorityKept_NullNewInvestorId_PreservesOriginal()
+    {
+        var eng = NewEngine(out var sink);
+        var orig = new InvestorId(3, 300);
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 500, 11, 1000)
+        {
+            InvestorId = orig,
+        });
+        var oid = sink.Accepted[0].OrderId;
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("c1", PetrSecId, oid, Px(10m), 300, 2000));
+        Assert.Single(sink.QtyReduced);
+        sink.Clear();
+
+        int n = eng.MassCancel(new[] { oid }, new MassCancelCommand(0, null, 9_000)
+        {
+            InvestorIdFilter = orig,
+        });
+        Assert.Equal(1, n);
+        Assert.Equal(oid, Assert.Single(sink.Canceled).OrderId);
+    }
+
+    // Issue #451: when Replace forces a DEL+NEW (priority lost), the
+    // replacement resting order must also carry the new InvestorId; the
+    // synthesized NewOrderCommand must use cmd.NewInvestorId ?? resting.InvestorId.
+    [Fact]
+    public void Replace_PriorityLost_WithNewInvestorId_PropagatesToReplacement()
+    {
+        var eng = NewEngine(out var sink);
+        var orig = new InvestorId(1, 100);
+        var changed = new InvestorId(2, 200);
+        eng.Submit(new NewOrderCommand("c1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000)
+        {
+            InvestorId = orig,
+        });
+        var oldOid = sink.Accepted[0].OrderId;
+        sink.Clear();
+
+        // Price change → priority lost (DEL + fresh NEW path).
+        eng.Replace(new ReplaceOrderCommand("c1", PetrSecId, oldOid, Px(10.05m), 100, 2000)
+        {
+            NewInvestorId = changed,
+        });
+        Assert.Equal(CancelReason.ReplaceLostPriority, Assert.Single(sink.Canceled).Reason);
+        var newOid = Assert.Single(sink.Accepted).OrderId;
+        Assert.NotEqual(oldOid, newOid);
+        sink.Clear();
+
+        // Replacement resting order must carry the NEW InvestorId.
+        int n = eng.MassCancel(new[] { newOid }, new MassCancelCommand(0, null, 9_000)
+        {
+            InvestorIdFilter = changed,
+        });
+        Assert.Equal(1, n);
+        Assert.Equal(newOid, Assert.Single(sink.Canceled).OrderId);
+    }
 }
 
 public class SnapshotEnumerationTests


### PR DESCRIPTION
Closes #451.

## What

Per *B3 Binary EntryPoint Messaging Guidelines 8.4.2.1* §7.4 (`OrderCancelReplaceRequest` mutation table), `InvestorID` is mutable on Replace (`Add ✓ Change ✓`). The decoder previously dropped the composite and the engine always preserved the resting order's value, so clients had no way to correct an on-behalf identifier or reassign mid-life — and `MassCancel` filters that key on the corrected InvestorID would silently miss the order.

## How

- **Decoder** (`InboundMessageDecoder.OrderCancelReplace`): read the 6-byte composite at body offset 136 (Prefix uint16 + Document uint32, all-zero == NULL) on both happy-path and fat-finger commands.
- **Command** (`ReplaceOrderCommand.NewInvestorId`): new optional slot. `null` ⇒ preserve resting (spec §7.4 footer: "Fields that are not sent will be considered the same as the original order"). Spec table omits `Remove` for InvestorID, so explicit clearing is intentionally not supported.
- **Engine** (`MatchingEngine.Replace`):
  - Priority-kept: mutate `resting.InvestorId` before emitting `OrderQuantityReducedEvent`/`OrderModifiedEvent`.
  - Priority-lost: synthesized `NewOrderCommand` uses `cmd.NewInvestorId ?? resting.InvestorId`.
- **`RestingOrder.InvestorId`** becomes `{ get; set; }` — book is not indexed by InvestorId so post-construction mutation is safe.

## Tests

- Decoder: non-zero composite → `NewInvestorId` populated; all-zero sentinel → null.
- Engine priority-kept: `MassCancel` by ORIGINAL InvestorID misses, by NEW InvestorID hits — proves in-place mutation.
- Engine priority-kept null: backward-compat (resting InvestorID preserved).
- Engine priority-lost: replacement resting order carries the new InvestorID.

## Out of scope (follow-up)

ER_Modify echo of the changed InvestorID (touches `FixpOutboundEncoder.WriteExecutionReportModify` and `FixpSession` plumbing). Engine-state correctness — the gap for mass-cancel / persistence / replay — is fixed by this PR.

## Spec citation

> §7.4 Order Characteristics Modification table: `InvestorID` row — `Add ✓ Change ✓`. `OrdTagID` absent → preserved.
> Footer: "Only the fields that are being changed need to be sent in the replacement. Fields that are not sent will be considered the same as the original order."