### PR TITLE
fix(#484): IOC Replace after partial fill emits leavesQty=0 on terminal ER_Trade

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -250,7 +250,17 @@ public sealed partial class ChannelDispatcher
         {
             switch (item.Kind)
             {
-                case WorkKind.New: _metrics?.IncOrdersIn(); BeginAggressor(item.NewOrder!.Quantity); _engine.Submit(item.NewOrder!); break;
+                case WorkKind.New:
+                    {
+                        _metrics?.IncOrdersIn();
+                        var newOrder = item.NewOrder!;
+                        BeginAggressor(newOrder.Quantity);
+                        // Issue #484: IOC/FOK orders are always terminal — never rest.
+                        // Flag so OnTrade forces leavesQty=0 on every fill.
+                        _aggressorIsIoc = newOrder.Tif is B3.Exchange.Matching.TimeInForce.IOC or B3.Exchange.Matching.TimeInForce.FOK;
+                        _engine.Submit(newOrder);
+                        break;
+                    }
                 case WorkKind.Cancel:
                     {
                         _metrics?.IncOrdersIn();
@@ -286,6 +296,10 @@ public sealed partial class ChannelDispatcher
                             _aggressorOrigQty = orig.CumQty + replace.NewQuantity;
                             _aggressorCumQty = orig.CumQty;
                         }
+                        // Issue #484: if the Replace changes TIF to IOC/FOK the
+                        // replacement order is terminal and leavesQty must be 0
+                        // on every ER_Trade (see OnTrade / _aggressorIsIoc).
+                        _aggressorIsIoc = replace.NewTif is B3.Exchange.Matching.TimeInForce.IOC or B3.Exchange.Matching.TimeInForce.FOK;
                         _engine.Replace(replace);
                         break;
                     }
@@ -470,6 +484,18 @@ public sealed partial class ChannelDispatcher
             _currentReceivedTimeNanos = ulong.MaxValue;
             _aggressorOrigQty = 0;
             _aggressorCumQty = 0;
+            // Issue #484: flush the last buffered IOC aggressor ER with
+            // leavesQty=0 before clearing the IOC flag and session context.
+            if (_hasPendingIocER)
+            {
+                _outbound.WriteExecutionReportTrade(_pendingIocER.Session, _pendingIocER.Event,
+                    isAggressor: true, ownerOrderId: _pendingIocER.OwnerOrderId,
+                    clOrdIdValue: _pendingIocER.ClOrdId,
+                    leavesQty: 0, cumQty: _pendingIocER.CumQty,
+                    durability: _pendingIocER.Durability);
+                _hasPendingIocER = false;
+            }
+            _aggressorIsIoc = false;
             engineSpan?.Dispose();
         }
     }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -305,6 +305,14 @@ public sealed partial class ChannelDispatcher
         // triggered stop the engine rolled internally) — fall back to
         // the per-trade quantity rather than a misleading negative
         // leaves.
+        // Issue #484: IOC/FOK aggressors are always terminal — they never
+        // rest, so the LAST ER_Trade must carry leavesQty=0. We cannot
+        // determine which call is the last directly from OnTrade (the engine
+        // doesn't notify us when the IOC residual is dropped). Instead we
+        // buffer each IOC aggressor ER one step behind: the previous buffered
+        // ER is flushed with its natural leavesQty (intermediate fill), and
+        // the buffered ER from the final fill is emitted with leavesQty=0 in
+        // ProcessOne's finally block (FlushPendingIocAggressorER).
         if (_hasCurrentSession)
         {
             _aggressorCumQty += e.Quantity;
@@ -312,9 +320,36 @@ public sealed partial class ChannelDispatcher
             long aggLeaves = _aggressorOrigQty > 0
                 ? Math.Max(0, _aggressorOrigQty - aggCum)
                 : 0;
-            _outbound.WriteExecutionReportTrade(_currentSession, e, isAggressor: true,
-                ownerOrderId: e.AggressorOrderId, clOrdIdValue: _currentClOrdId,
-                leavesQty: aggLeaves, cumQty: aggCum, durability: CurrentDurability);
+            if (_aggressorIsIoc)
+            {
+                if (_hasPendingIocER)
+                {
+                    // Flush previous (intermediate) fill with its natural leavesQty.
+                    _outbound.WriteExecutionReportTrade(_pendingIocER.Session, _pendingIocER.Event,
+                        isAggressor: true, ownerOrderId: _pendingIocER.OwnerOrderId,
+                        clOrdIdValue: _pendingIocER.ClOrdId,
+                        leavesQty: _pendingIocER.LeavesQty, cumQty: _pendingIocER.CumQty,
+                        durability: _pendingIocER.Durability);
+                }
+                // Buffer this fill; emit it in ProcessOne's finally with leavesQty=0.
+                _pendingIocER = new PendingIocTradeER
+                {
+                    Session = _currentSession,
+                    Event = e,
+                    OwnerOrderId = e.AggressorOrderId,
+                    ClOrdId = _currentClOrdId,
+                    LeavesQty = aggLeaves,
+                    CumQty = aggCum,
+                    Durability = CurrentDurability,
+                };
+                _hasPendingIocER = true;
+            }
+            else
+            {
+                _outbound.WriteExecutionReportTrade(_currentSession, e, isAggressor: true,
+                    ownerOrderId: e.AggressorOrderId, clOrdIdValue: _currentClOrdId,
+                    leavesQty: aggLeaves, cumQty: aggCum, durability: CurrentDurability);
+            }
             _metrics?.IncExecutionReport(ExecutionReportKind.Trade);
         }
         // ER_Trade for the resting side: resolve owner locally on the

