### PR TITLE
feat(umdf): emit option fields in SecurityDefinition_12 (T-2: OPT-02)

### DIFF
--- a/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
+++ b/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
@@ -130,6 +130,10 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
                     packetWritten = StartPacket();
                 }
 
+                var optionFields = BuildOptionFields(inst);
+                long validityTs = optionFields.HasValue
+                    ? ComputeOptionValidityUtcSeconds(inst.ExpirationDate!.Value)
+                    : 0L;
                 int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(
                     _packetBuf.AsSpan(packetWritten),
                     securityId: inst.SecurityId,
@@ -137,7 +141,8 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
                     isin: inst.Isin,
                     securityTypeByte: SecurityTypeMap.ToSbeByte(inst.SecurityType),
                     totNoRelatedSym: (uint)_instruments.Count,
-                    optionFields: BuildOptionFields(inst));
+                    securityValidityTimestamp: validityTs,
+                    optionFields: optionFields);
                 packetWritten += n;
             }
             if (packetWritten > WireOffsets.PacketHeaderSize)
@@ -211,6 +216,37 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
             UnderlyingSecurityId = underlyingId,
             UnderlyingSymbol = underlyingSymbol,
         };
+    }
+
+    // B3 venue timezone. The RFC requires the option securityValidityTimestamp
+    // to be derived from ExpirationDate end-of-day in venue local time, then
+    // expressed as a UTC second count.
+    private static readonly TimeZoneInfo VenueTimezone = ResolveVenueTimezone();
+
+    private static TimeZoneInfo ResolveVenueTimezone()
+    {
+        // America/Sao_Paulo is the IANA id and also works on Windows via the
+        // ICU TZ database that ships with .NET 6+. Fall back to UTC only if
+        // the host has no TZ data at all — better to encode UTC seconds than
+        // to crash the publisher.
+        try { return TimeZoneInfo.FindSystemTimeZoneById("America/Sao_Paulo"); }
+        catch (TimeZoneNotFoundException) { return TimeZoneInfo.Utc; }
+        catch (InvalidTimeZoneException) { return TimeZoneInfo.Utc; }
+    }
+
+    /// <summary>
+    /// Returns the UTC Unix-seconds timestamp marking the end of the
+    /// expiration day in the venue timezone (the moment trading for the
+    /// option is no longer valid). End-of-day is defined as the last second
+    /// of the calendar date in venue local time (23:59:59 BRT/BRST).
+    /// </summary>
+    internal static long ComputeOptionValidityUtcSeconds(DateOnly expirationDate)
+    {
+        var localEod = new DateTime(
+            expirationDate.Year, expirationDate.Month, expirationDate.Day,
+            23, 59, 59, DateTimeKind.Unspecified);
+        var utc = TimeZoneInfo.ConvertTimeToUtc(localEod, VenueTimezone);
+        return new DateTimeOffset(utc, TimeSpan.Zero).ToUnixTimeSeconds();
     }
 
     private int StartPacket()

--- a/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
+++ b/src/B3.Exchange.Core/InstrumentDefinitionPublisher.cs
@@ -31,8 +31,8 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
     /// </summary>
     public const int MaxPacketBytes = 1400;
 
-    private const int FrameSize =
-        WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecDefBodyTotal;
+    private const int FrameSizeMax =
+        WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecDefBodyTotalOneUnderlying;
 
     public byte ChannelNumber { get; }
     public ushort SequenceVersion { get; }
@@ -60,12 +60,13 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
         ArgumentNullException.ThrowIfNull(sink);
         if (cadence <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(cadence), "cadence must be positive");
-        // SecDef frame is ~251 bytes; we need to fit at least one with the
-        // 16-byte PacketHeader inside MaxPacketBytes — guaranteed by const,
-        // but keep the assertion in case future schema bumps grow the body.
-        if (FrameSize + WireOffsets.PacketHeaderSize > MaxPacketBytes)
+        // SecDef option frame (one NoUnderlyings entry) is ~279 bytes; we
+        // need to fit at least one with the 16-byte PacketHeader inside
+        // MaxPacketBytes — guaranteed by const, but keep the assertion in
+        // case future schema bumps grow the body.
+        if (FrameSizeMax + WireOffsets.PacketHeaderSize > MaxPacketBytes)
             throw new InvalidOperationException(
-                $"SecurityDefinition frame ({FrameSize} bytes) does not fit in InstrumentDef packet ({MaxPacketBytes} bytes).");
+                $"SecurityDefinition frame ({FrameSizeMax} bytes) does not fit in InstrumentDef packet ({MaxPacketBytes} bytes).");
 
         ChannelNumber = channelNumber;
         _instruments = instruments;
@@ -121,25 +122,95 @@ public sealed class InstrumentDefinitionPublisher : IAsyncDisposable
             int packetWritten = StartPacket();
             for (int i = 0; i < _instruments.Count; i++)
             {
-                if (packetWritten + FrameSize > MaxPacketBytes)
+                var inst = _instruments[i];
+                int frameSize = SecDefFrameSizeFor(inst);
+                if (packetWritten + frameSize > MaxPacketBytes)
                 {
                     FlushPacket(packetWritten);
                     packetWritten = StartPacket();
                 }
 
-                var inst = _instruments[i];
                 int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(
                     _packetBuf.AsSpan(packetWritten),
                     securityId: inst.SecurityId,
                     symbol: inst.Symbol,
                     isin: inst.Isin,
                     securityTypeByte: SecurityTypeMap.ToSbeByte(inst.SecurityType),
-                    totNoRelatedSym: (uint)_instruments.Count);
+                    totNoRelatedSym: (uint)_instruments.Count,
+                    optionFields: BuildOptionFields(inst));
                 packetWritten += n;
             }
             if (packetWritten > WireOffsets.PacketHeaderSize)
                 FlushPacket(packetWritten);
         }
