### PR TITLE
Implement GTD time-in-force end-to-end (GAP-23, #499)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -178,6 +178,18 @@ public sealed partial class ChannelDispatcher
             return;
         }
 
+        if (item.Kind == WorkKind.OperatorExpireGtd)
+        {
+            ProcessExpireGtd(item.ExpireGtd!, item.ExpireGtdCompletion);
+            // GAP-23 (#499): force-persist after the sweep so the cancelled
+            // GTD orders are gone from the engine snapshot and any RptSeq
+            // consumed by the per-order ER_Cancel frames survive a restart.
+            // Operator commands are not WAL-logged; the forced snapshot is
+            // the durability boundary — mirrors the ExpireSecurity path.
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
         _currentSession = item.Session;
         _currentFirm = item.Firm;
         _hasCurrentSession = item.HasSession;

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -708,4 +708,54 @@ public sealed partial class ChannelDispatcher
             throw;
         }
     }
+
+    /// <summary>
+    /// GAP-23 / issue #499: enqueue an end-of-trading-day Good-Till-Date
+    /// expiry sweep for the trading day being closed
+    /// (<paramref name="currentDate"/>, a B3 <c>LocalMktDate</c> = days
+    /// since Unix epoch). On the dispatch thread the dispatcher cancels
+    /// every resting GTD order across the channel's books whose
+    /// <c>ExpireDate</c> is on or before that date, driving per-order
+    /// <c>ER_Cancel</c> + UMDF <c>OrderDelete</c> frames via the existing
+    /// <c>OnOrderCanceled</c> sink path, packed into one packet. No trading
+    /// phase changes. Idempotent and safe to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorExpireGtd(ushort currentDate,
+        TaskCompletionSource<ExpireGtdOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorExpireGtd))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; ExpireGtd rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorExpireGtd, default, 0, false,
+            0, 0, null, null, null, null,
+            ExpireGtd: new OperatorExpireGtd(currentDate),
+            ExpireGtdCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; ExpireGtd rejected"));
+        return false;
+    }
+
+    private void ProcessExpireGtd(OperatorExpireGtd op,
+        TaskCompletionSource<ExpireGtdOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _packetWritten = 0;
+        try
+        {
+            int cancelled = _engine.ExpireGtdOrders(op.CurrentDate, _timeSource.NowNanos());
+            if (_packetWritten > 0) FlushPacket();
+            completion?.TrySetResult(new ExpireGtdOutcome(cancelled));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -11,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity, OperatorExpireGtd }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -42,6 +42,7 @@ public sealed partial class ChannelDispatcher
         "AuditCheckpoint",
         "ShutdownBarrier",
         "OperatorExpireSecurity",
+        "OperatorExpireGtd",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -75,6 +76,8 @@ public sealed partial class ChannelDispatcher
         TaskCompletionSource<bool>? ShutdownBarrier = null,
         OperatorExpireSecurity? ExpireSecurity = null,
         TaskCompletionSource<ExpireSecurityOutcome>? ExpireCompletion = null,
+        OperatorExpireGtd? ExpireGtd = null,
+        TaskCompletionSource<ExpireGtdOutcome>? ExpireGtdCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -142,6 +145,25 @@ public sealed partial class ChannelDispatcher
     /// phase actually changed (false if it was already <c>Close</c>).
     /// </summary>
     public readonly record struct ExpireSecurityOutcome(int CancelledOrderCount, bool PhaseChanged);
+
+    /// <summary>
+    /// GAP-23 / issue #499: end-of-trading-day Good-Till-Date expiry sweep
+    /// payload. Carries the trading day being closed as a B3
+    /// <c>LocalMktDate</c> (days since Unix epoch). The dispatcher cancels
+    /// every resting GTD order across the channel's books whose
+    /// <c>ExpireDate</c> is on or before this date (per-order
+    /// <c>ER_Cancel</c> + UMDF <c>OrderDelete</c>), in one dispatch-thread
+    /// step. Unlike <see cref="OperatorExpireSecurity"/> it never changes a
+    /// trading phase.
+    /// </summary>
+    internal sealed record OperatorExpireGtd(ushort CurrentDate);
+
+    /// <summary>
+    /// GAP-23 / issue #499: outcome of a GTD expiry sweep — how many
+    /// resting GTD orders were cancelled (0 when none had reached their
+    /// ExpireDate).
+    /// </summary>
+    public readonly record struct ExpireGtdOutcome(int CancelledOrderCount);
 
     /// <summary>
     /// ADR 0008 PR-2: operator bust request payload (post-trade audit

--- a/src/B3.Exchange.Core/ChannelStateSnapshot.cs
+++ b/src/B3.Exchange.Core/ChannelStateSnapshot.cs
@@ -53,7 +53,7 @@ public sealed record ChannelStateSnapshot(
     EngineStateSnapshot Engine,
     IReadOnlyList<OrderOwnerSnapshot> Owners)
 {
-    public const int CurrentVersion = 5;
+    public const int CurrentVersion = 6;
 
     /// <summary>
     /// Issue #269: monotonic counter of commands the dispatcher has

--- a/src/B3.Exchange.Core/SnapshotMigrations.cs
+++ b/src/B3.Exchange.Core/SnapshotMigrations.cs
@@ -86,6 +86,11 @@ public sealed class SnapshotMigrationSet
         // the new fields at their record defaults (0 / null / null) on
         // deserialise.
         set.Register(4, MigrateV4ToV5);
+        // Issue #499: v6 only adds an optional ExpireDate field on each
+        // RestingOrderRecord. v5 trees upgrade by stamping the version;
+        // STJ's missing-property tolerance leaves ExpireDate at its record
+        // default (0 == no GTD expiry) on deserialise.
+        set.Register(5, MigrateV5ToV6);
         return set;
     }
 
@@ -114,6 +119,13 @@ public sealed class SnapshotMigrationSet
     {
         if (previous is JsonObject obj)
             obj["Version"] = 5;
+        return previous;
+    }
+
+    private static JsonNode MigrateV5ToV6(JsonNode previous)
+    {
+        if (previous is JsonObject obj)
+            obj["Version"] = 6;
         return previous;
     }
 

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -172,9 +172,19 @@ internal static partial class InboundMessageDecoder
             cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (expireDate != 0)
+        // GAP-23 / #499: GTD requires a non-zero ExpireDate; ExpireDate is
+        // only meaningful for GTD. Reject the contradictory pairings as an
+        // ER_Reject (UnsupportedFeature keeps the session open) rather than
+        // terminating. Valid GTD+ExpireDate is plumbed into the command.
+        if (tif == TimeInForce.Gtd && expireDate == 0)
         {
-            message = "ExpireDate not supported (only Day/IOC/FOK)";
+            message = "GTD requires ExpireDate";
+            cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
+        if (tif != TimeInForce.Gtd && expireDate != 0)
+        {
+            message = "ExpireDate only valid with GTD time-in-force";
             cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
@@ -227,6 +237,7 @@ internal static partial class InboundMessageDecoder
                 StopPxMantissa = engineStopPx,
                 OrdTagId = ordTagId,
                 InvestorId = investorId,
+                ExpireDate = expireDate,
                 PreTradeRejectReason = preTradeRejectReason,
             };
             return InboundDecodeOutcome.UnsupportedFeature;
@@ -248,6 +259,7 @@ internal static partial class InboundMessageDecoder
             StopPxMantissa = engineStopPx,
             OrdTagId = ordTagId,
             InvestorId = investorId,
+            ExpireDate = expireDate,
         };
         return InboundDecodeOutcome.Success;
     }

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -161,12 +161,14 @@ internal static partial class InboundMessageDecoder
             cmd = UnsupportedCommand(ordType, newTif);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
