### PR TITLE
feat(instruments): option-specific fields + minPx relaxation (T-1: OPT-01/05/09)

### DIFF
--- a/src/B3.Exchange.Instruments/Instrument.cs
+++ b/src/B3.Exchange.Instruments/Instrument.cs
@@ -24,4 +24,32 @@ public sealed record Instrument
 
     /// <summary>FIX SecurityType, e.g. "CS" (common stock), "OPT", "FUT".</summary>
     public required string SecurityType { get; init; }
+
+    public decimal? StrikePrice { get; init; }
+    public DateOnly? ExpirationDate { get; init; }
+    public PutOrCall? PutOrCall { get; init; }
+    public ExerciseStyle? ExerciseStyle { get; init; }
+    public long? UnderlyingSecurityId { get; init; }
+    public string? UnderlyingSymbol { get; init; }
+    public decimal? ContractMultiplier { get; init; }
+    public OptPayoutType? OptPayoutType { get; init; }
+}
+
+public enum PutOrCall
+{
+    Put,
+    Call,
+}
+
+public enum ExerciseStyle
+{
+    European,
+    American,
+}
+
+public enum OptPayoutType
+{
+    Vanilla,
+    Capped,
+    Binary,
 }

--- a/src/B3.Exchange.Instruments/InstrumentLoader.cs
+++ b/src/B3.Exchange.Instruments/InstrumentLoader.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -54,7 +55,7 @@ public static class InstrumentLoader
         var seenSymbols = new HashSet<string>(StringComparer.Ordinal);
         var seenSecurityIds = new HashSet<long>();
 
