### PR TITLE
feat(umdf): PriceBand_22 encoder + opt-in emission policy (OPT-07)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -65,6 +65,10 @@
       "ttl": 1,
       "selfTradePrevention": "none",
       "instruments": "config/instruments-eqt.json",
+      // Optional static PriceBand_22 cadence on the incremental feed.
+      // 0 (default) disables emission; instruments without lower/upper
+      // price-band fields are always skipped.
+      "priceBandPublishIntervalMs": 0,
       // Optional snapshot publisher. Multicast group/port MUST be distinct
       // from the incremental channel; consumers subscribe to both
       // independently and use the snapshot to bootstrap the order book on

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -35,8 +35,20 @@ public sealed partial class ChannelDispatcher
         if (item.Kind == WorkKind.PriceBandPublish)
         {
             AssertOnLoopThread();
+            if (Volatile.Read(ref _walHalted) != 0)
+            {
+                _metrics?.IncWalHaltReject();
+                LogWalHalted(ChannelNumber, item.Kind);
+                return;
+            }
+
             if (_priceBandPublisher?.PublishOnce(FrameSink, _engine.AllocateNextRptSeq, _timeSource.NowNanos()) > 0)
+            {
                 FlushPacket();
+                // PriceBand_22 republish consumes engine RptSeq values, so persist
+                // them like the other synthetic incremental emissions.
+                OnAfterCommandFlushed(force: true);
+            }
             return;
         }
 

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -32,6 +32,14 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.PriceBandPublish)
+        {
+            AssertOnLoopThread();
+            if (_priceBandPublisher?.PublishOnce(FrameSink, _engine.AllocateNextRptSeq, _timeSource.NowNanos()) > 0)
+                FlushPacket();
+            return;
+        }
+
         if (item.Kind == WorkKind.OperatorPersistSnapshot)
         {
             // Issue #271: admin "snapshot/force" — capture + persist the

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -86,6 +86,20 @@ public sealed partial class ChannelDispatcher
     }
 
     /// <summary>
+    /// Attaches a <see cref="PriceBandPublisher"/> to this dispatcher. May only
+    /// be called once. After this returns, any caller may invoke
+    /// <see cref="EnqueuePriceBandTick"/> to schedule a publish on the
+    /// dispatch thread.
+    /// </summary>
+    public void AttachPriceBandPublisher(PriceBandPublisher publisher)
+    {
+        ArgumentNullException.ThrowIfNull(publisher);
+        if (_priceBandPublisher != null)
+            throw new InvalidOperationException("price-band publisher already attached");
+        _priceBandPublisher = publisher;
+    }
+
+    /// <summary>
     /// Posts a snapshot tick into the inbound queue. Returns <c>false</c> if
     /// the queue is full (snapshots are idempotent — losing a tick simply
     /// defers the next refresh by one period). Safe to call from any thread.
@@ -93,6 +107,16 @@ public sealed partial class ChannelDispatcher
     public bool EnqueueSnapshotTick()
         => _inbound.Writer.TryWrite(new WorkItem(WorkKind.SnapshotRotation, default, 0, false,
             0, 0, null, null, null, null));
+
+    /// <summary>
+    /// Posts a price-band tick into the inbound queue. Returns <c>false</c>
+    /// when no publisher is attached or the queue is full. Safe to call from
+    /// any thread.
+    /// </summary>
+    public bool EnqueuePriceBandTick()
+        => _priceBandPublisher != null
+            && _inbound.Writer.TryWrite(new WorkItem(WorkKind.PriceBandPublish, default, 0, false,
+                0, 0, null, null, null, null));
 
     /// <summary>
     /// Operator command (issue #6): forces an immediate snapshot publish on

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -11,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -29,6 +29,7 @@ public sealed partial class ChannelDispatcher
         "MassCancel",
         "DecodeError",
         "SnapshotRotation",
+        "PriceBandPublish",
         "OperatorSnapshotNow",
         "OperatorBumpVersion",
         "OperatorTradeBust",

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -296,6 +296,7 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     private long? _crossSweepFilledQty;
 
     private SnapshotRotator? _snapshotRotator;
+    private PriceBandPublisher? _priceBandPublisher;
 
     /// <summary>
     /// Issue #319: outermost-command aggressor cumulative tracking. Set at
@@ -358,6 +359,13 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// work item so it observes a stable book.
     /// </summary>
     public SnapshotRotator? SnapshotRotator => _snapshotRotator;
+
+    /// <summary>
+    /// Static periodic <c>PriceBand_22</c> publisher bound to this dispatcher,
+    /// if any. Invoked only on the dispatch thread via
+    /// <see cref="WorkKind.PriceBandPublish"/>.
+    /// </summary>
+    public PriceBandPublisher? PriceBandPublisher => _priceBandPublisher;
 
     /// <summary>
     /// Issue #286: <c>false</c> once the channel has refused a WAL

