### PR TITLE
Fix #496: Establish-path session takeover for cold-resume reconnect

### DIFF
--- a/src/B3.Exchange.Gateway/EntryPointListener.cs
+++ b/src/B3.Exchange.Gateway/EntryPointListener.cs
@@ -445,7 +445,8 @@ public sealed class EntryPointListener : IAsyncDisposable
 
         // Re-attach decision: only meaningful when the first message is
         // an Establish targeting an already-claimed sessionId currently
-        // held by a Suspended FixpSession with matching SessionVerId.
+        // held by a FixpSession (Suspended, or still-Established and taken
+        // over per #496) with matching SessionVerId.
         if (templateId == EntryPointFrameReader.TidEstablish
             && firstFrame.Length >= EntryPointFrameReader.WireHeaderSize + EstablishDecoder.BlockLength
             && EstablishDecoder.TryDecode(
@@ -455,22 +456,54 @@ public sealed class EntryPointListener : IAsyncDisposable
             if (_sessionClaims.TryGetActiveClaim(req.SessionId, out var holder, out var lastVerId)
                 && holder is FixpSession existing
                 && existing.SessionVerId == req.SessionVerId
-                && req.SessionVerId == lastVerId
-                && existing.State == FixpState.Suspended)
+                && req.SessionVerId == lastVerId)
             {
-                var prepended = new PrependedStream(firstFrame, stream);
-                if (existing.TryReattach(prepended))
+                // Snapshot State ONCE so the takeover decision is consistent: a
+                // connection that matched a Suspended session must never later
+                // re-read State and escalate to SuspendForTakeover — by then a
+                // concurrent reconnect may have legitimately reattached and
+                // moved the session back to Established, and tearing that fresh
+                // transport down would steal a live successor. Only a connection
+                // that matched an Established session performs the takeover.
+                var matchedState = existing.State;
+                if (matchedState == FixpState.Suspended
+                    || matchedState == FixpState.Established)
                 {
+                    // Issue #496: a still-Established stale claim means the
+                    // prior TCP death has not been reaped yet (hard kill / no
+                    // FIN, before the idle-timeout watchdog fired). A resuming
+                    // Establish with a matching SessionId + SessionVerId is a
+                    // cold-resume reconnect (spec §5.3), not a fresh session —
+                    // the peer that holds the session demonstrably reconnected.
+                    // Force-suspend the stale session (preserving order
+                    // ownership + persistence, skipping Cancel-on-Disconnect) so
+                    // the proven re-attach path can take over deterministically,
+                    // instead of falling through to a fresh Idle session that
+                    // rejects UNNEGOTIATED. Mirrors the Negotiate-path takeover
+                    // added in #488.
+                    if (matchedState == FixpState.Established)
+                    {
+                        _logger.LogInformation(
+                            "establish-takeover: force-suspending still-Established session {ConnectionId} for resuming Establish (sessionId={SessionId} sessionVerId={SessionVerId} from {Remote})",
+                            existing.ConnectionId, req.SessionId, req.SessionVerId, SafeRemote(sock));
+                        existing.SuspendForTakeover(
+                            $"establish-takeover:sessionId={req.SessionId}");
+                    }
+
+                    var prepended = new PrependedStream(firstFrame, stream);
+                    if (existing.TryReattach(prepended))
+                    {
+                        _logger.LogInformation(
+                            "re-attached transport to existing session {ConnectionId} (sessionId={SessionId} from {Remote})",
+                            existing.ConnectionId, existing.SessionId, SafeRemote(sock));
+                        return;
+                    }
                     _logger.LogInformation(
-                        "re-attached transport to existing session {ConnectionId} (sessionId={SessionId} from {Remote})",
-                        existing.ConnectionId, existing.SessionId, SafeRemote(sock));
+                        "re-attach raced and lost for sessionId={SessionId} from {Remote}; closing new socket",
+                        req.SessionId, SafeRemote(sock));
+                    try { prepended.Dispose(); } catch { }
                     return;
                 }
-                _logger.LogInformation(
-                    "re-attach raced and lost for sessionId={SessionId} from {Remote}; closing new socket",
-                    req.SessionId, SafeRemote(sock));
-                try { prepended.Dispose(); } catch { }
-                return;
             }
         }
 

--- a/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.Lifecycle.cs
@@ -87,6 +87,26 @@ public sealed partial class FixpSession
     }
 
     /// <summary>
