### PR TITLE
feat(options): expiry-aware phase scheduling (OPT-03 / RFC 0002 T-3)

### DIFF
--- a/docs/adr/0013-option-series-expiry.md
+++ b/docs/adr/0013-option-series-expiry.md
@@ -1,0 +1,174 @@
+# 0013 — Option series expiry: two-path scheduling at the day boundary
+
+- **Status**: Accepted
+- **Date**: 2026-05-25
+- **Related ADRs**: [ADR 0005 — Clearing boundary out of scope](0005-clearing-boundary-out-of-scope.md),
+  [ADR 0009 — Single-writer per channel threading model](0009-single-writer-threading-model.md),
+  [ADR 0012 — Exchange-day boundary](0012-exchange-day-boundary.md).
+- **Related**: [RFC 0002 — Equity options support](../rfc/0002-equity-options-support.md)
+  (§3.4 "Expiry handling", §7 Q4); umbrella issue #463; child issue #477
+  (OPT-03).
+
+## Context
+
+RFC 0002 introduced first-class support for equity options. Trail
+T-1 of that RFC taught `InstrumentLoader` how to validate and persist
+option-only fields (strike, expirationDate, putOrCall, etc.). T-1 also
+rejects any option whose `expirationDate` has already passed at boot
+time — but RFC 0002 §3.4 also requires the simulator to handle the
+intra-day case: an option series whose final trading day is *today*
+should not stay open across the closing bell, and no new orders should
+land on it after the trading day ends.
+
+ADR 0012 is the relevant scope guardrail: the simulator owns the wall
+between the opening and closing bells. **Exercise, assignment,
+settlement, clearing, and any "after the bell" workflow on an expired
+series remain explicitly out of scope** (the family-of-repositories
+table in `README.md` assigns those to hypothetical clearing /
+analytics repos). The question this ADR settles is therefore narrow:
+"when an option series reaches its `expirationDate`, what should the
+matching engine + UMDF gateway do *between bells* and at the
+end-of-trading-day rollover?"
+
+A second open question, recorded as RFC 0002 §7 Q4, was whether the
+end-of-day expiry sweep should be at the boot-time loader, at the
+runtime daily-reset boundary, or at both. We landed on both: each
+covers a failure mode the other can't.
+
+## Decision
+
+Option-series expiry is handled by **two complementary paths** that
+together cover the lifecycle:
+
+1. **Boot-time rejection (loader path, T-1, already shipped)** —
+   `InstrumentLoader.LoadFromFile` refuses to admit any option whose
+   `expirationDate` is strictly before today (UTC). The host fails
+   `StartAsync` with an `InstrumentConfigException` carrying the
+   message *"expirationDate must be today or later"*. This catches
+   operator drift in the instruments JSON and forces stale series out
+   of the dictionary before any TCP session can place an order.
+
+2. **End-of-trading-day auto-Close sweep (runtime path, T-3,
+   this ADR)** — an `OptionExpirySweeper` host component runs at the
+   start of `ExchangeHost.TriggerDailyReset` (the codebase's
+   end-of-trading-day boundary). For every loaded option series whose
+   `ExpirationDate ≤ today` (UTC), the sweeper enqueues a new
+   `OperatorExpireSecurity` work item on the channel that owns the
+   series. The dispatcher processes that work item under its
+   single-writer invariant (ADR 0009):
+
+   1. Snapshot every resting `orderId` for the security from
+      `OrderRegistry`.
+   2. Call `MatchingEngine.MassCancel(...)` — each cancelled order
+      surfaces as a per-session `ER_Cancel` on the EntryPoint TCP path
+      and as a `DeleteOrder_MBO_51` frame in the UMDF buffer.
+   3. Call `MatchingEngine.SetTradingPhase(securityId, Close, now)` —
+      a terminal `SecurityStatus_3` frame with `SecurityTradingStatus
+      = 3 (CLOSE)` is buffered alongside the cancellations.
+   4. Flush the buffered frames as one UMDF packet so consumers see
+      "everything died → CLOSE" in a single sequence-number step.
+
+   The sweeper synchronously waits on `TaskCompletionSource`
+   completions before returning so that `TriggerDailyReset` does not
+   call `TerminateAllSessions` until every `ER_Cancel` has been
+   handed to the outbound encoder. Once `Close` is set the engine
+   rejects further admissions through the existing trading-phase
+   gate; the series is then re-rejected by `InstrumentLoader` on the
+   next boot.
+
+### Calendar-day interpretation
+
+`ExpirationDate` is interpreted as a **UTC calendar day**. The
+boot-time check (`InstrumentLoader`) and the runtime sweep both use
+`DateOnly.FromDateTime(DateTime.UtcNow)`. Local-time / exchange-time
+conversion is intentionally out of scope here — the rest of the
+codebase already operates in UTC for instrument metadata and
+audit-log day boundaries, and adding a per-exchange timezone here
+would cross the line into clearing/settlement workflow (out of scope
+per ADR 0005). The intentional consequence is that operators who
+configure series with broker-local expiration dates must convert
+them to UTC.
+
+### Threading
+
+The sweep itself runs on the caller's thread (the operator-trigger
+thread of `TriggerDailyReset` or the daily-reset timer). It never
+touches any `MatchingEngine` directly — every transition happens on
+the dispatcher's owner thread via the work-item queue, preserving
+ADR 0009's single-writer-per-channel invariant. The bounded inbound
+channel is the natural backpressure mechanism: a saturated channel
+will reject the enqueue and surface a warn log, which is the same
+fail-mode as every other operator command.
+
+## Scope boundary
+
+In line with ADR 0012, the runtime path **stops at the closing
+trading phase**. The simulator deliberately does **not**:
+
+- compute settlement prices, mark-to-market PnL, or assignment
+  allocations for ITM expiring options;
+- generate exercise notices, broker-side margin calls, or any
+  CCP-bound workflow;
+- model the post-bell auction / closing-print mechanics specific to
+  options;
+- remove the instrument from the loaded dictionary or strip it from
+  subsequent UMDF `SecurityDefinition_12` frames — the next-day
+  boot rejection is responsible for that pruning.
+
+Anything in that list belongs in a (hypothetical) clearing /
+analytics companion repo, not here. If a contributor wants
+auto-exercise or settlement, the answer per ADR 0012 is to file the
+work against that repo, not to extend this one.
+
+### Known gap (acceptable for MVP): parked stops
+
+`MatchingEngine.MassCancel` walks `_booksById` only and does not
+touch `_stopsBySymbol`. An expiring option series that has parked
+(non-triggered) stop orders will leave those stops in memory until
+the next-day boot rejection prunes the instrument. This parallels
+the existing operator `OrderMassActionRequest` behaviour and was
+deemed acceptable for the MVP — options stop-order workflows are
+themselves out of the equity-options RFC's first pass. If we later
+extend stops to options as first-class, this ADR will be amended
+to require `OperatorExpireSecurity` to walk both books.
+
+## Consequences
+
+- The two paths compose. A series expiring during a multi-day
+  scheduled outage gets caught by the boot rejection on
+  the next start, even if the auto-Close sweep never ran. A series
+  expiring during normal operation gets the in-process auto-Close
+  with the burst-of-cancels + `Close` framing consumers expect.
+- The auto-Close runs inside the existing single-writer
+  per-channel invariant. No new locks, no `async` in the dispatch
+  loop, no cross-thread state.
+- Operators who want to keep an option series alive past its
+  `expirationDate` for testing purposes must bump the date in the
+  instruments JSON — there is no override knob, by design.
+- The sweep's wait-for-completion is bounded by a 15-second timeout.
+  A wedged dispatcher (already a fatal-failure scenario in this
+  codebase) logs a warning rather than holding the daily-reset
+  thread forever.
+
+## Alternatives considered
+
+- **Loader-only path (RFC §7 Q4 option A)**: rejected. Operators
+  who never restart the host would never see an expiring series
+  close — the engine would keep accepting orders on a stale series
+  for arbitrarily long, contradicting RFC 0002 §3.4.
+- **Runtime-only path (RFC §7 Q4 option B)**: rejected. A host that
+  starts up the morning after a series expired would silently load
+  an expired security and rely on the next daily-reset window to
+  close it. Failing fast at boot is cheaper and louder.
+- **Hooking into `PhaseScheduler` end-of-day transition**: rejected.
+  `PhaseScheduler` is a per-channel cron-style scheduler with no
+  notion of "end of trading day for the whole host"; it would have
+  required either a new scheduler-level callback or duplicating the
+  HH:mm config per group. `TriggerDailyReset` already exists, is
+  already the codebase's "end of trading day" boundary, and is
+  already wired to the operator HTTP endpoint + the daily-reset
+  timer.
+- **Cancelling all orders on the series without a phase transition**:
+  rejected. Without the terminal `Close` transition, the engine
+  would still accept new orders on the series between the sweep
+  and the next boot, defeating the purpose.