--- a/src/B3.Exchange.Core/PriceBandPublisher.cs
+++ b/src/B3.Exchange.Core/PriceBandPublisher.cs
@@ -1,0 +1,62 @@
+using B3.Exchange.Instruments;
+using B3.Exchange.Matching;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Core;
+
+/// <summary>
+/// Periodic incremental-feed publisher for static <c>PriceBand_22</c> frames.
+/// The host schedules <see cref="PublishOnce"/> onto the owning dispatch thread
+/// so <c>RptSeq</c> allocation stays inside the channel's single-writer domain.
+/// </summary>
+public sealed class PriceBandPublisher
+{
+    private readonly Entry[] _entries;
+
+    public TimeSpan Cadence { get; }
+    public int Count => _entries.Length;
+
+    public PriceBandPublisher(IReadOnlyList<Instrument> instruments, TimeSpan cadence)
+    {
+        ArgumentNullException.ThrowIfNull(instruments);
+        if (cadence <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(cadence), "cadence must be positive");
+
+        Cadence = cadence;
+        var entries = new List<Entry>(instruments.Count);
+        for (int i = 0; i < instruments.Count; i++)
+        {
+            var rules = new InstrumentTradingRules(instruments[i]);
+            if (!rules.HasPriceBand) continue;
+            entries.Add(new Entry(
+                rules.Instrument.SecurityId,
+                rules.LowerPriceBandMantissa!.Value,
+                rules.UpperPriceBandMantissa!.Value));
+        }
+        _entries = entries.ToArray();
+    }
+
+    public int PublishOnce(IUmdfFrameSink sink, Func<uint> nextRptSeq, ulong mdEntryTimestampNanos)
+    {
+        ArgumentNullException.ThrowIfNull(nextRptSeq);
+        if (_entries.Length == 0) return 0;
+
+        foreach (ref readonly var entry in _entries.AsSpan())
+        {
+            UmdfFrameBuilder.WritePriceBand(
+                sink,
+                securityId: entry.SecurityId,
+                lowLimitPriceMantissa: entry.LowLimitPriceMantissa,
+                highLimitPriceMantissa: entry.HighLimitPriceMantissa,
+                mdEntryTimestampNanos: mdEntryTimestampNanos,
+                rptSeq: nextRptSeq());
+        }
+
+        return _entries.Length;
+    }
+
+    private readonly record struct Entry(
+        long SecurityId,
+        long LowLimitPriceMantissa,
+        long HighLimitPriceMantissa);
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -35,6 +35,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private readonly List<InstrumentDefinitionPublisher> _instrumentDefPublishers = new();
     private readonly List<IDisposable> _ownedSinks = new();
     private readonly List<Timer> _snapshotTimers = new();
+    private readonly List<Timer> _priceBandTimers = new();
     private readonly List<B3.Exchange.PostTrade.FileAuditLogWriter> _auditWriters = new();
     private readonly List<Timer> _auditRetentionTimers = new();
     private readonly Dictionary<byte, EodExportContext> _eodExportByChannel = new();
@@ -435,6 +436,26 @@ public sealed class ExchangeHost : IAsyncDisposable
                 _snapshotTimers.Add(timer);
                 _logger.LogInformation("channel {ChannelNumber}: snapshot → {Group}:{Port} every {CadenceMs:n0}ms",
                     ch.ChannelNumber, snap.Group, snap.Port, cadence.TotalMilliseconds);
+            }
+
+            if (ch.PriceBandPublishIntervalMs > 0)
+            {
+                var cadence = TimeSpan.FromMilliseconds(Math.Max(1, ch.PriceBandPublishIntervalMs));
+                var publisher = new PriceBandPublisher(instruments, cadence);
+                if (publisher.Count > 0)
+                {
+                    disp.AttachPriceBandPublisher(publisher);
+                    var capturedDisp = disp;
+                    var timer = new Timer(_ => capturedDisp.EnqueuePriceBandTick(), null, cadence, cadence);
+                    _priceBandTimers.Add(timer);
+                    _logger.LogInformation("channel {ChannelNumber}: price-band on incremental feed every {CadenceMs:n0}ms for {InstrumentCount} instruments",
+                        ch.ChannelNumber, cadence.TotalMilliseconds, publisher.Count);
+                }
+                else
+                {
+                    _logger.LogInformation("channel {ChannelNumber}: price-band cadence configured but no instruments carry lowerPriceBand/upperPriceBand",
+                        ch.ChannelNumber);
+                }
             }
 
             if (ch.InstrumentDefinition is { } idCfg)