+    /// Issue #496: demote a still-<see cref="FixpState.Established"/> stale
+    /// session for an Establish-path session takeover. Identical to
+    /// <see cref="Suspend(string)"/> except it does NOT arm the
+    /// cancel-on-disconnect timer: the successor transport has already
+    /// arrived (the listener parsed its resuming <c>Establish</c> with a
+    /// matching SessionId + SessionVerId), so the old transport's
+    /// disconnect is immediately superseded and the firm's resting orders
+    /// must be preserved — mirroring the <see cref="CloseKind.SessionTakeOver"/>
+    /// semantics on the Negotiate-path takeover (#488). The caller follows
+    /// this with <see cref="TryReattach"/> to bind the new transport.
+    /// </summary>
+    public void SuspendForTakeover(string reason)
+    {
+        lock (_attachLock)
+        {
+            SuspendLocked(reason, armCancelOnDisconnect: false);
+        }
+    }
+
+    /// <summary>
     /// <summary>
     /// Issue #405: writes the current FIXP envelope state to
     /// <see cref="_statePersister"/> if one is wired. Best-effort —
@@ -148,7 +168,7 @@ public sealed partial class FixpSession
     /// holds <see cref="_attachLock"/>. Idempotent — second caller is a
     /// no-op via the <see cref="_isAttached"/> CAS.
     /// </summary>
-    private void SuspendLocked(string reason)
+    private void SuspendLocked(string reason, bool armCancelOnDisconnect = true)
     {
         // Atomically claim the right to suspend; second caller is a no-op.
         // We use a separate CAS guard (not _isAttached) so the public
@@ -185,7 +205,11 @@ public sealed partial class FixpSession
             return;
         }
         Volatile.Write(ref _suspendedSinceMs, NowMs());
-        ScheduleCodTimerLocked();
+        // Issue #496: an Establish-path takeover suspends a still-Established
+        // session whose successor transport has already arrived, so CoD must
+        // be skipped (the disconnect is immediately superseded).
+        if (armCancelOnDisconnect)
+            ScheduleCodTimerLocked();
         // Issue #405: persist the envelope on suspend so a host crash
         // while the session is parked still produces an
         // EstablishmentAck.lastIncomingSeqNo matching reality.
@@ -482,6 +506,14 @@ public sealed partial class FixpSession
             Volatile.Write(ref _suspendedSinceMs, 0);
             Volatile.Write(ref _lastInboundMs, NowMs());
             Volatile.Write(ref _isAttached, 1);
+            // Installing a fresh attached generation begins a new suspend
+            // cycle: clear the one-shot SuspendLocked guard so a subsequent
+            // disconnect can demote this session again. Without this reset a
+            // second drop after any reattach would silently no-op the suspend
+            // (the guard is only otherwise cleared on the never-attached early
+            // return), leaving the session wedged Established over a dead
+            // transport.
+            Volatile.Write(ref _suspendInProgress, 0);
 
             // Spin up new send / recv / watchdog loops bound to the fresh
             // transport + cancellation source. The buffered Establish frame

