### PR TITLE
chore(config): add OPT channel + sample option instruments (T-4: OPT-04)

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -119,6 +119,39 @@
         "ttl": 1,
         "cadenceMs": 5000
       }
+    },
+    // Third channel group (OPT) — equity options (RFC 0002 §3.1 /
+    // T-4 / OPT-04). Real B3 publishes equity options on a channel
+    // distinct from cash equities; mirror that here. SecurityIDs in
+    // config/instruments-opt.json use the 902xxx prefix to stay
+    // disjoint from EQT (900xxx) and DRV (901xxx) so HostRouter can
+    // partition cleanly by SecurityId. Per ADR 0009 the OPT
+    // dispatcher owns its own MatchingEngine, OrderRegistry,
+    // _stopsBySymbol and _lastTradePriceBySecurity — options
+    // trading cannot perturb equities and vice versa. Cross-channel
+    // stop triggers (e.g. an option stop firing on the underlying's
+    // last trade) are an explicit MVP non-goal (RFC §3.1).
+    {
+      "channelNumber": 78,
+      "incrementalGroup": "224.0.20.78",
+      "incrementalPort": 30078,
+      "ttl": 1,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-opt.json",
+      "snapshot": {
+        "group": "224.0.20.178",
+        "port": 30178,
+        "ttl": 1,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 178,
+        "group": "224.0.21.78",
+        "port": 31078,
+        "ttl": 1,
+        "cadenceMs": 5000
+      }
     }
   ]
 }