-        if (expireDate != 0)
-        {
-            message = "ExpireDate not supported (only Day/IOC/FOK)";
-            cmd = UnsupportedCommand(ordType, newTif);
-            return InboundDecodeOutcome.UnsupportedFeature;
-        }
+        // GAP-23 / #499: ExpireDate is plumbed through as NewExpireDate.
+        // Unlike NewOrderSingle the decoder does NOT enforce the GTD<->
+        // ExpireDate pairing here: a replace may omit TimeInForce (preserve
+        // the resting order's TIF), so the engine — which knows the resting
+        // order's current TIF — is the single point that validates the
+        // resolved (effectiveTif, effectiveExpireDate) pair. A wire
+        // ExpireDate of 0 (SBE null) means "not supplied / preserve".
+        ushort? newExpireDate = expireDate == 0 ? null : expireDate;
         // #238: V6 trailer reject — see NewOrderSingle decoder.
         if (body.Length > OrderCancelReplaceV2BodySize)
         {
@@ -215,6 +217,7 @@ internal static partial class InboundMessageDecoder
             {
                 NewOrdType = ordType,
                 NewTif = newTif,
+                NewExpireDate = newExpireDate,
                 PreTradeRejectReason = preTradeRejectReason,
                 NewInvestorId = investorId,
             };
@@ -231,6 +234,7 @@ internal static partial class InboundMessageDecoder
         {
             NewOrdType = ordType,
             NewTif = newTif,
+            NewExpireDate = newExpireDate,
             NewInvestorId = investorId,
         };
         return InboundDecodeOutcome.Success;

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -51,6 +51,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private DailyResetScheduler? _dailyReset;
     private PhaseScheduler? _phaseScheduler;
     private OptionExpirySweeper? _optionExpirySweeper;
+    private GtdExpirySweeper? _gtdExpirySweeper;
     private readonly List<B3.Exchange.Persistence.DataDirLock> _dataDirLocks = new();
     private B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal? _outboundJournal;
     private B3.Exchange.Gateway.Persistence.FileFixpSessionStatePersister? _statePersister;
@@ -98,6 +99,14 @@ public sealed class ExchangeHost : IAsyncDisposable
         // guarantees the resting orders' cancels reach the wire
         // before TerminateAllSessions closes the sockets.
         _optionExpirySweeper?.SweepExpiredSeries(reason, waitTimeout: TimeSpan.FromSeconds(15));
+        // GAP-23 / #499: sweep expired GTD orders BEFORE the listener tears
+        // down, for the same routing reason as the option sweep above — each
+        // per-order ER_Cancel must reach its originating TCP session while
+        // the gateway is still attached. Runs after the option sweep so any
+        // GTD order on an expiring option series is already gone (no-op
+        // here); waits on per-channel completions so the cancels reach the
+        // outbound encoder before DrainAllSessionsOutbound + TerminateAllSessions.
+        _gtdExpirySweeper?.Sweep(reason, waitTimeout: TimeSpan.FromSeconds(15));
         // Issue #487: drain outbound queues BEFORE closing sockets.
         // ER_Cancel frames from the sweep are enqueued to the session's
         // send queue but may not have been written to the socket yet.
@@ -542,6 +551,19 @@ public sealed class ExchangeHost : IAsyncDisposable
                     "option-expiry sweeper armed for {SeriesCount} option series across {ChannelCount} channels",
                     sinks.Count, _dispatchers.Count);
             }
+        }
+        // GAP-23 / #499: stand up the GTD expiry sweeper. It fans out one
+        // expiry command per channel at daily reset; "today" is the B3 local
+        // market date in the configured daily-reset timezone (the engine
+        // stays clockless and receives the date as a command argument).
+        {
+            var todayProvider = GtdExpirySweeper.BuildTodayProvider(
+                _config.DailyReset?.Timezone,
+                _loggerFactory.CreateLogger<GtdExpirySweeper>());
+            _gtdExpirySweeper = new GtdExpirySweeper(
+                _dispatchers,
+                _loggerFactory.CreateLogger<GtdExpirySweeper>(),
+                todayProvider);
         }
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
         var sessionOptions = new FixpSessionOptions

--- a/src/B3.Exchange.Host/GtdExpirySweeper.cs
+++ b/src/B3.Exchange.Host/GtdExpirySweeper.cs
@@ -47,25 +47,35 @@ public sealed class GtdExpirySweeper
         _todayLocal = todayLocal;
     }
 
+    /// <summary>The B3 venue timezone the local market date is interpreted
+    /// in; matches <c>DailyResetConfig.Timezone</c>'s default. Used when the
+    /// daily-reset section is absent so the GTD boundary still follows the
+    /// B3 local market date rather than UTC.</summary>
+    private const string DefaultMarketTimezone = "America/Sao_Paulo";
+
     /// <summary>
     /// Builds the timezone-aware "today" provider for the sweeper from the
-    /// configured daily-reset timezone. Falls back to UTC when the timezone
-    /// id is unknown so the host never fails to start over a bad config.
+    /// configured daily-reset timezone. A null/blank id (daily-reset section
+    /// absent) defaults to the B3 market timezone (<c>America/Sao_Paulo</c>)
+    /// so the GTD <c>LocalMktDate</c> boundary is the B3 local market date,
+    /// not UTC. An explicitly configured but unknown timezone id falls back
+    /// to UTC so the host never fails to start over a bad config.
     /// </summary>
     public static Func<DateOnly> BuildTodayProvider(string? timezoneId, ILogger logger)
     {
+        string resolvedId = string.IsNullOrWhiteSpace(timezoneId)
+            ? DefaultMarketTimezone
+            : timezoneId;
         TimeZoneInfo tz;
         try
         {
-            tz = string.IsNullOrWhiteSpace(timezoneId)
-                ? TimeZoneInfo.Utc
-                : TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+            tz = TimeZoneInfo.FindSystemTimeZoneById(resolvedId);
         }
         catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
         {
             logger.LogWarning(ex,
                 "GTD expiry: unknown timezone '{Timezone}', falling back to UTC for the local market date",
-                timezoneId);
+                resolvedId);
             tz = TimeZoneInfo.Utc;
         }
         return () => DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz));