--- a/docs/adr/0014-option-series-expiry.md
+++ b/docs/adr/0014-option-series-expiry.md
@@ -1,4 +1,4 @@
-# 0013 — Option series expiry: two-path scheduling at the day boundary
+# 0014 — Option series expiry: two-path scheduling at the day boundary
 
 - **Status**: Accepted
 - **Date**: 2026-05-25

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -96,7 +96,7 @@ public sealed partial class ChannelDispatcher
             item.HaltCompletion?.TrySetException(
                 new InvalidOperationException(
                     $"channel {ChannelNumber} WAL-halted; halt/resume command rejected"));
-            // OPT-03 (ADR 0013): expiry sweep awaits ExpireCompletion.
+            // OPT-03 (ADR 0014): expiry sweep awaits ExpireCompletion.
             item.ExpireCompletion?.TrySetException(
                 new InvalidOperationException(
                     $"channel {ChannelNumber} WAL-halted; ExpireSecurity rejected"));
@@ -170,7 +170,7 @@ public sealed partial class ChannelDispatcher
         if (item.Kind == WorkKind.OperatorExpireSecurity)
         {
             ProcessExpireSecurity(item.ExpireSecurity!, item.ExpireCompletion);
-            // OPT-03 (ADR 0013): force-persist after expiry so the engine's
+            // OPT-03 (ADR 0014): force-persist after expiry so the engine's
             // _phaseById flip to Close and any RptSeq consumed by the
             // SecurityStatus_3 + per-order ER_Cancel frames survive a
             // restart — mirroring the OperatorSetTradingPhase path.

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -96,6 +96,10 @@ public sealed partial class ChannelDispatcher
             item.HaltCompletion?.TrySetException(
                 new InvalidOperationException(
                     $"channel {ChannelNumber} WAL-halted; halt/resume command rejected"));
+            // OPT-03 (ADR 0013): expiry sweep awaits ExpireCompletion.
+            item.ExpireCompletion?.TrySetException(
+                new InvalidOperationException(
+                    $"channel {ChannelNumber} WAL-halted; ExpireSecurity rejected"));
             return;
         }
 
@@ -159,6 +163,17 @@ public sealed partial class ChannelDispatcher
         if (item.Kind == WorkKind.OperatorResumeInstrument)
         {
             ProcessResume(item.Resume!, item.HaltCompletion);
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorExpireSecurity)
+        {
+            ProcessExpireSecurity(item.ExpireSecurity!, item.ExpireCompletion);
+            // OPT-03 (ADR 0013): force-persist after expiry so the engine's
+            // _phaseById flip to Close and any RptSeq consumed by the
+            // SecurityStatus_3 + per-order ER_Cancel frames survive a
+            // restart — mirroring the OperatorSetTradingPhase path.
             OnAfterCommandFlushed(force: true);
             return;
         }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -617,7 +617,7 @@ public sealed partial class ChannelDispatcher
     }
 
     /// <summary>
-    /// OPT-03 (ADR 0013): enqueue an end-of-trading-day expiry sweep for
+    /// OPT-03 (ADR 0014): enqueue an end-of-trading-day expiry sweep for
     /// <paramref name="securityId"/>. On the dispatch thread the
     /// dispatcher (a) snapshots every resting <c>OrderID</c> for the
     /// security from the local <see cref="OrderRegistry"/>, (b) calls

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -615,4 +615,97 @@ public sealed partial class ChannelDispatcher
             throw;
         }
     }
