### PR TITLE
fix(gateway): drain outbound queues before closing sockets

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -253,6 +253,56 @@ public sealed class EntryPointListener : IAsyncDisposable
     }
 
     /// <summary>
+    /// Issue #487: waits for all live sessions' outbound queues to drain
+    /// before closing. Prevents frames (e.g., ER_Cancel from option expiry
+    /// sweep) from being lost when <see cref="TerminateAllSessions"/> closes
+    /// sockets. Per-session failures are logged and swallowed so one stuck
+    /// session never blocks the rest.
+    /// </summary>
+    public async Task DrainAllSessionsOutboundAsync(TimeSpan timeout)
+    {
+        FixpSession[] snapshot;
+        lock (_lock) snapshot = _sessions.ToArray();
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        int drained = 0, pending = 0, closed = 0;
+        var tasks = new List<Task<(FixpSession s, bool ok)>>(snapshot.Length);
+        foreach (var s in snapshot)
+        {
+            if (!s.IsOpen) { closed++; continue; }
+            if (s.SendQueueDepth == 0) { drained++; continue; }
+            pending++;
+            tasks.Add(DrainOneAsync(s, timeout));
+        }
+        if (tasks.Count > 0)
+        {
+            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            foreach (var (s, ok) in results)
+            {
+                if (ok) drained++;
+                else _logger.LogWarning(
+                    "drain-outbound: session {ConnectionId} timed out with {Depth} frames pending",
+                    s.ConnectionId, s.SendQueueDepth);
+            }
+        }
+        _logger.LogInformation(
+            "drain-outbound: drained={Drained} timedOut={TimedOut} alreadyClosed={Closed} duration={DurationMs}ms",
+            drained, pending - (drained - (snapshot.Length - pending - closed)), closed, sw.ElapsedMilliseconds);
+    }
+
+    private static async Task<(FixpSession s, bool ok)> DrainOneAsync(FixpSession s, TimeSpan timeout)
+    {
+        try
+        {
+            var ok = await s.WaitForSendQueueDrainAsync(timeout).ConfigureAwait(false);
+            return (s, ok);
+        }
+        catch
+        {
+            return (s, false);
+        }
+    }
+
+    /// <summary>
     /// Graceful-shutdown phase 1 (issue #171 / A7): stop accepting new TCP
     /// connections without closing the existing sessions or unbinding the
     /// listening socket. The accept loop and the suspended-session reaper

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -306,6 +306,14 @@ public sealed partial class FixpSession : IAsyncDisposable
     /// </summary>
     public int SendQueueDepth => _transport.SendQueueDepth;
 
+    /// <summary>
+    /// Issue #487: waits until the session's outbound queue drains to empty
+    /// or the timeout expires. Call before closing to ensure pending frames
+    /// (e.g., ER_Cancel from option expiry sweep) reach the wire.
+    /// </summary>
+    public Task<bool> WaitForSendQueueDrainAsync(TimeSpan timeout) =>
+        _transport.WaitForSendQueueDrainAsync(timeout);
+
     /// <summary>Number of in-buffer business frames available to replay
     /// in response to a <c>RetransmitRequest</c>. Diagnostic only.</summary>
     public int RetxBufferDepth => _retxBuffer.Count;

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -35,6 +35,13 @@ public sealed class TcpTransport : IAsyncDisposable
     private int _isOpen = 1;
     private long _lastOutboundTickMs;
     private Task? _sendTask;
+    /// <summary>
+    /// Issue #487: tracks frames that have been dequeued but not yet fully
+    /// written to the socket. WaitForSendQueueDrainAsync must wait for both
+    /// SendQueueDepth == 0 AND this counter == 0 to guarantee all frames
+    /// have reached the wire.
+    /// </summary>
+    private int _inFlightFrames;
 
     /// <summary>
     /// Issue #312: per-frame envelope tying the encoded bytes to the
@@ -78,9 +85,9 @@ public sealed class TcpTransport : IAsyncDisposable
     public long LastOutboundTickMs => Volatile.Read(ref _lastOutboundTickMs);
 
     /// <summary>
-    /// Issue #487: waits until the send queue drains to empty (all queued
-    /// frames have been written to the socket) or the timeout expires.
-    /// Returns true if the queue drained within the timeout, false if
+    /// Issue #487: waits until the send queue drains to empty AND all
+    /// in-flight frames have been written to the socket, or the timeout
+    /// expires. Returns true if drained within the timeout, false if
     /// timed out or transport closed. Call before <see cref="Close"/> to
     /// ensure pending frames reach the wire.
     /// </summary>