-        for (int i = 0; i < raw.Count; i++)
+        for (var i = 0; i < raw.Count; i++)
         {
             var r = raw[i];
             var inst = ValidateAndConvert(r, i, sourceName);
@@ -75,6 +76,40 @@ public static class InstrumentLoader
     {
         string Where(string field) => $"instrument index {index} in '{sourceName}': {field}";
 
+        static string? NormalizeOptionalText(string? value)
+            => string.IsNullOrWhiteSpace(value) ? null : value;
+
+        static TEnum? ParseEnum<TEnum>(string? value, string field, Func<string, string> where, bool required)
+            where TEnum : struct, Enum
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                if (required)
+                    throw new InstrumentConfigException(where($"{field} is required"));
+                return null;
+            }
+
+            if (Enum.TryParse<TEnum>(value, ignoreCase: true, out var parsed))
+                return parsed;
+
+            throw new InstrumentConfigException(where($"{field} must be one of: {string.Join(", ", Enum.GetNames<TEnum>())}"));
+        }
+
+        static DateOnly? ParseDateOnly(string? value, string field, Func<string, string> where, bool required)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                if (required)
+                    throw new InstrumentConfigException(where($"{field} is required"));
+                return null;
+            }
+
+            if (DateOnly.TryParseExact(value, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+                return parsed;
+
+            throw new InstrumentConfigException(where($"{field} must be YYYY-MM-DD"));
+        }
+
         if (string.IsNullOrWhiteSpace(r.Symbol))
             throw new InstrumentConfigException(Where("symbol is required"));
         if (r.SecurityId is null || r.SecurityId.Value <= 0)
@@ -83,12 +118,6 @@ public static class InstrumentLoader
             throw new InstrumentConfigException(Where("tickSize must be > 0"));
         if (r.LotSize is null || r.LotSize.Value <= 0)
             throw new InstrumentConfigException(Where("lotSize must be > 0"));
-        if (r.MinPrice is null || r.MinPrice.Value <= 0)
-            throw new InstrumentConfigException(Where("minPx must be > 0"));
-        if (r.MaxPrice is null || r.MaxPrice.Value <= 0)
-            throw new InstrumentConfigException(Where("maxPx must be > 0"));
-        if (r.MaxPrice.Value < r.MinPrice.Value)
-            throw new InstrumentConfigException(Where($"maxPx ({r.MaxPrice.Value}) must be >= minPx ({r.MinPrice.Value})"));
         if (string.IsNullOrWhiteSpace(r.Currency))
             throw new InstrumentConfigException(Where("currency is required"));
         if (string.IsNullOrWhiteSpace(r.Isin))
@@ -96,12 +125,42 @@ public static class InstrumentLoader
         if (string.IsNullOrWhiteSpace(r.SecurityType))
             throw new InstrumentConfigException(Where("securityType is required"));
 
-        // tickSize must divide minPx and maxPx evenly (otherwise no
-        // legal price exists at the boundary). This catches typos.
+        var isOption = InstrumentSecurityTypes.IsOption(r.SecurityType);
+
+        if (r.MinPrice is null || r.MinPrice.Value < 0 || (!isOption && r.MinPrice.Value == 0))
+            throw new InstrumentConfigException(Where(isOption ? "minPx must be >= 0" : "minPx must be > 0"));
+        if (r.MaxPrice is null || r.MaxPrice.Value <= 0)
+            throw new InstrumentConfigException(Where("maxPx must be > 0"));
+        if (r.MaxPrice.Value < r.MinPrice.Value)
+            throw new InstrumentConfigException(Where($"maxPx ({r.MaxPrice.Value}) must be >= minPx ({r.MinPrice.Value})"));
+
         if (decimal.Remainder(r.MinPrice.Value, r.TickSize.Value) != 0)
             throw new InstrumentConfigException(Where($"minPx ({r.MinPrice.Value}) is not a multiple of tickSize ({r.TickSize.Value})"));
         if (decimal.Remainder(r.MaxPrice.Value, r.TickSize.Value) != 0)
             throw new InstrumentConfigException(Where($"maxPx ({r.MaxPrice.Value}) is not a multiple of tickSize ({r.TickSize.Value})"));
+
+        var strikePrice = r.StrikePrice;
+        if (isOption && strikePrice is null)
+            throw new InstrumentConfigException(Where("strikePrice is required"));
+
+        var expirationDate = ParseDateOnly(r.ExpirationDate, "expirationDate", Where, required: isOption);
+        var putOrCall = ParseEnum<PutOrCall>(r.PutOrCall, "putOrCall", Where, required: isOption);
+        var exerciseStyle = ParseEnum<ExerciseStyle>(r.ExerciseStyle, "exerciseStyle", Where, required: isOption);
+        var optPayoutType = ParseEnum<OptPayoutType>(r.OptPayoutType, "optPayoutType", Where, required: false);
+
+        if (r.UnderlyingSecurityId is <= 0)
+            throw new InstrumentConfigException(Where("underlyingSecurityId must be > 0"));
+        if (isOption && r.UnderlyingSecurityId is null)
+            throw new InstrumentConfigException(Where("underlyingSecurityId is required"));
+
+        var underlyingSymbol = NormalizeOptionalText(r.UnderlyingSymbol);
+        if (isOption && underlyingSymbol is null)
+            throw new InstrumentConfigException(Where("underlyingSymbol is required"));
+
+        if (r.ContractMultiplier is <= 0)
+            throw new InstrumentConfigException(Where("contractMultiplier must be > 0"));
+        if (isOption && r.ContractMultiplier is null)
+            throw new InstrumentConfigException(Where("contractMultiplier is required"));
 
         return new Instrument
         {
@@ -114,6 +173,14 @@ public static class InstrumentLoader
             Currency = r.Currency!,
             Isin = r.Isin!,
             SecurityType = r.SecurityType!,
+            StrikePrice = strikePrice,
+            ExpirationDate = expirationDate,
+            PutOrCall = putOrCall,
+            ExerciseStyle = exerciseStyle,
+            UnderlyingSecurityId = r.UnderlyingSecurityId,
+            UnderlyingSymbol = underlyingSymbol,
+            ContractMultiplier = r.ContractMultiplier,
+            OptPayoutType = optPayoutType ?? (isOption ? B3.Exchange.Instruments.OptPayoutType.Vanilla : null),
         };
     }
 
@@ -128,6 +195,14 @@ public static class InstrumentLoader
         [JsonPropertyName("currency")] public string? Currency { get; set; }
         [JsonPropertyName("isin")] public string? Isin { get; set; }
         [JsonPropertyName("securityType")] public string? SecurityType { get; set; }