--- a/tests/B3.Exchange.Gateway.Tests/EstablishSessionTakeoverTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/EstablishSessionTakeoverTests.cs
@@ -1,0 +1,172 @@
+using B3.Exchange.Contracts;
+using B3.EntryPoint.Wire;
+using B3.Exchange.Gateway;
+using B3.Exchange.Matching;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Buffers.Binary;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+
+namespace B3.Exchange.Gateway.Tests;
+
+/// <summary>
+/// Issue #496 — Establish-path session takeover. After an OMS restart the
+/// matcher stays up, so the only reattach path that can fire is the hot
+/// reattach in <see cref="EntryPointListener"/>. When the prior TCP died
+/// without a timely FIN (hard kill / partition), the stale
+/// <see cref="FixpSession"/> is still <see cref="FixpState.Established"/>
+/// when the resuming <c>Establish</c> (same SessionId + same SessionVerId,
+/// per Binary EntryPoint spec §5.3) arrives. Before #496 that landed on a
+/// fresh <see cref="FixpState.Idle"/> session and was rejected
+/// <c>UNNEGOTIATED</c>, forcing the client to <c>Negotiate</c> and bump the
+/// SessionVerID (orphaning resting orders). The fix force-suspends the
+/// still-Established stale session and re-attaches the new transport
+/// deterministically, mirroring the Negotiate-path takeover from #488.
+/// </summary>
+public class EstablishSessionTakeoverTests
+{
+    private sealed class NoOpEngineSink : IInboundCommandSink
+    {
+        public bool EnqueueNewOrder(in NewOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue) => true;
+        public bool EnqueueCancel(in CancelOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueReplace(in ReplaceOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm, ulong clOrdIdValue, ulong origClOrdIdValue) => true;
+        public bool EnqueueCross(in CrossOrderCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) => true;
+        public bool EnqueueMassCancel(in MassCancelCommand cmd, B3.Exchange.Contracts.SessionId session, uint enteringFirm) => true;
+        public void OnDecodeError(B3.Exchange.Contracts.SessionId session, string error) { }
+        public void OnSessionClosed(B3.Exchange.Contracts.SessionId session) { }
+    }
+
+    private static EntryPointListener NewListener(out int port)
+    {
+        var firms = new FirmRegistry(
+            new[] { new Firm(Id: "F1", Name: "Firm 1", EnteringFirmCode: 42u) },
+            new[] { new SessionCredential(SessionId: "1", FirmId: "F1", AccessKey: "", AllowedSourceCidrs: null, Policy: SessionPolicy.Default) });
+        var claims = new SessionClaimRegistry();
+        var negValidator = new NegotiationValidator(firms, claims, devMode: true, timestampSkewToleranceNs: 0);
+        var estValidator = new EstablishValidator(timestampSkewToleranceNs: 0);
+
+        var listener = new EntryPointListener(
+            new IPEndPoint(IPAddress.Loopback, 0),
+            new NoOpEngineSink(),
+            new SessionRegistry(),
+            NullLoggerFactory.Instance,
+            sessionOptions: new FixpSessionOptions
+            {
+                HeartbeatIntervalMs = 60_000,
+                IdleTimeoutMs = 60_000,
+                TestRequestGraceMs = 60_000,
+                SuspendedTimeoutMs = 0,
+                FirstFrameTimeoutMs = 5_000,
+            },
+            negotiationValidator: negValidator,
+            sessionClaims: claims,
+            establishValidator: estValidator,
+            persistedSessionStates: null);
+        listener.Start();
+        port = listener.LocalEndpoint!.Port;
+        return listener;
+    }
+
+    private static byte[] BuildNegotiate(uint sessionId, ulong sessionVerId)
+    {
+        var creds = Encoding.UTF8.GetBytes("{\"auth_type\":\"basic\",\"username\":\"1\",\"access_key\":\"\"}");
+        var buf = new byte[256];
+        int len = EntryPointFixpFrameCodec.EncodeNegotiate(buf,
+            sessionId: sessionId, sessionVerId: sessionVerId,
+            timestampNanos: 0UL, enteringFirm: 42u, onBehalfFirm: null,
+            credentials: creds,
+            clientIp: ReadOnlySpan<byte>.Empty,
+            clientAppName: ReadOnlySpan<byte>.Empty,
+            clientAppVersion: ReadOnlySpan<byte>.Empty);
+        return buf.AsSpan(0, len).ToArray();
+    }
+
+    private static byte[] BuildEstablish(uint sessionId, ulong sessionVerId)
+    {
+        var buf = new byte[256];
+        int len = EntryPointFixpFrameCodec.EncodeEstablish(buf,
+            sessionId: sessionId, sessionVerId: sessionVerId,
+            timestampNanos: 0UL, keepAliveIntervalMillis: 60_000UL,
+            nextSeqNo: 1u,
+            cancelOnDisconnectType: 0, codTimeoutWindowMillis: 0UL,
+            credentials: ReadOnlySpan<byte>.Empty);
+        return buf.AsSpan(0, len).ToArray();
+    }
+
+    private static async Task<ushort> ReadTemplateIdAsync(NetworkStream s, CancellationToken ct)
+    {
+        var hdr = new byte[EntryPointFrameReader.WireHeaderSize];
+        int total = 0;
+        while (total < hdr.Length)
+        {
+            int n = await s.ReadAsync(hdr.AsMemory(total), ct);
+            if (n == 0) throw new EndOfStreamException();
+            total += n;
+        }
+        ushort messageLen = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(0, 2));
+        ushort tid = BinaryPrimitives.ReadUInt16LittleEndian(hdr.AsSpan(6, 2));
+        int bodyLen = messageLen - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        int btotal = 0;
+        while (btotal < bodyLen)
+        {
+            int n = await s.ReadAsync(body.AsMemory(btotal), ct);
+            if (n == 0) throw new EndOfStreamException();
+            btotal += n;
+        }
+        return tid;
+    }
+
+    [Fact]
+    public async Task ResumingEstablish_OnStillEstablishedStaleSession_TakesOver_AckNotUnnegotiated()
+    {
+        await using var listener = NewListener(out int port);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        // Phase 1: first connection performs the full Negotiate + Establish
+        // handshake and reaches Established. Its TCP is intentionally left
+        // OPEN below to model a hard-killed peer whose dead transport the
+        // server has not yet detected (the stale session is still
+        // Established when the resume arrives).
+        using var client1 = new TcpClient();
+        await client1.ConnectAsync(IPAddress.Loopback, port, cts.Token);
+        var s1 = client1.GetStream();
+        await s1.WriteAsync(BuildNegotiate(sessionId: 1, sessionVerId: 100UL), cts.Token);
+        Assert.Equal(EntryPointFrameReader.TidNegotiateResponse, await ReadTemplateIdAsync(s1, cts.Token));
+        await s1.WriteAsync(BuildEstablish(sessionId: 1, sessionVerId: 100UL), cts.Token);
+        Assert.Equal(EntryPointFrameReader.TidEstablishAck, await ReadTemplateIdAsync(s1, cts.Token));
+
+        var established = await TestUtil.WaitUntilAsync(
+            () => listener.ActiveSessions.Any(x => x.SessionId == 1 && x.State == FixpState.Established),
+            TimeSpan.FromSeconds(5));
+        Assert.True(established);
+        var original = listener.ActiveSessions.Single(x => x.SessionId == 1);
+        var originalConnectionId = original.ConnectionId;
+
+        // Phase 2: a brand-new connection sends a resuming Establish reusing
+        // the SAME SessionId + SessionVerId while the stale session is still
+        // Established. Per #496 this must be taken over (force-suspend +
+        // reattach), and the new transport must receive an EstablishAck —
+        // NOT an EstablishReject(UNNEGOTIATED).
+        using var client2 = new TcpClient();
+        await client2.ConnectAsync(IPAddress.Loopback, port, cts.Token);
+        var s2 = client2.GetStream();
+        await s2.WriteAsync(BuildEstablish(sessionId: 1, sessionVerId: 100UL), cts.Token);
+
+        var tid = await ReadTemplateIdAsync(s2, cts.Token);
+        Assert.Equal(EntryPointFrameReader.TidEstablishAck, tid);
+
+        // The takeover reuses the SAME session instance (no fresh Idle
+        // session was spun up) and the session ends back in Established
+        // bound to the new transport, with its identity preserved.
+        var afterTakeover = await TestUtil.WaitUntilAsync(
+            () => listener.ActiveSessions.Count(x => x.SessionId == 1) == 1
+                && listener.ActiveSessions.Single(x => x.SessionId == 1).State == FixpState.Established,
+            TimeSpan.FromSeconds(5));
+        Assert.True(afterTakeover);
+        var resumed = listener.ActiveSessions.Single(x => x.SessionId == 1);
+        Assert.Equal(originalConnectionId, resumed.ConnectionId);
+        Assert.Equal(100UL, resumed.SessionVerId);
+    }
+}