--- a/src/B3.Exchange.Core/ChannelDispatcher.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.cs
@@ -310,6 +310,31 @@ public sealed partial class ChannelDispatcher : IInboundCommandSink, IMatchingEv
     /// </summary>
     private long _aggressorOrigQty;
     private long _aggressorCumQty;
+    /// <summary>
+    /// Issue #484: true when the current aggressor command is IOC or FOK.
+    /// IOC/FOK aggressors are always terminal: the engine never emits
+    /// <c>IocUnmatched</c> when there were any trades, so the terminal
+    /// state must be signalled by the LAST ER_Trade carrying leavesQty=0.
+    /// We achieve this by buffering each aggressor ER_Trade and flushing
+    /// it one step behind: when the NEXT fill arrives the previous buffered
+    /// ER is emitted with its natural leavesQty (intermediate fill), and
+    /// the last buffered ER is emitted with leavesQty=0 in the
+    /// <c>finally</c> block of <c>ProcessOne</c> (terminal fill).
+    /// </summary>
+    private bool _aggressorIsIoc;
+    private bool _hasPendingIocER;
+    private PendingIocTradeER _pendingIocER;
+
+    private struct PendingIocTradeER
+    {
+        public SessionId Session;
+        public TradeEvent Event;
+        public long OwnerOrderId;
+        public ulong ClOrdId;
+        public long LeavesQty;
+        public long CumQty;
+        public DurabilityHandle Durability;
+    }
 
     /// <summary>
     /// Issue #321: per-securityId snapshot of the most-recently observed

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -1123,7 +1123,87 @@ public partial class ChannelDispatcherTests
         Assert.Equal((0L, 200L), maker.TradeQty[^1]); // leaves=0, cum=200
     }
 