+        [JsonPropertyName("strikePrice")] public decimal? StrikePrice { get; set; }
+        [JsonPropertyName("expirationDate")] public string? ExpirationDate { get; set; }
+        [JsonPropertyName("putOrCall")] public string? PutOrCall { get; set; }
+        [JsonPropertyName("exerciseStyle")] public string? ExerciseStyle { get; set; }
+        [JsonPropertyName("underlyingSecurityId")] public long? UnderlyingSecurityId { get; set; }
+        [JsonPropertyName("underlyingSymbol")] public string? UnderlyingSymbol { get; set; }
+        [JsonPropertyName("contractMultiplier")] public decimal? ContractMultiplier { get; set; }
+        [JsonPropertyName("optPayoutType")] public string? OptPayoutType { get; set; }
     }
 
     /// <summary>
@@ -148,8 +223,7 @@ public static class InstrumentLoader
                     {
                         var s = reader.GetString();
                         if (string.IsNullOrWhiteSpace(s)) return null;
-                        if (decimal.TryParse(s, System.Globalization.NumberStyles.Number,
-                                System.Globalization.CultureInfo.InvariantCulture, out var d))
+                        if (decimal.TryParse(s, NumberStyles.Number, CultureInfo.InvariantCulture, out var d))
                             return d;
                         throw new JsonException($"Invalid decimal: '{s}'");
                     }
