### PR TITLE
fix(#488): session takeover on reconnect + responsive heartbeat defaults

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -9,8 +9,8 @@
     // firms[]/sessions[] are empty. New deployments should declare
     // firms[] and sessions[] explicitly (see below).
     "enteringFirm": 1,
-    "heartbeatIntervalMs": 30000,
-    "idleTimeoutMs": 30000,
+    "heartbeatIntervalMs": 10000,
+    "idleTimeoutMs": 10000,
     "testRequestGraceMs": 5000,
     "sendingTimeSkewToleranceMs": 5000,
     // Decode-time fat-finger guardrails. Price is the EntryPoint /10000

--- a/src/B3.Exchange.Gateway/CloseKind.cs
+++ b/src/B3.Exchange.Gateway/CloseKind.cs
@@ -74,4 +74,23 @@ public enum CloseKind
     /// removed.
     /// </summary>
     SuspendedTimeout,
+
+    /// <summary>
+    /// Issue #488: a new connection from the same firm arrived with a
+    /// strictly higher <c>sessionVerID</c> while this session still
+    /// held the active claim. The new connection atomically took over
+    /// the claim; this session is being torn down so the new one can
+    /// proceed. The underlying transport may already be dead (e.g. the
+    /// peer crashed), so this close has the same persistence semantics
+    /// as <see cref="TransportError"/>:
+    /// <list type="bullet">
+    ///   <item>Persisted state is kept (new session can resync).</item>
+    ///   <item>CancelOnDisconnect is NOT fired (orders remain alive
+    ///   and are now owned by the new connection's session).</item>
+    ///   <item><c>OnSessionClosed</c> is NOT invoked (order ownership
+    ///   entries in <c>HostRouter</c> are preserved for routing passive
+    ///   fills to the reconnected session).</item>
+    /// </list>
+    /// </summary>
+    SessionTakeOver,
 }

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -328,12 +328,18 @@ public sealed partial class FixpSession
         // session (see IInboundCommandSink.OnSessionClosed). Without this the
         // ChannelDispatcher's order-owners map keeps the session rooted for
         // the lifetime of every resting order it placed → unbounded memory.
-        try { _sink.OnSessionClosed(Identity); }
-        catch (Exception ex)
+        // Issue #488: skip for SessionTakeOver — the new session has the same
+        // Identity and has already taken over the claim; evicting ownership
+        // entries here would break routing of passive fills to the new session.
+        if (kind != CloseKind.SessionTakeOver)
         {
-            _logger.LogWarning(ex,
-                "fixp session {ConnectionId} OnSessionClosed callback threw",
-                ConnectionId);
+            try { _sink.OnSessionClosed(Identity); }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "fixp session {ConnectionId} OnSessionClosed callback threw",
+                    ConnectionId);
+            }
         }
         // Issue #289 / #405 / #416: terminal close ⇒ drop the persisted
         // retransmit ring file AND the unbounded outbound journal AND

--- a/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Negotiate.cs
@@ -126,6 +126,28 @@ public sealed partial class FixpSession
         // sessionID (or the version is stale by the time we commit), we
         // must reject — spec §4.5.2.
         var claim = _claims.TryClaim(req.SessionId, req.SessionVerId, this);
+        // Issue #488: track a stale session evicted by TryForceTakeOver. The
+        // close is deferred until AFTER TrySaveStateSnapshot succeeds so that
+        // a persistence rollback does not leave order ownership orphaned with
+        // no live session to own it — the old session's TCP will time out
+        // naturally and call OnSessionClosed via the TransportError path.
+        FixpSession? evictedByTakeOver = null;
+        if (claim == SessionClaimRegistry.ClaimResult.DuplicateConnection)
+        {
+            // Session takeover — the peer crashed and reconnected before our
+            // idle-timeout detected the dead TCP. If the new sessionVerId is
+            // strictly greater, atomically evict the stale claim and continue
+            // to the accept path.
+            claim = _claims.TryForceTakeOver(req.SessionId, req.SessionVerId, this,
+                out var evicted);
+            if (claim == SessionClaimRegistry.ClaimResult.Accepted && evicted is FixpSession oldSession)
+            {
+                _logger.LogInformation(
+                    "session {ConnectionId} taking over sessionId={SessionId} from {OldConnectionId} (new verId={NewVerId})",
+                    ConnectionId, req.SessionId, oldSession.ConnectionId, req.SessionVerId);
+                evictedByTakeOver = oldSession;
+            }
+        }
         if (claim != SessionClaimRegistry.ClaimResult.Accepted)
         {
             var code = claim switch
@@ -187,6 +209,9 @@ public sealed partial class FixpSession
         NegotiateResponseEncoder.Encode(responseFrame, req.SessionId, req.SessionVerId,
             req.TimestampNanos, outcome.Firm.EnteringFirmCode,
             semVerMajor: 8, semVerMinor: 4, semVerPatch: 2);
+        // Issue #488: persistence committed — safe to evict the stale session now.
+        // Its Release() call is a no-op (registry already holds this session's token).
+        evictedByTakeOver?.Close("session-takeover:evicted-by-newer-verId", CloseKind.SessionTakeOver);
         return NegotiateStep.Accepted(responseFrame,
             $"negotiate-accept (sid={req.SessionId} firm={outcome.Firm.Id})");
     }