+    }
+
+    private static int SecDefFrameSizeFor(Instrument inst)
+    {
+        int body = InstrumentSecurityTypes.IsOption(inst.SecurityType)
+            ? WireOffsets.SecDefBodyTotalOneUnderlying
+            : WireOffsets.SecDefBodyTotalNoUnderlyings;
+        return WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + body;
+    }
+
+    /// <summary>
+    /// Translates an option <see cref="Instrument"/> into the
+    /// <see cref="UmdfWireEncoder.OptionDefinitionFields"/> payload expected
+    /// by the encoder. Returns <c>null</c> for non-option instruments so the
+    /// encoder writes SBE NULL sentinels for every option field. Throws when
+    /// an option instrument is missing a required field — the loader and
+    /// trading-rules layer should have rejected such a config long before
+    /// we get here, but a clear error here beats a silently-mis-encoded
+    /// frame on the wire.
+    /// </summary>
+    private static UmdfWireEncoder.OptionDefinitionFields? BuildOptionFields(Instrument inst)
+    {
+        if (!InstrumentSecurityTypes.IsOption(inst.SecurityType))
+            return null;
+
+        decimal strike = inst.StrikePrice
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required StrikePrice.");
+        DateOnly expiry = inst.ExpirationDate
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required ExpirationDate.");
+        var putOrCall = inst.PutOrCall
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required PutOrCall.");
+        var exerciseStyle = inst.ExerciseStyle
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required ExerciseStyle.");
+        long underlyingId = inst.UnderlyingSecurityId
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required UnderlyingSecurityId.");
+        string underlyingSymbol = inst.UnderlyingSymbol
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required UnderlyingSymbol.");
+        decimal multiplier = inst.ContractMultiplier
+            ?? throw new InvalidOperationException($"Option instrument {inst.Symbol} ({inst.SecurityId}) is missing required ContractMultiplier.");
+
+        return new UmdfWireEncoder.OptionDefinitionFields
+        {
+            StrikePrice = strike,
+            ContractMultiplier = multiplier,
+            ExpirationDate = expiry,
+            PutOrCallByte = putOrCall switch
+            {
+                B3.Exchange.Instruments.PutOrCall.Put => (byte)B3.Umdf.Mbo.Sbe.V16.PutOrCall.PUT,
+                B3.Exchange.Instruments.PutOrCall.Call => (byte)B3.Umdf.Mbo.Sbe.V16.PutOrCall.CALL,
+                _ => throw new InvalidOperationException($"Unsupported PutOrCall value: {putOrCall}"),
+            },
+            ExerciseStyleByte = exerciseStyle switch
+            {
+                B3.Exchange.Instruments.ExerciseStyle.European => (byte)B3.Umdf.Mbo.Sbe.V16.ExerciseStyle.EUROPEAN,
+                B3.Exchange.Instruments.ExerciseStyle.American => (byte)B3.Umdf.Mbo.Sbe.V16.ExerciseStyle.AMERICAN,
+                _ => throw new InvalidOperationException($"Unsupported ExerciseStyle value: {exerciseStyle}"),
+            },
+            OptPayoutTypeByte = inst.OptPayoutType switch
+            {
+                null => null,
+                B3.Exchange.Instruments.OptPayoutType.Vanilla => (byte)B3.Umdf.Mbo.Sbe.V16.OptPayoutType.VANILLA,
+                B3.Exchange.Instruments.OptPayoutType.Capped => (byte)B3.Umdf.Mbo.Sbe.V16.OptPayoutType.CAPPED,
+                B3.Exchange.Instruments.OptPayoutType.Binary => (byte)B3.Umdf.Mbo.Sbe.V16.OptPayoutType.BINARY,
+                _ => throw new InvalidOperationException($"Unsupported OptPayoutType value: {inst.OptPayoutType}"),
+            },
+            UnderlyingSecurityId = underlyingId,
+            UnderlyingSymbol = underlyingSymbol,
+        };
     }
 
     private int StartPacket()

--- a/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
+++ b/src/B3.Umdf.WireEncoder/UmdfWireEncoder.cs
@@ -287,16 +287,71 @@ public static class UmdfWireEncoder
     }
 
     /// <summary>
-    /// Writes <c>SecurityDefinition_12</c> with the minimum fields needed
-    /// for the consumer's instrument pipeline (SecurityID, SecurityExchange,
+    /// Optional option-specific payload for <see cref="WriteSecurityDefinitionFrame"/>.
+    /// When supplied, the encoder fills in the SBE option fields
+    /// (strikePrice, contractMultiplier, maturityMonthYear, exerciseStyle,
+    /// putOrCall, optPayoutType) and emits one entry in the NoUnderlyings
+    /// repeating group. Equity / non-option instruments must pass
+    /// <c>null</c>; the encoder then writes SBE NULL sentinels for every
+    /// option field and a zero-entry NoUnderlyings group.
+    /// </summary>
+    public readonly struct OptionDefinitionFields
+    {
+        /// <summary>Human-units strike price (e.g. 28.50). Required.</summary>
+        public required decimal StrikePrice { get; init; }
+
+        /// <summary>Contract size multiplier (e.g. 100 shares per contract). Required.</summary>
+        public required decimal ContractMultiplier { get; init; }
+
+        /// <summary>Last trading / expiration date.</summary>
+        public required DateOnly ExpirationDate { get; init; }
+
+        /// <summary>0 = Put, 1 = Call (SBE PutOrCall enum).</summary>
+        public required byte PutOrCallByte { get; init; }
+
+        /// <summary>0 = European, 1 = American (SBE ExerciseStyle enum).</summary>
+        public required byte ExerciseStyleByte { get; init; }
+
+        /// <summary>SBE OptPayoutType enum byte (1=Vanilla, 2=Capped, 3=Binary). Null = SBE NULL sentinel (255).</summary>
+        public byte? OptPayoutTypeByte { get; init; }
+
+        /// <summary>SecurityID of the underlying instrument (e.g. the equity series the option references).</summary>
+        public required long UnderlyingSecurityId { get; init; }
+
+        /// <summary>Ticker symbol of the underlying instrument (≤ 20 ASCII chars, space-padded on the wire).</summary>
+        public required string UnderlyingSymbol { get; init; }
+    }
+
+    // SBE NULL sentinels for the optional SecurityDefinition_12 fields.
+    // Centralised here so encoder+tests share one source of truth.
+    private const long SecDefPriceOptionalNull = long.MinValue;  // PriceOptional & Fixed8 mantissa NULL.
+    private const byte SecDefByteEnumNull = 255;                 // ExerciseStyle / PutOrCall / OptPayoutType / ImpliedMarketIndicator NULL.
+    private const long SecDefPriceMantissaScale = 10_000L;       // PriceOptional exponent = -4.
+    private const long SecDefFixed8MantissaScale = 100_000_000L; // Fixed8 exponent = -8.
+    private const ushort SecDefNoUnderlyingsEntryBlockLength = (ushort)WireOffsets.SecDefNoUnderlyingsEntrySize;
+
+    /// <summary>
+    /// Writes <c>SecurityDefinition_12</c> (V16) with the fields the
+    /// consumer's instrument pipeline needs (SecurityID, SecurityExchange,
     /// Symbol, SecurityType, TotNoRelatedSym, ISIN, optional ValidityTimestamp,