@@ -161,7 +235,7 @@ public static class InstrumentLoader
         public override void Write(Utf8JsonWriter writer, decimal? value, JsonSerializerOptions options)
         {
             if (value is null) writer.WriteNullValue();
-            else writer.WriteStringValue(value.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            else writer.WriteStringValue(value.Value.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/src/B3.Exchange.Instruments/InstrumentLoader.cs
+++ b/src/B3.Exchange.Instruments/InstrumentLoader.cs
@@ -116,8 +116,6 @@ public static class InstrumentLoader
             throw new InstrumentConfigException(Where("securityId must be > 0"));
         if (r.TickSize is null || r.TickSize.Value <= 0)
             throw new InstrumentConfigException(Where("tickSize must be > 0"));
-        if (r.LotSize is null || r.LotSize.Value <= 0)
-            throw new InstrumentConfigException(Where("lotSize must be > 0"));
         if (string.IsNullOrWhiteSpace(r.Currency))
             throw new InstrumentConfigException(Where("currency is required"));
         if (string.IsNullOrWhiteSpace(r.Isin))
@@ -126,6 +124,18 @@ public static class InstrumentLoader
             throw new InstrumentConfigException(Where("securityType is required"));
 
         var isOption = InstrumentSecurityTypes.IsOption(r.SecurityType);
+        var lotSize = r.LotSize;
+        if (isOption)
+        {
+            if (lotSize is null)
+                lotSize = 1;
+            else if (lotSize.Value != 1)
+                throw new InstrumentConfigException(Where("lotSize must be 1 for option securityTypes"));
+        }
+        else if (lotSize is null || lotSize.Value <= 0)
+        {
+            throw new InstrumentConfigException(Where("lotSize must be > 0"));
+        }
 
         if (r.MinPrice is null || r.MinPrice.Value < 0 || (!isOption && r.MinPrice.Value == 0))
             throw new InstrumentConfigException(Where(isOption ? "minPx must be >= 0" : "minPx must be > 0"));
@@ -144,6 +154,9 @@ public static class InstrumentLoader
             throw new InstrumentConfigException(Where("strikePrice is required"));
 
         var expirationDate = ParseDateOnly(r.ExpirationDate, "expirationDate", Where, required: isOption);
+        if (expirationDate is { } parsedExpirationDate && parsedExpirationDate < DateOnly.FromDateTime(DateTime.UtcNow))
+            throw new InstrumentConfigException(Where("expirationDate must be today or later"));
+
         var putOrCall = ParseEnum<PutOrCall>(r.PutOrCall, "putOrCall", Where, required: isOption);
         var exerciseStyle = ParseEnum<ExerciseStyle>(r.ExerciseStyle, "exerciseStyle", Where, required: isOption);
         var optPayoutType = ParseEnum<OptPayoutType>(r.OptPayoutType, "optPayoutType", Where, required: false);
@@ -167,7 +180,7 @@ public static class InstrumentLoader
             Symbol = r.Symbol!,
             SecurityId = r.SecurityId.Value,
             TickSize = r.TickSize.Value,
-            LotSize = r.LotSize.Value,
+            LotSize = lotSize!.Value,
             MinPrice = r.MinPrice.Value,
             MaxPrice = r.MaxPrice.Value,
             Currency = r.Currency!,

--- a/src/B3.Exchange.Instruments/InstrumentSecurityTypes.cs
+++ b/src/B3.Exchange.Instruments/InstrumentSecurityTypes.cs
@@ -1,0 +1,15 @@
+namespace B3.Exchange.Instruments;
+
+public static class InstrumentSecurityTypes
+{
+    public static bool IsOption(string securityType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(securityType);
+
+        return securityType.ToUpperInvariant() switch
+        {
+            "OPT" or "INDEXOPT" or "FOPT" or "OPTION" or "INDEXOPTION" => true,
+            _ => false,
+        };
+    }
+}

--- a/src/B3.Exchange.Matching/InstrumentTradingRules.cs
+++ b/src/B3.Exchange.Matching/InstrumentTradingRules.cs
@@ -17,6 +17,8 @@ public sealed class InstrumentTradingRules
     public long MinPriceMantissa { get; }
     public long MaxPriceMantissa { get; }
     public long LotSize { get; }
+    public decimal? ContractMultiplier { get; }
+    public long? ExpirationTimestamp { get; }
 
     public InstrumentTradingRules(Instrument instrument)
     {
@@ -26,9 +28,17 @@ public sealed class InstrumentTradingRules
         MinPriceMantissa = ToMantissaChecked(instrument.MinPrice, nameof(instrument.MinPrice));
         MaxPriceMantissa = ToMantissaChecked(instrument.MaxPrice, nameof(instrument.MaxPrice));
         LotSize = instrument.LotSize;
+        ContractMultiplier = instrument.ContractMultiplier;
+        ExpirationTimestamp = instrument.ExpirationDate is { } expirationDate
+            ? expirationDate.ToDateTime(TimeOnly.MaxValue).Ticks
+            : null;
+
+        var isOption = InstrumentSecurityTypes.IsOption(instrument.SecurityType);
+
         if (TickSizeMantissa <= 0) throw new ArgumentException("TickSize must be > 0 after scale", nameof(instrument));
         if (LotSize <= 0) throw new ArgumentException("LotSize must be > 0", nameof(instrument));
-        if (MinPriceMantissa <= 0) throw new ArgumentException("MinPrice must be > 0 after scale", nameof(instrument));
+        if (MinPriceMantissa < 0 || (!isOption && MinPriceMantissa == 0))
+            throw new ArgumentException(isOption ? "MinPrice must be >= 0 after scale" : "MinPrice must be > 0 after scale", nameof(instrument));
         if (MaxPriceMantissa < MinPriceMantissa) throw new ArgumentException("MaxPrice < MinPrice", nameof(instrument));
         if (MinPriceMantissa % TickSizeMantissa != 0) throw new ArgumentException("MinPrice not a multiple of TickSize", nameof(instrument));
         if (MaxPriceMantissa % TickSizeMantissa != 0) throw new ArgumentException("MaxPrice not a multiple of TickSize", nameof(instrument));

--- a/tests/B3.Exchange.Instruments.Tests/InstrumentLoaderOptionsTests.cs
+++ b/tests/B3.Exchange.Instruments.Tests/InstrumentLoaderOptionsTests.cs
@@ -41,6 +41,20 @@ public class InstrumentLoaderOptionsTests
     }
 
     [Fact]
+    public void Load_OptionWithoutLotSize_DefaultsToOneContract()
+    {
+        var inst = InstrumentLoader.LoadFromString(BuildOptionJson(omitFields: ["lotSize"]))[0];
+        Assert.Equal(1, inst.LotSize);
+    }
+
+    [Fact]
+    public void Load_OptionLotSizeOtherThanOne_Throws()
+    {
+        var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(BuildOptionJson(("lotSize", "100"))));
+        Assert.Contains("lotSize must be 1", ex.Message);
+    }
+
+    [Fact]
     public void Load_OptionMinPxZero_IsAccepted()
     {
         var inst = InstrumentLoader.LoadFromString(BuildOptionJson(("minPx", "\"0.00\"")))[0];
@@ -61,6 +75,14 @@ public class InstrumentLoaderOptionsTests
     {
         var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(BuildOptionJson(("contractMultiplier", contractMultiplier))));
         Assert.Contains("contractMultiplier must be > 0", ex.Message);
+    }
+
+    [Fact]
+    public void Load_ExpiredOption_Throws()
+    {
+        var expiredDate = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1).ToString("yyyy-MM-dd");
+        var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(BuildOptionJson(("expirationDate", $"\"{expiredDate}\""))));
+        Assert.Contains("expirationDate must be today or later", ex.Message);
     }
 
     private static string BuildOptionJson((string Key, string Value)? overrideField = null, string[]? omitFields = null)