--- a/src/B3.Exchange.Gateway/FixpSessionOptions.cs
+++ b/src/B3.Exchange.Gateway/FixpSessionOptions.cs
@@ -24,8 +24,8 @@ namespace B3.Exchange.Gateway;
 /// </summary>
 public sealed record FixpSessionOptions
 {
-    public int HeartbeatIntervalMs { get; init; } = 30_000;
-    public int IdleTimeoutMs { get; init; } = 30_000;
+    public int HeartbeatIntervalMs { get; init; } = 10_000;
+    public int IdleTimeoutMs { get; init; } = 10_000;
     public int TestRequestGraceMs { get; init; } = 5_000;
     public int SuspendedTimeoutMs { get; init; } = 5 * 60_000;
     /// <summary>

--- a/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
+++ b/src/B3.Exchange.Gateway/SessionClaimRegistry.cs
@@ -144,6 +144,49 @@ public sealed class SessionClaimRegistry
     }
 
     /// <summary>
+    /// Issue #488: atomically evict an existing claim and register a new one
+    /// when the incoming <paramref name="sessionVerId"/> is strictly greater
+    /// than the last recorded version for <paramref name="sessionId"/>. This
+    /// enables the FIXP session-takeover path: a peer that crashed and
+    /// restarted fast (before the server's idle-timeout fired) can reclaim
+    /// its session without being blocked by <see cref="TryClaim"/> returning
+    /// <see cref="ClaimResult.DuplicateConnection"/>.
+    ///
+    /// <para>All state mutations occur under <see cref="_lock"/>, so no
+    /// intermediate state is visible to concurrent callers. The evicted token
+    /// is returned via <paramref name="evictedToken"/> so the caller can close
+    /// the old session AFTER the atomic swap; the old session's own
+    /// <see cref="Release"/> call will then be a no-op (the dictionary value
+    /// no longer matches its token).</para>
+    ///
+    /// <para>Returns <see cref="ClaimResult.Accepted"/> (with a non-null
+    /// <paramref name="evictedToken"/>) when the takeover succeeds, or
+    /// <see cref="ClaimResult.StaleVersion"/> when the version is not
+    /// strictly greater (reject: this is not a legitimate reconnect).</para>
+    /// </summary>
+    public ClaimResult TryForceTakeOver(uint sessionId, ulong sessionVerId,
+        object newToken, out object? evictedToken)
+    {
+        ArgumentNullException.ThrowIfNull(newToken);
+        evictedToken = null;
+        if (sessionVerId == 0UL) return ClaimResult.ZeroVersion;
+
+        lock (_lock)
+        {
+            // New verId must be strictly greater than the last recorded
+            // version — the FIXP monotonicity rule still applies.
+            if (_lastSessionVerId.TryGetValue(sessionId, out var last) && sessionVerId <= last)
+                return ClaimResult.StaleVersion;
+
+            // Evict old claim atomically (may or may not exist).
+            _activeClaims.TryGetValue(sessionId, out evictedToken);
+            _activeClaims[sessionId] = newToken;
+            _lastSessionVerId[sessionId] = sessionVerId;
+            return ClaimResult.Accepted;
+        }
+    }
+
+    /// <summary>
     /// Returns the live owner of <paramref name="sessionId"/>, if any,
     /// along with the recorded last-seen sessionVerID. Used by the
     /// rebind path (#69b-2): if the new transport's <c>Establish</c>

--- a/tests/B3.Exchange.Gateway.Tests/SessionClaimRegistryTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/SessionClaimRegistryTests.cs
@@ -143,4 +143,97 @@ public class SessionClaimRegistryTests
         Assert.Equal(SessionClaimRegistry.ClaimResult.Accepted, result);
         Assert.Equal(11UL, r.CurrentSessionVerId(42));
     }