-    /// optional MaturityDate). Trailing 9 bytes encode three empty groups
-    /// (NoUnderlyings, NoLegs, NoInstrAttribs); the final byte is the
-    /// <c>securityDesc</c> TextEncoding length prefix, written as 0 (empty
-    /// description). The length prefix is mandatory even when no text is
-    /// attached — without it the consumer's generated
-    /// <c>SecurityDefinition_12DataReader</c> reads past the SBE message
-    /// boundary and throws (issue #222).
+    /// optional MaturityDate). When <paramref name="optionFields"/> is
+    /// non-null the encoder additionally fills the SBE option fields
+    /// (StrikePrice, ContractMultiplier, MaturityMonthYear, ExerciseStyle,
+    /// PutOrCall, OptPayoutType) and emits one entry in the NoUnderlyings
+    /// repeating group. Equity callers pass <c>null</c> and the corresponding
+    /// optional fields are written as SBE NULL sentinels.
+    /// <para>
+    /// Trailing 9 bytes encode three empty group dimension headers
+    /// (NoUnderlyings, NoLegs, NoInstrAttribs) plus the <c>securityDesc</c>
+    /// TextEncoding length prefix (uint8, always 0 — empty description).
+    /// The length prefix is mandatory even when no text is attached —
+    /// without it the consumer's generated <c>SecurityDefinition_12DataReader</c>
+    /// reads past the SBE message boundary and throws (issue #222).
+    /// </para>
+    /// Returns total bytes written; the value depends on whether
+    /// <paramref name="optionFields"/> is null (no NoUnderlyings entry,
+    /// <see cref="WireOffsets.SecDefBodyTotalNoUnderlyings"/>) or non-null
+    /// (one NoUnderlyings entry, <see cref="WireOffsets.SecDefBodyTotalOneUnderlying"/>).
     /// </summary>
     public static int WriteSecurityDefinitionFrame(
         Span<byte> dst,
@@ -306,18 +361,27 @@ public static class UmdfWireEncoder
         byte securityTypeByte,
         uint totNoRelatedSym,
         long securityValidityTimestamp = 0L,
-        int maturityDate = 0)
+        int maturityDate = 0,
+        OptionDefinitionFields? optionFields = null)
     {
-        int total = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecDefBodyTotal;
+        bool hasOption = optionFields.HasValue;
+        int bodyTotal = hasOption
+            ? WireOffsets.SecDefBodyTotalOneUnderlying
+            : WireOffsets.SecDefBodyTotalNoUnderlyings;
+        int total = WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + bodyTotal;
         if (dst.Length < total) ThrowTooSmall(nameof(dst), total);
 
         WriteFramingHeader(dst, total);
-        B3.Umdf.Mbo.Sbe.V16.V6.SecurityDefinition_12Data.WriteHeader(
+        // V16 WriteHeader stamps BlockLength=232, TemplateId=12, SchemaId=2, Version=16.
+        // The consumer's V16 reader dispatches on the explicit BlockLength
+        // field, so equity and option frames share the same header shape
+        // and only differ in the trailing NoUnderlyings group dimensions.
+        B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.WriteHeader(
             dst.Slice(WireOffsets.FramingHeaderSize, WireOffsets.SbeMessageHeaderSize));
 
         var body = dst.Slice(
             WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize,
-            WireOffsets.SecDefBodyTotal);
+            bodyTotal);
         body.Clear();
 
         MemoryMarshal.Write(body.Slice(WireOffsets.SecDefSecurityIdOffset, 8), in securityId);
@@ -329,8 +393,83 @@ public static class UmdfWireEncoder
         MemoryMarshal.Write(body.Slice(WireOffsets.SecDefSecurityValidityTimestampOffset, 8), in securityValidityTimestamp);
         MemoryMarshal.Write(body.Slice(WireOffsets.SecDefMaturityDateOffset, 4), in maturityDate);
         WriteFixedAscii(body.Slice(WireOffsets.SecDefIsinNumberOffset, 12), isin);
-        // Trailing GroupSizeEncodings already zero from body.Clear().
+
+        // Option-related optional fields: default to SBE NULL sentinels so
+        // equity decoders observe null rather than a stray zero
+        // (e.g. PriceOptional mantissa 0 == 0.0, not NULL). Overwritten
+        // below when optionFields is supplied.
+        long priceNull = SecDefPriceOptionalNull;
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecDefStrikePriceOffset, 8), in priceNull);
+        MemoryMarshal.Write(body.Slice(WireOffsets.SecDefContractMultiplierOffset, 8), in priceNull);
+        body[WireOffsets.SecDefExerciseStyleOffset] = SecDefByteEnumNull;
+        body[WireOffsets.SecDefPutOrCallOffset] = SecDefByteEnumNull;
+        body[WireOffsets.SecDefImpliedMarketIndicatorOffset] = SecDefByteEnumNull;
+        body[WireOffsets.SecDefOptPayoutTypeOffset] = SecDefByteEnumNull;
+        // MaturityMonthYear: all-zero bytes are the SBE NULL representation
+        // (year=0 sentinel), already written by body.Clear().
+
+        // Trailing group dimensions + securityDesc length prefix layout:
+        //   [NoUnderlyings dim 3][N×28 entries][NoLegs dim 3][NoInstrAttribs dim 3][descLen 1]
+        int p = WireOffsets.SecDefBlockLength;
+
+        if (hasOption)
+        {
+            var opt = optionFields!.Value;
+
+            // Option scalar fields.
+            long strikeMantissa = ToScaledMantissa(opt.StrikePrice, SecDefPriceMantissaScale, nameof(opt.StrikePrice));
+            long multiplierMantissa = ToScaledMantissa(opt.ContractMultiplier, SecDefFixed8MantissaScale, nameof(opt.ContractMultiplier));
+            MemoryMarshal.Write(body.Slice(WireOffsets.SecDefStrikePriceOffset, 8), in strikeMantissa);
+            MemoryMarshal.Write(body.Slice(WireOffsets.SecDefContractMultiplierOffset, 8), in multiplierMantissa);
+
+            // MaturityMonthYear: year (ushort)@0, month (byte)@2, day (byte)@3, week (byte)@4.
+            var mmy = body.Slice(WireOffsets.SecDefMaturityMonthYearOffset, WireOffsets.SecDefMaturityMonthYearSize);
+            ushort year = (ushort)opt.ExpirationDate.Year;
+            byte month = (byte)opt.ExpirationDate.Month;
+            byte day = (byte)opt.ExpirationDate.Day;
+            MemoryMarshal.Write(mmy.Slice(0, 2), in year);
+            mmy[2] = month;
+            mmy[3] = day;
+            mmy[4] = 0; // week: not modelled by the venue simulator.
+
+            body[WireOffsets.SecDefExerciseStyleOffset] = opt.ExerciseStyleByte;
+            body[WireOffsets.SecDefPutOrCallOffset] = opt.PutOrCallByte;
+            body[WireOffsets.SecDefOptPayoutTypeOffset] = opt.OptPayoutTypeByte ?? SecDefByteEnumNull;
+
+            // NoUnderlyings dimension header: BlockLength=28 (ushort), NumInGroup=1 (byte).
+            ushort entryBlockLen = SecDefNoUnderlyingsEntryBlockLength;
+            MemoryMarshal.Write(body.Slice(p, 2), in entryBlockLen);
+            body[p + 2] = 1;
+            p += WireOffsets.GroupSizeEncodingSize;
+
+            // Single entry: underlyingSecurityID@0, underlyingSymbol@8 (20 ASCII).
+            var entry = body.Slice(p, WireOffsets.SecDefNoUnderlyingsEntrySize);
+            long underlyingSecId = opt.UnderlyingSecurityId;
+            MemoryMarshal.Write(entry.Slice(WireOffsets.SecDefNoUnderlyingsEntrySecurityIdOffset, 8), in underlyingSecId);
+            WriteFixedAscii(
+                entry.Slice(
+                    WireOffsets.SecDefNoUnderlyingsEntrySymbolOffset,
+                    WireOffsets.SecDefNoUnderlyingsEntrySymbolSize),
+                opt.UnderlyingSymbol);
+            p += WireOffsets.SecDefNoUnderlyingsEntrySize;
+        }
+        else
+        {
+            // Empty NoUnderlyings dimension header — zeros from body.Clear().
+            p += WireOffsets.GroupSizeEncodingSize;
+        }
+
+        // NoLegs + NoInstrAttribs dimension headers and securityDesc length
+        // prefix are all zero (from body.Clear()). No further writes needed.
         return total;