--- a/src/B3.Exchange.Host/GtdExpirySweeper.cs
+++ b/src/B3.Exchange.Host/GtdExpirySweeper.cs
@@ -1,0 +1,173 @@
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// GAP-23 / issue #499 — end-of-trading-day Good-Till-Date (GTD) expiry
+/// sweep.
+///
+/// <para>At the end of each trading day the host enqueues one
+/// <c>EnqueueOperatorExpireGtd</c> command per channel dispatcher carrying
+/// the trading day being closed as a B3 <c>LocalMktDate</c> (days since the
+/// Unix epoch). On the dispatch thread the engine cancels every resting GTD
+/// order whose <c>ExpireDate</c> is on or before that date, driving a
+/// per-order <c>ER_Cancel</c> back to the originating session and a UMDF
+/// <c>OrderDelete</c> frame under the channel's single-writer invariant
+/// (ADR 0009).</para>
+///
+/// <para>Like <see cref="OptionExpirySweeper"/> the sweeper does not own a
+/// timer — it is invoked from <c>ExchangeHost.TriggerDailyReset</c> before
+/// the listener is torn down, so the per-order <c>ER_Cancel</c> still routes
+/// to its originating session. The boundary "today" is computed in the
+/// configured daily-reset timezone (B3 local market date defaults to
+/// <c>America/Sao_Paulo</c>); the engine itself stays clockless (ADR 0009),
+/// receiving the date as an explicit command argument.</para>
+/// </summary>
+public sealed class GtdExpirySweeper
+{
+    /// <summary>1970-01-01 expressed as a <see cref="DateOnly.DayNumber"/>,
+    /// used to convert a calendar date to the wire's days-since-epoch
+    /// <c>LocalMktDate</c>.</summary>
+    private static readonly int UnixEpochDayNumber = new DateOnly(1970, 1, 1).DayNumber;
+
+    private readonly IReadOnlyList<ChannelDispatcher> _dispatchers;
+    private readonly ILogger<GtdExpirySweeper> _logger;
+    private readonly Func<DateOnly> _todayLocal;
+
+    public GtdExpirySweeper(IReadOnlyList<ChannelDispatcher> dispatchers,
+        ILogger<GtdExpirySweeper> logger,
+        Func<DateOnly> todayLocal)
+    {
+        ArgumentNullException.ThrowIfNull(dispatchers);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(todayLocal);
+        _dispatchers = dispatchers;
+        _logger = logger;
+        _todayLocal = todayLocal;
+    }
+
+    /// <summary>
+    /// Builds the timezone-aware "today" provider for the sweeper from the
+    /// configured daily-reset timezone. Falls back to UTC when the timezone
+    /// id is unknown so the host never fails to start over a bad config.
+    /// </summary>
+    public static Func<DateOnly> BuildTodayProvider(string? timezoneId, ILogger logger)
+    {
+        TimeZoneInfo tz;
+        try
+        {
+            tz = string.IsNullOrWhiteSpace(timezoneId)
+                ? TimeZoneInfo.Utc
+                : TimeZoneInfo.FindSystemTimeZoneById(timezoneId);
+        }
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            logger.LogWarning(ex,
+                "GTD expiry: unknown timezone '{Timezone}', falling back to UTC for the local market date",
+                timezoneId);
+            tz = TimeZoneInfo.Utc;
+        }
+        return () => DateOnly.FromDateTime(TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, tz));
+    }
+
+    /// <summary>
+    /// Enqueues a GTD expiry sweep on every channel for the trading day
+    /// being closed.
+    ///
+    /// <para>When <paramref name="waitTimeout"/> is provided (default 5s)
+    /// the call blocks until every enqueued sweep has finished on its
+    /// dispatch thread — required from <c>TriggerDailyReset</c> so the
+    /// gateway can flush ER_Cancel frames before <c>TerminateAllSessions</c>
+    /// tears down the response channels. Pass <see cref="TimeSpan.Zero"/> to
+    /// fire and forget.</para>
+    ///
+    /// <para>Returns the total number of GTD orders cancelled across all
+    /// channels (0 when nothing had reached its ExpireDate). Per-channel
+    /// enqueue failures are logged at warn level and do not abort the
+    /// sweep.</para>
+    /// </summary>
+    public int Sweep(string trigger, TimeSpan? waitTimeout = null)
+    {
+        if (_dispatchers.Count == 0) return 0;
+        var today = _todayLocal();
+        int dayNumber = today.DayNumber - UnixEpochDayNumber;
+        if (dayNumber < 0 || dayNumber > ushort.MaxValue)
+        {
+            _logger.LogError(
+                "GTD expiry sweep ({Trigger}): local market date {Today} is outside the LocalMktDate range; skipping",
+                trigger, today);
+            return 0;
+        }
+        ushort currentDate = (ushort)dayNumber;
+
+        var pending = waitTimeout is { } t && t > TimeSpan.Zero
+            ? new List<Task<ChannelDispatcher.ExpireGtdOutcome>>()
+            : null;
+        int enqueued = 0;
+        int rejected = 0;
+        foreach (var dispatcher in _dispatchers)
+        {
+            var completion = pending is null
+                ? null
+                : new TaskCompletionSource<ChannelDispatcher.ExpireGtdOutcome>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            bool ok;
+            try
+            {
+                ok = dispatcher.EnqueueOperatorExpireGtd(currentDate, completion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "GTD expiry sweep ({Trigger}): enqueue threw channel={Channel}",
+                    trigger, dispatcher.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            if (!ok)
+            {
+                _logger.LogWarning(
+                    "GTD expiry sweep ({Trigger}): enqueue rejected channel={Channel}",
+                    trigger, dispatcher.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            enqueued++;
+            if (completion != null) pending!.Add(completion.Task);
+        }
+
+        int cancelled = 0;
+        if (pending is { Count: > 0 })
+        {
+            bool completedInTime;
+            try
+            {
+                completedInTime = Task.WaitAll(pending.ToArray(), waitTimeout!.Value);
+            }
+            catch (AggregateException ex)
+            {
+                completedInTime = pending.TrueForAll(t => t.IsCompleted);
+                _logger.LogWarning(ex,
+                    "GTD expiry sweep ({Trigger}): one or more ExpireGtd completions faulted",
+                    trigger);
+            }
+            foreach (var task in pending)
+            {
+                if (task.IsCompletedSuccessfully) cancelled += task.Result.CancelledOrderCount;
+            }
+            if (!completedInTime)
+            {
+                int incomplete = pending.Count(t => !t.IsCompleted);
+                _logger.LogError(
+                    "GTD expiry sweep ({Trigger}): timed out after {TimeoutMs}ms with {Incomplete} of {Enqueued} ExpireGtd completions still pending — TerminateAllSessions may close sessions before ER_Cancel reaches the wire",
+                    trigger, (int)waitTimeout!.Value.TotalMilliseconds, incomplete, enqueued);
+            }
+        }
+
+        _logger.LogInformation(
+            "GTD expiry sweep ({Trigger}): channels={ChannelCount} enqueued={Enqueued} rejected={Rejected} cancelled={Cancelled} currentDate={CurrentDate} today={Today}",
+            trigger, _dispatchers.Count, enqueued, rejected, cancelled, currentDate, today);
+        return cancelled;
+    }
+}

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -183,6 +183,13 @@ public enum CancelReason : byte
     /// to the originating session — no MBO frame, since the order was
     /// never visible on the public book.</summary>
     IocUnmatched,
+    /// <summary>Resting <see cref="TimeInForce.Gtd"/> order whose
+    /// <c>ExpireDate</c> (last tradeable local-market date) has passed.
+    /// Cancelled by the end-of-trading-day GTD expiry sweep
+    /// (GAP-23 / issue #499) — drives an <c>ER_Cancel</c> back to the
+    /// originating session and a UMDF <c>OrderDelete</c>, exactly like a
+    /// client cancel.</summary>
+    GtdExpired,
 }
 
 /// <summary>
@@ -206,7 +213,17 @@ public sealed record NewOrderCommand(
     public InvestorId? InvestorId { get; init; }
 
     /// <summary>
-    /// Optional minimum-fill (FIX MinQty). When non-zero, the engine
+    /// Good-Till-Date expiry as a B3 <c>LocalMktDateOptional</c>: the
+    /// number of days since the Unix epoch of the LAST local-market date
+    /// the order may trade (0 == not supplied / SBE null). Required and
+    /// must be non-zero when <see cref="Tif"/> is
+    /// <see cref="TimeInForce.Gtd"/> (else
+    /// <see cref="RejectReason.InvalidField"/>); must be 0 for every other
+    /// TIF. The order rests until cancelled, filled, or swept by the
+    /// end-of-trading-day GTD expiry when the trading day being closed is
+    /// on or after this date. GAP-23 / issue #499.
+    /// </summary>
+    public ushort ExpireDate { get; init; }
     /// requires that at submission time the immediately fillable quantity
     /// against the opposite side at this order's limit (or any price for
     /// market orders) is at least <c>MinQty</c>; otherwise the order is
@@ -310,6 +327,18 @@ public sealed record ReplaceOrderCommand(
     /// clearing is intentionally not supported. Issue #451.
     /// </summary>
     public InvestorId? NewInvestorId { get; init; }
+
+    /// <summary>
+    /// New Good-Till-Date expiry (B3 <c>LocalMktDateOptional</c>, days
+    /// since Unix epoch). <c>null</c> means "not supplied on the wire" —
+    /// preserve the resting order's existing <c>ExpireDate</c> when the
+    /// effective TIF stays <see cref="TimeInForce.Gtd"/>. When the
+    /// effective TIF is GTD the resolved expiry must be non-zero (else
+    /// <see cref="RejectReason.InvalidField"/>); when the effective TIF is
+    /// not GTD an explicitly-supplied non-zero value is rejected. GAP-23 /
+    /// issue #499.
+    /// </summary>
+    public ushort? NewExpireDate { get; init; }
 
     public bool UnsupportedOrderCharacteristic { get; init; }
 

--- a/src/B3.Exchange.Matching/EngineStateSnapshot.cs
+++ b/src/B3.Exchange.Matching/EngineStateSnapshot.cs
@@ -61,7 +61,8 @@ public sealed record RestingOrderRecord(
     long HiddenQuantity,
     byte OrdTagId = 0,
     string? Asset = null,
-    InvestorId? InvestorId = null)
+    InvestorId? InvestorId = null,
+    ushort ExpireDate = 0)
 {
     public byte[] Memo { get; init; } = [];
 }

--- a/src/B3.Exchange.Matching/LimitOrderBook.cs
+++ b/src/B3.Exchange.Matching/LimitOrderBook.cs
@@ -26,13 +26,22 @@ internal sealed class RestingOrder
     public ulong InsertTimestampNanos;
 
     /// <summary>
-    /// TIF the order was originally accepted with (Day or Gtc — the only
+    /// TIF the order was originally accepted with (Day, Gtc or Gtd — the
     /// TIFs that can rest). Tracked so a subsequent
     /// <see cref="ReplaceOrderCommand"/> that omits TIF on the wire
     /// preserves the resting order's original TIF instead of silently
-    /// downgrading to <see cref="TimeInForce.Day"/>. Issue #204.
+    /// downgrading to <see cref="TimeInForce.Day"/>. Issue #204 / #499.
     /// </summary>
     public TimeInForce Tif { get; init; } = TimeInForce.Day;
+
+    /// <summary>
+    /// Good-Till-Date expiry for <see cref="TimeInForce.Gtd"/> orders: the
+    /// last local-market date (days since Unix epoch) the order may trade.
+    /// 0 for every non-GTD resting order. Mutable so a priority-preserving
+    /// <see cref="ReplaceOrderCommand"/> can amend the expiry in place
+    /// without rebuilding the order. GAP-23 / issue #499.
+    /// </summary>
+    public ushort ExpireDate { get; set; }
 
     /// <summary>
     /// Iceberg visible-slice size (FIX MaxFloor). 0 means "not an iceberg"
@@ -309,7 +318,8 @@ internal sealed class LimitOrderBook
                         HiddenQuantity: o.HiddenQuantity,
                         OrdTagId: o.OrdTagId,
                         Asset: o.Asset,
-                        InvestorId: o.InvestorId)
+                        InvestorId: o.InvestorId,
+                        ExpireDate: o.ExpireDate)
                     { Memo = o.Memo };
                 }
             }