+
+    /// <summary>
+    /// OPT-03 (ADR 0013): enqueue an end-of-trading-day expiry sweep for
+    /// <paramref name="securityId"/>. On the dispatch thread the
+    /// dispatcher (a) snapshots every resting <c>OrderID</c> for the
+    /// security from the local <see cref="OrderRegistry"/>, (b) calls
+    /// <see cref="MatchingEngine.MassCancel(IReadOnlyCollection{long}, MassCancelCommand)"/>
+    /// to cancel them (driving per-order <c>ER_Cancel</c> +
+    /// UMDF <c>OrderDelete</c> frames via the existing
+    /// <c>OnOrderCanceled</c> sink path), and (c) calls
+    /// <see cref="MatchingEngine.SetTradingPhase"/> to transition the
+    /// security to <see cref="B3.Exchange.Matching.TradingPhase.Close"/>
+    /// (emitting one terminal UMDF <c>SecurityStatus_3</c> CLOSE). Both
+    /// effects pack into one packet via the standard per-command
+    /// <c>FlushPacket</c> flow, so consumers observe the cancellations
+    /// and the terminal status atomically.
+    /// <para>
+    /// Idempotent: a no-op call (no resting orders + already
+    /// <c>Close</c>) returns <c>ExpireSecurityOutcome(0, false)</c>
+    /// and emits no frames. Safe to call from any thread.
+    /// </para>
+    /// </summary>
+    public bool EnqueueOperatorExpireSecurity(long securityId,
+        TaskCompletionSource<ExpireSecurityOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorExpireSecurity))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; ExpireSecurity rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorExpireSecurity, default, 0, false,
+            0, 0, null, null, null, null,
+            ExpireSecurity: new OperatorExpireSecurity(securityId),
+            ExpireCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; ExpireSecurity rejected"));
+        return false;
+    }
+
+    private void ProcessExpireSecurity(OperatorExpireSecurity op,
+        TaskCompletionSource<ExpireSecurityOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _packetWritten = 0;
+        try
+        {
+            // Snapshot every order owned for this security (regardless of
+            // session/firm). The registry is single-writer per ADR 0009,
+            // so iterating it on the dispatch thread is race-free.
+            var orderIds = _orders.SnapshotForSecurity(op.SecurityId);
+            int cancelled = 0;
+            if (orderIds.Count > 0)
+            {
+                try
+                {
+                    cancelled = _engine.MassCancel(orderIds,
+                        new B3.Exchange.Matching.MassCancelCommand(op.SecurityId, null, _timeSource.NowNanos()));
+                }
+                catch (KeyNotFoundException ex)
+                {
+                    completion?.TrySetException(ex);
+                    return;
+                }
+            }
+
+            bool phaseChanged;
+            try
+            {
+                phaseChanged = _engine.SetTradingPhase(op.SecurityId,
+                    B3.Exchange.Matching.TradingPhase.Close, _timeSource.NowNanos());
+            }
+            catch (KeyNotFoundException ex)
+            {
+                // Flush any cancel frames already buffered so we don't
+                // drop them on the floor when the phase transition fails.
+                if (_packetWritten > 0) FlushPacket();
+                completion?.TrySetException(ex);
+                return;
+            }
+
+            if (_packetWritten > 0) FlushPacket();
+            completion?.TrySetResult(new ExpireSecurityOutcome(cancelled, phaseChanged));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -11,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -41,6 +41,7 @@ public sealed partial class ChannelDispatcher
         "OperatorBustV2",
         "AuditCheckpoint",
         "ShutdownBarrier",
+        "OperatorExpireSecurity",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -72,6 +73,8 @@ public sealed partial class ChannelDispatcher
         TaskCompletionSource<OperatorBustV2Outcome>? BustCompletion = null,
         AuditCheckpointRequest? AuditCheckpoint = null,
         TaskCompletionSource<bool>? ShutdownBarrier = null,
+        OperatorExpireSecurity? ExpireSecurity = null,
+        TaskCompletionSource<ExpireSecurityOutcome>? ExpireCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -120,6 +123,25 @@ public sealed partial class ChannelDispatcher
     /// Issue #322: operator-triggered resume payload.
     /// </summary>
     internal sealed record OperatorResume(long SecurityId);
+
+    /// <summary>
+    /// OPT-03 (ADR 0013): end-of-trading-day expiry payload. Carries the
+    /// security id whose option series has reached its terminal trading
+    /// day. The dispatcher cancels every resting order on that security
+    /// (per-order <c>ER_Cancel</c> + UMDF <c>OrderDelete</c>) and
+    /// transitions the trading phase to <c>Close</c>
+    /// (UMDF <c>SecurityStatus_3</c> CLOSE) in one dispatch-thread
+    /// step so consumers observe the cancellations and the terminal
+    /// status under one packet.
+    /// </summary>
+    internal sealed record OperatorExpireSecurity(long SecurityId);
+
+    /// <summary>
+    /// OPT-03 (ADR 0013): outcome of an expire-security command. Reports
+    /// how many resting orders were cancelled and whether the trading
+    /// phase actually changed (false if it was already <c>Close</c>).
+    /// </summary>
+    public readonly record struct ExpireSecurityOutcome(int CancelledOrderCount, bool PhaseChanged);
 
     /// <summary>
     /// ADR 0008 PR-2: operator bust request payload (post-trade audit

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -125,7 +125,7 @@ public sealed partial class ChannelDispatcher
     internal sealed record OperatorResume(long SecurityId);
 
     /// <summary>
-    /// OPT-03 (ADR 0013): end-of-trading-day expiry payload. Carries the
+    /// OPT-03 (ADR 0014): end-of-trading-day expiry payload. Carries the
     /// security id whose option series has reached its terminal trading
     /// day. The dispatcher cancels every resting order on that security
     /// (per-order <c>ER_Cancel</c> + UMDF <c>OrderDelete</c>) and
@@ -137,7 +137,7 @@ public sealed partial class ChannelDispatcher
     internal sealed record OperatorExpireSecurity(long SecurityId);
 
     /// <summary>
-    /// OPT-03 (ADR 0013): outcome of an expire-security command. Reports
+    /// OPT-03 (ADR 0014): outcome of an expire-security command. Reports
     /// how many resting orders were cancelled and whether the trading
     /// phase actually changed (false if it was already <c>Close</c>).
     /// </summary>

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -209,7 +209,7 @@ public sealed class OrderRegistry
     /// Returns every <c>OrderId</c> currently registered for
     /// <paramref name="securityId"/> on this channel, regardless of
     /// owning session/firm. Used by the end-of-day option-expiry sweep
-    /// (OPT-03, ADR 0013) to enumerate the full set of orders to
+    /// (OPT-03, ADR 0014) to enumerate the full set of orders to
     /// cancel before transitioning the security to <c>Close</c>. Must
     /// be called from the dispatch thread (the only writer to the
     /// registry under ADR 0009 single-writer semantics).

--- a/src/B3.Exchange.Core/OrderRegistry.cs
+++ b/src/B3.Exchange.Core/OrderRegistry.cs
@@ -206,6 +206,26 @@ public sealed class OrderRegistry
     }
 
     /// <summary>
+    /// Returns every <c>OrderId</c> currently registered for
+    /// <paramref name="securityId"/> on this channel, regardless of
+    /// owning session/firm. Used by the end-of-day option-expiry sweep
+    /// (OPT-03, ADR 0013) to enumerate the full set of orders to
+    /// cancel before transitioning the security to <c>Close</c>. Must
+    /// be called from the dispatch thread (the only writer to the
+    /// registry under ADR 0009 single-writer semantics).
+    /// </summary>
+    public IReadOnlyList<long> SnapshotForSecurity(long securityId)
+    {
+        List<long>? matches = null;
+        foreach (var kv in _byOrderId)
+        {
+            if (kv.Value.SecurityId != securityId) continue;
+            (matches ??= new List<long>()).Add(kv.Key);
+        }
+        return (IReadOnlyList<long>?)matches ?? Array.Empty<long>();
+    }
+
+    /// <summary>
     /// Drops every entry owned by <paramref name="session"/>. Called when
     /// a transport closes so the orders themselves stay on the book but
     /// passive fills against them no longer route to a (now-defunct)

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -50,6 +50,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private HttpServer? _http;
     private DailyResetScheduler? _dailyReset;
     private PhaseScheduler? _phaseScheduler;
+    private OptionExpirySweeper? _optionExpirySweeper;
     private readonly List<B3.Exchange.Persistence.DataDirLock> _dataDirLocks = new();
     private B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal? _outboundJournal;
     private B3.Exchange.Gateway.Persistence.FileFixpSessionStatePersister? _statePersister;
@@ -82,6 +83,21 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// </summary>
     public int TriggerDailyReset(string reason = "operator-trigger", CloseKind closeKind = CloseKind.DailyReset)
     {
+        // OPT-03 / ADR 0013: sweep expired option series BEFORE the
+        // listener tears down. Each per-order ER_Cancel from the
+        // sweep's MassCancel must route back to its originating TCP
+        // session via the OrderRegistry → IEntryPointResponseChannel
+        // path — that path is only live while the gateway sessions
+        // are still attached.
+        //
+        // SweepExpiredSeries blocks on a per-channel
+        // TaskCompletionSource until every enqueued ExpireSecurity
+        // work item has been processed end-to-end (MassCancel +
+        // SetTradingPhase Close + UMDF packet flushed + ER_Cancel
+        // frames handed to the outbound encoder). That ordering
+        // guarantees the resting orders' cancels reach the wire
+        // before TerminateAllSessions closes the sockets.
+        _optionExpirySweeper?.SweepExpiredSeries(reason, waitTimeout: TimeSpan.FromSeconds(15));
         var listener = _listener;
         int terminated = listener is null ? -1 : listener.TerminateAllSessions(reason, closeKind);
         // Issue #330 PR-3 (review BLOCKING): drain per-channel inbound
@@ -224,6 +240,10 @@ public sealed class ExchangeHost : IAsyncDisposable
         var firmRegistry = FirmRegistry;
         var defaultSession = ResolveDefaultSession(firmRegistry);
         var routing = new Dictionary<long, ChannelDispatcher>();
+        // OPT-03 / ADR 0013: accumulate (instrument, dispatcher) pairs
+        // across every channel so OptionExpirySweeper can fan out per
+        // option series at end-of-trading-day.
+        var instrumentDispatcherPairs = new List<(Instrument Instrument, ChannelDispatcher Dispatcher)>();
         foreach (var ch in _config.Channels)
         {
             var instruments = InstrumentLoader.LoadFromFile(ch.InstrumentsFile);
@@ -347,6 +367,7 @@ public sealed class ExchangeHost : IAsyncDisposable
                 if (routing.ContainsKey(inst.SecurityId))
                     throw new InvalidOperationException($"SecurityId {inst.SecurityId} mapped to multiple channels");
                 routing.Add(inst.SecurityId, disp);
+                instrumentDispatcherPairs.Add((inst, disp));
             }
             _logger.LogInformation("channel {ChannelNumber}: {InstrumentCount} instruments → {Group}:{Port}",
                 ch.ChannelNumber, instruments.Count, ch.IncrementalGroup, ch.IncrementalPort);
@@ -487,6 +508,23 @@ public sealed class ExchangeHost : IAsyncDisposable
         }
 
         _router = new HostRouter(routing, gatewayRouter, _loggerFactory.CreateLogger<HostRouter>());
+
+        // OPT-03 / ADR 0013: stand up the option-expiry sweeper once
+        // every channel dispatcher has been built. Only instruments
+        // whose SecurityType is option and that carry an
+        // ExpirationDate are admitted as sinks; non-option channels
+        // therefore pay nothing here.
+        {
+            var sinks = OptionExpirySweeper.BuildSinks(instrumentDispatcherPairs);
+            _optionExpirySweeper = new OptionExpirySweeper(sinks,
+                _loggerFactory.CreateLogger<OptionExpirySweeper>());
+            if (sinks.Count > 0)
+            {
+                _logger.LogInformation(
+                    "option-expiry sweeper armed for {SeriesCount} option series across {ChannelCount} channels",
+                    sinks.Count, _dispatchers.Count);
+            }
+        }
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
         var sessionOptions = new FixpSessionOptions
         {

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -83,7 +83,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     /// </summary>
     public int TriggerDailyReset(string reason = "operator-trigger", CloseKind closeKind = CloseKind.DailyReset)
     {
-        // OPT-03 / ADR 0013: sweep expired option series BEFORE the
+        // OPT-03 / ADR 0014: sweep expired option series BEFORE the
         // listener tears down. Each per-order ER_Cancel from the
         // sweep's MassCancel must route back to its originating TCP
         // session via the OrderRegistry → IEntryPointResponseChannel
@@ -240,7 +240,7 @@ public sealed class ExchangeHost : IAsyncDisposable
         var firmRegistry = FirmRegistry;
         var defaultSession = ResolveDefaultSession(firmRegistry);
         var routing = new Dictionary<long, ChannelDispatcher>();
-        // OPT-03 / ADR 0013: accumulate (instrument, dispatcher) pairs
+        // OPT-03 / ADR 0014: accumulate (instrument, dispatcher) pairs
         // across every channel so OptionExpirySweeper can fan out per
         // option series at end-of-trading-day.
         var instrumentDispatcherPairs = new List<(Instrument Instrument, ChannelDispatcher Dispatcher)>();
@@ -509,7 +509,7 @@ public sealed class ExchangeHost : IAsyncDisposable
 
         _router = new HostRouter(routing, gatewayRouter, _loggerFactory.CreateLogger<HostRouter>());
 
-        // OPT-03 / ADR 0013: stand up the option-expiry sweeper once
+        // OPT-03 / ADR 0014: stand up the option-expiry sweeper once
         // every channel dispatcher has been built. Only instruments
         // whose SecurityType is option and that carry an
         // ExpirationDate are admitted as sinks; non-option channels

--- a/src/B3.Exchange.Host/OptionExpirySweeper.cs
+++ b/src/B3.Exchange.Host/OptionExpirySweeper.cs
@@ -130,15 +130,31 @@ public sealed class OptionExpirySweeper
         }
         if (pending is { Count: > 0 })
         {
+            bool completedInTime;
             try
             {
-                Task.WaitAll(pending.ToArray(), waitTimeout!.Value);
+                completedInTime = Task.WaitAll(pending.ToArray(), waitTimeout!.Value);
             }
             catch (AggregateException ex)
             {
+                completedInTime = pending.TrueForAll(t => t.IsCompleted);
                 _logger.LogWarning(ex,
                     "option-expiry sweep ({Trigger}): one or more ExpireSecurity completions faulted",
                     trigger);
+            }
+            if (!completedInTime)
+            {
+                int incomplete = pending.Count(t => !t.IsCompleted);
+                // Loud, distinctive log so an operator running daily-reset
+                // can correlate a stuck dispatcher with the resulting
+                // missing ER_Cancel / lingering Open phase. See ADR 0013
+                // — by design we do NOT abort the rest of the daily-reset
+                // flow on this timeout (a wedged dispatcher is already a
+                // fatal-failure scenario and TerminateAllSessions must
+                // still run).
+                _logger.LogError(
+                    "option-expiry sweep ({Trigger}): timed out after {TimeoutMs}ms with {Incomplete} of {Enqueued} ExpireSecurity completions still pending — TerminateAllSessions may close sessions before ER_Cancel reaches the wire",
+                    trigger, (int)waitTimeout!.Value.TotalMilliseconds, incomplete, enqueued);
             }
         }
         _logger.LogInformation(

--- a/src/B3.Exchange.Host/OptionExpirySweeper.cs
+++ b/src/B3.Exchange.Host/OptionExpirySweeper.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 namespace B3.Exchange.Host;
 
 /// <summary>
-/// OPT-03 / ADR 0013 — end-of-trading-day option-series expiry sweep.
+/// OPT-03 / ADR 0014 — end-of-trading-day option-series expiry sweep.
 ///
 /// <para>At the end of each trading day the host walks the configured
 /// option instruments and, for every series whose
@@ -147,7 +147,7 @@ public sealed class OptionExpirySweeper
                 int incomplete = pending.Count(t => !t.IsCompleted);
                 // Loud, distinctive log so an operator running daily-reset
                 // can correlate a stuck dispatcher with the resulting
-                // missing ER_Cancel / lingering Open phase. See ADR 0013
+                // missing ER_Cancel / lingering Open phase. See ADR 0014
                 // — by design we do NOT abort the rest of the daily-reset
                 // flow on this timeout (a wedged dispatcher is already a
                 // fatal-failure scenario and TerminateAllSessions must

--- a/src/B3.Exchange.Host/OptionExpirySweeper.cs
+++ b/src/B3.Exchange.Host/OptionExpirySweeper.cs
@@ -1,0 +1,199 @@
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// OPT-03 / ADR 0013 — end-of-trading-day option-series expiry sweep.
+///
+/// <para>At the end of each trading day the host walks the configured
+/// option instruments and, for every series whose
+/// <see cref="Instrument.ExpirationDate"/> is on or before the supplied
+/// "today" (UTC), enqueues an <c>EnqueueOperatorExpireSecurity</c>
+/// command on the channel that owns the security. The dispatcher then
+/// cancels every resting order for the series and transitions the
+/// trading phase to <see cref="B3.Exchange.Matching.TradingPhase.Close"/>
+/// in one packet under the channel's single-writer invariant (ADR
+/// 0009). The instrument stays loaded for the remainder of the calendar
+/// day; the next-day boot rejects it via <c>InstrumentLoader</c>
+/// (T-1).</para>
+///
+/// <para>The sweeper does not own a timer — it is invoked from
+/// <c>ExchangeHost.TriggerDailyReset</c> (the natural "end of trading
+/// day" boundary in this codebase). This keeps the expiry decision
+/// aligned with the rest of the daily-rollover flow: the listener is
+/// not yet torn down, so any per-order <c>ER_Cancel</c> still routes to
+/// the originating session.</para>
+/// </summary>
+public sealed class OptionExpirySweeper
+{
+    /// <summary>One configured option instrument together with the
+    /// dispatcher that owns its <c>SecurityId</c>.</summary>
+    public interface IExpireSink
+    {
+        long SecurityId { get; }
+        string Symbol { get; }
+        DateOnly ExpirationDate { get; }
+        byte ChannelNumber { get; }
+
+        /// <summary>Returns <c>false</c> when the inbound queue rejects
+        /// the enqueue (queue full / WAL halted). The sweeper logs and
+        /// continues with the next series.</summary>
+        bool EnqueueExpire(TaskCompletionSource<ChannelDispatcher.ExpireSecurityOutcome>? completion);
+    }
+
+    private readonly IReadOnlyList<IExpireSink> _sinks;
+    private readonly ILogger<OptionExpirySweeper> _logger;
+    private readonly Func<DateOnly> _todayUtc;
+
+    public OptionExpirySweeper(IReadOnlyList<IExpireSink> sinks,
+        ILogger<OptionExpirySweeper> logger,
+        Func<DateOnly>? todayUtcOverride = null)
+    {
+        ArgumentNullException.ThrowIfNull(sinks);
+        ArgumentNullException.ThrowIfNull(logger);
+        _sinks = sinks;
+        _logger = logger;
+        _todayUtc = todayUtcOverride ?? (() => DateOnly.FromDateTime(DateTime.UtcNow));
+    }
+
+    /// <summary>True when the host has at least one configured option
+    /// series — the daily-reset path uses this to skip the sweep work
+    /// + log entirely on equities-only deployments.</summary>
+    public bool HasOptionSeries => _sinks.Count > 0;
+
+    /// <summary>
+    /// Walks every configured option series and, for each one whose
+    /// expiration date is on or before <see cref="_todayUtc"/>,
+    /// enqueues an <c>ExpireSecurity</c> command on the owning channel.
+    ///
+    /// <para>When <paramref name="waitTimeout"/> is provided (default
+    /// 5s) the call blocks until every enqueued command has finished
+    /// processing on the dispatcher thread — this is required from
+    /// <c>TriggerDailyReset</c> so the gateway can flush ER_Cancel
+    /// frames before <c>TerminateAllSessions</c> tears down the
+    /// response channels. Pass <see cref="TimeSpan.Zero"/> to fire and
+    /// forget.</para>
+    ///
+    /// <para>Returns the number of series that were enqueued. Per-series
+    /// enqueue failures are logged at warn level and do not abort the
+    /// sweep.</para>
+    /// </summary>
+    public int SweepExpiredSeries(string trigger, TimeSpan? waitTimeout = null)
+    {
+        if (_sinks.Count == 0) return 0;
+        var today = _todayUtc();
+        int enqueued = 0;
+        int skipped = 0;
+        int rejected = 0;
+        var pending = waitTimeout is { } t && t > TimeSpan.Zero
+            ? new List<Task>()
+            : null;
+        foreach (var sink in _sinks)
+        {
+            if (sink.ExpirationDate > today)
+            {
+                skipped++;
+                continue;
+            }
+            var completion = pending is null
+                ? null
+                : new TaskCompletionSource<ChannelDispatcher.ExpireSecurityOutcome>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            bool ok;
+            try
+            {
+                ok = sink.EnqueueExpire(completion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "option-expiry sweep ({Trigger}): enqueue threw symbol={Symbol} secId={SecurityId} channel={Channel}",
+                    trigger, sink.Symbol, sink.SecurityId, sink.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            if (!ok)
+            {
+                _logger.LogWarning(
+                    "option-expiry sweep ({Trigger}): enqueue rejected symbol={Symbol} secId={SecurityId} channel={Channel}",
+                    trigger, sink.Symbol, sink.SecurityId, sink.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            enqueued++;
+            if (completion != null) pending!.Add(completion.Task);
+            _logger.LogInformation(
+                "option-expiry sweep ({Trigger}): enqueued symbol={Symbol} secId={SecurityId} channel={Channel} expirationDate={ExpirationDate} today={Today}",
+                trigger, sink.Symbol, sink.SecurityId, sink.ChannelNumber, sink.ExpirationDate, today);
+        }
+        if (pending is { Count: > 0 })
+        {
+            try
+            {
+                Task.WaitAll(pending.ToArray(), waitTimeout!.Value);
+            }
+            catch (AggregateException ex)
+            {
+                _logger.LogWarning(ex,
+                    "option-expiry sweep ({Trigger}): one or more ExpireSecurity completions faulted",
+                    trigger);
+            }
+        }
+        _logger.LogInformation(
+            "option-expiry sweep ({Trigger}): enqueued={Enqueued} skipped={Skipped} rejected={Rejected} total={Total} today={Today}",
+            trigger, enqueued, skipped, rejected, _sinks.Count, today);
+        return enqueued;
+    }
+
+    /// <summary>
+    /// Production sink that bridges an <see cref="Instrument"/> +
+    /// <see cref="ChannelDispatcher"/> pair to the expire-security
+    /// enqueue path. Kept as a nested type so test code can drop in
+    /// its own <see cref="IExpireSink"/> without depending on a live
+    /// dispatcher.
+    /// </summary>
+    public sealed class DispatcherExpireSink : IExpireSink
+    {
+        private readonly ChannelDispatcher _dispatcher;
+        public long SecurityId { get; }
+        public string Symbol { get; }
+        public DateOnly ExpirationDate { get; }
+        public byte ChannelNumber => _dispatcher.ChannelNumber;
+
+        public DispatcherExpireSink(Instrument instrument, ChannelDispatcher dispatcher)
+        {
+            ArgumentNullException.ThrowIfNull(instrument);
+            ArgumentNullException.ThrowIfNull(dispatcher);
+            if (instrument.ExpirationDate is null)
+                throw new ArgumentException("DispatcherExpireSink requires an instrument with an ExpirationDate.", nameof(instrument));
+            _dispatcher = dispatcher;
+            SecurityId = instrument.SecurityId;
+            Symbol = instrument.Symbol;
+            ExpirationDate = instrument.ExpirationDate.Value;
+        }
+
+        public bool EnqueueExpire(TaskCompletionSource<ChannelDispatcher.ExpireSecurityOutcome>? completion)
+            => _dispatcher.EnqueueOperatorExpireSecurity(SecurityId, completion);
+    }
+
+    /// <summary>
+    /// Builds the production sink set from the host's per-channel
+    /// instrument lists. Skips non-option instruments and instruments
+    /// without an <see cref="Instrument.ExpirationDate"/>.
+    /// </summary>
+    public static IReadOnlyList<IExpireSink> BuildSinks(
+        IEnumerable<(Instrument Instrument, ChannelDispatcher Dispatcher)> instrumentsByDispatcher)
+    {
+        ArgumentNullException.ThrowIfNull(instrumentsByDispatcher);
+        var result = new List<IExpireSink>();
+        foreach (var (inst, disp) in instrumentsByDispatcher)
+        {
+            if (!InstrumentSecurityTypes.IsOption(inst.SecurityType)) continue;
+            if (inst.ExpirationDate is null) continue;
+            result.Add(new DispatcherExpireSink(inst, disp));
+        }
+        return result;
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostExpiryBootRejectTests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostExpiryBootRejectTests.cs
@@ -4,7 +4,7 @@ using B3.Exchange.Instruments;
 namespace B3.Exchange.Host.Tests;
 
 /// <summary>
-/// OPT-03 / ADR 0013 — host-level integration test confirming that an
+/// OPT-03 / ADR 0014 — host-level integration test confirming that an
 /// option series whose expirationDate has already passed is rejected
 /// at <see cref="ExchangeHost.StartAsync"/> time. The actual rejection
 /// lives in <see cref="InstrumentLoader"/> (T-1); this test pins the

--- a/tests/B3.Exchange.Host.Tests/ExchangeHostExpiryBootRejectTests.cs
+++ b/tests/B3.Exchange.Host.Tests/ExchangeHostExpiryBootRejectTests.cs
@@ -1,0 +1,130 @@
+using B3.Exchange.Core;
+using B3.Exchange.Instruments;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// OPT-03 / ADR 0013 — host-level integration test confirming that an
+/// option series whose expirationDate has already passed is rejected
+/// at <see cref="ExchangeHost.StartAsync"/> time. The actual rejection
+/// lives in <see cref="InstrumentLoader"/> (T-1); this test pins the
+/// guarantee that the host bootstrap surfaces it instead of silently
+/// loading the stale instrument.
+/// </summary>
+public class ExchangeHostExpiryBootRejectTests
+{
+    private sealed class NullSink : IUmdfPacketSink
+    {
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet) { }
+    }
+
+    private static string WriteInstrumentsJson(DateOnly expirationDate, string scratchDir)
+    {
+        Directory.CreateDirectory(scratchDir);
+        var path = Path.Combine(scratchDir, "instruments-opt-expired.json");
+        var json = $$"""
+        [
+          {
+            "symbol": "PETRC120",
+            "securityId": 900000099999,
+            "tickSize": "0.01",
+            "lotSize": 1,
+            "minPx": "0.01",
+            "maxPx": "999999.99",
+            "currency": "BRL",
+            "isin": "BRPETRC1ZZZ0",
+            "securityType": "OPT",
+            "strikePrice": "12.00",
+            "expirationDate": "{{expirationDate:yyyy-MM-dd}}",
+            "putOrCall": "Call",
+            "exerciseStyle": "American",
+            "underlyingSecurityId": 900000000001,
+            "underlyingSymbol": "PETR4",
+            "contractMultiplier": "100"
+          }
+        ]
+        """;
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public async Task StartAsync_ThrowsWhenOptionExpirationDateIsInThePast()
+    {
+        // Write the instruments file under the test's bin directory
+        // (the repo-rule blocks /tmp). The directory is auto-cleaned
+        // by the temp helper below.
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "opt-t3-boot-reject-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteInstrumentsJson(
+                expirationDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-1),
+                scratchDir: scratch);
+
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 91,
+                        IncrementalGroup = "239.255.42.91",
+                        IncrementalPort = 30191,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            var ex = await Assert.ThrowsAsync<InstrumentConfigException>(() => host.StartAsync());
+            Assert.Contains("expirationDate must be today or later", ex.Message);
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task StartAsync_AcceptsOptionExpiringToday()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "opt-t3-boot-accept-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteInstrumentsJson(
+                expirationDate: DateOnly.FromDateTime(DateTime.UtcNow),
+                scratchDir: scratch);
+
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 92,
+                        IncrementalGroup = "239.255.42.92",
+                        IncrementalPort = 30192,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => new NullSink());
+            // Should not throw — boundary case: expiry == today is admitted.
+            await host.StartAsync();
+            await host.StopAsync();
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/OptionExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/OptionExpiryE2ETests.cs
@@ -1,0 +1,213 @@
+using B3.EntryPoint.Wire;
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// OPT-03 / ADR 0013 — end-to-end: boot an <see cref="ExchangeHost"/> with
+/// a single option series that expires today, place a resting limit order
+/// on it, then call <see cref="ExchangeHost.TriggerDailyReset"/> and assert
+/// the originating session receives an <c>ER_Cancel</c> and at least one
+/// multicast packet containing the <c>SecurityStatus_3</c> CLOSE frame.
+///
+/// Multicast packets are captured by a recording <see cref="IUmdfPacketSink"/>
+/// (the same pattern <c>ExchangeHostE2ETests</c> uses). The packet scanner
+/// only checks for the presence of TemplateId 3 — packet schema fidelity is
+/// already covered by <c>UmdfWireEncoderTests</c>.
+/// </summary>
+public class OptionExpiryE2ETests
+{
+    private const long OptSecId = 900000099111L;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    private static string WriteOptionInstrumentsJson(string scratchDir, DateOnly expirationDate)
+    {
+        Directory.CreateDirectory(scratchDir);
+        var path = Path.Combine(scratchDir, "instruments-opt-today.json");
+        var json = $$"""
+        [
+          {
+            "symbol": "PETRZ12",
+            "securityId": {{OptSecId}},
+            "tickSize": "0.01",
+            "minPx": "0.01",
+            "maxPx": "999999.99",
+            "currency": "BRL",
+            "isin": "BRPETRZ12ZZ0",
+            "securityType": "OPT",
+            "lotSize": 1,
+            "strikePrice": "12.00",
+            "expirationDate": "{{expirationDate:yyyy-MM-dd}}",
+            "putOrCall": "Call",
+            "exerciseStyle": "American",
+            "underlyingSecurityId": 900000000001,
+            "underlyingSymbol": "PETR4",
+            "contractMultiplier": "100"
+          }
+        ]
+        """;
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_CancelsRestingOrderAndEmitsSecurityStatusCloseForExpiringOption()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "opt-t3-e2e-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteOptionInstrumentsJson(scratch,
+                expirationDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 93,
+                        IncrementalGroup = "239.255.42.93",
+                        IncrementalPort = 30193,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            // Rest a BUY @ 12.34 on the expiring option series.
+            var newOrder = BuildSimpleNewOrder(clOrdId: 11_001, secId: OptSecId,
+                side: '1', ordType: '2', tif: '0', qty: 100, priceMantissa: 123_400);
+            await stream.WriteAsync(newOrder);
+            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+            // Trigger end-of-trading-day. The sweep enqueues the
+            // ExpireSecurity work item, the drain inside TriggerDailyReset
+            // blocks until the dispatcher has processed it.
+            int packetsBefore;
+            lock (sink.Packets) packetsBefore = sink.Packets.Count;
+            host.TriggerDailyReset(reason: "test-expiry");
+
+            // The resting BUY should now come back as an ER_Cancel.
+            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, er2.TemplateId);
+            // ER_Cancel body[18] carries Side; the resting order was Buy.
+            Assert.Equal((byte)'1', er2.Body[18]);
+
+            // The dispatcher must have emitted at least one new UMDF packet
+            // since the sweep, and that packet (or any packet emitted
+            // afterwards) must contain a SecurityStatus_3 frame (templateId
+            // = 3) — the terminal CLOSE for the expired series.
+            List<byte[]> packetsAfter;
+            lock (sink.Packets) packetsAfter = sink.Packets.GetRange(packetsBefore, sink.Packets.Count - packetsBefore);
+            Assert.NotEmpty(packetsAfter);
+            Assert.Contains(packetsAfter, PacketContainsTemplateId3);
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Walks the inc messages inside a UMDF packet and returns true if any
+    /// SBE message header carries TemplateId == 3 (SecurityStatus_3).
+    /// PacketHeader is 16 bytes; each inc message is prefixed by a 4-byte
+    /// FramingHeader (length@0, encodingType@2) and then an 8-byte SBE
+    /// message header (blockLength@0, templateId@2, schemaId@4,
+    /// version@6).
+    /// </summary>
+    private static bool PacketContainsTemplateId3(byte[] packet)
+    {
+        const int PacketHeaderSize = 16;
+        const int FramingHeaderSize = 4;
+        int cursor = PacketHeaderSize;
+        while (cursor + FramingHeaderSize + 8 <= packet.Length)
+        {
+            ushort msgLen = BinaryPrimitives.ReadUInt16LittleEndian(
+                packet.AsSpan(cursor, 2));
+            if (msgLen == 0 || cursor + msgLen > packet.Length) break;
+            ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(
+                packet.AsSpan(cursor + FramingHeaderSize + 2, 2));
+            if (templateId == 3) return true;
+            cursor += msgLen;
+        }
+        return false;
+    }
+
+    // ---- helpers duplicated from ExchangeHostE2ETests (same wire format) ----
+
+    private static byte[] BuildSimpleNewOrder(ulong clOrdId, long secId, char side, char ordType,
+        char tif, long qty, long priceMantissa)
+    {
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + 82];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: 82, templateId: EntryPointFrameReader.TidSimpleNewOrder, version: 2);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)ordType;
+        body[58] = (byte)tif;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        return frame;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/OptionExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/OptionExpiryE2ETests.cs
@@ -7,7 +7,7 @@ using B3.Exchange.Gateway;
 namespace B3.Exchange.Host.Tests;
 
 /// <summary>
-/// OPT-03 / ADR 0013 — end-to-end: boot an <see cref="ExchangeHost"/> with
+/// OPT-03 / ADR 0014 — end-to-end: boot an <see cref="ExchangeHost"/> with
 /// a single option series that expires today, place a resting limit order
 /// on it, then call <see cref="ExchangeHost.TriggerDailyReset"/> and assert
 /// the originating session receives an <c>ER_Cancel</c> and at least one

--- a/tests/B3.Exchange.Host.Tests/OptionExpirySweeperTests.cs
+++ b/tests/B3.Exchange.Host.Tests/OptionExpirySweeperTests.cs
@@ -1,0 +1,126 @@
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// OPT-03 / ADR 0013 — unit tests for <see cref="OptionExpirySweeper"/>.
+/// Uses a fake <see cref="OptionExpirySweeper.IExpireSink"/> so the test
+/// never touches a live <see cref="ChannelDispatcher"/>.
+/// </summary>
+public class OptionExpirySweeperTests
+{
+    private sealed class FakeSink : OptionExpirySweeper.IExpireSink
+    {
+        public long SecurityId { get; }
+        public string Symbol { get; }
+        public DateOnly ExpirationDate { get; }
+        public byte ChannelNumber { get; }
+        public int EnqueueCount { get; private set; }
+        public bool ResultOk { get; init; } = true;
+        public Exception? ThrowOnEnqueue { get; init; }
+
+        public FakeSink(long secId, DateOnly expiry, string symbol = "OPT", byte channel = 1)
+        {
+            SecurityId = secId;
+            Symbol = symbol;
+            ExpirationDate = expiry;
+            ChannelNumber = channel;
+        }
+
+        public bool EnqueueExpire(TaskCompletionSource<ChannelDispatcher.ExpireSecurityOutcome>? completion)
+        {
+            EnqueueCount++;
+            if (ThrowOnEnqueue != null) throw ThrowOnEnqueue;
+            return ResultOk;
+        }
+    }
+
+    private static readonly DateOnly Today = new(2026, 5, 25);
+
+    private static OptionExpirySweeper Sweeper(params OptionExpirySweeper.IExpireSink[] sinks)
+        => new(sinks, NullLogger<OptionExpirySweeper>.Instance, todayUtcOverride: () => Today);
+
+    [Fact]
+    public void Sweep_EnqueuesSeriesExpiringToday()
+    {
+        var s = new FakeSink(secId: 100, expiry: Today);
+        var sweeper = Sweeper(s);
+        var n = sweeper.SweepExpiredSeries("test");
+        Assert.Equal(1, n);
+        Assert.Equal(1, s.EnqueueCount);
+    }
+
+    [Fact]
+    public void Sweep_EnqueuesSeriesAlreadyPastDue()
+    {
+        var s = new FakeSink(secId: 100, expiry: Today.AddDays(-3));
+        var sweeper = Sweeper(s);
+        var n = sweeper.SweepExpiredSeries("test");
+        Assert.Equal(1, n);
+        Assert.Equal(1, s.EnqueueCount);
+    }
+
+    [Fact]
+    public void Sweep_DoesNotEnqueueFutureSeries()
+    {
+        var s = new FakeSink(secId: 100, expiry: Today.AddDays(1));
+        var sweeper = Sweeper(s);
+        var n = sweeper.SweepExpiredSeries("test");
+        Assert.Equal(0, n);
+        Assert.Equal(0, s.EnqueueCount);
+    }
+
+    [Fact]
+    public void Sweep_PartitionsBetweenDueAndFuture()
+    {
+        var due1 = new FakeSink(secId: 101, expiry: Today);
+        var due2 = new FakeSink(secId: 102, expiry: Today.AddDays(-1));
+        var future = new FakeSink(secId: 103, expiry: Today.AddDays(2));
+        var sweeper = Sweeper(due1, due2, future);
+
+        var n = sweeper.SweepExpiredSeries("test");
+        Assert.Equal(2, n);
+        Assert.Equal(1, due1.EnqueueCount);
+        Assert.Equal(1, due2.EnqueueCount);
+        Assert.Equal(0, future.EnqueueCount);
+    }
+
+    [Fact]
+    public void Sweep_ContinuesWhenSinkReturnsFalse()
+    {
+        var rejected = new FakeSink(secId: 101, expiry: Today) { ResultOk = false };
+        var accepted = new FakeSink(secId: 102, expiry: Today) { ResultOk = true };
+        var sweeper = Sweeper(rejected, accepted);
+
+        var n = sweeper.SweepExpiredSeries("test");
+        // Only the accepted sink counts toward the enqueued total —
+        // but both were attempted (no early abort).
+        Assert.Equal(1, n);
+        Assert.Equal(1, rejected.EnqueueCount);
+        Assert.Equal(1, accepted.EnqueueCount);
+    }
+
+    [Fact]
+    public void Sweep_ContinuesWhenSinkThrows()
+    {
+        var bad = new FakeSink(secId: 101, expiry: Today)
+        {
+            ThrowOnEnqueue = new InvalidOperationException("boom"),
+        };
+        var good = new FakeSink(secId: 102, expiry: Today);
+        var sweeper = Sweeper(bad, good);
+
+        var n = sweeper.SweepExpiredSeries("test");
+        Assert.Equal(1, n);
+        Assert.Equal(1, good.EnqueueCount);
+    }
+
+    [Fact]
+    public void Sweep_WithNoSinks_IsNoop()
+    {
+        var sweeper = Sweeper();
+        Assert.False(sweeper.HasOptionSeries);
+        Assert.Equal(0, sweeper.SweepExpiredSeries("test"));
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/OptionExpirySweeperTests.cs
+++ b/tests/B3.Exchange.Host.Tests/OptionExpirySweeperTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace B3.Exchange.Host.Tests;
 
 /// <summary>
-/// OPT-03 / ADR 0013 — unit tests for <see cref="OptionExpirySweeper"/>.
+/// OPT-03 / ADR 0014 — unit tests for <see cref="OptionExpirySweeper"/>.
 /// Uses a fake <see cref="OptionExpirySweeper.IExpireSink"/> so the test
 /// never touches a live <see cref="ChannelDispatcher"/>.
 /// </summary>

--- a/tests/B3.Exchange.Host.Tests/OptionsChannelE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/OptionsChannelE2ETests.cs
@@ -9,7 +9,7 @@ namespace B3.Exchange.Host.Tests;
 
 /// <summary>
 /// Validates the OPT channel wiring shipped by T-4 / OPT-04 (RFC 0002
-/// §3.1, ADR 0013):
+/// §3.1, ADR 0014):
 ///
 /// <list type="number">
 ///   <item>The bundled <c>config/exchange-simulator.json</c> declares


### PR DESCRIPTION
Closes #477. Refs #463 (RFC 0002 umbrella).

Implements the runtime end-of-trading-day auto-Close half of RFC 0002 §3.4 / §7 Q4, complementing T-1's boot-time loader rejection.

## What

Two-path expiry policy (codified in [ADR 0013](docs/adr/0013-option-series-expiry.md)):

1. **Boot-time (loader, T-1, already shipped)** — `InstrumentLoader` rejects options whose `expirationDate` is strictly before today (UTC). New host integration test pins this end-to-end through `ExchangeHost.StartAsync`.
2. **End-of-trading-day (runtime, T-3, this PR)** — new `OptionExpirySweeper` fires from `ExchangeHost.TriggerDailyReset`. For every loaded option series with `ExpirationDate <= today` (UTC), it enqueues a new `OperatorExpireSecurity` work item on the channel that owns it.

The dispatcher processes the work item under its single-writer invariant (ADR 0009):

1. Snapshot every resting `orderId` via `OrderRegistry.SnapshotForSecurity`.
2. `MatchingEngine.MassCancel(...)` → per-session `ER_Cancel` + `DeleteOrder_MBO_51` frames.
3. `MatchingEngine.SetTradingPhase(secId, Close, now)` → terminal `SecurityStatus_3` CLOSE frame.
4. Flush all of the above as **one UMDF packet** so consumers see "everything died → CLOSE" in a single sequence-number step.

`SweepExpiredSeries` blocks on per-channel `TaskCompletionSource`s before returning so `TriggerDailyReset` does not call `TerminateAllSessions` until every `ER_Cancel` has been handed to the outbound encoder.

## Where

- `src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs` — new `OperatorExpireSecurity` `WorkKind` + payload + `ExpireSecurityOutcome`.
- `src/B3.Exchange.Core/ChannelDispatcher.Operator.cs` — `EnqueueOperatorExpireSecurity` + `ProcessExpireSecurity`.
- `src/B3.Exchange.Core/ChannelDispatcher.Loop.cs` — early-return dispatch + WAL-halted TCS-fail path.
- `src/B3.Exchange.Core/OrderRegistry.cs` — `SnapshotForSecurity`.
- `src/B3.Exchange.Host/OptionExpirySweeper.cs` — new component (with testable `IExpireSink` abstraction mirroring the `IPhaseScheduledTarget` pattern).
- `src/B3.Exchange.Host/ExchangeHost.cs` — accumulate `(Instrument, Dispatcher)` tuples; build sweeper; invoke at the top of `TriggerDailyReset`.

## ADR

[`docs/adr/0013-option-series-expiry.md`](docs/adr/0013-option-series-expiry.md) — codifies the two-path policy, the UTC calendar-day interpretation, the scope boundary (no auto-exercise / settlement per ADR 0005 / 0012), and the known parked-stops gap.

## Tests

- `OptionExpirySweeperTests.cs` — 7 unit tests with a fake `IExpireSink` (today, past, future, partition, sink rejects, sink throws, no sinks).
- `ExchangeHostExpiryBootRejectTests.cs` — 2 host integration tests: `StartAsync` rejects an option with `expirationDate = yesterday`; admits `expirationDate = today`.
- `OptionExpiryE2ETests.cs` — full end-to-end: boot host with option expiring today + rest a buy order, `TriggerDailyReset`, assert `ER_Cancel` on TCP and a packet carrying `SecurityStatus_3` (templateId = 3).

## Pre-PR checklist

- ✅ `dotnet restore SbeB3Exchange.slnx`
- ✅ `dotnet build SbeB3Exchange.slnx --no-restore -c Release` (0 warnings)
- ✅ `dotnet test SbeB3Exchange.slnx --no-build -c Release` (all suites pass — 101 host tests, 535 gateway tests, 165 persistence tests, etc.)
- ✅ `dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn` (no diffs)

Draft pending the mandatory gpt-5.5 review pass per AGENTS.md §1.