+    }
+
+    private static long ToScaledMantissa(decimal value, long scale, string fieldName)
+    {
+        decimal scaled = decimal.Round(value * scale, 0, MidpointRounding.AwayFromZero);
+        if (scaled < long.MinValue + 1 || scaled > long.MaxValue)
+            throw new ArgumentOutOfRangeException(fieldName, value, "value does not fit in a SBE Fixed8/PriceOptional mantissa");
+        return (long)scaled;
     }
 
     /// <summary>

--- a/src/B3.Umdf.WireEncoder/WireOffsets.cs
+++ b/src/B3.Umdf.WireEncoder/WireOffsets.cs
@@ -266,19 +266,42 @@ public static class WireOffsets
     public const int ChannelResetBodyMdEntryTimestampOffset = 4;
 
     // ---- SecurityDefinition_12 (V16) ----
-    public const int SecDefBlockLength = 230;
+    // BlockLength bumped from 230 (V6) to 232 (V16) to make room for
+    // impliedMarketIndicator@230 and optPayoutType@231. The V16 reader is
+    // backwards-compatible — it dispatches on the explicit BlockLength field
+    // in the SBE message header.
+    public const int SecDefBlockLength = 232;
     public const int SecDefSecurityIdOffset = 0;
     public const int SecDefSecurityExchangeOffset = 8;
     public const int SecDefSymbolOffset = 16;
     public const int SecDefSecurityTypeOffset = 37;
     public const int SecDefTotNoRelatedSymOffset = 40;
+    public const int SecDefStrikePriceOffset = 52;            // PriceOptional (long mantissa, /10000; long.MinValue = NULL)
+    public const int SecDefContractMultiplierOffset = 60;     // Fixed8 (long mantissa, /1e8; long.MinValue = NULL)
     public const int SecDefSecurityValidityTimestampOffset = 76;
     public const int SecDefMaturityDateOffset = 140;
     public const int SecDefIsinNumberOffset = 164;