--- a/tests/B3.Exchange.Instruments.Tests/InstrumentLoaderOptionsTests.cs
+++ b/tests/B3.Exchange.Instruments.Tests/InstrumentLoaderOptionsTests.cs
@@ -1,0 +1,121 @@
+using B3.Exchange.Instruments;
+
+namespace B3.Exchange.Instruments.Tests;
+
+public class InstrumentLoaderOptionsTests
+{
+    [Fact]
+    public void Load_OptionInstrument_ParsesOptionFields()
+    {
+        var inst = InstrumentLoader.LoadFromString(BuildOptionJson(("optPayoutType", "\"Binary\"")))[0];
+
+        Assert.Equal(32.00m, inst.StrikePrice);
+        Assert.Equal(new DateOnly(2026, 8, 21), inst.ExpirationDate);
+        Assert.Equal(PutOrCall.Call, inst.PutOrCall);
+        Assert.Equal(ExerciseStyle.American, inst.ExerciseStyle);
+        Assert.Equal(900000000001L, inst.UnderlyingSecurityId);
+        Assert.Equal("PETR4", inst.UnderlyingSymbol);
+        Assert.Equal(100m, inst.ContractMultiplier);
+        Assert.Equal(OptPayoutType.Binary, inst.OptPayoutType);
+    }
+
+    [Theory]
+    [InlineData("strikePrice")]
+    [InlineData("expirationDate")]
+    [InlineData("putOrCall")]
+    [InlineData("exerciseStyle")]
+    [InlineData("underlyingSecurityId")]
+    [InlineData("underlyingSymbol")]
+    [InlineData("contractMultiplier")]
+    public void Load_OptionMissingRequiredField_Throws(string field)
+    {
+        var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(BuildOptionJson(omitFields: [field])));
+        Assert.Contains(field, ex.Message);
+    }
+
+    [Fact]
+    public void Load_OptionWithoutOptPayoutType_DefaultsToVanilla()
+    {
+        var inst = InstrumentLoader.LoadFromString(BuildOptionJson(omitFields: ["optPayoutType"]))[0];
+        Assert.Equal(OptPayoutType.Vanilla, inst.OptPayoutType);
+    }
+
+    [Fact]
+    public void Load_OptionMinPxZero_IsAccepted()
+    {
+        var inst = InstrumentLoader.LoadFromString(BuildOptionJson(("minPx", "\"0.00\"")))[0];
+        Assert.Equal(0m, inst.MinPrice);
+    }
+
+    [Fact]
+    public void Load_EquityMinPxZero_IsRejected()
+    {
+        var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(BuildEquityJson(("minPx", "\"0.00\""))));
+        Assert.Contains("minPx must be > 0", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("\"0\"")]
+    [InlineData("\"-1\"")]
+    public void Load_OptionNonPositiveContractMultiplier_Throws(string contractMultiplier)
+    {
+        var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(BuildOptionJson(("contractMultiplier", contractMultiplier))));
+        Assert.Contains("contractMultiplier must be > 0", ex.Message);
+    }
+
+    private static string BuildOptionJson((string Key, string Value)? overrideField = null, string[]? omitFields = null)
+    {
+        var fields = new Dictionary<string, string>
+        {
+            ["symbol"] = "\"PETRH320\"",
+            ["securityId"] = "900000001234",
+            ["tickSize"] = "\"0.01\"",
+            ["lotSize"] = "1",
+            ["minPx"] = "\"0.01\"",
+            ["maxPx"] = "\"100.00\"",
+            ["currency"] = "\"BRL\"",
+            ["isin"] = "\"BROPTEST0001\"",
+            ["securityType"] = "\"OPT\"",
+            ["strikePrice"] = "\"32.00\"",
+            ["expirationDate"] = "\"2026-08-21\"",
+            ["putOrCall"] = "\"Call\"",
+            ["exerciseStyle"] = "\"American\"",
+            ["underlyingSecurityId"] = "900000000001",
+            ["underlyingSymbol"] = "\"PETR4\"",
+            ["contractMultiplier"] = "\"100\"",
+            ["optPayoutType"] = "\"Vanilla\"",
+        };
+
+        if (overrideField is { } pair)
+            fields[pair.Key] = pair.Value;
+
+        if (omitFields is not null)
+        {
+            foreach (var field in omitFields)
+                fields.Remove(field);
+        }
+
+        return "[{" + string.Join(",", fields.Select(kv => $"\"{kv.Key}\":{kv.Value}")) + "}]";
+    }
+
+    private static string BuildEquityJson((string Key, string Value)? overrideField = null)
+    {
+        var fields = new Dictionary<string, string>
+        {
+            ["symbol"] = "\"PETR4\"",
+            ["securityId"] = "900000000001",
+            ["tickSize"] = "\"0.01\"",
+            ["lotSize"] = "100",
+            ["minPx"] = "\"0.01\"",
+            ["maxPx"] = "\"100.00\"",
+            ["currency"] = "\"BRL\"",
+            ["isin"] = "\"BRPETRACNPR6\"",
+            ["securityType"] = "\"CS\"",
+        };
+
+        if (overrideField is { } pair)
+            fields[pair.Key] = pair.Value;
+
+        return "[{" + string.Join(",", fields.Select(kv => $"\"{kv.Key}\":{kv.Value}")) + "}]";
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/InstrumentTradingRulesOptionsTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/InstrumentTradingRulesOptionsTests.cs
@@ -1,0 +1,56 @@
+using B3.Exchange.Instruments;
+
+namespace B3.Exchange.Matching.Tests;
+
+public class InstrumentTradingRulesOptionsTests
+{
+    [Fact]
+    public void Constructor_OptionInstrument_ExposesOptionMetadataAndAllowsZeroMinPrice()
+    {
+        var instrument = new Instrument
+        {
+            Symbol = "PETRH320",
+            SecurityId = 900000001234,
+            TickSize = 0.01m,
+            LotSize = 1,
+            MinPrice = 0m,
+            MaxPrice = 100m,
+            Currency = "BRL",
+            Isin = "BROPTEST0001",
+            SecurityType = "OPT",
+            StrikePrice = 32m,
+            ExpirationDate = new DateOnly(2026, 8, 21),
+            PutOrCall = PutOrCall.Call,
+            ExerciseStyle = ExerciseStyle.American,
+            UnderlyingSecurityId = TestFactory.PetrSecId,
+            UnderlyingSymbol = "PETR4",
+            ContractMultiplier = 100m,
+            OptPayoutType = OptPayoutType.Vanilla,
+        };
+
+        var rules = new InstrumentTradingRules(instrument);
+
+        Assert.Equal(0, rules.MinPriceMantissa);
+        Assert.Equal(100m, rules.ContractMultiplier);
+        Assert.Equal(instrument.ExpirationDate.Value.ToDateTime(TimeOnly.MaxValue).Ticks, rules.ExpirationTimestamp);
+    }
+
+    [Fact]
+    public void Constructor_NonOptionWithZeroMinPrice_Throws()
+    {
+        var instrument = new Instrument
+        {
+            Symbol = "PETR4",
+            SecurityId = TestFactory.PetrSecId,
+            TickSize = 0.01m,
+            LotSize = 100,
+            MinPrice = 0m,
+            MaxPrice = 100m,
+            Currency = "BRL",
+            Isin = "BRPETRACNPR6",
+            SecurityType = "EQUITY",
+        };
+
+        Assert.Throws<ArgumentException>(() => _ = new InstrumentTradingRules(instrument));
+    }
+}


### PR DESCRIPTION
Implements trail T-1 of RFC 0002 (OPT-01, OPT-05, OPT-09):

- add option-specific fields and enums to `Instrument`
- extend `InstrumentLoader` to parse/validate option metadata
- relax `minPx` to allow `0` for option security types only
- expose `ContractMultiplier` + `ExpirationTimestamp` on `InstrumentTradingRules`
- add loader + matching tests for the new validation branches

RFC: docs/rfc/0002-equity-options-support.md
Umbrella: #463

Closes #466
Closes #467
Closes #469