@@ -342,6 +352,7 @@ internal sealed class LimitOrderBook
             MaxFloor = record.MaxFloor,
             HiddenQuantity = record.HiddenQuantity,
             RemainingQuantity = record.RemainingQuantity,
+            ExpireDate = record.ExpireDate,
             Memo = record.Memo,
         };
         Insert(order);

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -812,13 +812,27 @@ public sealed class MatchingEngine
 
             // #201: trading-phase gating combined with #202 TIF semantics.
             // Day/IOC/FOK/GTC require Open. AtClose requires FinalClosingCall.
-            // GoodForAuction requires Reserved (pre-open auction). GTD is
-            // wire-accepted but not yet implementable in the engine — the
-            // ExpireDate is not plumbed through NewOrderCommand yet.
+            // GoodForAuction requires Reserved (pre-open auction). GTD
+            // (#499) rests like Day/Gtc (requires Open) but carries an
+            // ExpireDate driving the end-of-day expiry sweep.
             var phase = _phaseById[cmd.SecurityId];
+            // GAP-23 / #499: GTD requires a non-zero ExpireDate; a non-zero
+            // ExpireDate is meaningless on any other TIF. The gateway
+            // decoder enforces the same pairing for NewOrderSingle, but
+            // re-validate here so direct-API and WAL-replay paths stay
+            // consistent. (The engine is clockless, so a date already in
+            // the past is accepted and removed by the next daily sweep.)
             if (cmd.Tif == TimeInForce.Gtd)
             {
-                Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.TimeInForceNotSupported, cmd.EnteredAtNanos);
+                if (cmd.ExpireDate == 0)
+                {
+                    Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos);
+                    return;
+                }
+            }
+            else if (cmd.ExpireDate != 0)
+            {
+                Reject(cmd.ClOrdId, cmd.SecurityId, 0, RejectReason.InvalidField, cmd.EnteredAtNanos);
                 return;
             }
             var requiredPhase = cmd.Tif switch
@@ -1073,6 +1087,50 @@ public sealed class MatchingEngine
         finally { ExitDispatch(); }
     }
 