@@ -1041,6 +1062,7 @@ public sealed class ExchangeHost : IAsyncDisposable
         if (_phaseScheduler != null) await _phaseScheduler.DisposeAsync().ConfigureAwait(false);
         if (_http != null) await _http.DisposeAsync().ConfigureAwait(false);
         foreach (var t in _snapshotTimers) await t.DisposeAsync().ConfigureAwait(false);
+        foreach (var t in _priceBandTimers) await t.DisposeAsync().ConfigureAwait(false);
         if (_listener != null) await _listener.DisposeAsync().ConfigureAwait(false);
         foreach (var p in _instrumentDefPublishers) await p.DisposeAsync().ConfigureAwait(false);
         foreach (var d in _dispatchers) await d.DisposeAsync().ConfigureAwait(false);
@@ -1170,6 +1192,11 @@ public sealed class ExchangeHost : IAsyncDisposable
             try { await t.DisposeAsync().ConfigureAwait(false); } catch { }
         }
         _snapshotTimers.Clear();
+        foreach (var t in _priceBandTimers)
+        {
+            try { await t.DisposeAsync().ConfigureAwait(false); } catch { }
+        }
+        _priceBandTimers.Clear();
         foreach (var p in _instrumentDefPublishers)
         {
             try { await p.DisposeAsync().ConfigureAwait(false); } catch { }

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -370,6 +370,14 @@ public sealed class ChannelConfig
     [JsonPropertyName("instrumentDefinition")] public InstrumentDefinitionConfig? InstrumentDefinition { get; set; }
 
     /// <summary>
+    /// Optional periodic <c>PriceBand_22</c> cadence for the incremental feed.
+    /// <c>0</c> (default) disables the publisher; a positive value schedules a
+    /// dispatch-thread tick that emits one static price-band frame per
+    /// configured instrument carrying <c>lowerPriceBand</c>/<c>upperPriceBand</c>.
+    /// </summary>
+    [JsonPropertyName("priceBandPublishIntervalMs")] public int PriceBandPublishIntervalMs { get; set; }
+
+    /// <summary>
     /// Optional UMDF retransmit ring sizing (issue #216 / Onda L · L3a).
     /// When omitted, the default ring size is used. Set
     /// <c>bufferSize=0</c> to disable retransmit buffering entirely (the

--- a/src/B3.Exchange.Instruments/Instrument.cs
+++ b/src/B3.Exchange.Instruments/Instrument.cs
@@ -19,6 +19,18 @@ public sealed record Instrument
     public required decimal MinPrice { get; init; }
     public required decimal MaxPrice { get; init; }
 
+    /// <summary>
+    /// Optional static lower price-band limit in human price units. When null,
+    /// the host does not emit <c>PriceBand_22</c> for this instrument.
+    /// </summary>
+    public decimal? LowerPriceBand { get; init; }
+
+    /// <summary>
+    /// Optional static upper price-band limit in human price units. When null,
+    /// the host does not emit <c>PriceBand_22</c> for this instrument.
+    /// </summary>
+    public decimal? UpperPriceBand { get; init; }
+
     public required string Currency { get; init; }
     public required string Isin { get; init; }
 

--- a/src/B3.Exchange.Instruments/InstrumentLoader.cs
+++ b/src/B3.Exchange.Instruments/InstrumentLoader.cs
@@ -116,6 +116,14 @@ public static class InstrumentLoader
             throw new InstrumentConfigException(Where("securityId must be > 0"));
         if (r.TickSize is null || r.TickSize.Value <= 0)
             throw new InstrumentConfigException(Where("tickSize must be > 0"));
+        if (r.LowerPriceBand.HasValue != r.UpperPriceBand.HasValue)
+            throw new InstrumentConfigException(Where("lowerPriceBand and upperPriceBand must both be set or both be null"));
+        if (r.LowerPriceBand is { } lowerBand && lowerBand <= 0)
+            throw new InstrumentConfigException(Where("lowerPriceBand must be > 0"));
+        if (r.UpperPriceBand is { } upperBand && upperBand <= 0)
+            throw new InstrumentConfigException(Where("upperPriceBand must be > 0"));
+        if (r.LowerPriceBand is { } bandLow && r.UpperPriceBand is { } bandHigh && bandHigh < bandLow)
+            throw new InstrumentConfigException(Where($"upperPriceBand ({bandHigh}) must be >= lowerPriceBand ({bandLow})"));
         if (string.IsNullOrWhiteSpace(r.Currency))
             throw new InstrumentConfigException(Where("currency is required"));
         if (string.IsNullOrWhiteSpace(r.Isin))
@@ -148,6 +156,20 @@ public static class InstrumentLoader
             throw new InstrumentConfigException(Where($"minPx ({r.MinPrice.Value}) is not a multiple of tickSize ({r.TickSize.Value})"));
         if (decimal.Remainder(r.MaxPrice.Value, r.TickSize.Value) != 0)
             throw new InstrumentConfigException(Where($"maxPx ({r.MaxPrice.Value}) is not a multiple of tickSize ({r.TickSize.Value})"));
+        if (r.LowerPriceBand is { } lowerPriceBand)
+        {
+            if (lowerPriceBand < r.MinPrice.Value || lowerPriceBand > r.MaxPrice.Value)
+                throw new InstrumentConfigException(Where($"lowerPriceBand ({lowerPriceBand}) must be within minPx/maxPx bounds"));
+            if (decimal.Remainder(lowerPriceBand, r.TickSize.Value) != 0)
+                throw new InstrumentConfigException(Where($"lowerPriceBand ({lowerPriceBand}) is not a multiple of tickSize ({r.TickSize.Value})"));
+        }
+        if (r.UpperPriceBand is { } upperPriceBand)
+        {
+            if (upperPriceBand < r.MinPrice.Value || upperPriceBand > r.MaxPrice.Value)
+                throw new InstrumentConfigException(Where($"upperPriceBand ({upperPriceBand}) must be within minPx/maxPx bounds"));
+            if (decimal.Remainder(upperPriceBand, r.TickSize.Value) != 0)
+                throw new InstrumentConfigException(Where($"upperPriceBand ({upperPriceBand}) is not a multiple of tickSize ({r.TickSize.Value})"));
+        }
 
         var strikePrice = r.StrikePrice;
         if (isOption && strikePrice is null)
@@ -183,6 +205,8 @@ public static class InstrumentLoader
             LotSize = lotSize!.Value,
             MinPrice = r.MinPrice.Value,
             MaxPrice = r.MaxPrice.Value,
+            LowerPriceBand = r.LowerPriceBand,
+            UpperPriceBand = r.UpperPriceBand,
             Currency = r.Currency!,
             Isin = r.Isin!,
             SecurityType = r.SecurityType!,
@@ -205,6 +229,8 @@ public static class InstrumentLoader
         [JsonPropertyName("lotSize")] public int? LotSize { get; set; }
         [JsonPropertyName("minPx")] public decimal? MinPrice { get; set; }
         [JsonPropertyName("maxPx")] public decimal? MaxPrice { get; set; }
+        [JsonPropertyName("lowerPriceBand")] public decimal? LowerPriceBand { get; set; }
+        [JsonPropertyName("upperPriceBand")] public decimal? UpperPriceBand { get; set; }
         [JsonPropertyName("currency")] public string? Currency { get; set; }
         [JsonPropertyName("isin")] public string? Isin { get; set; }
         [JsonPropertyName("securityType")] public string? SecurityType { get; set; }

--- a/src/B3.Exchange.Matching/InstrumentTradingRules.cs
+++ b/src/B3.Exchange.Matching/InstrumentTradingRules.cs
@@ -19,6 +19,9 @@ public sealed class InstrumentTradingRules
     public long LotSize { get; }
     public decimal? ContractMultiplier { get; }
     public long? ExpirationTimestamp { get; }
+    public long? LowerPriceBandMantissa { get; }
+    public long? UpperPriceBandMantissa { get; }
+    public bool HasPriceBand => LowerPriceBandMantissa.HasValue && UpperPriceBandMantissa.HasValue;
 
     public InstrumentTradingRules(Instrument instrument)
     {
@@ -27,6 +30,12 @@ public sealed class InstrumentTradingRules
         TickSizeMantissa = ToMantissaChecked(instrument.TickSize, nameof(instrument.TickSize));
         MinPriceMantissa = ToMantissaChecked(instrument.MinPrice, nameof(instrument.MinPrice));
         MaxPriceMantissa = ToMantissaChecked(instrument.MaxPrice, nameof(instrument.MaxPrice));
+        LowerPriceBandMantissa = instrument.LowerPriceBand.HasValue
+            ? ToMantissaChecked(instrument.LowerPriceBand.Value, nameof(instrument.LowerPriceBand))
+            : null;
+        UpperPriceBandMantissa = instrument.UpperPriceBand.HasValue
+            ? ToMantissaChecked(instrument.UpperPriceBand.Value, nameof(instrument.UpperPriceBand))
+            : null;
         LotSize = instrument.LotSize;
         ContractMultiplier = instrument.ContractMultiplier;
         ExpirationTimestamp = instrument.ExpirationDate is { } expirationDate
@@ -42,6 +51,24 @@ public sealed class InstrumentTradingRules
         if (MaxPriceMantissa < MinPriceMantissa) throw new ArgumentException("MaxPrice < MinPrice", nameof(instrument));
         if (MinPriceMantissa % TickSizeMantissa != 0) throw new ArgumentException("MinPrice not a multiple of TickSize", nameof(instrument));
         if (MaxPriceMantissa % TickSizeMantissa != 0) throw new ArgumentException("MaxPrice not a multiple of TickSize", nameof(instrument));
+        if (LowerPriceBandMantissa.HasValue != UpperPriceBandMantissa.HasValue)
+            throw new ArgumentException("LowerPriceBand and UpperPriceBand must both be set or both be null", nameof(instrument));
+        if (LowerPriceBandMantissa is { } lower)
+        {
+            if (lower < MinPriceMantissa || lower > MaxPriceMantissa)
+                throw new ArgumentException("LowerPriceBand outside instrument bounds", nameof(instrument));
+            if (lower % TickSizeMantissa != 0)
+                throw new ArgumentException("LowerPriceBand not a multiple of TickSize", nameof(instrument));
+        }
+        if (UpperPriceBandMantissa is { } upper)
+        {
+            if (upper < MinPriceMantissa || upper > MaxPriceMantissa)
+                throw new ArgumentException("UpperPriceBand outside instrument bounds", nameof(instrument));
+            if (upper % TickSizeMantissa != 0)
+                throw new ArgumentException("UpperPriceBand not a multiple of TickSize", nameof(instrument));
+        }
+        if (LowerPriceBandMantissa is { } low && UpperPriceBandMantissa is { } high && high < low)
+            throw new ArgumentException("UpperPriceBand < LowerPriceBand", nameof(instrument));
     }
 
     private static long ToMantissaChecked(decimal value, string name)

--- a/src/B3.Umdf.WireEncoder/UmdfFrameBuilder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfFrameBuilder.cs
@@ -222,6 +222,39 @@ public static class UmdfFrameBuilder
     }
 
     /// <summary>