@@ -88,7 +95,10 @@ public sealed class TcpTransport : IAsyncDisposable
     {
         if (!IsOpen) return false;
         var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
-        while (SendQueueDepth > 0)
+        // Must wait for both: queued frames AND in-flight frame (dequeued but
+        // not yet written). The send loop increments _inFlightFrames before
+        // dequeue and decrements after WriteAsync completes.
+        while (SendQueueDepth > 0 || Volatile.Read(ref _inFlightFrames) > 0)
         {
             if (!IsOpen) return false;
             if (Environment.TickCount64 >= deadline) return false;
@@ -189,6 +199,9 @@ public sealed class TcpTransport : IAsyncDisposable
         {
             await foreach (var frame in _sendQueue.Reader.ReadAllAsync(ct).ConfigureAwait(false))
             {
+                // Issue #487: track in-flight frame for drain synchronization.
+                // Increment immediately after dequeue, decrement after write.
+                Interlocked.Increment(ref _inFlightFrames);
                 try
                 {
                     try
@@ -225,6 +238,10 @@ public sealed class TcpTransport : IAsyncDisposable
                     _logger.LogWarning(ex, "tcp transport {ConnectionId} send IO error; closing", _connectionId);
                     Close("send-io-error");
                     return;
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref _inFlightFrames);
                 }
             }
         }

--- a/src/B3.Exchange.Gateway/TcpTransport.cs
+++ b/src/B3.Exchange.Gateway/TcpTransport.cs
@@ -77,6 +77,26 @@ public sealed class TcpTransport : IAsyncDisposable
     /// </summary>
     public long LastOutboundTickMs => Volatile.Read(ref _lastOutboundTickMs);
 
+    /// <summary>
+    /// Issue #487: waits until the send queue drains to empty (all queued
+    /// frames have been written to the socket) or the timeout expires.
+    /// Returns true if the queue drained within the timeout, false if
+    /// timed out or transport closed. Call before <see cref="Close"/> to
+    /// ensure pending frames reach the wire.
+    /// </summary>
+    public async Task<bool> WaitForSendQueueDrainAsync(TimeSpan timeout)
+    {
+        if (!IsOpen) return false;
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (SendQueueDepth > 0)
+        {
+            if (!IsOpen) return false;
+            if (Environment.TickCount64 >= deadline) return false;
+            await Task.Delay(5).ConfigureAwait(false);
+        }
+        return true;
+    }
+
     public TcpTransport(long connectionId, Stream stream, ILogger<TcpTransport> logger,
         int sendQueueCapacity, Action<string>? onClose = null,
         Action? onSendQueueFull = null)

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -98,6 +98,13 @@ public sealed class ExchangeHost : IAsyncDisposable
         // guarantees the resting orders' cancels reach the wire
         // before TerminateAllSessions closes the sockets.
         _optionExpirySweeper?.SweepExpiredSeries(reason, waitTimeout: TimeSpan.FromSeconds(15));
+        // Issue #487: drain outbound queues BEFORE closing sockets.
+        // ER_Cancel frames from the sweep are enqueued to the session's
+        // send queue but may not have been written to the socket yet.
+        // Without this drain, TerminateAllSessions can close the socket
+        // while frames are still pending, causing clients to see EOF
+        // instead of the ER_Cancel.
+        _listener?.DrainAllSessionsOutboundAsync(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
         var listener = _listener;
         int terminated = listener is null ? -1 : listener.TerminateAllSessions(reason, closeKind);
         // Issue #330 PR-3 (review BLOCKING): drain per-channel inbound
@@ -1217,7 +1224,17 @@ public sealed class ExchangeHost : IAsyncDisposable
                 sw.ElapsedMilliseconds, residual);
         }
 
-        // Phase 4: broadcast Terminate(Finished) and close each session.
+        // Phase 4: drain outbound queues then broadcast Terminate(Finished).
+        // Issue #487: ensure pending ER frames reach the wire before close.
+        sw.Restart();
+        if (_listener != null)
+        {
+            try { await _listener.DrainAllSessionsOutboundAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false); }
+            catch (Exception ex) { _logger.LogWarning(ex, "drain-outbound threw"); }
+        }
+        sw.Stop();
+        _logger.LogInformation("shutdown phase=drain-outbound duration={DurationMs}ms", sw.ElapsedMilliseconds);
+
         sw.Restart();
         int terminated = 0;
         if (_listener != null)


### PR DESCRIPTION
## Summary

Fixes #487 — graceful shutdown races outbound frames vs socket close.

## Problem

`TriggerDailyReset` (and `StopAsync`) close TCP sockets before pending outbound frames have been written to the wire. This causes clients to see EOF instead of the expected frames (e.g., `ER_Cancel` from option expiry sweep).

## Solution

1. Add `WaitForSendQueueDrainAsync(timeout)` to `TcpTransport` — polls until send queue is empty or timeout expires
2. Expose via `FixpSession.WaitForSendQueueDrainAsync`
3. Add `DrainAllSessionsOutboundAsync(timeout)` to `EntryPointListener` — drains all live sessions in parallel
4. Call drain BEFORE `TerminateAllSessions`:
   - In `TriggerDailyReset`: sync call after `SweepExpiredSeries`
   - In `StopAsync`: new Phase 4 before terminate-sessions

## Testing

- All 1449 tests pass
- `OptionExpiryE2ETests` (the flaky test that exposed this) should now be reliable

## Logging

New log entries:
- `drain-outbound: drained=N timedOut=M alreadyClosed=K duration=Xms`
- `shutdown phase=drain-outbound duration=Xms`