+    /// <summary>
+    /// GAP-23 / issue #499: end-of-trading-day Good-Till-Date expiry sweep.
+    /// Cancels every resting <see cref="TimeInForce.Gtd"/> order across all
+    /// books owned by this engine whose <c>ExpireDate</c> (last tradeable
+    /// local-market date, days since Unix epoch) is on or before
+    /// <paramref name="currentDate"/> — the trading day being closed. Each
+    /// cancellation flows through the standard
+    /// <see cref="IMatchingEventSink.OnOrderCanceled"/> path with
+    /// <see cref="CancelReason.GtdExpired"/>, so the dispatcher emits a
+    /// per-order <c>ER_Cancel</c> back to the originating session and a UMDF
+    /// <c>OrderDelete</c> frame exactly like a client cancel.
+    /// <para>The engine is clockless by design (ADR 0009): the caller
+    /// supplies the boundary date. Idempotent — a second sweep with the same
+    /// date is a no-op once the matching orders are gone. Returns the number
+    /// of orders cancelled.</para>
+    /// </summary>
+    public int ExpireGtdOrders(ushort currentDate, ulong txnNanos)
+    {
+        EnterDispatch();
+        try
+        {
+            int cancelled = 0;
+            foreach (var book in _booksById.Values)
+            {
+                // SnapshotOrders() copies into the book's scratch buffer, so
+                // EmitCanceled (which mutates the book's index) is safe to
+                // call while iterating the snapshot. The buffer is consumed
+                // fully before the next book's SnapshotOrders() overwrites it.
+                foreach (var resting in book.SnapshotOrders())
+                {
+                    if (resting.Tif == TimeInForce.Gtd
+                        && resting.ExpireDate != 0
+                        && resting.ExpireDate <= currentDate)
+                    {
+                        EmitCanceled(book, resting, txnNanos, CancelReason.GtdExpired);
+                        cancelled++;
+                    }
+                }
+            }
+            return cancelled;
+        }
+        finally { ExitDispatch(); }
+    }
+
     private static bool MatchesMassCancelFilter(LimitOrderBook book, RestingOrder resting, MassCancelCommand command)
     {
         if (command.SecurityId != 0 && book.SecurityId != command.SecurityId) return false;
@@ -1129,13 +1187,36 @@ public sealed class MatchingEngine
             var effectiveType = cmd.NewOrdType ?? OrderType.Limit;
             var effectiveTif = cmd.NewTif ?? resting.Tif;
 
+            // GAP-23 / #499: resolve the effective GTD ExpireDate from the
+            // replace and the resting order. A wire ExpireDate (NewExpireDate
+            // non-null) overrides; otherwise an order that stays GTD keeps
+            // its current ExpireDate. A transition away from GTD clears it.
+            ushort effectiveExpireDate;
+            if (effectiveTif == TimeInForce.Gtd)
+            {
+                effectiveExpireDate = cmd.NewExpireDate
+                    ?? (resting.Tif == TimeInForce.Gtd ? resting.ExpireDate : (ushort)0);
+            }
+            else
+            {
+                effectiveExpireDate = 0;
+            }
+
             // Phase gating — same rules as a brand-new order. A replace that
             // lands during a trading halt must be rejected before mutating
             // the resting order; if the new TIF is incompatible with the
             // current phase the replace is treated like a new order would be.
             var phase = _phaseById[cmd.SecurityId];
+            // GTD validation mirrors the new-order path: a GTD result needs a
+            // non-zero ExpireDate; an explicit non-zero ExpireDate on a
+            // non-GTD result is contradictory.
             if (effectiveTif == TimeInForce.Gtd)
-            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.TimeInForceNotSupported, cmd.EnteredAtNanos); return; }
+            {
+                if (effectiveExpireDate == 0)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
+            }
+            else if (cmd.NewExpireDate is { } suppliedExpire && suppliedExpire != 0)
+            { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
             var requiredPhase = effectiveTif switch
             {
                 TimeInForce.AtClose => TradingPhase.FinalClosingCall,
@@ -1184,6 +1265,11 @@ public sealed class MatchingEngine
                 {
                     resting.InvestorId = newInvestorKept;
                 }
+                // GAP-23 / #499: a priority-preserving replace may amend the
+                // GTD ExpireDate in place (effectiveTif == resting.Tif here,
+                // so this only changes the date, never the TIF). For non-GTD
+                // orders effectiveExpireDate is 0, leaving the field untouched.
+                resting.ExpireDate = effectiveExpireDate;
                 uint rptSeq = NextRptSeq();
                 _sink.OnOrderQuantityReduced(new OrderQuantityReducedEvent(
                     SecurityId: book.SecurityId,
@@ -1245,6 +1331,7 @@ public sealed class MatchingEngine
                 OrdTagId = resting.OrdTagId,
                 Asset = resting.Asset,
                 InvestorId = cmd.NewInvestorId ?? resting.InvestorId,
+                ExpireDate = effectiveExpireDate,
                 Memo = cmd.Memo,
             };
 
@@ -1301,6 +1388,7 @@ public sealed class MatchingEngine
             Tif = cmd.Tif,
             MaxFloor = (long)cmd.MaxFloor,
             HiddenQuantity = hidden,
+            ExpireDate = cmd.ExpireDate,
         };
         book.Insert(resting);
         _sink.OnOrderAccepted(new OrderAcceptedEvent(
@@ -1757,6 +1845,7 @@ public sealed class MatchingEngine
                 Tif = cmd.Tif,
                 MaxFloor = (long)cmd.MaxFloor,
                 HiddenQuantity = hidden,
+                ExpireDate = cmd.ExpireDate,
                 Memo = cmd.Memo,
             };
             book.Insert(resting);

--- a/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
+++ b/src/B3.Exchange.Persistence/BinaryChannelStateSnapshotCodec.cs
@@ -346,7 +346,10 @@ public static class BinaryChannelStateSnapshotCodec
         // no per-resting-order OrdTagId/Asset/InvestorId trailer, and
         // ReadRestingOrder defaults them to 0/null/null for older
         // versions.
-        int effectiveVersion = (version == 1 || version == 2 || version == 3 || version == 4) ? ChannelStateSnapshot.CurrentVersion : version;
+        // Issue #499: v5 → v6 is also a clean migration — v5 files have
+        // no per-resting-order ExpireDate trailer, and ReadRestingOrder
+        // defaults it to 0 (no GTD expiry) for older versions.
+        int effectiveVersion = (version == 1 || version == 2 || version == 3 || version == 4 || version == 5) ? ChannelStateSnapshot.CurrentVersion : version;
         return new ChannelStateSnapshot(effectiveVersion, channelNumber, sequenceNumber, sequenceVersion, engine, owners)
         {
             LastAppliedSeq = lastAppliedSeq,
@@ -385,6 +388,13 @@ public static class BinaryChannelStateSnapshotCodec
                 w.WriteByte(0);
             }
         }
+        // Issue #499 (codec v6): GTD ExpireDate tail. Older versions wrote
+        // nothing here; ReadRestingOrder defaults to 0 (no GTD expiry) when
+        // the trailer is absent.
+        if (version >= 6)
+        {
+            w.WriteUInt16(o.ExpireDate);
+        }
     }
 
     private static RestingOrderRecord ReadRestingOrder(ref BinaryBufferReader r, int version)
@@ -415,8 +425,13 @@ public static class BinaryChannelStateSnapshotCodec
                 investor = new InvestorId(prefix, document);
             }
         }
+        ushort expireDate = 0;
+        if (version >= 6)
+        {
+            expireDate = r.ReadUInt16();
+        }
         return new RestingOrderRecord(orderId, clOrdId, (Side)side, price, qty, firm, ts,
-            (TimeInForce)tif, maxFloor, hidden, ordTagId, asset, investor);
+            (TimeInForce)tif, maxFloor, hidden, ordTagId, asset, investor, expireDate);
     }
 
     private static void WriteRestingStop(BinaryBufferWriter w, RestingStopRecord s, int version)

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -31,7 +31,8 @@ public class NewOrderSingleAndReplaceDecoderTests
         long price = 12_3400L,
         long stopPx = PriceNull,
         ulong minQty = 0UL,
-        ulong maxFloor = 0UL)
+        ulong maxFloor = 0UL,
+        ushort expireDate = 0)
     {
         var body = new byte[125];
         Span<byte> s = body;
@@ -46,6 +47,7 @@ public class NewOrderSingleAndReplaceDecoderTests
         MemoryMarshal.Write(s.Slice(76, 8), in stopPx);
         MemoryMarshal.Write(s.Slice(84, 8), in minQty);
         MemoryMarshal.Write(s.Slice(92, 8), in maxFloor);
+        MemoryMarshal.Write(s.Slice(105, 2), in expireDate);
         return body;
     }
 
@@ -64,7 +66,8 @@ public class NewOrderSingleAndReplaceDecoderTests
         ulong minQty = 0UL,
         ulong maxFloor = 0UL,
         ushort investorPrefix = 0,
-        uint investorDocument = 0)
+        uint investorDocument = 0,
+        ushort expireDate = 0)
     {
         var body = new byte[142];
         Span<byte> s = body;
@@ -81,6 +84,7 @@ public class NewOrderSingleAndReplaceDecoderTests
         MemoryMarshal.Write(s.Slice(92, 8), in stopPx);
         MemoryMarshal.Write(s.Slice(100, 8), in minQty);
         MemoryMarshal.Write(s.Slice(108, 8), in maxFloor);
+        MemoryMarshal.Write(s.Slice(122, 2), in expireDate);
         MemoryMarshal.Write(s.Slice(136, 2), in investorPrefix);
         MemoryMarshal.Write(s.Slice(138, 4), in investorDocument);
         return body;
@@ -113,7 +117,6 @@ public class NewOrderSingleAndReplaceDecoderTests
     [InlineData((byte)'3', TimeInForce.IOC)]
     [InlineData((byte)'4', TimeInForce.FOK)]
     [InlineData((byte)'1', TimeInForce.Gtc)]
-    [InlineData((byte)'6', TimeInForce.Gtd)]
     [InlineData((byte)'7', TimeInForce.AtClose)]
     [InlineData((byte)'A', TimeInForce.GoodForAuction)]
     public void NewOrderSingle_AcceptsSupportedTif(byte tifByte, TimeInForce expected)
@@ -125,6 +128,36 @@ public class NewOrderSingleAndReplaceDecoderTests
 
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
         Assert.Equal(expected, cmd.Tif);
+    }
+
+    // GAP-23 / #499: GTD with a non-zero ExpireDate is now accepted and the
+    // ExpireDate is plumbed through to the command.
+    [Fact]
+    public void NewOrderSingle_GtdWithExpireDate_AcceptedAndPlumbed()
+    {
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 0x1234);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal(TimeInForce.Gtd, cmd.Tif);
+        Assert.Equal((ushort)0x1234, cmd.ExpireDate);
+    }
+
+    // GAP-23 / #499: GTD without an ExpireDate is rejected as unsupported
+    // (BMR-eligible) rather than terminating the session.
+    [Fact]
+    public void NewOrderSingle_GtdWithoutExpireDate_RejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 0);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out _, out _, out var msg);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.Contains("ExpireDate", msg);
     }
 
     [Fact]