+    /// Writes a <c>PriceBand_22</c> frame.
+    /// </summary>
+    public static void WritePriceBand(
+        IUmdfFrameSink sink,
+        long securityId,
+        long lowLimitPriceMantissa,
+        long highLimitPriceMantissa,
+        ulong mdEntryTimestampNanos,
+        uint rptSeq,
+        byte priceBandType = (byte)B3.Umdf.Mbo.Sbe.V16.PriceBandType.HARD_LIMIT,
+        byte priceLimitType = (byte)B3.Umdf.Mbo.Sbe.V16.PriceLimitType.PRICE_UNIT,
+        long tradingReferencePriceMantissa = long.MinValue,
+        byte priceBandMidpointPriceType = 255)
+    {
+        const int size = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.PriceBandBlockLength;
+        var dst = sink.Reserve(size);
+        int n = UmdfWireEncoder.WritePriceBandFrame(
+            dst,
+            securityId,
+            lowLimitPriceMantissa,
+            highLimitPriceMantissa,
+            mdEntryTimestampNanos,
+            rptSeq,
+            priceBandType,
+            priceLimitType,
+            tradingReferencePriceMantissa,
+            priceBandMidpointPriceType);
+        sink.Commit(n);
+    }
+
+    /// <summary>
     /// Writes a <c>TheoreticalOpeningPrice_16</c> frame. Used for the first
     /// frame in <c>OnAuctionTopChanged</c>.
     /// </summary>

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -564,6 +564,50 @@ public static class UmdfWireEncoder
     }
 
     /// <summary>