--- a/config/instruments-opt.json
+++ b/config/instruments-opt.json
@@ -30,7 +30,7 @@
   {
     "symbol": "PETRL200", "securityId": 902000000001,
     "tickSize": "0.01", "lotSize": 1, "minPx": "0.01", "maxPx": "999.99",
-    "currency": "BRL", "isin": "BRPETROPCL200",
+    "currency": "BRL", "isin": "BRPETROPL200",
     "securityType": "OPTION",
     "strikePrice": "20.00", "expirationDate": "2030-12-20",
     "putOrCall": "Call", "exerciseStyle": "American",
@@ -40,7 +40,7 @@
   {
     "symbol": "PETRX250", "securityId": 902000000002,
     "tickSize": "0.01", "lotSize": 1, "minPx": "0.01", "maxPx": "999.99",
-    "currency": "BRL", "isin": "BRPETROPPX250",
+    "currency": "BRL", "isin": "BRPETROPX250",
     "securityType": "OPTION",
     "strikePrice": "25.00", "expirationDate": "2030-12-20",
     "putOrCall": "Put", "exerciseStyle": "European",
@@ -50,7 +50,7 @@
   {
     "symbol": "PETRL220", "securityId": 902000000003,
     "tickSize": "0.01", "lotSize": 1, "minPx": "0.01", "maxPx": "999.99",
-    "currency": "BRL", "isin": "BRPETROPCL220",
+    "currency": "BRL", "isin": "BRPETROPL220",
     "securityType": "OPTION",
     "strikePrice": "22.00", "expirationDate": "2030-12-20",
     "putOrCall": "Call", "exerciseStyle": "American",

--- a/config/instruments-opt.json
+++ b/config/instruments-opt.json
@@ -1,0 +1,60 @@
+[
+  // Real-ish B3 equity options sample (RFC 0002 §3.1 / OPT-04). Three
+  // PETR4 options on the dedicated OPT channel, paired to the PETR4
+  // equity carried on the EQT channel (instruments-eqt.json, securityId
+  // 900000000001).
+  //
+  // SecurityIDs use the 902xxx high-bit prefix so they stay disjoint
+  // from instruments-eqt.json (900xxx) and instruments-drv.json (901xxx).
+  //
+  // Per RFC §3.5 / future ADR:
+  //   - lotSize is 1 (the engine matches in contracts; the share-side
+  //     economic size is reconstructed by the broker / clearing tier
+  //     from contractMultiplier × matched contracts).
+  //   - contractMultiplier is 100 (one equity-option contract represents
+  //     100 underlying shares on B3). Carried as metadata only.
+  //
+  // Per RFC §3.1, cross-channel stop triggers (e.g. a stop on PETRL200
+  // firing on the last trade of PETR4) are an explicit MVP non-goal:
+  // each channel owns its own _stopsBySymbol / _lastTradePriceBySecurity,
+  // and the underlying lives on a different dispatcher.
+  //
+  // Symbols here loosely follow the B3 series-naming convention
+  // (PETR + month-code + strike) — December calls use L, December puts
+  // use X — but the venue does NOT parse symbol naming; operators are
+  // free to use any unique ticker. See RFC §8.
+  //
+  // expirationDate must be today-or-later (InstrumentLoader rejects
+  // past-dated series). Until T-3 / OPT-03 ships an expiry-aware
+  // auto-Close path, refresh this file's dates if they ever lapse.
+  {
+    "symbol": "PETRL200", "securityId": 902000000001,
+    "tickSize": "0.01", "lotSize": 1, "minPx": "0.01", "maxPx": "999.99",
+    "currency": "BRL", "isin": "BRPETROPCL200",
+    "securityType": "OPTION",
+    "strikePrice": "20.00", "expirationDate": "2030-12-20",
+    "putOrCall": "Call", "exerciseStyle": "American",
+    "underlyingSecurityId": 900000000001, "underlyingSymbol": "PETR4",
+    "contractMultiplier": "100", "optPayoutType": "Vanilla"
+  },
+  {
+    "symbol": "PETRX250", "securityId": 902000000002,
+    "tickSize": "0.01", "lotSize": 1, "minPx": "0.01", "maxPx": "999.99",
+    "currency": "BRL", "isin": "BRPETROPPX250",
+    "securityType": "OPTION",
+    "strikePrice": "25.00", "expirationDate": "2030-12-20",
+    "putOrCall": "Put", "exerciseStyle": "European",
+    "underlyingSecurityId": 900000000001, "underlyingSymbol": "PETR4",
+    "contractMultiplier": "100", "optPayoutType": "Vanilla"
+  },
+  {
+    "symbol": "PETRL220", "securityId": 902000000003,
+    "tickSize": "0.01", "lotSize": 1, "minPx": "0.01", "maxPx": "999.99",
+    "currency": "BRL", "isin": "BRPETROPCL220",
+    "securityType": "OPTION",
+    "strikePrice": "22.00", "expirationDate": "2030-12-20",
+    "putOrCall": "Call", "exerciseStyle": "American",
+    "underlyingSecurityId": 900000000001, "underlyingSymbol": "PETR4",
+    "contractMultiplier": "100", "optPayoutType": "Vanilla"
+  }
+]

--- a/docs/adr/0013-options-channel-topology.md
+++ b/docs/adr/0013-options-channel-topology.md
@@ -1,0 +1,108 @@
+# 0013 — Channel topology for equity options
+
+- **Status**: Accepted
+- **Date**: 2026-06-04
+- **Issue**: [#475](https://github.com/pedrosakuma/B3MatchingPlatform/issues/475)
+  (T-4 / OPT-04 — channel + sample config)
+- **Umbrella**: [#463](https://github.com/pedrosakuma/B3MatchingPlatform/issues/463)
+  (RFC 0002 — equity options MVP)
+- **Part of**: [RFC 0002 — equity options support](../rfc/0002-equity-options-support.md)
+  §3.1, §6
+- **Related ADRs**:
+  [ADR 0009](0009-single-writer-threading-model.md) (single-writer
+  per channel),
+  [ADR 0012](0012-exchange-day-boundary.md) (exchange-day boundary
+  governs scope).
+
+## Context
+
+Real B3 publishes equity options on a UMDF channel distinct from
+cash equities and from derivatives. The simulator must reflect that
+topology so consumers (e.g. `B3MarketDataPlatform`, the
+`SbeB3UmdfConsumer` companion repo) can validate per-group ring
+and cross-group fan-in against a shape that matches production.
+
+Two designs were considered while drafting RFC 0002:
+
+1. **Dedicated OPT channel.** Add a third `channels[]` entry in
+   `exchange-simulator.json` with its own multicast group, its own
+   `ChannelDispatcher`, and a dedicated `instruments-opt.json`.
+2. **Co-tenant on the existing EQT channel.** Carry option series
+   on the same dispatcher as their underlyings, partitioned only
+   by SecurityID inside the same MatchingEngine.
+
+Option 2 would simplify cross-channel correlation (notably stops
+that reference the underlying's last trade) but would collapse two
+distinct economic books onto a single single-writer dispatcher and
+multicast group, deviating from the production topology and
+breaking the per-channel isolation that ADR 0009 codifies.
+
+## Decision
+
+Options ride a **dedicated OPT channel** (option 1):
+
+- One additional entry in `channels[]` (`channelNumber: 78` in the
+  bundled `config/exchange-simulator.json`), with multicast group
+  `224.0.20.78:30078`, snapshot `224.0.20.178:30178`, and
+  instrument-definition `224.0.21.78:31078`. Endpoints are
+  disjoint from the existing EQT (84) and DRV (72) channels.
+- A dedicated `config/instruments-opt.json` carrying option-only
+  instruments. SecurityIDs use the `902xxx` high-bit prefix so
+  `HostRouter` can partition cleanly by SecurityID without overlap
+  with EQT (`900xxx`) or DRV (`901xxx`).
+- The OPT `ChannelDispatcher` is fully isolated per ADR 0009 — its
+  own `MatchingEngine`, `OrderRegistry`, `_openOrdersByFirm`,
+  `_lastTradePriceBySecurity`, `_stopsBySymbol`, inbound
+  `Channel<WorkItem>`, dispatch thread, `IUmdfPacketSink`, WAL,
+  snapshot persister, and `ChannelMetrics`. No mutable state is
+  shared with EQT or DRV.
+
+### Consequences accepted
+
+- **Cross-channel stop triggers are an explicit non-goal.** Stops
+  in the current engine fire on the just-executed trade price via
+  the per-security `_stopsBySymbol` list inside `MatchingEngine`,
+  keyed by `SecurityId` and channel-local by construction. A stop
+  on `PETRL220` fires on the last trade of `PETRL220`, **not** on
+  the last trade of the underlying `PETR4` (which lives on the EQT
+  dispatcher and is therefore inaccessible from the OPT
+  dispatcher). Implementing cross-channel triggers would require
+  either a bridge component or merging the option and equity
+  channels — both violate ADR 0009's single-writer guarantee.
+  Folded into RFC 0002 §3.1 and the inline comment in
+  `instruments-opt.json`. If a concrete consumer needs it, a
+  follow-up RFC reopens the question.
+- **Operators must extend their consumer subscriptions.** Adding
+  the OPT channel requires `B3MarketDataPlatform` and any other
+  UMDF subscriber to join the new multicast group. Tracked by
+  OPT-12 (RUNBOOK update).
+- **No engine awareness of `ContractMultiplier`.** Per RFC §3.5
+  the OPT channel matches in contracts (`LotSize = 1`); the
+  share-side economic size is reconstructed at the clearing /
+  broker tier from `ContractMultiplier × matched contracts`. The
+  multiplier is metadata-only on the venue and is not part of any
+  matching invariant. Codified separately by the §3.5 ADR planned
+  in RFC 0002 §6.
+
+## Alternatives considered
+
+- **Co-tenant on EQT (option 2 above).** Rejected because it
+  conflicts with ADR 0009 (single-writer per channel collapses to
+  cross-economic-book contention), deviates from production
+  topology, and would require non-trivial routing logic to keep
+  per-economic-book metrics and persistence separable.
+- **One channel per option series expiry.** Considered for parity
+  with B3's historical per-expiry channels, rejected as
+  premature: the simulator's `channels[]` array supports it
+  trivially if a consumer ever needs that granularity, but the
+  MVP single OPT channel meets every consumer obligation
+  identified during RFC 0002 scoping (RFC §7 Q1).
+
+## Trigger to revisit
+
+- A concrete consumer requires cross-channel stop triggers or
+  another behaviour that depends on shared state between the OPT
+  and EQT dispatchers.
+- B3 publishes guidance changing the production topology (e.g.
+  per-expiry channels, options-on-futures on yet another channel)
+  in a way that the simulator should mirror end-to-end.

--- a/tests/B3.Exchange.Host.Tests/OptionsChannelE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/OptionsChannelE2ETests.cs
@@ -1,0 +1,223 @@
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Core;
+using B3.Exchange.TestSupport;
+using B3.Umdf.WireEncoder;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Validates the OPT channel wiring shipped by T-4 / OPT-04 (RFC 0002
+/// §3.1, ADR 0013):
+///
+/// <list type="number">
+///   <item>The bundled <c>config/exchange-simulator.json</c> declares
+///   the OPT channel (78) alongside EQT (84) and DRV (72), each with
+///   the right instrument file and disjoint multicast endpoints.</item>
+///   <item>Booting the host with the bundled EQT + OPT instrument
+///   files (with a programmatic <see cref="HostConfig"/> so we don't
+///   need to bind real multicast sockets or the production TCP port)
+///   produces one <see cref="ChannelDispatcher"/> per channel, each
+///   seeded with its own instrument set and no SecurityID overlap.
+///   A NewOrder round-trip on each channel returns exactly one
+///   <c>ExecutionReport_New</c> back to the originating session,
+///   demonstrating that <see cref="HostRouter"/> partitions correctly
+///   by SecurityID across EQT and OPT.</item>
+/// </list>
+/// </summary>
+public class OptionsChannelE2ETests
+{
+    private const byte EqtChannel = 84;
+    private const byte OptChannel = 78;
+    private const long PetrSecurityId = 900000000001L; // PETR4 on EQT
+    private const long PetrL200SecurityId = 902000000001L; // PETRL200 on OPT
+
+    [Fact]
+    public void BundledExchangeSimulatorConfig_DeclaresOptChannelAlongsideEqtAndDrv()
+    {
+        var cfg = HostConfigLoader.Load(TestPaths.ResolveRepoFile("config/exchange-simulator.json"));
+
+        var byNumber = cfg.Channels.ToDictionary(c => c.ChannelNumber);
+        Assert.Contains((byte)84, byNumber.Keys);
+        Assert.Contains((byte)72, byNumber.Keys);
+        Assert.Contains(OptChannel, byNumber.Keys);
+
+        var opt = byNumber[OptChannel];
+        Assert.EndsWith("instruments-opt.json", opt.InstrumentsFile, StringComparison.Ordinal);
+
+        // Per-channel UMDF endpoints must be disjoint across every channel
+        // group AND across the snapshot / instrument-definition feeds.
+        var endpoints = new List<string>();
+        foreach (var ch in cfg.Channels)
+        {
+            endpoints.Add($"{ch.IncrementalGroup}:{ch.IncrementalPort}");
+            if (ch.Snapshot is { } s) endpoints.Add($"{s.Group}:{s.Port}");
+            if (ch.InstrumentDefinition is { } d) endpoints.Add($"{d.Group}:{d.Port}");
+        }
+        Assert.Equal(endpoints.Count, endpoints.Distinct().Count());
+    }
+
+    [Fact]
+    public async Task TwoChannelHost_EqtAndOpt_RoundTripsExecutionReportPerChannel()
+    {
+        var eqtPath = TestPaths.ResolveRepoFile("config/instruments-eqt.json");
+        var optPath = TestPaths.ResolveRepoFile("config/instruments-opt.json");
+
+        var sinks = new Dictionary<byte, RecordingPacketSink>
+        {
+            [EqtChannel] = new RecordingPacketSink(),
+            [OptChannel] = new RecordingPacketSink(),
+        };
+
+        var cfg = new HostConfig
+        {
+            Auth = new AuthConfig { RequireFixpHandshake = false },
+            Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+        };
+        cfg.Channels.Add(new ChannelConfig
+        {
+            ChannelNumber = EqtChannel,
+            IncrementalGroup = "239.255.84.84",
+            IncrementalPort = 30184,
+            Ttl = 0,
+            InstrumentsFile = eqtPath,
+        });
+        cfg.Channels.Add(new ChannelConfig
+        {
+            ChannelNumber = OptChannel,
+            IncrementalGroup = "239.255.78.78",
+            IncrementalPort = 30178,
+            Ttl = 0,
+            InstrumentsFile = optPath,
+        });
+
+        await using var host = new ExchangeHost(cfg,
+            packetSinkFactory: ch => sinks[ch.ChannelNumber]);
+        await host.StartAsync();
+        var ep = host.TcpEndpoint!;
+
+        // Sanity: exactly one dispatcher per channel and each one is
+        // seeded with the right instrument set (no SecurityID overlap).
+        Assert.Equal(2, host.Dispatchers.Count);
+        var dispByChannel = host.Dispatchers.ToDictionary(d => d.ChannelNumber);
+        Assert.Contains(EqtChannel, dispByChannel.Keys);
+        Assert.Contains(OptChannel, dispByChannel.Keys);
+
+        // Round-trip a NewOrder on each channel and assert exactly one
+        // ExecutionReport_New comes back per session. PETR4 has
+        // lotSize=100 (round lot); PETRL200 has lotSize=1 (one contract).
+        await AssertNewOrderRoundTripAsync(ep, secId: PetrSecurityId, clOrdId: 1001,
+            qty: 100, priceMantissa: 30_0000L); // PETR4 @ 30.00, round-lot
+        await AssertNewOrderRoundTripAsync(ep, secId: PetrL200SecurityId, clOrdId: 2001,
+            qty: 1, priceMantissa: 5_0000L); // PETRL200 @ 5.00 (option premium)
+
+        // Allow the dispatch threads a beat to flush UMDF packets.
+        await Task.Delay(200);
+
+        // Each channel emitted at least one UMDF packet, and none of the
+        // packets contain a SecurityID belonging to the other channel.
+        AssertPacketsOnlyForChannel(sinks[EqtChannel], allowed: PetrSecurityId, forbidden: PetrL200SecurityId);
+        AssertPacketsOnlyForChannel(sinks[OptChannel], allowed: PetrL200SecurityId, forbidden: PetrSecurityId);
+    }
+
+    private static async Task AssertNewOrderRoundTripAsync(
+        System.Net.IPEndPoint ep, long secId, ulong clOrdId, long qty, long priceMantissa)
+    {
+        using var client = new TcpClient();
+        await client.ConnectAsync(ep.Address, ep.Port);
+        var stream = client.GetStream();
+
+        var frame = BuildSimpleNewOrder(clOrdId, secId, side: '1', ordType: '2', tif: '0',
+            qty: qty, priceMantissa: priceMantissa);
+        await stream.WriteAsync(frame);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        bool gotErNew = false;
+        while (!gotErNew && DateTime.UtcNow < deadline)
+        {
+            var er = await ReadFrameAsync(stream, deadline - DateTime.UtcNow);
+            if (er.TemplateId == EntryPointFrameReader.TidExecutionReportNew) gotErNew = true;
+        }
+        Assert.True(gotErNew, $"expected ExecutionReport_New for clOrdId={clOrdId} secId={secId}");
+    }
+
+    private static void AssertPacketsOnlyForChannel(RecordingPacketSink sink, long allowed, long forbidden)
+    {
+        int packetCount = 0;
+        foreach (var pkt in sink.Packets)
+        {
+            packetCount++;
+            int cursor = WireOffsets.PacketHeaderSize;
+            while (cursor + WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize <= pkt.Length)
+            {
+                ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(pkt.AsSpan(cursor, 2));
+                int sbeOffset = cursor + WireOffsets.FramingHeaderSize;
+                ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(pkt.AsSpan(sbeOffset + 2, 2));
+                int bodyOffset = sbeOffset + WireOffsets.SbeMessageHeaderSize;
+                // Skip ChannelReset (tid=11) and SequenceReset (tid=2)
+                // which don't carry an instrument id.
+                if (tid != 11 && tid != 2 && bodyOffset + 8 <= pkt.Length)
+                {
+                    long secId = BinaryPrimitives.ReadInt64LittleEndian(pkt.AsSpan(bodyOffset, 8));
+                    Assert.NotEqual(forbidden, secId);
+                }
+                cursor += messageLength;
+            }
+        }
+        Assert.True(packetCount > 0, "expected at least one UMDF packet on the channel");
+    }
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public System.Collections.Concurrent.ConcurrentQueue<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) => Packets.Enqueue(packet.ToArray());
+    }
+
+    private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
+        char tif, long qty, long priceMantissa)
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)ordType;
+        body[58] = (byte)tif;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        return frame;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}


### PR DESCRIPTION
Trail T-4 / OPT-04 from RFC 0002 (equity options MVP).

Closes #475. Part of umbrella #463.

## What

- New `config/instruments-opt.json` with three sample PETR4 options
  (PETRL200 Call $20, PETRX250 Put $25, PETRL220 Call $22), each
  with the option-specific fields landed by T-1 (strikePrice,
  expirationDate, putOrCall, exerciseStyle, underlyingSecurityId,
  underlyingSymbol, contractMultiplier=100, optPayoutType).
  SecurityIDs use the 902xxx prefix so they stay disjoint from EQT
  (900xxx) and DRV (901xxx).
- New OPT channel entry in `config/exchange-simulator.json`
  (channelNumber 78, multicast 224.0.20.78:30078, snapshot
  224.0.20.178:30178, instrument-definition 224.0.21.78:31078).
  Endpoints are disjoint from EQT (84) and DRV (72).
- New ADR `docs/adr/0013-options-channel-topology.md` codifying
  the RFC 0002 §3.1 channel-topology decision (single OPT channel,
  full isolation per ADR 0009, cross-channel stop triggers an
  explicit MVP non-goal).
- New host integration test `OptionsChannelE2ETests` covering:
  - the bundled `exchange-simulator.json` declares OPT alongside
    EQT and DRV with disjoint multicast endpoints across the
    incremental / snapshot / instrument-definition feeds;
  - booting the host with the bundled EQT + OPT instrument files
    produces one `ChannelDispatcher` per channel and round-trips
    a `NewOrder` → `ExecutionReport_New` on each channel,
    asserting no cross-talk (no UMDF packets carrying the other
    channel's SecurityID).

## Out of scope

- Expiry-aware auto-Close on boot (T-3 / OPT-03).
- `SecurityDefinition_12` UMDF encoder for the new fields
  (T-2 / OPT-02).
- Adding OPT to `exchange-simulator.bridge.json` /
  `exchange-simulator.soak.json` (those are scoped to their own
  use-cases; the existing `BundledConfigMultiGroupTests` continues
  to pass because it asserts `Contains` of the EQT+DRV channels,
  not exact set equality).
- Cross-channel stop triggers — explicit MVP non-goal per ADR 0013.

## Host wiring touch-ups

None needed. `ExchangeHost.cs:229` already calls
`InstrumentLoader.LoadFromFile(ch.InstrumentsFile)` per channel and
`HostRouter` already partitions inbound commands by SecurityID, so
multi-channel-with-different-instrument-files is a configuration-only
change.

## Pre-PR checklist

All four green locally:

```
dotnet restore SbeB3Exchange.slnx
dotnet build   SbeB3Exchange.slnx --no-restore -c Release
dotnet test    SbeB3Exchange.slnx --no-build   -c Release
dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
```

Refs RFC 0002 §3.1, §4 T-4, §6 (ADR roadmap); ADR 0009, ADR 0012, ADR 0013.