+    public const int SecDefMaturityMonthYearOffset = 188;     // MaturityMonthYear (5 bytes: year@0 ushort, month@2 byte, day@3 byte, week@4 byte; 0 = NULL)
+    public const int SecDefMaturityMonthYearSize = 5;
+    public const int SecDefExerciseStyleOffset = 213;         // byte (255 = NULL)
+    public const int SecDefPutOrCallOffset = 214;             // byte (255 = NULL)
+    public const int SecDefImpliedMarketIndicatorOffset = 230; // byte (255 = NULL)
+    public const int SecDefOptPayoutTypeOffset = 231;         // byte (255 = NULL)
 
-    // SecDef body emits three empty repeating-group headers
+    // SecDef body emits three repeating-group headers
     // (NoUnderlyings, NoLegs, NoInstrAttribs) so consumer ReadGroups paths stay safe.
     public const int GroupSizeEncodingSize = 3;
+
+    // NoUnderlyings group entry (V16, MESSAGE_SIZE = 28):
+    // @0  underlyingSecurityID (long, 8 bytes)
+    // @8  underlyingSymbol (Symbol, 20-byte fixed ASCII; underlyingSecurityExchange
+    //     overlaps at @8 with a zero-byte SecurityExchangeBVMF constant
+    //     "BVMF", so it consumes no wire bytes)
+    public const int SecDefNoUnderlyingsEntrySize = 28;
+    public const int SecDefNoUnderlyingsEntrySecurityIdOffset = 0;
+    public const int SecDefNoUnderlyingsEntrySymbolOffset = 8;
+    public const int SecDefNoUnderlyingsEntrySymbolSize = 20;
+
     // Trailing var-data section: TextEncoding 'securityDesc' (uint8 length
     // prefix + 0..250 UTF-8 bytes). Required by the consumer's generated
     // SecurityDefinition_12DataReader — when omitted, TextEncoding.Create
@@ -287,5 +310,23 @@ public static class WireOffsets
     // (empty description) so the prefix is present even when no text is
     // attached.
     public const int SecDefSecurityDescLengthSize = 1;
-    public const int SecDefBodyTotal = SecDefBlockLength + GroupSizeEncodingSize * 3 + SecDefSecurityDescLengthSize;
+
+    /// <summary>
+    /// Total body bytes for a SecurityDefinition_12 frame that emits zero
+    /// entries in every repeating group (equity / non-option instrument).
+    /// </summary>
+    public const int SecDefBodyTotalNoUnderlyings = SecDefBlockLength + GroupSizeEncodingSize * 3 + SecDefSecurityDescLengthSize;
+
+    /// <summary>
+    /// Total body bytes for a SecurityDefinition_12 frame that emits one
+    /// entry in the NoUnderlyings group (single-underlying equity option).
+    /// </summary>
+    public const int SecDefBodyTotalOneUnderlying = SecDefBodyTotalNoUnderlyings + SecDefNoUnderlyingsEntrySize;
+
+    /// <summary>
+    /// Legacy alias preserved for callers that pre-allocate a fixed-size
+    /// buffer. Equal to the no-underlyings body total; option frames now
+    /// require <see cref="SecDefBodyTotalOneUnderlying"/> bytes.
+    /// </summary>
+    public const int SecDefBodyTotal = SecDefBodyTotalNoUnderlyings;
 }

--- a/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
@@ -39,6 +39,26 @@ public class InstrumentDefinitionPublisherTests
         SecurityType = type,
     };
 
+    private static Instrument OptionInst(string sym, long secId, string isin) => new()
+    {
+        Symbol = sym,
+        SecurityId = secId,
+        TickSize = 0.01m,
+        LotSize = 1,
+        MinPrice = 0.01m,
+        MaxPrice = 1_000m,
+        Currency = "BRL",
+        Isin = isin,
+        SecurityType = "OPT",
+        StrikePrice = 28.50m,
+        ExpirationDate = new DateOnly(2025, 12, 19),
+        PutOrCall = B3.Exchange.Instruments.PutOrCall.Call,
+        ExerciseStyle = B3.Exchange.Instruments.ExerciseStyle.American,
+        UnderlyingSecurityId = 900_000_000_001L,
+        UnderlyingSymbol = "PETR4",
+        ContractMultiplier = 100m,
+    };
+
     [Fact]
     public void PublishOnce_EmitsOneFramePerInstrument_AcrossPackets()
     {
@@ -191,5 +211,78 @@ public class InstrumentDefinitionPublisherTests
         var sink = new RecordingPacketSink();
         Assert.Throws<ArgumentOutOfRangeException>(() => new InstrumentDefinitionPublisher(
             1, instruments, sink, TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void PublishOnce_OptionInstrument_EmitsOptionFieldsAndOneUnderlying()
+    {
+        // T-2 / OPT-02: the publisher must translate option Instrument
+        // metadata into the SBE option fields on SecurityDefinition_12.
+        var instruments = new List<Instrument> { OptionInst("PETRZ285", 900_111_111_111L, "BROPTPETRZ285") };
+        var sink = new RecordingPacketSink();
+        var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 84, instruments, sink, TimeSpan.FromMinutes(1), new FakeNanosTimeSource(0UL));
+
+        pub.PublishOnce();
+
+        Assert.Single(sink.Packets);
+        var packet = sink.Packets[0];
+
+        // SBE message starts after PacketHeader + FramingHeader; reader
+        // expects the slice to start at the SBE message header.
+        var sbeMessage = packet.AsSpan(
+            WireOffsets.PacketHeaderSize + WireOffsets.FramingHeaderSize);
+        var bodyAndTail = sbeMessage.Slice(WireOffsets.SbeMessageHeaderSize);
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.TryParse(
+            bodyAndTail, blockLength: WireOffsets.SecDefBlockLength, out var rdr));
+
+        Assert.Equal(900_111_111_111L, (long)(ulong)rdr.Data.SecurityID.Value);
+        Assert.Equal(285_000L, rdr.Data.StrikePrice.Mantissa);
+        Assert.Equal(100L * 100_000_000L, rdr.Data.ContractMultiplier.Mantissa);
+        Assert.Equal(B3.Umdf.Mbo.Sbe.V16.PutOrCall.CALL, rdr.Data.PutOrCall);
+        Assert.Equal(B3.Umdf.Mbo.Sbe.V16.ExerciseStyle.AMERICAN, rdr.Data.ExerciseStyle);
+        Assert.Equal((ushort)2025, rdr.Data.MaturityMonthYear.Year);
+        Assert.Equal((byte)12, rdr.Data.MaturityMonthYear.Month);
+        Assert.Equal((byte)19, rdr.Data.MaturityMonthYear.Day);
+
+        int underlyingCount = 0;
+        long underlyingId = 0L;
+        rdr.ReadGroups(
+            (in B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.NoUnderlyingsData u) =>
+            {
+                underlyingCount++;
+                underlyingId = (long)(ulong)u.UnderlyingSecurityID.Value;
+            },
+            (in B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.NoLegsData _) => { },
+            (in B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.NoInstrAttribsData _) => { },
+            (B3.Umdf.Mbo.Sbe.V16.TextEncoding _) => { });
+        Assert.Equal(1, underlyingCount);
+        Assert.Equal(900_000_000_001L, underlyingId);
+    }
+
+    [Fact]
+    public void PublishOnce_MixedEquityAndOption_FlushesPacketWhenOptionFrameOverflows()
+    {
+        // Mixing equity (242-byte body) and option (270-byte body) frames
+        // exercises the variable-frame-size branch in SecDefFrameSizeFor;
+        // crank up the count to force at least one packet boundary so the
+        // overflow path runs.
+        var instruments = new List<Instrument>();
+        for (int i = 0; i < 6; i++)
+        {
+            instruments.Add(Inst($"EQ{i:00}", 2_000_000L + i, "BR" + i.ToString("D10")));
+            instruments.Add(OptionInst($"OPT{i:00}", 3_000_000L + i, "BR" + (1000 + i).ToString("D10")));
+        }
+        var sink = new RecordingPacketSink();
+        var pub = new InstrumentDefinitionPublisher(
+            channelNumber: 7, instruments, sink, TimeSpan.FromMinutes(1), new FakeNanosTimeSource(0UL));
+
+        pub.PublishOnce();
+
+        Assert.True(sink.Packets.Count >= 2, $"expected ≥2 packets to exercise overflow path, got {sink.Packets.Count}");
+        foreach (var p in sink.Packets)
+        {
+            Assert.True(p.Length <= InstrumentDefinitionPublisher.MaxPacketBytes);
+        }
     }
 }