+    /// Writes <c>PriceBand_22</c> (V16). Returns total bytes. The schema carries
+    /// one effective low/high envelope per instrument, so callers pass the
+    /// already-resolved absolute limit prices.
+    /// </summary>
+    public static int WritePriceBandFrame(
+        Span<byte> dst,
+        long securityId,
+        long lowLimitPriceMantissa,
+        long highLimitPriceMantissa,
+        ulong mdEntryTimestampNanos,
+        uint rptSeq,
+        byte priceBandType = (byte)PriceBandType.HARD_LIMIT,
+        byte priceLimitType = (byte)PriceLimitType.PRICE_UNIT,
+        long tradingReferencePriceMantissa = long.MinValue,
+        byte priceBandMidpointPriceType = 255)
+    {
+        const int total = WireOffsets.FramingHeaderSize
+            + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.PriceBandBlockLength;
+        if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
+
+        WriteFramingHeader(dst, total);
+        B3.Umdf.Mbo.Sbe.V16.PriceBand_22Data.WriteHeader(
+            dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
+
+        var body = dst.Slice(
+            WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
+            WireOffsets.PriceBandBlockLength);
+        body.Clear();
+
+        MemoryMarshal.Write(body.Slice(WireOffsets.PriceBandBodySecurityIdOffset, 8), in securityId);
+        body[WireOffsets.PriceBandBodyPriceBandTypeOffset] = priceBandType;
+        body[WireOffsets.PriceBandBodyPriceLimitTypeOffset] = priceLimitType;
+        body[WireOffsets.PriceBandBodyPriceBandMidpointPriceTypeOffset] = priceBandMidpointPriceType;
+        MemoryMarshal.Write(body.Slice(WireOffsets.PriceBandBodyLowLimitPriceOffset, 8), in lowLimitPriceMantissa);
+        MemoryMarshal.Write(body.Slice(WireOffsets.PriceBandBodyHighLimitPriceOffset, 8), in highLimitPriceMantissa);
+        MemoryMarshal.Write(body.Slice(WireOffsets.PriceBandBodyTradingReferencePriceOffset, 8), in tradingReferencePriceMantissa);
+        MemoryMarshal.Write(body.Slice(WireOffsets.PriceBandBodyMdEntryTimestampOffset, 8), in mdEntryTimestampNanos);
+        MemoryMarshal.Write(body.Slice(WireOffsets.PriceBandBodyRptSeqOffset, 4), in rptSeq);
+
+        return total;
+    }
+
+    /// <summary>
     /// Writes <c>SecurityGroupPhase_10</c> (V16). Returns total bytes.
     /// Emitted when a security group's phase transitions
     /// (gap-functional §5 / #201). <paramref name="securityGroup"/> is an

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -148,6 +148,26 @@ public static class WireOffsets
     public const int SecurityStatusBodyTransactTimeOffset = 24;
     public const int SecurityStatusBodyRptSeqOffset = 32;
 
+    // ---- PriceBand_22 (V16) ----
+    // Body layout (BLOCK_LENGTH=48): securityID@0 (long); securityExchange@8
+    // shares offset with matchEventIndicator@8 (byte); priceBandType@9
+    // (byte, 255 = NULL); priceLimitType@10 (byte, 255 = NULL);
+    // priceBandMidpointPriceType@11 (byte, 255 = NULL); lowLimitPrice@12
+    // (PriceOptional); highLimitPrice@20 (PriceOptional);
+    // tradingReferencePrice@28 (Fixed8, long.MinValue = NULL);
+    // mDEntryTimestamp@36 (ulong nanos); rptSeq@44 (uint, 0 = NULL).
+    public const int PriceBandBlockLength = 48;
+    public const int PriceBandBodySecurityIdOffset = 0;
+    public const int PriceBandBodyMatchEventIndicatorOffset = 8;
+    public const int PriceBandBodyPriceBandTypeOffset = 9;
+    public const int PriceBandBodyPriceLimitTypeOffset = 10;
+    public const int PriceBandBodyPriceBandMidpointPriceTypeOffset = 11;
+    public const int PriceBandBodyLowLimitPriceOffset = 12;
+    public const int PriceBandBodyHighLimitPriceOffset = 20;
+    public const int PriceBandBodyTradingReferencePriceOffset = 28;
+    public const int PriceBandBodyMdEntryTimestampOffset = 36;
+    public const int PriceBandBodyRptSeqOffset = 44;
+
     // ---- SecurityGroupPhase_10 (V16) ----
     // Body layout (BLOCK_LENGTH=32): securityGroup@0 (8-byte char array);
     // matchEventIndicator@8 (byte); tradingSessionID@9 (byte);

--- a/tests/B3.Exchange.Host.Tests/Data/instruments-priceband.json
+++ b/tests/B3.Exchange.Host.Tests/Data/instruments-priceband.json
@@ -1,0 +1,15 @@
+[
+  {
+    "symbol": "PETR4",
+    "securityId": 900000000001,
+    "tickSize": "0.01",
+    "lotSize": 100,
+    "minPx": "10.00",
+    "maxPx": "99.99",
+    "lowerPriceBand": "11.50",
+    "upperPriceBand": "18.25",
+    "currency": "BRL",
+    "isin": "BRPETRACNPR6",
+    "securityType": "CS"
+  }
+]

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostPriceBandE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostPriceBandE2ETests.cs
@@ -1,0 +1,112 @@
+using System.Runtime.InteropServices;
+using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
+using B3.Umdf.Mbo.Sbe.V16;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Host.Tests;
+
+public class ExchangeHostPriceBandE2ETests
+{
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    [Fact]
+    public async Task PriceBandTick_WithConfiguredBands_PublishesPriceBandOnIncrementalFeed()
+    {
+        var instrumentsPath = TestPaths.ResolveRepoFile("tests/B3.Exchange.Host.Tests/Data/instruments-priceband.json");
+        var cfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30184,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    PriceBandPublishIntervalMs = 60_000,
+                },
+            },
+        };
+        var incSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => incSink);
+        await host.StartAsync();
+
+        Assert.Single(host.Dispatchers);
+        Assert.NotNull(host.Dispatchers[0].PriceBandPublisher);
+        Assert.True(host.Dispatchers[0].EnqueuePriceBandTick());
+
+        byte[]? pkt = null;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (pkt is null && DateTime.UtcNow < deadline)
+        {
+            lock (incSink.Packets)
+            {
+                if (incSink.Packets.Count > 0)
+                    pkt = (byte[])incSink.Packets[0].Clone();
+            }
+
+            if (pkt is null)
+                await Task.Delay(20);
+        }
+
+        Assert.True(pkt is not null, "price-band packet not received");
+        ref readonly var hdr = ref MemoryMarshal.AsRef<PacketHeader>(pkt.AsSpan(0, WireOffsets.PacketHeaderSize));
+        Assert.Equal((byte)84, hdr.ChannelNumber);
+        Assert.Equal((ushort)1, hdr.SequenceVersion);
+        Assert.Equal(1u, hdr.SequenceNumber);
+
+        int frameOff = WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize;
+        Assert.True(PriceBand_22Data.TryParse(
+            pkt.AsSpan(frameOff, WireOffsets.PriceBandBlockLength), out var rdr));
+        Assert.Equal(900000000001L, (long)(ulong)rdr.Data.SecurityID.Value);
+        Assert.Equal(115_000L, rdr.Data.LowLimitPrice.Mantissa);
+        Assert.Equal(182_500L, rdr.Data.HighLimitPrice.Mantissa);
+        Assert.Equal(1u, rdr.Data.RptSeq);
+    }
+
+    [Fact]
+    public async Task PriceBandTick_WithoutConfiguredBands_IsSkipped()
+    {
+        var instrumentsPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+        var cfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+            Channels =
+            {
+                new ChannelConfig
+                {
+                    ChannelNumber = 84,
+                    IncrementalGroup = "239.255.42.84",
+                    IncrementalPort = 30184,
+                    Ttl = 0,
+                    InstrumentsFile = instrumentsPath,
+                    PriceBandPublishIntervalMs = 60_000,
+                },
+            },
+        };
+        var incSink = new RecordingPacketSink();
+        await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => incSink);
+        await host.StartAsync();
+
+        Assert.Single(host.Dispatchers);
+        Assert.Null(host.Dispatchers[0].PriceBandPublisher);
+        Assert.False(host.Dispatchers[0].EnqueuePriceBandTick());
+        await Task.Delay(100);
+        lock (incSink.Packets)
+        {
+            Assert.Empty(incSink.Packets);
+        }
+    }
+}