@@ -493,12 +526,12 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Contains("SelfTradePrevention", msg);
     }
 
+    // GAP-23 / #499: an ExpireDate on a non-GTD order is rejected as
+    // unsupported (the field is only meaningful with GTD time-in-force).
     [Fact]
-    public void NewOrderSingle_ExpireDateRejectsAsUnsupported()
+    public void NewOrderSingle_ExpireDateWithoutGtd_RejectsAsUnsupported()
     {
-        var body = BuildNewOrderSingleV2();
-        ushort expire = 0x1234;
-        MemoryMarshal.Write(((Span<byte>)body).Slice(105, 2), in expire);
+        var body = BuildNewOrderSingleV2(expireDate: 0x1234);
 
         var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
             body, 1, 0, out _, out _, out var msg);
@@ -717,18 +750,34 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Contains("SelfTradePrevention", msg);
     }
 
+    // GAP-23 / #499: a replace now plumbs ExpireDate through as
+    // NewExpireDate and defers GTD pairing validation to the engine (the
+    // wire TimeInForce may be omitted/preserved on a replace).
     [Fact]
-    public void OrderCancelReplace_ExpireDateRejectsAsUnsupported()
+    public void OrderCancelReplace_ExpireDate_PopulatesNewExpireDate()
     {
-        var body = BuildOrderCancelReplaceV2();
-        ushort expire = 0x1234;
-        MemoryMarshal.Write(((Span<byte>)body).Slice(122, 2), in expire);
+        var body = BuildOrderCancelReplaceV2(expireDate: 0x1234);
 
         var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
-            body, 0UL, out _, out _, out _, out var msg);
+            body, 0UL, out var cmd, out _, out _, out var msg);
 
-        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
-        Assert.Contains("ExpireDate", msg);
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal((ushort)0x1234, cmd.NewExpireDate);
+    }
+
+    // A replace with no ExpireDate on the wire leaves NewExpireDate null
+    // (preserve the resting order's existing expiry).
+    [Fact]
+    public void OrderCancelReplace_NoExpireDate_LeavesNewExpireDateNull()
+    {
+        var body = BuildOrderCancelReplaceV2(expireDate: 0);
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out var cmd, out _, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(cmd.NewExpireDate);
     }
 
     // ---------------- #238: V6 trailer (StrategyID + TradingSubAccount) ----------------

--- a/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
@@ -1,0 +1,230 @@
+using B3.EntryPoint.Wire;
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// GAP-23 / issue #499 — end-to-end: boot an <see cref="ExchangeHost"/>,
+/// place a resting GTD order (full <c>NewOrderSingle_102</c> with a
+/// <c>TimeInForce=GTD</c> and an <c>ExpireDate</c> on or before today) over
+/// the wire, then call <see cref="ExchangeHost.TriggerDailyReset"/> and
+/// assert the originating session receives an <c>ER_Cancel</c> — proving the
+/// wire→engine→sweeper→gateway GTD expiry path works through the host.
+/// </summary>
+public class GtdExpiryE2ETests
+{
+    private const long SecId = 900000000001L;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    private static string WriteEquityInstrumentsJson(string scratchDir)
+    {
+        Directory.CreateDirectory(scratchDir);
+        var path = Path.Combine(scratchDir, "instruments-gtd.json");
+        var json = $$"""
+        [
+          {
+            "symbol": "PETR4",
+            "securityId": {{SecId}},
+            "tickSize": "0.01",
+            "minPx": "0.01",
+            "maxPx": "999999.99",
+            "currency": "BRL",
+            "isin": "BRPETRACNPR6",
+            "securityType": "EQUITY",
+            "lotSize": 100
+          }
+        ]
+        """;
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_CancelsRestingGtdOrderWithElapsedExpireDate()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "gtd-e2e-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 94,
+                        IncrementalGroup = "239.255.42.94",
+                        IncrementalPort = 30194,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            // GTD ExpireDate = today's B3 LocalMktDate (days since epoch).
+            // The host's daily-reset sweep computes the same boundary (UTC,
+            // since cfg.DailyReset is unset) and cancels ExpireDate <= today.
+            int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                - new DateOnly(1970, 1, 1).DayNumber;
+            ushort expireDate = (ushort)epochDay;
+
+            var newOrder = BuildNewOrderSingleGtd(clOrdId: 12_001, secId: SecId,
+                side: '1', qty: 100, priceMantissa: 123_400, expireDate: expireDate);
+            await stream.WriteAsync(newOrder);
+            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+            host.TriggerDailyReset(reason: "test-gtd-expiry");
+
+            // The resting GTD BUY should come back as an ER_Cancel.
+            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, er2.TemplateId);
+            // ER_Cancel body[18] carries Side; the resting order was Buy.
+            Assert.Equal((byte)'1', er2.Body[18]);
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_KeepsRestingGtdOrderWithFutureExpireDate()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "gtd-e2e-keep-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 95,
+                        IncrementalGroup = "239.255.42.95",
+                        IncrementalPort = 30195,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            // ExpireDate well in the future → the sweep must NOT cancel it.
+            int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                - new DateOnly(1970, 1, 1).DayNumber;
+            ushort expireDate = (ushort)(epochDay + 30);
+
+            var newOrder = BuildNewOrderSingleGtd(clOrdId: 12_101, secId: SecId,
+                side: '1', qty: 100, priceMantissa: 123_400, expireDate: expireDate);
+            await stream.WriteAsync(newOrder);
+            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+            host.TriggerDailyReset(reason: "test-gtd-keep");
+
+            // No ER_Cancel should arrive for this order within the window.
+            await Assert.ThrowsAnyAsync<Exception>(async () =>
+                await ReadFrameAsync(stream, TimeSpan.FromMilliseconds(750)));
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Builds a full NewOrderSingle_102 (V2) frame with a GTD
+    /// TimeInForce and the given ExpireDate. BlockLength = 125; no
+    /// var-data trailer (Account/Memo omitted).
+    /// </summary>
+    private static byte[] BuildNewOrderSingleGtd(ulong clOrdId, long secId, char side,
+        long qty, long priceMantissa, ushort expireDate)
+    {
+        const int BlockLength = 125;
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + BlockLength];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: BlockLength, templateId: EntryPointFrameReader.TidNewOrderSingle, version: 2);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)'2';          // OrdType = Limit
+        body[58] = (byte)'6';          // TimeInForce = GTD
+        body[59] = 255;                // Routing = null
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(76, 8), long.MinValue); // StopPx null
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(105, 2), expireDate);
+        return frame;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
@@ -84,12 +84,13 @@ public class GtdExpiryE2ETests
             await client.ConnectAsync(ep.Address, ep.Port);
             var stream = client.GetStream();
 
-            // GTD ExpireDate = today's B3 LocalMktDate (days since epoch).
-            // The host's daily-reset sweep computes the same boundary (UTC,
-            // since cfg.DailyReset is unset) and cancels ExpireDate <= today.
+            // GTD ExpireDate a few days in the past: unambiguously elapsed
+            // regardless of the UTC-vs-local-market-date boundary, so the
+            // daily-reset sweep must cancel it. (A past-dated GTD order is
+            // accepted at entry — the engine is clockless — and swept here.)
             int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
                 - new DateOnly(1970, 1, 1).DayNumber;