--- a/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/InstrumentDefinitionPublisherTests.cs
@@ -258,6 +258,25 @@ public class InstrumentDefinitionPublisherTests
             (B3.Umdf.Mbo.Sbe.V16.TextEncoding _) => { });
         Assert.Equal(1, underlyingCount);
         Assert.Equal(900_000_000_001L, underlyingId);
+
+        // securityValidityTimestamp must be derived from ExpirationDate
+        // end-of-day (23:59:59 BRT/BRST) and emitted as UTC seconds — not
+        // left at 0. (RFC 0002 / #463.) The OptionInst helper expires on
+        // 2025-12-19, so re-derive the expected stamp from the same helper.
+        long expectedValidity = InstrumentDefinitionPublisher.ComputeOptionValidityUtcSeconds(
+            new DateOnly(2025, 12, 19));
+        Assert.NotEqual(0L, expectedValidity);
+        Assert.Equal(expectedValidity, rdr.Data.SecurityValidityTimestamp.Time);
+    }
+
+    [Fact]
+    public void ComputeOptionValidityUtcSeconds_IsEndOfDayInVenueTimezone()
+    {
+        // 2025-12-19 23:59:59 BRT (UTC-3, no DST since 2019) == 2025-12-20 02:59:59 UTC.
+        long actual = InstrumentDefinitionPublisher.ComputeOptionValidityUtcSeconds(
+            new DateOnly(2025, 12, 19));
+        long expected = new DateTimeOffset(2025, 12, 20, 2, 59, 59, TimeSpan.Zero).ToUnixTimeSeconds();
+        Assert.Equal(expected, actual);
     }
 
     [Fact]

--- a/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
+++ b/tests/B3.Umdf.WireEncoder.Tests/UmdfWireEncoderTests.cs
@@ -295,6 +295,162 @@ public class UmdfWireEncoderTests
     }
 
     [Fact]