--- a/tests/B3.Exchange.Instruments.Tests/InstrumentLoaderTests.cs
+++ b/tests/B3.Exchange.Instruments.Tests/InstrumentLoaderTests.cs
@@ -28,6 +28,8 @@ public class InstrumentLoaderTests
         Assert.Equal("BRL", i.Currency);
         Assert.Equal("BRPETRACNPR6", i.Isin);
         Assert.Equal("CS", i.SecurityType);
+        Assert.Null(i.LowerPriceBand);
+        Assert.Null(i.UpperPriceBand);
     }
 
     [Fact]
@@ -129,6 +131,56 @@ public class InstrumentLoaderTests
             """;
         var insts = InstrumentLoader.LoadFromString(json);
         Assert.Single(insts);
+    }
+
+    [Fact]
+    public void Load_WithStaticPriceBands_RoundTripsOptionalFields()
+    {
+        var json = """
+            [
+              {
+                "symbol": "PETR4",
+                "securityId": 1,
+                "tickSize": "0.01",
+                "lotSize": 100,
+                "minPx": "10.00",
+                "maxPx": "99.99",
+                "lowerPriceBand": "11.50",
+                "upperPriceBand": "18.25",
+                "currency": "BRL",
+                "isin": "BRPETRACNPR6",
+                "securityType": "CS"
+              }
+            ]
+            """;
+
+        var inst = Assert.Single(InstrumentLoader.LoadFromString(json));
+        Assert.Equal(11.50m, inst.LowerPriceBand);
+        Assert.Equal(18.25m, inst.UpperPriceBand);
+    }
+
+    [Fact]
+    public void Load_WithOnlyOnePriceBandBound_Throws()
+    {
+        var json = """
+            [
+              {
+                "symbol": "PETR4",
+                "securityId": 1,
+                "tickSize": "0.01",
+                "lotSize": 100,
+                "minPx": "10.00",
+                "maxPx": "99.99",
+                "lowerPriceBand": "11.50",
+                "currency": "BRL",
+                "isin": "BRPETRACNPR6",
+                "securityType": "CS"
+              }
+            ]
+            """;
+
+        var ex = Assert.Throws<InstrumentConfigException>(() => InstrumentLoader.LoadFromString(json));
+        Assert.Contains("lowerPriceBand and upperPriceBand", ex.Message);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/CancelReplaceTests.cs
@@ -341,4 +341,28 @@ public class InstrumentRulesTests
         };
         Assert.Throws<ArgumentException>((Action)(() => { _ = new InstrumentTradingRules(bad); }));
     }
+
+    [Fact]
+    public void PriceBands_AreScaledToMantissas()
+    {
+        var inst = new Instrument
+        {
+            Symbol = "X",
+            SecurityId = 1,
+            TickSize = 0.05m,
+            LotSize = 1,
+            MinPrice = 10m,
+            MaxPrice = 20m,
+            LowerPriceBand = 10.50m,
+            UpperPriceBand = 19.95m,
+            Currency = "BRL",
+            Isin = "X",
+            SecurityType = "EQUITY",
+        };
+
+        var rules = new InstrumentTradingRules(inst);
+        Assert.True(rules.HasPriceBand);
+        Assert.Equal(105_000L, rules.LowerPriceBandMantissa);
+        Assert.Equal(199_500L, rules.UpperPriceBandMantissa);
+    }
 }

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfFrameBuilderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfFrameBuilderTests.cs
@@ -254,6 +254,23 @@ public class UmdfFrameBuilderTests
     }
 
     [Fact]
+    public void WritePriceBand_ReservesAndCommitsCorrectSize()
+    {
+        var sink = MakeSink();
+        UmdfFrameBuilder.WritePriceBand(sink,
+            securityId: 1L,
+            lowLimitPriceMantissa: 100_0000L,
+            highLimitPriceMantissa: 110_0000L,
+            mdEntryTimestampNanos: 0ul,
+            rptSeq: 12u);
+
+        int expected = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize
+            + WireOffsets.PriceBandBlockLength;
+        Assert.Equal(expected, sink.ReservedSize);
+        Assert.Equal(expected, sink.CommittedBytes);
+    }
+
+    [Fact]
     public void WriteTrade_ReservesAndCommitsCorrectSize()
     {
         var sink = MakeSink();

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -396,6 +396,42 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void PriceBand_Roundtrip()
+    {
+        var buf = new byte[80];
+        int n = UmdfWireEncoder.WritePriceBandFrame(buf,
+            securityId: 4242L,
+            lowLimitPriceMantissa: 123_450L,
+            highLimitPriceMantissa: 234_560L,
+            mdEntryTimestampNanos: 1_700_000_000_000_000_000UL,
+            rptSeq: 42,
+            priceBandType: (byte)PriceBandType.HARD_LIMIT,
+            priceLimitType: (byte)PriceLimitType.PRICE_UNIT,
+            tradingReferencePriceMantissa: long.MinValue,
+            priceBandMidpointPriceType: 255);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.PriceBandBlockLength, n);
+
+        Assert.True(PriceBand_22Data.TryParse(
+            buf.AsSpan(FrameOffset, WireOffsets.PriceBandBlockLength), out var rdr));
+        Assert.Equal(4242L, (long)(ulong)rdr.Data.SecurityID.Value);
+        Assert.Equal(PriceBandType.HARD_LIMIT, rdr.Data.PriceBandType);
+        Assert.Equal(PriceLimitType.PRICE_UNIT, rdr.Data.PriceLimitType);
+        Assert.Null(rdr.Data.PriceBandMidpointPriceType);
+        Assert.Equal(123_450L, rdr.Data.LowLimitPrice.Mantissa);
+        Assert.Equal(234_560L, rdr.Data.HighLimitPrice.Mantissa);
+        Assert.Null(rdr.Data.TradingReferencePrice.Mantissa);
+        Assert.Equal(1_700_000_000_000_000_000UL, rdr.Data.MDEntryTimestamp.Time);
+        Assert.Equal(42u, rdr.Data.RptSeq);
+    }
+
+    [Fact]
+    public void PriceBand_WireOffsetsMatchGeneratedCodec()
+    {
+        Assert.Equal(WireOffsets.PriceBandBlockLength, PriceBand_22Data.BLOCK_LENGTH);
+        Assert.Equal(WireOffsets.PriceBandBlockLength, Marshal.SizeOf<PriceBand_22Data>());
+    }
+
+    [Fact]
     public void TheoreticalOpeningPrice_Roundtrip_HasTop()
     {
         var buf = new byte[80];


### PR DESCRIPTION
## Summary
- add `PriceBand_22` wire offsets, encoder, and frame-builder coverage
- add opt-in static price-band metadata on instruments plus host-driven periodic emission on the incremental feed
- add host/instrument/matching tests for configured vs skipped emission

## Links
- RFC 0002 §2.1 / §5 / §8: `docs/rfc/0002-equity-options-support.md`
- Closes #470
- Umbrella: #463

## Notes
- Default behavior is unchanged: `channels[].priceBandPublishIntervalMs = 0` disables emission and instruments without `lowerPriceBand`/`upperPriceBand` are skipped.
- T-1 is running in parallel and may touch `Instrument.cs`; this change keeps the new fields additive to minimize the merge conflict surface.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>