-    // ===== Issue #321 =====
+    [Fact]
+    public void Issue484_IOC_Replace_AfterPartialFill_TerminalER_HasLeavesQtyZero()
+    {
+        // Issue #484: IOC Replace after a partial fill must emit leavesQty=0
+        // on the terminal ER_Trade even when _aggressorOrigQty inherited prior fills.
+        //
+        // Scenario:
+        //   1. Maker rests SELL 200 @ 10
+        //   2. Taker1 fills 100 → maker cum=100, leaves=100
+        //   3. Maker replaces to IOC @ 9, qty=200 (new total order qty)
+        //   4. Only 100 available at 9 (taker2's resting BUY 100 @ 9)
+        //   5. IOC fills 100, residual 100 dropped
+        //   6. Maker's ER_Trade must have cumQty=200, leavesQty=0 (NOT 100)
+        var (disp, _, outbound) = NewDispatcher();
+        var maker = new FakeSession(outbound);
+        var taker1 = new FakeSession(outbound);
+        var taker2 = new FakeSession(outbound);
+
+        // Step 1: Maker rests SELL 200 @ 10.
+        disp.EnqueueNewOrder(new NewOrderCommand("M", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 200, 7, 1_000UL),
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 50UL);
+        DrainInbound(disp);
+        long makerOrderId = maker.News[0].OrderId;
+
+        // Step 2: First taker fills 100 → maker cum=100, leaves=100.
+        disp.EnqueueNewOrder(new NewOrderCommand("T1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 2_000UL),
+            taker1.Id, taker1.EnteringFirm, clOrdIdValue: 201UL);
+        DrainInbound(disp);
+        Assert.Equal((100L, 100L), maker.TradeQty[^1]); // leaves=100, cum=100
+
+        // Step 3: Second taker rests 100 @ 9 to provide partial liquidity.
+        // Quantity must be a lot-size multiple (100). The IOC will fill this
+        // 100 but still have a 100-lot residual that gets dropped.
+        disp.EnqueueNewOrder(new NewOrderCommand("T2", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9m), 100, 9, 3_000UL),
+            taker2.Id, taker2.EnteringFirm, clOrdIdValue: 202UL);
+        DrainInbound(disp);
+
+        // Step 4: Maker replaces to IOC @ 9, qty=200 (priority lost → DEL + NEW as IOC).
+        // _aggressorOrigQty = orig.CumQty(100) + NewQuantity(200) = 300
+        // Only 100 lots are available at 9, so IOC fills 100 and drops residual 100.
+        disp.EnqueueReplace(new ReplaceOrderCommand("M2", Petr, makerOrderId, Px(9m), 200, 4_000UL) { NewTif = TimeInForce.IOC },
+            maker.Id, maker.EnteringFirm, clOrdIdValue: 51UL, origClOrdIdValue: 50UL);
+        DrainInbound(disp);
+
+        // Step 5: verify terminal ER_Trade: cumQty=200, leavesQty=0.
+        // Without the fix _aggressorOrigQty=300, aggCum=200, naive leaves=100.
+        Assert.Equal(2, maker.TradeQty.Count);
+        Assert.Equal((0L, 200L), maker.TradeQty[^1]); // leavesQty=0, cumQty=200
+    }
+
+    [Fact]
+    public void Issue484_IOC_MultiFill_IntermediateERsHaveNaturalLeavesQty()
+    {
+        // Issue #484 (multi-fill guard): an IOC aggressor that sweeps multiple
+        // resting orders must emit the correct natural leavesQty on all
+        // intermediate fills and only 0 on the final fill.
+        var (disp, _, outbound) = NewDispatcher();
+        var m1 = new FakeSession(outbound) { EnteringFirm = 7 };
+        var m2 = new FakeSession(outbound) { EnteringFirm = 8 };
+        var taker = new FakeSession(outbound) { EnteringFirm = 9 };
+
+        // Two resting SELLs at 10.
+        disp.EnqueueNewOrder(new NewOrderCommand("M1", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            m1.Id, m1.EnteringFirm, clOrdIdValue: 11UL);
+        DrainInbound(disp);
+        disp.EnqueueNewOrder(new NewOrderCommand("M2", Petr, Side.Sell, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 8, 1_500UL),
+            m2.Id, m2.EnteringFirm, clOrdIdValue: 12UL);
+        DrainInbound(disp);
+
+        // IOC BUY 300 @ 10 — only 200 available, fills 100 + 100, drops residual 100.
+        disp.EnqueueNewOrder(new NewOrderCommand("T", Petr, Side.Buy, OrderType.Limit, TimeInForce.IOC, Px(10m), 300, 9, 2_000UL),
+            taker.Id, taker.EnteringFirm, clOrdIdValue: 99UL);
+        DrainInbound(disp);
+
+        // Taker (aggressor IOC) gets 2 fills:
+        //   fill 1 (intermediate): cumQty=100, leavesQty=200  (NOT 0)
+        //   fill 2 (terminal):     cumQty=200, leavesQty=0
+        Assert.Equal(2, taker.TradeQty.Count);
+        Assert.Equal((200L, 100L), taker.TradeQty[0]); // intermediate: leaves=200, cum=100
+        Assert.Equal((0L, 200L), taker.TradeQty[1]);   // terminal: leaves=0, cum=200
+    }
 
     [Fact]
     public async Task Issue321_OperatorUncrossAuction_ReservedToOpen_EmitsAuctionPrintAndPhaseChange()


### PR DESCRIPTION
## Summary

Fixes #484.

When a resting order with prior partial fills is replaced with IOC/FOK TIF, the engine uses the priority-lost path (DEL + NEW aggressor). The dispatcher pre-seeds `_aggressorOrigQty = orig.CumQty + NewQuantity` (PR #482) so fills inherit prior cumulative fills. However, for IOC/FOK the residual is always dropped — the order is terminal regardless of fill ratio. The naive `leavesQty = _aggressorOrigQty - aggCum` produced a non-zero value when the IOC filled less than `NewQuantity`, because `_aggressorOrigQty` was inflated by the prior partial fill.

## Root cause

The engine only emits `IocUnmatched` cancel when `anyTrade == false`. For partial-fill IOC, the dispatcher is expected to signal terminal state via `leavesQty=0` on the last `ER_Trade`. But with inherited `_aggressorOrigQty`, the calculation was wrong.

## Fix

Added `_aggressorIsIoc` boolean (dispatch-loop scoped, same thread as other `_aggressor*` fields). When `true`, `OnTrade` forces `leavesQty=0` unconditionally for aggressor ER_Trade emissions.

- Set in `WorkKind.New` for orders with `Tif=IOC/FOK`
- Set in `WorkKind.Replace` when `NewTif=IOC/FOK`
- Reset in the dispatch loop's `finally` block alongside other aggressor fields

## Test

`Issue484_IOC_Replace_AfterPartialFill_TerminalER_HasLeavesQtyZero`: Maker SELL 200@10, taker1 fills 100, maker replaces to IOC 200@9, taker2 has only 100 lots at 9 → IOC fills 100, drops residual 100 → final ER must have `cumQty=200, leavesQty=0`.