+    public void SecurityDefinition_Equity_OptionFields_AreSbeNullSentinels()
+    {
+        // Regression: equity (non-option) instruments must encode the
+        // optional option fields as SBE NULL sentinels — not as a stray
+        // zero — so a consumer that filters by "options only" sees null.
+        var buf = new byte[512];
+        int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(buf, securityId: 900_000_000_001L,
+            symbol: "PETR4", isin: "BRPETRACNPR6", securityTypeByte: 1, totNoRelatedSym: 1);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecDefBodyTotalNoUnderlyings, n);
+
+        var body = buf.AsSpan(FrameOffset, WireOffsets.SecDefBlockLength);
+        Assert.Equal(long.MinValue, MemoryMarshal.Read<long>(body.Slice(WireOffsets.SecDefStrikePriceOffset, 8)));
+        Assert.Equal(long.MinValue, MemoryMarshal.Read<long>(body.Slice(WireOffsets.SecDefContractMultiplierOffset, 8)));
+        Assert.Equal((byte)255, body[WireOffsets.SecDefExerciseStyleOffset]);
+        Assert.Equal((byte)255, body[WireOffsets.SecDefPutOrCallOffset]);
+        Assert.Equal((byte)255, body[WireOffsets.SecDefImpliedMarketIndicatorOffset]);
+        Assert.Equal((byte)255, body[WireOffsets.SecDefOptPayoutTypeOffset]);
+        // MaturityMonthYear: year (ushort)@0 = 0 → SBE NULL.
+        var mmy = body.Slice(WireOffsets.SecDefMaturityMonthYearOffset, WireOffsets.SecDefMaturityMonthYearSize);
+        Assert.Equal((ushort)0, MemoryMarshal.Read<ushort>(mmy.Slice(0, 2)));
+
+        // NoUnderlyings dimension header: NumInGroup byte (offset +2) = 0 for equity.
+        int noUnderlyingsHeaderOffset = FrameOffset + WireOffsets.SecDefBlockLength;
+        Assert.Equal((byte)0, buf[noUnderlyingsHeaderOffset + 2]);
+    }
+
+    [Fact]
+    public void SecurityDefinition_Option_Call_EncodesAllFields()
+    {
+        var buf = new byte[512];
+        var optionFields = new UmdfWireEncoder.OptionDefinitionFields
+        {
+            StrikePrice = 28.50m,
+            ContractMultiplier = 100m,
+            ExpirationDate = new DateOnly(2025, 12, 19),
+            PutOrCallByte = (byte)PutOrCall.CALL,
+            ExerciseStyleByte = (byte)ExerciseStyle.AMERICAN,
+            OptPayoutTypeByte = (byte)OptPayoutType.VANILLA,
+            UnderlyingSecurityId = 900_000_000_001L,
+            UnderlyingSymbol = "PETR4",
+        };
+        int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(buf, securityId: 900_111_111_111L,
+            symbol: "PETRZ285", isin: "BROPTPETRZ285",
+            securityTypeByte: (byte)SecurityType.OPT, totNoRelatedSym: 1,
+            optionFields: optionFields);
+        Assert.Equal(WireOffsets.FramingHeaderSize + WireOffsets.SbeMessageHeaderSize + WireOffsets.SecDefBodyTotalOneUnderlying, n);
+
+        var body = buf.AsSpan(FrameOffset, WireOffsets.SecDefBlockLength);
+
+        // StrikePrice: PriceOptional mantissa = price * 10_000.
+        Assert.Equal(285_000L, MemoryMarshal.Read<long>(body.Slice(WireOffsets.SecDefStrikePriceOffset, 8)));
+        // ContractMultiplier: Fixed8 mantissa = value * 1e8.
+        Assert.Equal(100L * 100_000_000L, MemoryMarshal.Read<long>(body.Slice(WireOffsets.SecDefContractMultiplierOffset, 8)));
+        // MaturityMonthYear: ushort year@0, byte month@2, byte day@3, byte week@4.
+        var mmy = body.Slice(WireOffsets.SecDefMaturityMonthYearOffset, WireOffsets.SecDefMaturityMonthYearSize);
+        Assert.Equal((ushort)2025, MemoryMarshal.Read<ushort>(mmy.Slice(0, 2)));
+        Assert.Equal((byte)12, mmy[2]);
+        Assert.Equal((byte)19, mmy[3]);
+        Assert.Equal((byte)0, mmy[4]);
+        Assert.Equal((byte)ExerciseStyle.AMERICAN, body[WireOffsets.SecDefExerciseStyleOffset]);
+        Assert.Equal((byte)PutOrCall.CALL, body[WireOffsets.SecDefPutOrCallOffset]);
+        Assert.Equal((byte)OptPayoutType.VANILLA, body[WireOffsets.SecDefOptPayoutTypeOffset]);
+        Assert.Equal((byte)255, body[WireOffsets.SecDefImpliedMarketIndicatorOffset]);
+
+        // NoUnderlyings dimension header: BlockLength=28, NumInGroup=1.
+        int noUnderlyingsHeaderOffset = FrameOffset + WireOffsets.SecDefBlockLength;
+        Assert.Equal((ushort)WireOffsets.SecDefNoUnderlyingsEntrySize,
+            MemoryMarshal.Read<ushort>(buf.AsSpan(noUnderlyingsHeaderOffset, 2)));
+        Assert.Equal((byte)1, buf[noUnderlyingsHeaderOffset + 2]);
+
+        // NoUnderlyings entry: underlyingSecurityID@0, underlyingSymbol@8 (20-byte ASCII).
+        int entryOffset = noUnderlyingsHeaderOffset + WireOffsets.GroupSizeEncodingSize;
+        Assert.Equal(900_000_000_001L,
+            MemoryMarshal.Read<long>(buf.AsSpan(entryOffset + WireOffsets.SecDefNoUnderlyingsEntrySecurityIdOffset, 8)));
+        Assert.Equal("PETR4",
+            System.Text.Encoding.ASCII.GetString(buf.AsSpan(
+                entryOffset + WireOffsets.SecDefNoUnderlyingsEntrySymbolOffset, 5)));
+    }
+
+    [Fact]
+    public void SecurityDefinition_Option_Put_EncodesPutOrCallPut()
+    {
+        var buf = new byte[512];
+        var optionFields = new UmdfWireEncoder.OptionDefinitionFields
+        {
+            StrikePrice = 30m,
+            ContractMultiplier = 100m,
+            ExpirationDate = new DateOnly(2025, 6, 20),
+            PutOrCallByte = (byte)PutOrCall.PUT,
+            ExerciseStyleByte = (byte)ExerciseStyle.EUROPEAN,
+            OptPayoutTypeByte = null, // unspecified → SBE NULL sentinel
+            UnderlyingSecurityId = 42L,
+            UnderlyingSymbol = "VALE3",
+        };
+        UmdfWireEncoder.WriteSecurityDefinitionFrame(buf, securityId: 100L,
+            symbol: "VALER300", isin: "BROPTVALER300",
+            securityTypeByte: (byte)SecurityType.OPT, totNoRelatedSym: 1,
+            optionFields: optionFields);
+
+        var body = buf.AsSpan(FrameOffset, WireOffsets.SecDefBlockLength);
+        Assert.Equal((byte)PutOrCall.PUT, body[WireOffsets.SecDefPutOrCallOffset]);
+        Assert.Equal((byte)ExerciseStyle.EUROPEAN, body[WireOffsets.SecDefExerciseStyleOffset]);
+        // OptPayoutType: caller passed null → encoder writes NULL sentinel.
+        Assert.Equal((byte)255, body[WireOffsets.SecDefOptPayoutTypeOffset]);
+    }
+
+    [Fact]
+    public void SecurityDefinition_Option_RoundtripsViaGeneratedReader()
+    {
+        var buf = new byte[512];
+        var optionFields = new UmdfWireEncoder.OptionDefinitionFields
+        {
+            StrikePrice = 28.50m,
+            ContractMultiplier = 100m,
+            ExpirationDate = new DateOnly(2025, 12, 19),
+            PutOrCallByte = (byte)PutOrCall.CALL,
+            ExerciseStyleByte = (byte)ExerciseStyle.AMERICAN,
+            OptPayoutTypeByte = (byte)OptPayoutType.VANILLA,
+            UnderlyingSecurityId = 900_000_000_001L,
+            UnderlyingSymbol = "PETR4",
+        };
+        int n = UmdfWireEncoder.WriteSecurityDefinitionFrame(buf, securityId: 900_111_111_111L,
+            symbol: "PETRZ285", isin: "BROPTPETRZ285",
+            securityTypeByte: (byte)SecurityType.OPT, totNoRelatedSym: 1,
+            optionFields: optionFields);
+
+        var sbeMessage = buf.AsSpan(WireOffsets.FramingHeaderSize, n - WireOffsets.FramingHeaderSize);
+        var bodyAndTail = sbeMessage.Slice(WireOffsets.SbeMessageHeaderSize);
+        Assert.True(B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.TryParse(bodyAndTail,
+            blockLength: WireOffsets.SecDefBlockLength, out var rdr));
+
+        Assert.Equal(285_000L, rdr.Data.StrikePrice.Mantissa);
+        Assert.Equal(100L * 100_000_000L, rdr.Data.ContractMultiplier.Mantissa);
+        Assert.Equal((ushort)2025, rdr.Data.MaturityMonthYear.Year);
+        Assert.Equal((byte)12, rdr.Data.MaturityMonthYear.Month);
+        Assert.Equal((byte)19, rdr.Data.MaturityMonthYear.Day);
+        Assert.Equal(ExerciseStyle.AMERICAN, rdr.Data.ExerciseStyle);
+        Assert.Equal(PutOrCall.CALL, rdr.Data.PutOrCall);
+        Assert.Equal(OptPayoutType.VANILLA, rdr.Data.OptPayoutType);
+
+        int underlyings = 0;
+        long underlyingSecId = 0L;
+        rdr.ReadGroups(
+            (in B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.NoUnderlyingsData u) =>
+            {
+                underlyings++;
+                underlyingSecId = (long)(ulong)u.UnderlyingSecurityID.Value;
+            },
+            (in B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.NoLegsData _) => { },
+            (in B3.Umdf.Mbo.Sbe.V16.SecurityDefinition_12Data.NoInstrAttribsData _) => { },
+            (B3.Umdf.Mbo.Sbe.V16.TextEncoding _) => { });
+        Assert.Equal(1, underlyings);
+        Assert.Equal(900_000_000_001L, underlyingSecId);
+    }
+
+    [Fact]
     public void Sequence_Roundtrip()
     {
         var buf = new byte[64];


### PR DESCRIPTION
## Summary

Trail T-2 (OPT-02) from RFC 0002. Starts populating the option-specific
fields on `SecurityDefinition_12` so a downstream UMDF consumer can
build an equity-options chain end-to-end.

The wire encoder is bumped from V6 (`BLOCK_LENGTH=230`) to V16
(`BLOCK_LENGTH=232`). The V16 reader is backward-compatible because
it dispatches on the explicit `MessageHeader.BlockLength` field — see
the long-standing comment in `WireOffsets.cs`:

> Publishers that claim a lower Version in the SbeMessageHeader but
> write the V16 physical body still get correctly read by the V16
> reader iff the MessageHeader.BlockLength field matches the bytes
> actually written.

Equity rows decode unchanged: every new optional field is stamped with
its SBE NULL sentinel (`long.MinValue` for prices, `0` year for
`MaturityMonthYear`, `255` for the byte enums).

## Changes

**Encoder (`B3.Umdf.WireEncoder`):**
- `WireOffsets`: V16 SecDef offsets + 28-byte NoUnderlyings entry layout.
- `UmdfWireEncoder`: switch to V16 `WriteHeader`; new
  `OptionDefinitionFields` struct; optional `optionFields` parameter
  on `WriteSecurityDefinitionFrame`; always emit NULL sentinels;
  emit a 1-entry NoUnderlyings group for options.

**Publisher (`B3.Exchange.Core.InstrumentDefinitionPublisher`):**
- Per-instrument frame size (`SecDefFrameSizeFor`).
- `BuildOptionFields(Instrument)` maps the option fields added in
  T-1 (`StrikePrice`, `ExpirationDate`, `PutOrCall`, `ExerciseStyle`,
  `UnderlyingSecurityId`, `UnderlyingSymbol`, `ContractMultiplier`,
  `OptPayoutType`) to the encoder enum bytes.

**Tests:**
- 4 encoder tests: equity NULL-sentinel regression, Call full-field
  byte-level encoding, Put with null `OptPayoutType`, full V16-reader
  round-trip including `NoUnderlyings` `ReadGroups`.
- 2 publisher tests: option instrument emits option fields + one
  underlying; mixed equity/option workload exercises the variable
  frame-size + packet-overflow path.

## Compatibility note

The encoder now stamps `SchemaVersion=16` (was 6). Per the
`WireOffsets` comment quoted above, this is safe because consumers
dispatch on the explicit `BlockLength` byte in the SBE header.
Equity rows that did not previously carry any of these fields decode
to `null` because every optional is initialised to its NULL sentinel.

## Validation

```
dotnet restore SbeB3Exchange.slnx
dotnet build   SbeB3Exchange.slnx --no-restore -c Release   # clean, warnings-as-errors
dotnet test    SbeB3Exchange.slnx --no-build   -c Release   # 1 unrelated flake (passes on retry)
dotnet format  SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn   # clean
```

Refs #463, closes #476.