-            ushort expireDate = (ushort)epochDay;
+            ushort expireDate = (ushort)(epochDay - 5);
 
             var newOrder = BuildNewOrderSingleGtd(clOrdId: 12_001, secId: SecId,
                 side: '1', qty: 100, priceMantissa: 123_400, expireDate: expireDate);

--- a/tests/B3.Exchange.Matching.Tests/ExtendedTimeInForceTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/ExtendedTimeInForceTests.cs
@@ -5,11 +5,10 @@ using static TestFactory;
 /// <summary>
 /// Issue #202 (gap-functional §9): the engine must accept the full
 /// B3 TimeInForce surface — Day, IOC, FOK, GTC, GTD, AtClose,
-/// GoodForAuction. GTC is currently identical to Day (no daily-reset
-/// operator command exists yet); GTD is rejected with
-/// <see cref="RejectReason.TimeInForceNotSupported"/> until ExpireDate is
-/// plumbed through <see cref="NewOrderCommand"/>; AtClose and
-/// GoodForAuction are gated on the instrument's
+/// GoodForAuction. GTC is currently identical to Day (the daily-reset
+/// operator command exists but GTC is not swept); GTD (GAP-23 / #499)
+/// rests with an <c>ExpireDate</c> and is swept at the end-of-day GTD
+/// boundary; AtClose and GoodForAuction are gated on the instrument's
 /// <see cref="TradingPhase"/> (FinalClosingCall and Reserved
 /// respectively).
 /// </summary>
@@ -28,14 +27,46 @@ public class ExtendedTimeInForceTests
     }
 
     [Fact]
-    public void Gtd_AlwaysRejected_UntilExpireDatePlumbed()
+    public void Gtd_WithExpireDate_RestsLikeDayOrder()
+    {
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtd, Px(10m), 100, 11, 1000)
+        {
+            ExpireDate = 20_000,
+        });
+
+        Assert.Single(sink.Accepted);
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void Gtd_WithoutExpireDate_RejectedAsInvalidField()
     {
         var eng = NewEngine(out var sink);
 
         eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtd, Px(10m), 100, 11, 1000));
 
         var rej = Assert.Single(sink.Rejects);
-        Assert.Equal(RejectReason.TimeInForceNotSupported, rej.Reason);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void NonGtd_WithExpireDate_RejectedAsInvalidField()
+    {
+        // Defense for direct/WAL-replay commands: an ExpireDate is only
+        // meaningful on a GTD order.
+        var eng = NewEngine(out var sink);
+
+        eng.Submit(new NewOrderCommand("o1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000)
+        {
+            ExpireDate = 20_000,
+        });
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
         Assert.Equal(0, eng.OrderCount(PetrSecId));
     }
 

--- a/tests/B3.Exchange.Matching.Tests/GtdExpiryTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/GtdExpiryTests.cs
@@ -1,0 +1,151 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// GAP-23 / issue #499 — Good-Till-Date (GTD) expiry semantics. A resting
+/// GTD order carries a B3 <c>LocalMktDate</c> (<c>ExpireDate</c>, days since
+/// the Unix epoch) and is cancelled by the end-of-trading-day sweep
+/// (<see cref="MatchingEngine.ExpireGtdOrders"/>) when the trading day being
+/// closed is on or after that date. Non-GTD orders are never swept. Replace
+/// resolves the effective expiry from the resting order plus any wire
+/// override.
+/// </summary>
+public class GtdExpiryTests
+{
+    private const ulong Txn = 9_000;
+
+    private static long PlaceGtd(MatchingEngine eng, RecordingSink sink, ushort expireDate,
+        long qty = 100, decimal px = 10m, Side side = Side.Buy, ulong at = 1000)
+    {
+        eng.Submit(new NewOrderCommand("g" + expireDate, PetrSecId, side, OrderType.Limit, TimeInForce.Gtd, Px(px), qty, 11, at)
+        {
+            ExpireDate = expireDate,
+        });
+        return sink.Accepted[^1].OrderId;
+    }
+
+    [Fact]
+    public void ExpireGtdOrders_CancelsOnAndBeforeBoundary_KeepsAfter()
+    {
+        var eng = NewEngine(out var sink);
+        // Three GTD orders at distinct, non-crossing buy prices so they all rest.
+        PlaceGtd(eng, sink, expireDate: 19_999, px: 9.97m); // before boundary -> cancel
+        PlaceGtd(eng, sink, expireDate: 20_000, px: 9.98m); // on boundary     -> cancel
+        PlaceGtd(eng, sink, expireDate: 20_001, px: 9.99m); // after boundary  -> keep
+        Assert.Equal(3, eng.OrderCount(PetrSecId));
+        sink.Clear();
+
+        int cancelled = eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn);
+
+        Assert.Equal(2, cancelled);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+        Assert.All(sink.Canceled, c => Assert.Equal(CancelReason.GtdExpired, c.Reason));
+        Assert.Equal(2, sink.Canceled.Count);
+    }
+
+    [Fact]
+    public void ExpireGtdOrders_DoesNotTouchGtcOrDayOrders()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("day", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.98m), 100, 11, 1000));
+        eng.Submit(new NewOrderCommand("gtc", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(9.99m), 100, 11, 1100));
+        Assert.Equal(2, eng.OrderCount(PetrSecId));
+        sink.Clear();
+
+        int cancelled = eng.ExpireGtdOrders(currentDate: 60_000, txnNanos: Txn);
+
+        Assert.Equal(0, cancelled);
+        Assert.Equal(2, eng.OrderCount(PetrSecId));
+        Assert.Empty(sink.Canceled);
+    }
+
+    [Fact]
+    public void Replace_PriorityKept_PreservesExpireDate()
+    {
+        var eng = NewEngine(out var sink);
+        long oid = PlaceGtd(eng, sink, expireDate: 20_000, qty: 200);
+        sink.Clear();
+
+        // Reduce qty at the same price with no TIF/ExpireDate override:
+        // priority kept, ExpireDate preserved.
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000));
+        Assert.Empty(sink.Rejects);
+
+        Assert.Equal(0, eng.ExpireGtdOrders(currentDate: 19_999, txnNanos: Txn));
+        Assert.Equal(1, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+    }
+
+    [Fact]
+    public void Replace_PriorityKept_AmendsExpireDate()
+    {
+        var eng = NewEngine(out var sink);
+        long oid = PlaceGtd(eng, sink, expireDate: 20_000, qty: 200);
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewExpireDate = 30_000,
+        });
+        Assert.Empty(sink.Rejects);
+
+        // Old boundary no longer cancels; the amended later boundary does.
+        Assert.Equal(0, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+        Assert.Equal(1, eng.ExpireGtdOrders(currentDate: 30_000, txnNanos: Txn));
+    }
+
+    [Fact]
+    public void Replace_DayToGtd_RequiresExpireDate()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("d1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        long oid = sink.Accepted[^1].OrderId;
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewTif = TimeInForce.Gtd,
+        });
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void Replace_DayToGtd_WithExpireDate_RestsAndExpires()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("d1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        long oid = sink.Accepted[^1].OrderId;
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewTif = TimeInForce.Gtd,
+            NewExpireDate = 20_000,
+        });
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+
+        Assert.Equal(1, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+    }
+
+    [Fact]
+    public void Replace_GtdToDay_ClearsExpiryAndIsNotSwept()
+    {
+        var eng = NewEngine(out var sink);
+        long oid = PlaceGtd(eng, sink, expireDate: 20_000, qty: 100);
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewTif = TimeInForce.Day,
+        });
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+
+        // Now a Day order: never swept, even well past the old ExpireDate.
+        Assert.Equal(0, eng.ExpireGtdOrders(currentDate: 60_000, txnNanos: Txn));
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+    }
+}