--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionReattachTests.cs
@@ -115,27 +115,77 @@ public class FixpSessionReattachTests
     }
 
     [Fact]
-    public async Task TryReattach_concurrent_calls_only_one_wins()
+    public async Task TryReattach_resets_suspend_guard_allowing_a_second_suspend_cycle()
     {
+        // Regression for the #496 follow-up: SuspendLocked's one-shot
+        // _suspendInProgress guard was never cleared on a successful
+        // suspend, and TryReattach did not reset it — so a SECOND
+        // disconnect after any reattach silently no-opped the suspend,
+        // wedging the session Established over a dead transport. Reattach
+        // must begin a fresh suspend cycle.
         var session = await NewSuspendedSessionAsync();
         try
         {
-            var (_, s1, c1) = await ConnectPairAsync();
-            var (_, s2, c2) = await ConnectPairAsync();
+            var (_, serverStream, client) = await ConnectPairAsync();
             try
             {
-                using var barrier = new ManualResetEventSlim(false);
-                var winners = 0;
-                var t1 = Task.Run(() => { barrier.Wait(); if (session.TryReattach(s1)) Interlocked.Increment(ref winners); });
-                var t2 = Task.Run(() => { barrier.Wait(); if (session.TryReattach(s2)) Interlocked.Increment(ref winners); });
-                barrier.Set();
-                await Task.WhenAll(t1, t2);
-                Assert.Equal(1, winners);
+                Assert.True(session.TryReattach(serverStream));
+                // Drive the state machine back to Established as a real
+                // Establish replay would, so the second Suspend has an
+                // Established → Suspended transition available.
+                session.ApplyTransition(FixpEvent.Establish);
+                Assert.Equal(FixpState.Established, session.State);
+
+                // Second suspend cycle must actually demote the session.
+                session.Suspend("second-cycle");
+                Assert.Equal(FixpState.Suspended, session.State);
             }
-            finally { c1.Close(); c2.Close(); }
+            finally { client.Close(); }
         }
         finally
         {
+            session.Close("test-cleanup");
+            await session.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task SuspendForTakeover_does_not_arm_cancel_on_disconnect()
+    {
+        // Issue #496: an Establish-path takeover demotes a still-Established
+        // session whose successor transport has already arrived, so CoD must
+        // NOT be armed (the disconnect is immediately superseded and resting
+        // orders must survive). A reattach must then succeed.
+        var (_, serverStream0, client0) = await ConnectPairAsync();
+        var session = new FixpSession(
+            connectionId: 1, enteringFirm: 7, sessionId: 100,
+            stream: serverStream0, sink: new NoOpEngineSink(),
+            logger: NullLogger<FixpSession>.Instance);
+        try
+        {
+            session.Start();
+            session.ApplyTransition(FixpEvent.Negotiate);
+            session.ApplyTransition(FixpEvent.Establish);
+            // Opt the session into cancel-on-disconnect with a zero window so
+            // the normal Suspend path would fire CoD essentially immediately.
+            session.SetCancelOnDisconnectForTest(
+                B3.Entrypoint.Fixp.Sbe.V6.CancelOnDisconnectType.CANCEL_ON_DISCONNECT_OR_TERMINATE,
+                codTimeoutWindowMs: 0);
+
+            session.SuspendForTakeover("establish-takeover:test");
+            Assert.Equal(FixpState.Suspended, session.State);
+
+            var (_, serverStream1, client1) = await ConnectPairAsync();
+            try
+            {
+                Assert.True(session.TryReattach(serverStream1));
+                Assert.True(session.IsAttached);
+            }
+            finally { client1.Close(); }
+        }
+        finally
+        {
+            client0.Close();
             session.Close("test-cleanup");
             await session.DisposeAsync();
         }


### PR DESCRIPTION
Closes #496.

## Problem

On an OMS (FIXP client) restart while the matcher process stays up, a cold-resume reconnect is an `Establish` carrying the **same** `SessionId` + `SessionVerId` (Binary EntryPoint spec §5.3). The hot-reattach branch in `EntryPointListener` only accepted a stale session in `FixpState.Suspended`. When the prior TCP died **without a timely FIN** (hard termination / partition), the stale `FixpSession` is still `Established` when the resume arrives, so it fell through to the boot-rehydration path (no entry — the matcher never rebooted) → a fresh `Idle` session → `EstablishValidator` rejects `UNNEGOTIATED`. The client then falls back to `Negotiate`, bumping `SessionVerID` and orphaning the firm's resting orders.

This is the asymmetric counterpart to #488 (Negotiate-path takeover).

## Fix

Mirror the #488 takeover on the **Establish** path:

- **`EntryPointListener`** — broaden the reattach branch to also match a still-`Established` claim with matching `SessionId` + `SessionVerId`; force-suspend it and re-attach the new transport. State is snapshotted **once** so a `Suspended`-matched connection can't re-read State and escalate to tearing down a live successor under a concurrent reconnect (review finding).
- **`FixpSession.SuspendForTakeover`** — demote without arming Cancel-on-Disconnect (the successor transport already arrived; resting orders must survive), mirroring `CloseKind.SessionTakeOver` semantics.
- **`TryReattach`** — reset the one-shot `_suspendInProgress` guard when installing a new generation. It was never cleared on a successful suspend, so a **second** disconnect after any reattach silently no-opped the suspend, wedging the session `Established` over a dead transport (latent bug the takeover relies on).

## Tests

- `EstablishSessionTakeoverTests` — end-to-end over a real listener: first connection Negotiates + Establishes, its TCP is left open (modeling an undetected dead transport), a second connection sends a resuming `Establish` with the same verId and receives an **`EstablishAck`** (not `EstablishReject(UNNEGOTIATED)`); the same session instance is reused and identity preserved. Verified to fail without the fix (returns reject tid 6 instead of ack tid 5).
- `FixpSessionReattachTests` — second suspend cycle after reattach actually demotes; `SuspendForTakeover` does not arm CoD.

## Validation

- `dotnet build -c Release` — 0 warnings (TreatWarningsAsErrors).
- `B3.Exchange.Gateway.Tests` — 543 passed.
- `dotnet format --verify-no-changes` — clean.

A gpt-5.5 code-review pass flagged one TOCTOU (Suspended-matched connection escalating to a takeover of a live successor); addressed by the single State snapshot.