+
+    // ===== TryForceTakeOver (issue #488) =====
+
+    [Fact]
+    public void TryForceTakeOver_HigherVersion_EvictsExistingClaim()
+    {
+        var r = new SessionClaimRegistry();
+        var oldToken = new object();
+        r.TryClaim(42, 5, oldToken);
+
+        var newToken = new object();
+        var result = r.TryForceTakeOver(42, 6, newToken, out var evicted);
+
+        Assert.Equal(SessionClaimRegistry.ClaimResult.Accepted, result);
+        Assert.Same(oldToken, evicted);
+        Assert.Equal(6UL, r.CurrentSessionVerId(42));
+        Assert.Equal(1, r.ActiveCount);
+        // New token is now the claim holder.
+        Assert.True(r.TryGetActiveClaim(42, out var holder, out _));
+        Assert.Same(newToken, holder);
+    }
+
+    [Fact]
+    public void TryForceTakeOver_SameVersion_RejectsAsStale()
+    {
+        var r = new SessionClaimRegistry();
+        var oldToken = new object();
+        r.TryClaim(42, 5, oldToken);
+
+        var result = r.TryForceTakeOver(42, 5, new object(), out var evicted);
+
+        Assert.Equal(SessionClaimRegistry.ClaimResult.StaleVersion, result);
+        Assert.Null(evicted);
+        // Old claim is still active.
+        Assert.Equal(1, r.ActiveCount);
+    }
+
+    [Fact]
+    public void TryForceTakeOver_LowerVersion_RejectsAsStale()
+    {
+        var r = new SessionClaimRegistry();
+        var oldToken = new object();
+        r.TryClaim(42, 10, oldToken);
+
+        var result = r.TryForceTakeOver(42, 9, new object(), out var evicted);
+
+        Assert.Equal(SessionClaimRegistry.ClaimResult.StaleVersion, result);
+        Assert.Null(evicted);
+    }
+
+    [Fact]
+    public void TryForceTakeOver_ZeroVersion_RejectsAsZero()
+    {
+        var r = new SessionClaimRegistry();
+        r.TryClaim(42, 5, new object());
+        var result = r.TryForceTakeOver(42, 0, new object(), out var evicted);
+        Assert.Equal(SessionClaimRegistry.ClaimResult.ZeroVersion, result);
+        Assert.Null(evicted);
+    }
+
+    [Fact]
+    public void TryForceTakeOver_NoClaim_AcceptsAndRegisters()
+    {
+        // No existing claim: TryForceTakeOver behaves like a regular TryClaim.
+        var r = new SessionClaimRegistry();
+        var token = new object();
+        var result = r.TryForceTakeOver(42, 7, token, out var evicted);
+
+        Assert.Equal(SessionClaimRegistry.ClaimResult.Accepted, result);
+        Assert.Null(evicted); // nothing was evicted
+        Assert.Equal(7UL, r.CurrentSessionVerId(42));
+    }
+
+    [Fact]
+    public void TryForceTakeOver_OldSessionRelease_IsNoopAfterTakeover()
+    {
+        // After TryForceTakeOver, the old session calls Release. Since the
+        // registry now holds the new token, Release must be a no-op (it
+        // should NOT evict the new session's claim).
+        var r = new SessionClaimRegistry();
+        var oldToken = new object();
+        r.TryClaim(42, 5, oldToken);
+
+        var newToken = new object();
+        r.TryForceTakeOver(42, 6, newToken, out _);
+        // Simulate old session calling Release during its CloseLocked.
+        r.Release(42, oldToken);
+
+        // New claim must still be active.
+        Assert.Equal(1, r.ActiveCount);
+        Assert.True(r.TryGetActiveClaim(42, out var holder, out _));
+        Assert.Same(newToken, holder);
+    }
 }


### PR DESCRIPTION
Fixes #488

## Root cause

When a trading host crashes and reconnects before the Exchange's idle-timeout fires (~65 s with old 30 s defaults), the new Negotiate is rejected with `DUPLICATE_SESSION_CONNECTION` because the stale claim is still held by the dead TCP session.

## Fix: two complementary approaches

### 1. Heartbeat defaults reduced (30 s → 10 s)
Dead TCP is now detected in ~15 s (10 s idle + 5 s grace), covering most production reconnect scenarios automatically.

### 2. Session takeover (robust fix for the race window)
When `TryClaim` returns `DuplicateConnection` and the new `sessionVerId` is strictly greater:
- `SessionClaimRegistry.TryForceTakeOver` atomically evicts the stale claim and registers the new session (FIXP monotonicity still enforced)
- The old session is closed with `CloseKind.SessionTakeOver`:
  - Skips `OnSessionClosed` → order ownership preserved for the reconnecting session
  - Skips CancelOnDisconnect → orders remain alive
  - Preserves persistence → new session can resync

The evicted session's own `Release()` call is a safe no-op (the registry already holds the new session's token).

## Tests
6 new `SessionClaimRegistry` unit tests covering `TryForceTakeOver` semantics (higher verId accepted, same/lower rejected, old Release is no-op after takeover).