--- a/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/BinaryChannelStateSnapshotCodecTests.cs
@@ -30,6 +30,13 @@ public class BinaryChannelStateSnapshotCodecTests
                 OrdTagId: 77,
                 Asset: "PETR",
                 InvestorId: new InvestorId(0xABCD, 1_234_567u)),
+            // GAP-23 / #499: exercise the v6 ExpireDate trailer so the
+            // round-trip catches any regression (record equality covers it).
+            new RestingOrderRecord(105, "gtd-1", Side.Buy,
+                PriceMantissa: 249900, RemainingQuantity: 200,
+                EnteringFirm: 7, InsertTimestampNanos: 555_000UL,
+                Tif: TimeInForce.Gtd, MaxFloor: 200, HiddenQuantity: 0,
+                ExpireDate: 20_000),
         };
         var stops = new[]
         {
@@ -128,6 +135,52 @@ public class BinaryChannelStateSnapshotCodecTests
         var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
         var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
         Assert.Null(decoded.Engine.Stops);
+    }
+
+    [Fact]
+    public void Encode_AtV5_OmitsExpireDateTrailer_AndV5DecodeFillsDefaults()
+    {
+        // GAP-23 / #499 backward-compat: a snapshot stamped at Version=5
+        // (the codec's pre-#499 schema) MUST round-trip without the
+        // per-resting-order ExpireDate trailer. Re-decoded ExpireDate
+        // defaults to 0 and the codec re-stamps the loaded snapshot at
+        // CurrentVersion so RestoreChannelState's strict version check
+        // accepts it.
+        var orders = new[]
+        {
+            new RestingOrderRecord(101, "CLI-A", Side.Buy,
+                PriceMantissa: 250000, RemainingQuantity: 100,
+                EnteringFirm: 7, InsertTimestampNanos: 123456789UL,
+                Tif: TimeInForce.Gtc, MaxFloor: 100, HiddenQuantity: 0,
+                OrdTagId: 77,
+                Asset: "PETR",
+                InvestorId: new InvestorId(0xABCD, 1_234_567u),
+                // Would be written under v6 but MUST NOT be on the wire
+                // when Version=5.
+                ExpireDate: 20_000),
+        };
+        var books = new[]
+        {
+            new EngineStateSnapshot.BookSnapshot(999_001, orders),
+        };
+        var engine = new EngineStateSnapshot(
+            NextOrderId: 102, NextTradeId: 1, RptSeq: 0,
+            Phases: Array.Empty<EngineStateSnapshot.PhaseEntry>(),
+            Books: books,
+            Stops: null);
+        var snap = new ChannelStateSnapshot(
+            Version: 5, ChannelNumber: 1, SequenceNumber: 0, SequenceVersion: 0,
+            Engine: engine, Owners: Array.Empty<OrderOwnerSnapshot>());
+
+        var bytes = BinaryChannelStateSnapshotCodec.Encode(snap);
+        var decoded = BinaryChannelStateSnapshotCodec.Decode(bytes);
+
+        Assert.Equal(ChannelStateSnapshot.CurrentVersion, decoded.Version);
+        var roundTripped = Assert.Single(decoded.Engine.Books[0].Orders);
+        Assert.Equal((ushort)0, roundTripped.ExpireDate);
+        // The v5 trailer fields (OrdTagId/Asset/InvestorId) still survive.
+        Assert.Equal((byte)77, roundTripped.OrdTagId);
+        Assert.Equal("PETR", roundTripped.Asset);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/SnapshotMigrationTests.cs
@@ -49,9 +49,9 @@ public class SnapshotMigrationTests
             var p = new FileChannelStatePersister(dir, NullLogger<FileChannelStatePersister>.Instance);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #455: chain now upgrades to v5, the new
-            // CurrentVersion (was v4 in #453).
-            Assert.Equal(5, loaded!.Version);
+            // GAP-23 / #499: chain now upgrades to v6, the new
+            // CurrentVersion (was v5 in #455).
+            Assert.Equal(6, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }
@@ -82,10 +82,10 @@ public class SnapshotMigrationTests
                 migrations: migrations);
             var loaded = p.TryLoad(7);
             Assert.NotNull(loaded);
-            // Issue #455: chain is 0→1 (registered here) followed by
-            // 1→2, 2→3, 3→4, and 4→5 (registered by BuildDefault), so
-            // the loaded version reflects CurrentVersion = 5.
-            Assert.Equal(5, loaded!.Version);
+            // Issue #455 / GAP-23 #499: chain is 0→1 (registered here)
+            // followed by 1→2 … 5→6 (registered by BuildDefault), so the
+            // loaded version reflects CurrentVersion = 6.
+            Assert.Equal(6, loaded!.Version);
         }
         finally { try { Directory.Delete(dir, true); } catch { } }
     }


### PR DESCRIPTION
## Summary

Closes #499 / GAP-23. Plumbs the B3 EntryPoint **ExpireDate**
(`LocalMktDate`, days since the Unix epoch) so the matching engine
accepts **Good-Till-Date (GTD)** orders, rests them, and expires them at
the end-of-trading-day daily-reset boundary. Unblocks #498.

## What changed

- **Wire / decoder** — `NewOrderSingle` enforces GTD↔ExpireDate pairing
  (GTD requires a non-zero ExpireDate; ExpireDate only valid with GTD),
  rejecting violations as BMR-eligible `UnsupportedFeature` rather than
  terminating. `OrderCancelReplace` plumbs ExpireDate as `NewExpireDate`
  and defers validation to the engine (TIF may be omitted/preserved on a
  replace, so the engine is the single validation point).
- **Commands** — `NewOrderCommand.ExpireDate`,
  `ReplaceOrderCommand.NewExpireDate`, `CancelReason.GtdExpired`.
- **Engine** — GTD validation (`InvalidField` when the pairing is
  violated, defending direct/WAL-replay paths), GTD rests like Day/Gtc,
  replace resolves the effective expiry from the resting order + wire
  override, and new `ExpireGtdOrders(currentDate, txn)` cancels resting
  GTD orders whose ExpireDate has elapsed (`<=` the trading day being
  closed — mirrors the option-expiry sweep's on-or-before semantics).
- **Snapshot** — `RestingOrder(Record).ExpireDate`; binary codec
  **v5→v6** trailer (backward-compatible decode defaults v5 to 0); JSON
  **v5→v6** migration.
- **Dispatcher** — `OperatorExpireGtd` work item +
  `EnqueueOperatorExpireGtd`, with a forced post-flush snapshot (operator
  commands are not WAL-logged, same as `ExpireSecurity`).
- **Host** — new `GtdExpirySweeper` fans out one expiry command per
  channel at `TriggerDailyReset` (right after the option sweep, before
  the drain/teardown so each per-order `ER_Cancel` still routes to its
  originating session). "Today" is the B3 local market date in the
  configured daily-reset timezone; the engine stays clockless (ADR 0009).

## Tests

- Decoder: GTD+ExpireDate accepted/plumbed; GTD w/o ExpireDate rejected;
  ExpireDate w/o GTD rejected; replace plumbs / null-preserves NewExpireDate.
- Engine (`GtdExpiryTests`): GTD rests; sweep cancels on/before boundary
  and keeps after; GTC/Day never swept; replace preserves / amends / sets
  / clears ExpireDate across priority-kept and TIF-transition paths.
- Snapshot: binary v6 round-trip + v5-omits-trailer back-compat; JSON
  migration version assertions bumped to 6.
- Host E2E (`GtdExpiryE2ETests`): place a GTD order over the wire, trigger
  the daily reset, assert ER_Cancel for an elapsed ExpireDate and no
  cancel for a future one.

Full `-c Release` build (warnings-as-errors), test suite, and
`dotnet format --verify-no-changes` are green.

## Known limitation / follow-up

A stale **past-dated** ExpireDate is accepted at entry (the engine is
clockless) and swept at the next daily reset. Worth a small follow-up
issue if entry-time rejection is desired.