### PR TITLE
Daily GTC/GTD restatement at session boundary (#498/GAP-26)

### DIFF
--- a/src/B3.Exchange.Contracts/Ports.cs
+++ b/src/B3.Exchange.Contracts/Ports.cs
@@ -74,6 +74,22 @@ public interface ICoreOutbound
 
     bool WriteExecutionReportReject(SessionId session, in MatchingRejectEvent e, ulong clOrdIdValue,
         DurabilityHandle durability = default);
+
+    /// <summary>
+    /// GAP-26 / issue #498: routes a private daily Good-Till restatement
+    /// <c>ExecutionReport_Modify</c> (OrdStatus=RESTATED,
+    /// ExecRestatementReason=GT_RESTATEMENT) for the owner of the surviving
+    /// GTC / unexpired-GTD order to <paramref name="ownerSession"/>. The Core
+    /// resolves the owner on the dispatch thread (read-only — the order stays
+    /// on the book) and passes <paramref name="ownerClOrdId"/> as the wire
+    /// ClOrdID. No UMDF frame, RptSeq advance, or registry mutation
+    /// accompanies a restatement.
+    ///
+    /// <para>Default no-op (returns <c>false</c>) so legacy fakes compile
+    /// unchanged; the Gateway overrides it.</para>
+    /// </summary>
+    bool WriteExecutionReportRestate(SessionId ownerSession, ulong ownerClOrdId,
+        in OrderRestatedEvent e, DurabilityHandle durability = default) => false;
 }
 
 /// <summary>

--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -100,6 +100,14 @@ public sealed partial class ChannelDispatcher
             item.ExpireCompletion?.TrySetException(
                 new InvalidOperationException(
                     $"channel {ChannelNumber} WAL-halted; ExpireSecurity rejected"));
+            // GAP-23 (#499) / GAP-26 (#498): GTD-expiry and GT-restatement
+            // sweeps await their completions too.
+            item.ExpireGtdCompletion?.TrySetException(
+                new InvalidOperationException(
+                    $"channel {ChannelNumber} WAL-halted; ExpireGtd rejected"));
+            item.RestateGtCompletion?.TrySetException(
+                new InvalidOperationException(
+                    $"channel {ChannelNumber} WAL-halted; RestateGt rejected"));
             return;
         }
 
@@ -186,6 +194,17 @@ public sealed partial class ChannelDispatcher
             // consumed by the per-order ER_Cancel frames survive a restart.
             // Operator commands are not WAL-logged; the forced snapshot is
             // the durability boundary — mirrors the ExpireSecurity path.
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorRestateGt)
+        {
+            ProcessRestateGt(item.RestateGt!, item.RestateGtCompletion);
+            // GAP-26 (#498): a restatement does not mutate engine state (no
+            // book change, no RptSeq advance), so the forced snapshot is a
+            // no-op delta. We still force-persist to keep the operator-command
+            // durability contract uniform with the sibling sweeps above.
             OnAfterCommandFlushed(force: true);
             return;
         }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -758,4 +758,58 @@ public sealed partial class ChannelDispatcher
             throw;
         }
     }
+
+    /// <summary>
+    /// GAP-26 / issue #498: enqueue a daily Good-Till restatement sweep for
+    /// the trading day being closed (<paramref name="currentDate"/>, a B3
+    /// <c>LocalMktDate</c> = days since the Unix epoch). On the dispatch
+    /// thread the engine emits a private restatement
+    /// <c>ExecutionReport_Modify</c> (OrdStatus=RESTATED,
+    /// ExecRestatementReason=GT_RESTATEMENT) for every surviving GTC order
+    /// and every GTD order whose <c>ExpireDate</c> is strictly after
+    /// <paramref name="currentDate"/>, routed back to the owning session via
+    /// the <c>OnOrderRestated</c> sink path. The book is unchanged: no UMDF
+    /// frame, no <c>RptSeq</c> advance, no phase change. Idempotent and safe
+    /// to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorRestateGt(ushort currentDate,
+        TaskCompletionSource<RestateGtOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorRestateGt))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; RestateGt rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorRestateGt, default, 0, false,
+            0, 0, null, null, null, null,
+            RestateGt: new OperatorRestateGt(currentDate),
+            RestateGtCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; RestateGt rejected"));
+        return false;
+    }
+
+    private void ProcessRestateGt(OperatorRestateGt op,
+        TaskCompletionSource<RestateGtOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _packetWritten = 0;
+        try
+        {
+            int restated = _engine.RestateGtOrders(op.CurrentDate, _timeSource.NowNanos());
+            // Restatement emits no UMDF frames (the book is unchanged), so
+            // _packetWritten stays 0; the guard mirrors the sibling sweeps.
+            if (_packetWritten > 0) FlushPacket();
+            completion?.TrySetResult(new RestateGtOutcome(restated));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -261,6 +261,21 @@ public sealed partial class ChannelDispatcher
         }
     }
 
+    public void OnOrderRestated(in OrderRestatedEvent e)
+    {
+        AssertOnLoopThread();
+        // GAP-26 / issue #498: a daily Good-Till restatement is a private
+        // notification to the owning session only. The order stays on the
+        // book unchanged, so we emit NO UMDF frame, consume NO RptSeq, and
+        // do NOT evict the registry entry or decrement the firm's open-order
+        // count (TryResolve is read-only, unlike OnOrderCanceled's TryEvict).
+        if (_orders.TryResolve(e.OrderId, out var owner))
+        {
+            _outbound.WriteExecutionReportRestate(owner.Session, owner.ClOrdId, e, CurrentDurability);
+            _metrics?.IncExecutionReport(ExecutionReportKind.Replace);
+        }
+    }
+
     public void OnOrderFilled(in OrderFilledEvent e)
     {
         AssertOnLoopThread();

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -11,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity, OperatorExpireGtd }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity, OperatorExpireGtd, OperatorRestateGt }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -43,6 +43,7 @@ public sealed partial class ChannelDispatcher
         "ShutdownBarrier",
         "OperatorExpireSecurity",
         "OperatorExpireGtd",
+        "OperatorRestateGt",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -78,6 +79,8 @@ public sealed partial class ChannelDispatcher
         TaskCompletionSource<ExpireSecurityOutcome>? ExpireCompletion = null,
         OperatorExpireGtd? ExpireGtd = null,
         TaskCompletionSource<ExpireGtdOutcome>? ExpireGtdCompletion = null,
+        OperatorRestateGt? RestateGt = null,
+        TaskCompletionSource<RestateGtOutcome>? RestateGtCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -164,6 +167,21 @@ public sealed partial class ChannelDispatcher
     /// ExpireDate).
     /// </summary>
     public readonly record struct ExpireGtdOutcome(int CancelledOrderCount);
+
+    /// <summary>
+    /// GAP-26 / issue #498: payload for the daily Good-Till restatement sweep.
+    /// On the dispatch thread the engine emits a private restatement ER for
+    /// every surviving GTC order and every GTD order whose <c>ExpireDate</c>
+    /// is strictly after <see cref="CurrentDate"/> (a B3 <c>LocalMktDate</c>).
+    /// The book is not mutated; no trading phase changes.
+    /// </summary>
+    internal sealed record OperatorRestateGt(ushort CurrentDate);
+
+    /// <summary>
+    /// GAP-26 / issue #498: outcome of a Good-Till restatement sweep — how
+    /// many surviving GTC / unexpired-GTD orders were restated.
+    /// </summary>
+    public readonly record struct RestateGtOutcome(int RestatedOrderCount);
 
     /// <summary>
     /// ADR 0008 PR-2: operator bust request payload (post-trade audit

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -260,6 +260,7 @@ internal static class ExecutionReportEncoder
         Matching.Side side, ulong clOrdIdValue, long orderId,
         long securityId, ulong execId, ulong transactTimeNanos,
         long openQty, long priceMantissa, Matching.TimeInForce tif, ushort expireDate,
+        Matching.OrderType ordType = Matching.OrderType.Limit, long stopPxMantissa = 0,
         ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue,
         Matching.InvestorId? investorId = null)
     {
@@ -286,12 +287,15 @@ internal static class ExecutionReportEncoder
         MemoryMarshal.Write(body.Slice(96, 8), in clOrdIdValue);           // OrigClOrdID echoes the order's own ClOrdID
         long nullPx = PriceNullMantissa;
         MemoryMarshal.Write(body.Slice(104, 8), in nullPx);                 // ProtectionPrice
-        body[116] = OrdTypeLimit;
+        body[116] = EncodeOrdType(ordType);                                 // echo real OrdType (Limit / Stop / StopLimit)
         body[117] = EncodeTif(tif);                                         // echo real TIF (GTC / GTD)
         MemoryMarshal.Write(body.Slice(118, 2), in expireDate);            // ExpireDate (0 = null for GTC)
         MemoryMarshal.Write(body.Slice(120, 8), in openQty);               // OrderQty == LeavesQty on the new day
-        MemoryMarshal.Write(body.Slice(128, 8), in priceMantissa);
-        MemoryMarshal.Write(body.Slice(136, 8), in nullPx);                 // StopPx
+        // StopLoss carries no resting limit price (Market on trigger) → null.
+        long priceToWrite = ordType == Matching.OrderType.StopLoss ? nullPx : priceMantissa;
+        MemoryMarshal.Write(body.Slice(128, 8), in priceToWrite);
+        long stopToWrite = stopPxMantissa != 0 ? stopPxMantissa : nullPx;
+        MemoryMarshal.Write(body.Slice(136, 8), in stopToWrite);           // StopPx (null for non-stop orders)
         MemoryMarshal.Write(body.Slice(160, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
         if (investorId is { } iv)
         {

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -85,6 +85,7 @@ internal static class ExecutionReportEncoder
     private const byte OrdStatusFilled = (byte)'2';
     private const byte OrdStatusCanceled = (byte)'4';
     private const byte OrdStatusReplaced = (byte)'5';
+    private const byte OrdStatusRestated = (byte)'R';
     private const byte OrdStatusRejected = (byte)'8';
     private const byte OrdTypeMarket = (byte)'1';
     private const byte OrdTypeLimit = (byte)'2';
@@ -99,6 +100,11 @@ internal static class ExecutionReportEncoder
     private const byte TifAtClose = (byte)'7';
     private const byte TifGoodForAuction = (byte)'A';
     private const byte ExecTypeTrade = (byte)'F';
+
+    /// <summary>GAP-26 / issue #498: ExecRestatementReason = GT_RESTATEMENT.
+    /// Carried at body offset 179 on the V6 ER_Modify block (where the null
+    /// sentinel is 255).</summary>
+    private const byte ExecRestatementReasonGtRestatement = 1;
 
     private static byte EncodeSide(Matching.Side s) => s == Matching.Side.Buy ? SideBuy : SideSell;
     private static byte EncodeOrdType(Matching.OrderType t) => t switch
@@ -231,6 +237,71 @@ internal static class ExecutionReportEncoder
         body[179] = 255;                                                    // ExecRestatementReason null
         // strategyID@180 (int, null=0) and tradingSubAccount@184 (uint,
         // null=0) covered by body.Clear() above.
+        return WriteMemoTrailer(dst, ExecReportModifyBlock, memo);
+    }
+
+    /// <summary>
+    /// GAP-26 / issue #498: encodes a daily Good-Till restatement
+    /// <c>ExecutionReport_Modify</c> (template 201) for a surviving GTC /
+    /// unexpired-GTD order at the session boundary. Distinct from
+    /// <see cref="EncodeExecReportModify"/> (which hard-codes
+    /// <c>OrdStatus=REPLACED</c> + <c>TimeInForce=Day</c>): a restatement sets
+    /// <c>OrdStatus=RESTATED('R')</c>, <c>ExecRestatementReason=GT_RESTATEMENT</c>
+    /// at body[179], echoes the order's real <c>TimeInForce</c> and (for GTD)
+    /// its <c>ExpireDate</c>, and reports the new-trading-day quantities
+    /// (<c>CumQty=0</c>, <c>LeavesQty == OrderQty == openQty</c>).
+    /// <c>OrigClOrdID</c> echoes the order's own <c>ClOrdID</c> (no client
+    /// request drives a restatement). <paramref name="execId"/> is the
+    /// engine <c>OrderID</c> — unique per instrument — because a restatement
+    /// consumes no <c>RptSeq</c>.
+    /// </summary>
+    public static int EncodeExecReportRestate(Span<byte> dst,
+        uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,
+        Matching.Side side, ulong clOrdIdValue, long orderId,
+        long securityId, ulong execId, ulong transactTimeNanos,
+        long openQty, long priceMantissa, Matching.TimeInForce tif, ushort expireDate,
+        ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue,
+        Matching.InvestorId? investorId = null)
+    {
+        int total = TotalSize(ExecReportModifyBlock, memo.Length);
+        if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Restate", nameof(dst));
+        EntryPointFrameReader.WriteHeader(dst, messageLength: (ushort)total,
+            ExecReportModifyBlock, EntryPointFrameReader.TidExecutionReportModify, version: 6);
+        var body = dst.Slice(HeaderSize, ExecReportModifyBlock);
+        body.Clear();
+        WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
+        body[18] = EncodeSide(side);
+        body[19] = OrdStatusRestated;
+        MemoryMarshal.Write(body.Slice(20, 8), in clOrdIdValue);
+        MemoryMarshal.Write(body.Slice(28, 8), in orderId);                 // SecondaryOrderID = engine OrderID
+        MemoryMarshal.Write(body.Slice(36, 8), in securityId);
+        MemoryMarshal.Write(body.Slice(44, 8), in openQty);                 // overlap SecExchange — LeavesQty
+        MemoryMarshal.Write(body.Slice(56, 8), in execId);
+        MemoryMarshal.Write(body.Slice(64, 8), in transactTimeNanos);
+        long cumQty = 0;                                                    // new trading day: nothing executed yet
+        MemoryMarshal.Write(body.Slice(72, 8), in cumQty);
+        ulong nullTs = UTCTimestampNullValue;
+        MemoryMarshal.Write(body.Slice(80, 8), in nullTs);                  // MarketSegmentReceivedTime
+        MemoryMarshal.Write(body.Slice(88, 8), in orderId);
+        MemoryMarshal.Write(body.Slice(96, 8), in clOrdIdValue);           // OrigClOrdID echoes the order's own ClOrdID
+        long nullPx = PriceNullMantissa;
+        MemoryMarshal.Write(body.Slice(104, 8), in nullPx);                 // ProtectionPrice
+        body[116] = OrdTypeLimit;
+        body[117] = EncodeTif(tif);                                         // echo real TIF (GTC / GTD)
+        MemoryMarshal.Write(body.Slice(118, 2), in expireDate);            // ExpireDate (0 = null for GTC)
+        MemoryMarshal.Write(body.Slice(120, 8), in openQty);               // OrderQty == LeavesQty on the new day
+        MemoryMarshal.Write(body.Slice(128, 8), in priceMantissa);
+        MemoryMarshal.Write(body.Slice(136, 8), in nullPx);                 // StopPx
+        MemoryMarshal.Write(body.Slice(160, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
+        if (investorId is { } iv)
+        {
+            ushort prefix = iv.Prefix;
+            uint document = iv.Document;
+            MemoryMarshal.Write(body.Slice(172, 2), in prefix);
+            MemoryMarshal.Write(body.Slice(174, 4), in document);
+        }
+        body[178] = 255;                                                    // MmProtectionReset null
+        body[179] = ExecRestatementReasonGtRestatement;                     // ExecRestatementReason = GT_RESTATEMENT
         return WriteMemoTrailer(dst, ExecReportModifyBlock, memo);
     }
 

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -197,6 +197,7 @@ internal sealed class FixpOutboundEncoder
                     e.SecurityId, (ulong)e.OrderId, e.TransactTimeNanos,
                     openQty: e.OpenQuantity, priceMantissa: e.PriceMantissa,
                     tif: e.Tif, expireDate: e.ExpireDate,
+                    ordType: e.OrdType, stopPxMantissa: e.StopPxMantissa,
                     memo: memo.Span, investorId: e.InvestorId);
                 return AppendAndEnqueueLocked(exact, durability);
             }

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -177,6 +177,37 @@ internal sealed class FixpOutboundEncoder
     }
 
     /// <summary>
+    /// GAP-26 / issue #498: encodes and enqueues a private daily Good-Till
+    /// restatement <c>ExecutionReport_Modify</c> for a surviving order. The
+    /// engine <c>OrderID</c> doubles as the per-instrument <c>ExecID</c>
+    /// (a restatement consumes no <c>RptSeq</c>).
+    /// </summary>
+    public bool WriteExecutionReportRestate(in OrderRestatedEvent e, ulong ownerClOrdId,
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
+    {
+        if (!_isOpen()) return false;
+        var exact = PooledOutboundFrame.Rent(ExecutionReportEncoder.TotalSize(ExecutionReportEncoder.ExecReportModifyBlock, memo.Length));
+        try
+        {
+            lock (_outboundLock)
+            {
+                ExecutionReportEncoder.EncodeExecReportRestate(exact.Span,
+                    _sessionId(), _nextMsgSeqNum(), e.TransactTimeNanos,
+                    e.Side, ownerClOrdId, e.OrderId,
+                    e.SecurityId, (ulong)e.OrderId, e.TransactTimeNanos,
+                    openQty: e.OpenQuantity, priceMantissa: e.PriceMantissa,
+                    tif: e.Tif, expireDate: e.ExpireDate,
+                    memo: memo.Span, investorId: e.InvestorId);
+                return AppendAndEnqueueLocked(exact, durability);
+            }
+        }
+        finally
+        {
+            exact.Release();
+        }
+    }
+
+    /// <summary>
     /// Encodes and enqueues an <c>OrderMassActionReport</c> (template 702,
     /// spec §4.8 / #GAP-19) acknowledging — or rejecting — an inbound
     /// <c>OrderMassActionRequest</c>.

--- a/src/B3.Exchange.Gateway/FixpSession.cs
+++ b/src/B3.Exchange.Gateway/FixpSession.cs
@@ -620,6 +620,10 @@ public sealed partial class FixpSession : IAsyncDisposable
         => _outboundEncoder.WriteExecutionReportModify(securityId, orderId, clOrdIdValue, origClOrdIdValue,
             side, newPriceMantissa, newRemainingQty, transactTimeNanos, rptSeq, receivedTimeNanos, durability, memo, investorId);
 
+    public bool WriteExecutionReportRestate(in B3.Exchange.Matching.OrderRestatedEvent e, ulong ownerClOrdId,
+        DurabilityHandle durability = default, ReadOnlyMemory<byte> memo = default)
+        => _outboundEncoder.WriteExecutionReportRestate(e, ownerClOrdId, durability, memo);
+
     /// <summary>
     /// Encodes and enqueues an <c>OrderMassActionReport</c> (template 702,
     /// spec §4.8 / #GAP-19) acknowledging — or rejecting — an inbound

--- a/src/B3.Exchange.Gateway/GatewayRouter.cs
+++ b/src/B3.Exchange.Gateway/GatewayRouter.cs
@@ -100,6 +100,14 @@ public sealed class GatewayRouter : ICoreOutbound
         return s.WriteExecutionReportReject(e, clOrdIdValue, durability, e.Memo ?? ReadOnlyMemory<byte>.Empty);
     }
 
+    public bool WriteExecutionReportRestate(ContractsSessionId ownerSession, ulong ownerClOrdId,
+        in OrderRestatedEvent e, DurabilityHandle durability = default)
+    {
+        if (!_registry.TryGet(ownerSession, out var s)) { LogMiss(ownerSession, "ExecReportRestate"); return false; }
+        return s.WriteExecutionReportRestate(e, ownerClOrdId, durability,
+            e.Memo ?? ReadOnlyMemory<byte>.Empty);
+    }
+
     private void LogMiss(ContractsSessionId session, string kind)
     {
         // Common at session-close races; keep at trace so /metrics doesn't

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -52,6 +52,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private PhaseScheduler? _phaseScheduler;
     private OptionExpirySweeper? _optionExpirySweeper;
     private GtdExpirySweeper? _gtdExpirySweeper;
+    private GtRestatementSweeper? _gtRestatementSweeper;
     private readonly List<B3.Exchange.Persistence.DataDirLock> _dataDirLocks = new();
     private B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal? _outboundJournal;
     private B3.Exchange.Gateway.Persistence.FileFixpSessionStatePersister? _statePersister;
@@ -107,6 +108,15 @@ public sealed class ExchangeHost : IAsyncDisposable
         // here); waits on per-channel completions so the cancels reach the
         // outbound encoder before DrainAllSessionsOutbound + TerminateAllSessions.
         _gtdExpirySweeper?.Sweep(reason, waitTimeout: TimeSpan.FromSeconds(15));
+        // GAP-26 / #498: restate every surviving GTC / unexpired-GTD order
+        // BEFORE the listener tears down, so the private restatement
+        // ER_Modify (OrdStatus=RESTATED, ExecRestatementReason=GT_RESTATEMENT)
+        // reaches its originating session. Runs AFTER the GTD-expiry sweep so
+        // past-date GTD orders are already cancelled and not restated. The
+        // book is unchanged, so this never emits UMDF; waits on per-channel
+        // completions so the ERs reach the outbound encoder before
+        // DrainAllSessionsOutbound + TerminateAllSessions.
+        _gtRestatementSweeper?.Sweep(reason, waitTimeout: TimeSpan.FromSeconds(15));
         // Issue #487: drain outbound queues BEFORE closing sockets.
         // ER_Cancel frames from the sweep are enqueued to the session's
         // send queue but may not have been written to the socket yet.
@@ -563,6 +573,13 @@ public sealed class ExchangeHost : IAsyncDisposable
             _gtdExpirySweeper = new GtdExpirySweeper(
                 _dispatchers,
                 _loggerFactory.CreateLogger<GtdExpirySweeper>(),
+                todayProvider);
+            // GAP-26 / #498: the restatement sweeper shares the same
+            // timezone-aware "today" provider — both interpret the B3 local
+            // market date in the configured daily-reset timezone.
+            _gtRestatementSweeper = new GtRestatementSweeper(
+                _dispatchers,
+                _loggerFactory.CreateLogger<GtRestatementSweeper>(),
                 todayProvider);
         }
         var listenEp = ParseEndpoint(_config.Tcp.Listen);

--- a/src/B3.Exchange.Host/GtRestatementSweeper.cs
+++ b/src/B3.Exchange.Host/GtRestatementSweeper.cs
@@ -1,0 +1,149 @@
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// GAP-26 / issue #498 — daily Good-Till (GTC / unexpired-GTD) restatement
+/// sweep at the trading-day boundary.
+///
+/// <para>At each daily reset the host enqueues one
+/// <c>EnqueueOperatorRestateGt</c> command per channel dispatcher carrying
+/// the trading day being closed as a B3 <c>LocalMktDate</c> (days since the
+/// Unix epoch). On the dispatch thread the engine emits a private
+/// <c>ExecutionReport_Modify</c> (<c>OrdStatus=RESTATED</c>,
+/// <c>ExecRestatementReason=GT_RESTATEMENT</c>) for every surviving GTC order
+/// and every GTD order whose <c>ExpireDate</c> is strictly after that date,
+/// routed back to the originating session. Unlike the GTD-expiry sweep the
+/// book is unchanged — there is no UMDF frame and no <c>RptSeq</c> advance
+/// (ADR 0009).</para>
+///
+/// <para>Like <see cref="GtdExpirySweeper"/> the sweeper owns no timer: it is
+/// invoked from <c>ExchangeHost.TriggerDailyReset</c> after the GTD-expiry
+/// sweep but before the listener is torn down, so each restatement ER still
+/// routes to its originating session. The boundary "today" is computed in the
+/// configured daily-reset timezone (defaults to <c>America/Sao_Paulo</c>); the
+/// engine itself stays clockless, receiving the date as a command argument.</para>
+/// </summary>
+public sealed class GtRestatementSweeper
+{
+    /// <summary>1970-01-01 expressed as a <see cref="DateOnly.DayNumber"/>,
+    /// used to convert a calendar date to the wire's days-since-epoch
+    /// <c>LocalMktDate</c>.</summary>
+    private static readonly int UnixEpochDayNumber = new DateOnly(1970, 1, 1).DayNumber;
+
+    private readonly IReadOnlyList<ChannelDispatcher> _dispatchers;
+    private readonly ILogger<GtRestatementSweeper> _logger;
+    private readonly Func<DateOnly> _todayLocal;
+
+    public GtRestatementSweeper(IReadOnlyList<ChannelDispatcher> dispatchers,
+        ILogger<GtRestatementSweeper> logger,
+        Func<DateOnly> todayLocal)
+    {
+        ArgumentNullException.ThrowIfNull(dispatchers);
+        ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(todayLocal);
+        _dispatchers = dispatchers;
+        _logger = logger;
+        _todayLocal = todayLocal;
+    }
+
+    /// <summary>
+    /// Enqueues a Good-Till restatement sweep on every channel for the trading
+    /// day being closed.
+    ///
+    /// <para>When <paramref name="waitTimeout"/> is provided (default 5s) the
+    /// call blocks until every enqueued sweep has finished on its dispatch
+    /// thread — required from <c>TriggerDailyReset</c> so the gateway can
+    /// flush the restatement ERs before <c>TerminateAllSessions</c> tears down
+    /// the response channels. Pass <see cref="TimeSpan.Zero"/> to fire and
+    /// forget.</para>
+    ///
+    /// <para>Returns the total number of orders restated across all channels.
+    /// Per-channel enqueue failures are logged at warn level and do not abort
+    /// the sweep.</para>
+    /// </summary>
+    public int Sweep(string trigger, TimeSpan? waitTimeout = null)
+    {
+        if (_dispatchers.Count == 0) return 0;
+        var today = _todayLocal();
+        int dayNumber = today.DayNumber - UnixEpochDayNumber;
+        if (dayNumber < 0 || dayNumber > ushort.MaxValue)
+        {
+            _logger.LogError(
+                "GT restatement sweep ({Trigger}): local market date {Today} is outside the LocalMktDate range; skipping",
+                trigger, today);
+            return 0;
+        }
+        ushort currentDate = (ushort)dayNumber;
+
+        var pending = waitTimeout is { } t && t > TimeSpan.Zero
+            ? new List<Task<ChannelDispatcher.RestateGtOutcome>>()
+            : null;
+        int enqueued = 0;
+        int rejected = 0;
+        foreach (var dispatcher in _dispatchers)
+        {
+            var completion = pending is null
+                ? null
+                : new TaskCompletionSource<ChannelDispatcher.RestateGtOutcome>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            bool ok;
+            try
+            {
+                ok = dispatcher.EnqueueOperatorRestateGt(currentDate, completion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "GT restatement sweep ({Trigger}): enqueue threw channel={Channel}",
+                    trigger, dispatcher.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            if (!ok)
+            {
+                _logger.LogWarning(
+                    "GT restatement sweep ({Trigger}): enqueue rejected channel={Channel}",
+                    trigger, dispatcher.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            enqueued++;
+            if (completion != null) pending!.Add(completion.Task);
+        }
+
+        int restated = 0;
+        if (pending is { Count: > 0 })
+        {
+            bool completedInTime;
+            try
+            {
+                completedInTime = Task.WaitAll(pending.ToArray(), waitTimeout!.Value);
+            }
+            catch (AggregateException ex)
+            {
+                completedInTime = pending.TrueForAll(t => t.IsCompleted);
+                _logger.LogWarning(ex,
+                    "GT restatement sweep ({Trigger}): one or more RestateGt completions faulted",
+                    trigger);
+            }
+            foreach (var task in pending)
+            {
+                if (task.IsCompletedSuccessfully) restated += task.Result.RestatedOrderCount;
+            }
+            if (!completedInTime)
+            {
+                int incomplete = pending.Count(t => !t.IsCompleted);
+                _logger.LogError(
+                    "GT restatement sweep ({Trigger}): timed out after {TimeoutMs}ms with {Incomplete} of {Enqueued} RestateGt completions still pending — TerminateAllSessions may close sessions before the restatement ER reaches the wire",
+                    trigger, (int)waitTimeout!.Value.TotalMilliseconds, incomplete, enqueued);
+            }
+        }
+
+        _logger.LogInformation(
+            "GT restatement sweep ({Trigger}): channels={ChannelCount} enqueued={Enqueued} rejected={Rejected} restated={Restated} currentDate={CurrentDate} today={Today}",
+            trigger, _dispatchers.Count, enqueued, rejected, restated, currentDate, today);
+        return restated;
+    }
+}

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -322,6 +322,34 @@ public readonly record struct OrderModifiedEvent(
     InvestorId? InvestorId = null);
 
 /// <summary>
+/// GAP-26 / issue #498: fired once per surviving Good-Till (GTC or
+/// unexpired GTD) resting order at the daily session boundary, so the
+/// owning client is told its order carries into the new trading day. The
+/// integration layer translates this into a private
+/// <c>ExecutionReport_Modify</c> with <c>OrdStatus=RESTATED</c> and
+/// <c>ExecRestatementReason=GT_RESTATEMENT</c> back to the originating
+/// session.
+///
+/// <para>The book is <em>unchanged</em> by a restatement — there is no
+/// UMDF frame, no <c>RptSeq</c> advance, and no registry eviction. On the
+/// new trading day the order's cumulative executed quantity resets, so the
+/// wire <c>CumQty</c> is 0 and <c>OrderQty == LeavesQty ==</c>
+/// <see cref="OpenQuantity"/> (the engine's remaining open quantity,
+/// iceberg-aware: displayed + hidden).</para>
+/// </summary>
+public readonly record struct OrderRestatedEvent(
+    long SecurityId,
+    long OrderId,
+    Side Side,
+    long PriceMantissa,
+    long OpenQuantity,
+    TimeInForce Tif,
+    ushort ExpireDate,
+    ulong TransactTimeNanos,
+    byte[]? Memo = null,
+    InvestorId? InvestorId = null);
+
+/// <summary>
 /// Fired when an instrument is placed into administrative halt via
 /// <see cref="MatchingEngine.HaltInstrument"/> (issue #322). The
 /// integration layer translates this to a UMDF
@@ -372,6 +400,16 @@ public interface IMatchingEventSink
     /// unchanged. Issue #251.
     /// </summary>
     void OnOrderModified(in OrderModifiedEvent e) { }
+
+    /// <summary>
+    /// Optional event emitted once per surviving Good-Till order at the daily
+    /// session boundary (GAP-26 / issue #498) to drive the private
+    /// restatement <c>ExecutionReport_Modify</c>. Default no-op so legacy
+    /// sinks compile; the production <c>ChannelDispatcher</c> overrides it to
+    /// route the restatement ER to the owning session without touching the
+    /// book or the UMDF feed.
+    /// </summary>
+    void OnOrderRestated(in OrderRestatedEvent e) { }
 
     /// <summary>
     /// Optional summary event emitted once per (SecurityId, Side) at the

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -346,6 +346,8 @@ public readonly record struct OrderRestatedEvent(
     TimeInForce Tif,
     ushort ExpireDate,
     ulong TransactTimeNanos,
+    OrderType OrdType = OrderType.Limit,
+    long StopPxMantissa = 0,
     byte[]? Memo = null,
     InvestorId? InvestorId = null);
 

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -1136,16 +1136,18 @@ public sealed class MatchingEngine
     /// every surviving resting GTC order and every unexpired GTD order
     /// (<c>ExpireDate &gt; <paramref name="currentDate"/></c>, a B3
     /// <c>LocalMktDate</c> = days since the Unix epoch) across the channel's
-    /// books. Past-or-equal-date GTD orders are intentionally skipped here —
+    /// books, plus every parked GTC stop order (stops are off-book and only
+    /// accept Day or GTC, so an unexpired-GTD stop cannot exist). Past-or-equal
+    /// date GTD orders are intentionally skipped here —
     /// <see cref="ExpireGtdOrders"/> runs first at the boundary and cancels
     /// them, so restating one would contradict its <c>ER_Cancel</c>. The
     /// engine stays clockless (ADR 0009): the boundary date is an explicit
     /// argument.
     ///
-    /// <para>A restatement does <em>not</em> mutate the book: no order is
-    /// removed, no price level changes, and no <c>RptSeq</c> is consumed. It
-    /// is a private notification to the owning session only. Returns the
-    /// number of orders restated.</para>
+    /// <para>A restatement does <em>not</em> mutate the book or the stop
+    /// collections: no order is removed, no price level changes, and no
+    /// <c>RptSeq</c> is consumed. It is a private notification to the owning
+    /// session only. Returns the number of orders restated.</para>
     /// </summary>
     public int RestateGtOrders(ushort currentDate, ulong txnNanos)
     {
@@ -1181,8 +1183,38 @@ public sealed class MatchingEngine
                         Tif: resting.Tif,
                         ExpireDate: resting.ExpireDate,
                         TransactTimeNanos: txnNanos,
+                        OrdType: OrderType.Limit,
+                        StopPxMantissa: 0,
                         Memo: resting.Memo,
                         InvestorId: resting.InvestorId));
+                    restated++;
+                }
+            }
+
+            // Parked GTC stop / stop-limit orders survive the day off-book and
+            // must be restated too (#507 review). Iterating _stopsBySymbol is
+            // read-only — restatement never triggers, cancels, or re-parks.
+            foreach (var bucket in _stopsBySymbol.Values)
+            {
+                foreach (var stop in bucket)
+                {
+                    if (stop.Tif != TimeInForce.Gtc) continue;
+                    bool isStopLoss = stop.StopType == OrderType.StopLoss;
+                    _sink.OnOrderRestated(new OrderRestatedEvent(
+                        SecurityId: stop.SecurityId,
+                        OrderId: stop.OrderId,
+                        // StopLoss has no resting limit price (it becomes a
+                        // Market on trigger); StopLimit echoes its limit price.
+                        PriceMantissa: isStopLoss ? 0 : stop.LimitPriceMantissa,
+                        Side: stop.Side,
+                        OpenQuantity: stop.Quantity,
+                        Tif: stop.Tif,
+                        ExpireDate: 0,
+                        TransactTimeNanos: txnNanos,
+                        OrdType: stop.StopType,
+                        StopPxMantissa: stop.StopPxMantissa,
+                        Memo: stop.Memo,
+                        InvestorId: stop.InvestorId));
                     restated++;
                 }
             }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -1131,6 +1131,66 @@ public sealed class MatchingEngine
         finally { ExitDispatch(); }
     }
 
+    /// <summary>
+    /// GAP-26 / issue #498: emits a daily Good-Till restatement event for
+    /// every surviving resting GTC order and every unexpired GTD order
+    /// (<c>ExpireDate &gt; <paramref name="currentDate"/></c>, a B3
+    /// <c>LocalMktDate</c> = days since the Unix epoch) across the channel's
+    /// books. Past-or-equal-date GTD orders are intentionally skipped here —
+    /// <see cref="ExpireGtdOrders"/> runs first at the boundary and cancels
+    /// them, so restating one would contradict its <c>ER_Cancel</c>. The
+    /// engine stays clockless (ADR 0009): the boundary date is an explicit
+    /// argument.
+    ///
+    /// <para>A restatement does <em>not</em> mutate the book: no order is
+    /// removed, no price level changes, and no <c>RptSeq</c> is consumed. It
+    /// is a private notification to the owning session only. Returns the
+    /// number of orders restated.</para>
+    /// </summary>
+    public int RestateGtOrders(ushort currentDate, ulong txnNanos)
+    {
+        EnterDispatch();
+        try
+        {
+            int restated = 0;
+            foreach (var book in _booksById.Values)
+            {
+                // SnapshotOrders() copies into the book's scratch buffer.
+                // Restatement is read-only (no book mutation), so the
+                // snapshot is purely defensive — it mirrors ExpireGtdOrders
+                // and keeps the iteration robust if the sink ever grows a
+                // side-effect.
+                foreach (var resting in book.SnapshotOrders())
+                {
+                    bool isGtc = resting.Tif == TimeInForce.Gtc;
+                    bool isUnexpiredGtd = resting.Tif == TimeInForce.Gtd
+                        && resting.ExpireDate != 0
+                        && resting.ExpireDate > currentDate;
+                    if (!isGtc && !isUnexpiredGtd) continue;
+
+                    // New trading day: cumulative executed qty resets, so the
+                    // open quantity (displayed + hidden for icebergs) is both
+                    // the leaves and the order quantity on the restatement.
+                    long open = resting.RemainingQuantity + resting.HiddenQuantity;
+                    _sink.OnOrderRestated(new OrderRestatedEvent(
+                        SecurityId: book.SecurityId,
+                        OrderId: resting.OrderId,
+                        Side: resting.Side,
+                        PriceMantissa: resting.PriceMantissa,
+                        OpenQuantity: open,
+                        Tif: resting.Tif,
+                        ExpireDate: resting.ExpireDate,
+                        TransactTimeNanos: txnNanos,
+                        Memo: resting.Memo,
+                        InvestorId: resting.InvestorId));
+                    restated++;
+                }
+            }
+            return restated;
+        }
+        finally { ExitDispatch(); }
+    }
+
     private static bool MatchesMassCancelFilter(LimitOrderBook book, RestingOrder resting, MassCancelCommand command)
     {
         if (command.SecurityId != 0 && book.SecurityId != command.SecurityId) return false;

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -51,6 +51,7 @@ public partial class ChannelDispatcherTests
         public List<ulong> RejectClOrdIds { get; } = new();
         public List<TradeEvent> Trades { get; } = new();
         public List<(long LeavesQty, long CumQty)> TradeQty { get; } = new();
+        public List<OrderRestatedEvent> Restates { get; } = new();
         public bool CaptureCancelIds { get; set; }
         public List<(ulong ClOrdId, ulong OrigClOrdId)> CancelIds { get; } = new();
         public ulong LastReceivedTime { get; set; } = ulong.MaxValue;
@@ -85,6 +86,8 @@ public partial class ChannelDispatcherTests
         { if (Find(session) is { } s) { s.Calls.Add("Modify"); s.LastReceivedTime = receivedTimeNanos; } return true; }
         public bool WriteExecutionReportReject(B3.Exchange.Contracts.SessionId session, in RejectEvent e, ulong clOrdIdValue, DurabilityHandle d = default)
         { if (Find(session) is { } s) { s.Rejects.Add(e); s.RejectClOrdIds.Add(clOrdIdValue); s.Calls.Add("Reject"); } return true; }
+        public bool WriteExecutionReportRestate(B3.Exchange.Contracts.SessionId ownerSession, ulong ownerClOrdId, in OrderRestatedEvent e, DurabilityHandle d = default)
+        { if (Find(ownerSession) is { } s) { s.Restates.Add(e); s.Calls.Add("Restate"); } return true; }
     }
 
     private static (ChannelDispatcher disp, RecordingPacketSink pkt, RecordingOutbound outbound) NewDispatcher(
@@ -920,6 +923,40 @@ public partial class ChannelDispatcherTests
     }
 
     private static void DrainInbound(ChannelDispatcher disp) => disp.CreateTestProbe().DrainInbound();
+
+    [Fact]
+    public void OperatorRestateGt_RoutesRestateToOwner_NoUmdfFrame_NoEviction()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        // Resting GTC order owned by `reply`.
+        disp.EnqueueNewOrder(new NewOrderCommand("g1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(10m), 100, 7, 1_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long orderId = Assert.Single(reply.News).OrderId;
+        int packetsAfterRest = pkt.Packets.Count;
+        uint seqAfterRest = disp.SequenceNumber;
+
+        disp.EnqueueOperatorRestateGt(currentDate: 20_000);
+        DrainInbound(disp);
+
+        // Routed to the owning session as a restatement.
+        var restate = Assert.Single(reply.Restates);
+        Assert.Equal(orderId, restate.OrderId);
+        Assert.Equal(TimeInForce.Gtc, restate.Tif);
+        Assert.Equal(100L, restate.OpenQuantity);
+        // Private ER only: no new UMDF packet, no RptSeq advance.
+        Assert.Equal(packetsAfterRest, pkt.Packets.Count);
+        Assert.Equal(seqAfterRest, disp.SequenceNumber);
+
+        // Registry NOT evicted: a subsequent cancel still resolves the owner.
+        disp.EnqueueCancel(new CancelOrderCommand("c1", Petr, orderId, 3_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+        Assert.Single(reply.Cancels);
+    }
+
 
     [Fact]
     public void OperatorSetTradingPhase_EmitsSecurityStatusFrameAndGatesNewOrders()

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -389,6 +389,46 @@ public class ExecutionReportEncoderTests
     }
 
     [Fact]
+    public void EncodeRestate_GtcStopLimit_EchoesOrdTypeAndStopPx()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        ExecutionReportEncoder.EncodeExecReportRestate(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 7, orderId: 9,
+            securityId: 3, execId: 9UL, transactTimeNanos: 0UL,
+            openQty: 100, priceMantissa: 105_0000L,
+            tif: TimeInForce.Gtc, expireDate: 0,
+            ordType: OrderType.StopLimit, stopPxMantissa: 104_0000L);
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'R', body[19]);                                       // OrdStatus=RESTATED
+        Assert.Equal((byte)'4', body[116]);                                      // OrdType=StopLimit
+        Assert.Equal((byte)'1', body[117]);                                      // TimeInForce=GTC
+        Assert.Equal(105_0000L, MemoryMarshal.Read<long>(body.Slice(128, 8)));   // limit Price echoed
+        Assert.Equal(104_0000L, MemoryMarshal.Read<long>(body.Slice(136, 8)));   // StopPx echoed
+        Assert.Equal((byte)1, body[179]);                                        // GT_RESTATEMENT
+    }
+
+    [Fact]
+    public void EncodeRestate_GtcStopLoss_NullsLimitPriceKeepsStopPx()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        ExecutionReportEncoder.EncodeExecReportRestate(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Sell, clOrdIdValue: 7, orderId: 9,
+            securityId: 3, execId: 9UL, transactTimeNanos: 0UL,
+            openQty: 200, priceMantissa: 0L,
+            tif: TimeInForce.Gtc, expireDate: 0,
+            ordType: OrderType.StopLoss, stopPxMantissa: 96_0000L);
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'3', body[116]);                                      // OrdType=StopLoss
+        // StopLoss carries no limit price → null sentinel.
+        Assert.Equal(long.MinValue, MemoryMarshal.Read<long>(body.Slice(128, 8)));
+        Assert.Equal(96_0000L, MemoryMarshal.Read<long>(body.Slice(136, 8)));    // StopPx echoed
+    }
+
+    [Fact]
     public void EncodeCancel_V6Header_VersionIs6()
     {
         Assert.Equal(182, ExecutionReportEncoder.ExecReportCancelBlock);

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -322,6 +322,72 @@ public class ExecutionReportEncoderTests
         Assert.Equal(0u, MemoryMarshal.Read<uint>(body.Slice(174, 4)));
     }
 
+    // ====== GAP-26 / issue #498: daily Good-Till restatement ======
+    //
+    // A restatement reuses the ER_Modify template (201) but flips
+    // OrdStatus to RESTATED('R') and sets ExecRestatementReason at body[179]
+    // to GT_RESTATEMENT(1). It echoes the real TIF + (for GTD) ExpireDate and
+    // reports new-trading-day quantities (cum=0, leaves==orderQty==open).
+
+    [Fact]
+    public void EncodeRestate_Gtc_SetsRestatedStatusAndGtReason()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        int n = ExecutionReportEncoder.EncodeExecReportRestate(buf,
+            sessionId: 5, msgSeqNum: 9, sendingTimeNanos: 1_234UL,
+            side: Side.Buy, clOrdIdValue: 42, orderId: 7777,
+            securityId: 11, execId: 7777UL, transactTimeNanos: 1_234UL,
+            openQty: 300, priceMantissa: 100_0000L,
+            tif: TimeInForce.Gtc, expireDate: 0);
+
+        Assert.Equal(ExecutionReportEncoder.ExecReportModifyTotal, n);
+        // Template id is ER_Modify (201) on the V6 schema.
+        var hdr = buf.AsSpan(EntryPointFrameReader.SofhSize, EntryPointFrameReader.SbeHeaderSize);
+        Assert.Equal((ushort)ExecutionReportEncoder.ExecReportModifyBlock, MemoryMarshal.Read<ushort>(hdr.Slice(0, 2)));
+        Assert.Equal((ushort)EntryPointFrameReader.TidExecutionReportModify, MemoryMarshal.Read<ushort>(hdr.Slice(2, 2)));
+        Assert.Equal((ushort)6, MemoryMarshal.Read<ushort>(hdr.Slice(6, 2)));
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'1', body[18]);                                       // Side=Buy
+        Assert.Equal((byte)'R', body[19]);                                       // OrdStatus=RESTATED
+        Assert.Equal(42UL, MemoryMarshal.Read<ulong>(body.Slice(20, 8)));        // ClOrdID
+        Assert.Equal(7777L, MemoryMarshal.Read<long>(body.Slice(28, 8)));        // SecondaryOrderID = OrderID
+        Assert.Equal(300L, MemoryMarshal.Read<long>(body.Slice(44, 8)));         // LeavesQty = open (overlap)
+        Assert.Equal(7777UL, MemoryMarshal.Read<ulong>(body.Slice(56, 8)));      // ExecID = OrderID
+        Assert.Equal(0L, MemoryMarshal.Read<long>(body.Slice(72, 8)));           // CumQty = 0 (new day)
+        Assert.Equal(7777L, MemoryMarshal.Read<long>(body.Slice(88, 8)));        // OrderID
+        Assert.Equal(42UL, MemoryMarshal.Read<ulong>(body.Slice(96, 8)));        // OrigClOrdID echoes ClOrdID
+        Assert.Equal((byte)'2', body[116]);                                      // OrdType=Limit
+        Assert.Equal((byte)'1', body[117]);                                      // TimeInForce=GTC
+        Assert.Equal((ushort)0, MemoryMarshal.Read<ushort>(body.Slice(118, 2))); // ExpireDate null for GTC
+        Assert.Equal(300L, MemoryMarshal.Read<long>(body.Slice(120, 8)));        // OrderQty = open
+        Assert.Equal(100_0000L, MemoryMarshal.Read<long>(body.Slice(128, 8)));   // Price
+        Assert.Equal((byte)255, body[178]);                                      // MmProtectionReset null
+        Assert.Equal((byte)1, body[179]);                                        // ExecRestatementReason=GT_RESTATEMENT
+    }
+
+    [Fact]
+    public void EncodeRestate_Gtd_EchoesTifAndExpireDate()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportModifyTotal];
+        ExecutionReportEncoder.EncodeExecReportRestate(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Sell, clOrdIdValue: 7, orderId: 9,
+            securityId: 3, execId: 9UL, transactTimeNanos: 0UL,
+            openQty: 150, priceMantissa: 50_0000L,
+            tif: TimeInForce.Gtd, expireDate: 20_001,
+            investorId: new B3.Exchange.Matching.InvestorId(Prefix: 9, Document: 987_654));
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'2', body[18]);                                       // Side=Sell
+        Assert.Equal((byte)'R', body[19]);                                       // OrdStatus=RESTATED
+        Assert.Equal((byte)'6', body[117]);                                      // TimeInForce=GTD
+        Assert.Equal((ushort)20_001, MemoryMarshal.Read<ushort>(body.Slice(118, 2))); // ExpireDate echoed
+        Assert.Equal((byte)1, body[179]);                                        // GT_RESTATEMENT
+        Assert.Equal((ushort)9, MemoryMarshal.Read<ushort>(body.Slice(172, 2))); // InvestorID prefix
+        Assert.Equal(987_654u, MemoryMarshal.Read<uint>(body.Slice(174, 4)));    // InvestorID document
+    }
+
     [Fact]
     public void EncodeCancel_V6Header_VersionIs6()
     {

--- a/tests/B3.Exchange.Host.Tests/GtRestatementE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtRestatementE2ETests.cs
@@ -1,0 +1,196 @@
+using B3.EntryPoint.Wire;
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// GAP-26 / issue #498 — end-to-end: boot an <see cref="ExchangeHost"/>, rest a
+/// GTC order and a future-dated GTD order over the wire, then call
+/// <see cref="ExchangeHost.TriggerDailyReset"/> and assert each surviving order
+/// receives a private restatement <c>ER_Modify</c> (template 201,
+/// <c>OrdStatus=RESTATED('R')</c>, <c>ExecRestatementReason=GT_RESTATEMENT(1)</c>)
+/// proving the engine→sweeper→gateway GT-restatement path works through the host.
+/// </summary>
+public class GtRestatementE2ETests
+{
+    private const long SecId = 900000000001L;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    private static string WriteEquityInstrumentsJson(string scratchDir)
+    {
+        Directory.CreateDirectory(scratchDir);
+        var path = Path.Combine(scratchDir, "instruments-gt.json");
+        var json = $$"""
+        [
+          {
+            "symbol": "PETR4",
+            "securityId": {{SecId}},
+            "tickSize": "0.01",
+            "minPx": "0.01",
+            "maxPx": "999999.99",
+            "currency": "BRL",
+            "isin": "BRPETRACNPR6",
+            "securityType": "EQUITY",
+            "lotSize": 100
+          }
+        ]
+        """;
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_RestatesRestingGtcAndFutureGtdOrders()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "gt-restate-e2e-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 96,
+                        IncrementalGroup = "239.255.42.96",
+                        IncrementalPort = 30196,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                - new DateOnly(1970, 1, 1).DayNumber;
+            ushort futureExpire = (ushort)(epochDay + 30);
+
+            // Resting GTC order (ExpireDate null / 0).
+            var gtc = BuildNewOrderSingle(clOrdId: 13_001, secId: SecId, side: '1',
+                qty: 100, priceMantissa: 123_400, tif: '1', expireDate: 0);
+            await stream.WriteAsync(gtc);
+            var erGtcNew = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, erGtcNew.TemplateId);
+
+            // Resting future-dated GTD order at a non-crossing price.
+            var gtd = BuildNewOrderSingle(clOrdId: 13_002, secId: SecId, side: '1',
+                qty: 200, priceMantissa: 123_300, tif: '6', expireDate: futureExpire);
+            await stream.WriteAsync(gtd);
+            var erGtdNew = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, erGtdNew.TemplateId);
+
+            host.TriggerDailyReset(reason: "test-gt-restatement");
+
+            // Both surviving orders must come back as restatement ER_Modify frames.
+            var restates = new List<ReadFrame>();
+            for (int i = 0; i < 2; i++)
+                restates.Add(await ReadFrameAsync(stream, TimeSpan.FromSeconds(5)));
+
+            foreach (var r in restates)
+            {
+                Assert.Equal(EntryPointFrameReader.TidExecutionReportModify, r.TemplateId);
+                Assert.Equal((byte)'R', r.Body[19]);   // OrdStatus = RESTATED
+                Assert.Equal((byte)1, r.Body[179]);    // ExecRestatementReason = GT_RESTATEMENT
+                Assert.Equal((byte)'1', r.Body[18]);   // Side = Buy
+            }
+
+            // One restatement echoes the GTC TIF + null ExpireDate; the other the
+            // GTD TIF + the future ExpireDate.
+            var byTif = restates.ToDictionary(r => (char)r.Body[117]);
+            Assert.True(byTif.ContainsKey('1'), "expected a GTC ('1') restatement");
+            Assert.True(byTif.ContainsKey('6'), "expected a GTD ('6') restatement");
+            Assert.Equal(0, BinaryPrimitives.ReadUInt16LittleEndian(byTif['1'].Body.AsSpan(118, 2)));
+            Assert.Equal(futureExpire, BinaryPrimitives.ReadUInt16LittleEndian(byTif['6'].Body.AsSpan(118, 2)));
+
+            // OrderQty/LeavesQty reflect the open quantity on the new trading day.
+            Assert.Equal(100L, BinaryPrimitives.ReadInt64LittleEndian(byTif['1'].Body.AsSpan(120, 8)));
+            Assert.Equal(200L, BinaryPrimitives.ReadInt64LittleEndian(byTif['6'].Body.AsSpan(120, 8)));
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Builds a full NewOrderSingle_102 (V2) frame with the given TimeInForce
+    /// and ExpireDate. BlockLength = 125; no var-data trailer.
+    /// </summary>
+    private static byte[] BuildNewOrderSingle(ulong clOrdId, long secId, char side,
+        long qty, long priceMantissa, char tif, ushort expireDate)
+    {
+        const int BlockLength = 125;
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + BlockLength];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: BlockLength, templateId: EntryPointFrameReader.TidNewOrderSingle, version: 2);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)'2';          // OrdType = Limit
+        body[58] = (byte)tif;          // TimeInForce
+        body[59] = 255;                // Routing = null
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(76, 8), long.MinValue); // StopPx null
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(105, 2), expireDate);
+        return frame;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}

--- a/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
@@ -159,9 +159,15 @@ public class GtdExpiryE2ETests
 
             host.TriggerDailyReset(reason: "test-gtd-keep");
 
-            // No ER_Cancel should arrive for this order within the window.
-            await Assert.ThrowsAnyAsync<Exception>(async () =>
-                await ReadFrameAsync(stream, TimeSpan.FromMilliseconds(750)));
+            // The future-dated GTD survives the sweep — and as of GAP-26 (#498)
+            // it is restated for the new trading day: a private ER_Modify with
+            // OrdStatus=RESTATED('R') and ExecRestatementReason=GT_RESTATEMENT(1).
+            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportModify, er2.TemplateId);
+            Assert.Equal((byte)'R', er2.Body[19]);
+            Assert.Equal((byte)1, er2.Body[179]);
+            Assert.Equal((byte)'6', er2.Body[117]);   // TimeInForce echoed = GTD
+            Assert.Equal(expireDate, BinaryPrimitives.ReadUInt16LittleEndian(er2.Body.AsSpan(118, 2)));
         }
         finally
         {

--- a/tests/B3.Exchange.Matching.Tests/GtRestatementTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/GtRestatementTests.cs
@@ -1,0 +1,74 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// GAP-26 / issue #498 — daily Good-Till restatement semantics. At the
+/// session boundary <see cref="MatchingEngine.RestateGtOrders"/> emits a
+/// private <see cref="OrderRestatedEvent"/> for every surviving GTC order and
+/// every GTD order whose <c>ExpireDate</c> is strictly after the trading day
+/// being closed. Day orders and already-expired GTD orders are never
+/// restated, and the book is left untouched (no cancel, no quantity change,
+/// no RptSeq advance).
+/// </summary>
+public class GtRestatementTests
+{
+    private const ulong Txn = 9_000;
+
+    [Fact]
+    public void RestateGtOrders_RestatesGtcAndUnexpiredGtd_NotDayOrExpiredGtd()
+    {
+        var eng = NewEngine(out var sink);
+        // Distinct non-crossing buy prices so all four rest.
+        eng.Submit(new NewOrderCommand("day", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.96m), 100, 11, 1000));
+        eng.Submit(new NewOrderCommand("gtc", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(9.97m), 100, 11, 1100));
+        eng.Submit(new NewOrderCommand("gtdFuture", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtd, Px(9.98m), 100, 11, 1200) { ExpireDate = 20_001 });
+        eng.Submit(new NewOrderCommand("gtdPast", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtd, Px(9.99m), 100, 11, 1300) { ExpireDate = 20_000 });
+        long gtcOid = sink.Accepted[1].OrderId;
+        long gtdFutureOid = sink.Accepted[2].OrderId;
+        Assert.Equal(4, eng.OrderCount(PetrSecId));
+        sink.Clear();
+
+        int restated = eng.RestateGtOrders(currentDate: 20_000, txnNanos: Txn);
+
+        // Only GTC + future-dated GTD are restated; Day and on-boundary GTD skipped.
+        Assert.Equal(2, restated);
+        Assert.Equal(2, sink.Restated.Count);
+        Assert.Contains(sink.Restated, r => r.OrderId == gtcOid && r.Tif == TimeInForce.Gtc);
+        Assert.Contains(sink.Restated, r => r.OrderId == gtdFutureOid && r.Tif == TimeInForce.Gtd && r.ExpireDate == 20_001);
+        // Book is untouched.
+        Assert.Equal(4, eng.OrderCount(PetrSecId));
+        Assert.Empty(sink.Canceled);
+    }
+
+    [Fact]
+    public void RestateGtOrders_ReportsOpenQuantityIncludingHiddenIceberg()
+    {
+        var eng = NewEngine(out var sink);
+        // Iceberg GTC: 1000 total, 100 displayed -> 900 hidden. Open = 1000.
+        eng.Submit(new NewOrderCommand("ice", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(9.97m), 1000, 11, 1000)
+        {
+            MaxFloor = 100,
+        });
+        sink.Clear();
+
+        int restated = eng.RestateGtOrders(currentDate: 20_000, txnNanos: Txn);
+
+        Assert.Equal(1, restated);
+        var r = Assert.Single(sink.Restated);
+        Assert.Equal(1000, r.OpenQuantity);
+        Assert.Equal(Px(9.97m), r.PriceMantissa);
+        Assert.Equal(Txn, r.TransactTimeNanos);
+    }
+
+    [Fact]
+    public void RestateGtOrders_NoGtOrders_ReturnsZero()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("day", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.97m), 100, 11, 1000));
+        sink.Clear();
+
+        Assert.Equal(0, eng.RestateGtOrders(currentDate: 20_000, txnNanos: Txn));
+        Assert.Empty(sink.Restated);
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/GtRestatementTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/GtRestatementTests.cs
@@ -62,6 +62,41 @@ public class GtRestatementTests
     }
 
     [Fact]
+    public void RestateGtOrders_RestatesParkedGtcStops_NotDayStops()
+    {
+        var eng = NewEngine(out var sink);
+        // GTC stop-limit and GTC stop-loss park off-book; a Day stop must not
+        // be restated. None trigger (no trades occur).
+        eng.Submit(new NewOrderCommand("stopLimitGtc", PetrSecId, Side.Buy, OrderType.StopLimit, TimeInForce.Gtc, Px(10.50m), 100, 11, 1000)
+        {
+            StopPxMantissa = Px(10.40m),
+        });
+        eng.Submit(new NewOrderCommand("stopLossGtc", PetrSecId, Side.Buy, OrderType.StopLoss, TimeInForce.Gtc, 0, 200, 11, 1100)
+        {
+            StopPxMantissa = Px(10.60m),
+        });
+        eng.Submit(new NewOrderCommand("stopLimitDay", PetrSecId, Side.Buy, OrderType.StopLimit, TimeInForce.Day, Px(10.50m), 100, 11, 1200)
+        {
+            StopPxMantissa = Px(10.45m),
+        });
+        sink.Clear();
+
+        int restated = eng.RestateGtOrders(currentDate: 20_000, txnNanos: Txn);
+
+        Assert.Equal(2, restated);
+        var stopLimit = Assert.Single(sink.Restated, r => r.OrdType == OrderType.StopLimit);
+        Assert.Equal(TimeInForce.Gtc, stopLimit.Tif);
+        Assert.Equal(Px(10.40m), stopLimit.StopPxMantissa);
+        Assert.Equal(Px(10.50m), stopLimit.PriceMantissa);
+        Assert.Equal(100, stopLimit.OpenQuantity);
+
+        var stopLoss = Assert.Single(sink.Restated, r => r.OrdType == OrderType.StopLoss);
+        Assert.Equal(Px(10.60m), stopLoss.StopPxMantissa);
+        Assert.Equal(0, stopLoss.PriceMantissa);      // StopLoss has no limit price
+        Assert.Equal(200, stopLoss.OpenQuantity);
+    }
+
+    [Fact]
     public void RestateGtOrders_NoGtOrders_ReturnsZero()
     {
         var eng = NewEngine(out var sink);

--- a/tests/B3.Exchange.Matching.Tests/TestFactory.cs
+++ b/tests/B3.Exchange.Matching.Tests/TestFactory.cs
@@ -50,6 +50,7 @@ internal sealed class RecordingSink : IMatchingEventSink
     public List<AuctionPrintEvent> AuctionPrints => Events.OfType<AuctionPrintEvent>().ToList();
     public List<InstrumentHaltedEvent> Halted => Events.OfType<InstrumentHaltedEvent>().ToList();
     public List<InstrumentResumedEvent> Resumed => Events.OfType<InstrumentResumedEvent>().ToList();
+    public List<OrderRestatedEvent> Restated => Events.OfType<OrderRestatedEvent>().ToList();
     public void Clear() => Events.Clear();
     public void OnOrderAccepted(in OrderAcceptedEvent e) => Events.Add(e);
     public void OnOrderQuantityReduced(in OrderQuantityReducedEvent e) => Events.Add(e);
@@ -69,4 +70,5 @@ internal sealed class RecordingSink : IMatchingEventSink
     public void OnAuctionPrint(in AuctionPrintEvent e) => Events.Add(e);
     public void OnInstrumentHalted(in InstrumentHaltedEvent e) => Events.Add(e);
     public void OnInstrumentResumed(in InstrumentResumedEvent e) => Events.Add(e);
+    public void OnOrderRestated(in OrderRestatedEvent e) => Events.Add(e);
 }


### PR DESCRIPTION
Closes #498 (GAP-26).

## What
At each daily-reset boundary the exchange now emits a **private restatement** `ExecutionReport_Modify` (template 201) for every surviving **GTC** and **unexpired-GTD** order, so clients know the order carries into the new trading day:

- `OrdStatus = RESTATED ('R')`
- `ExecRestatementReason = GT_RESTATEMENT (1)`
- echoes the order's real `TimeInForce` and (for GTD) its `ExpireDate`
- new-trading-day quantities: `CumQty = 0`, `LeavesQty == OrderQty == open` (iceberg-aware: `RemainingQuantity + HiddenQuantity`)

## Invariants
Private ER only — **no UMDF frame, no RptSeq bump, no eviction**. The book is unchanged. The sweep runs **after** the GTD-expiry sweep in `TriggerDailyReset`, so past-dated GTD orders are cancelled (not restated). Owner routing via `OrderRegistry.TryResolve` (read, not evict).

## Layers
- **Matching**: `RestateGtOrders` + `OrderRestatedEvent` / optional `OnOrderRestated` sink.
- **Gateway**: `EncodeExecReportRestate`; `ICoreOutbound.WriteExecutionReportRestate` (default no-op) wired through `GatewayRouter` → `FixpSession` → `FixpOutboundEncoder` (execId = engine OrderID, since no RptSeq is consumed).
- **Core**: `OperatorRestateGt` work item + `EnqueueOperatorRestateGt` / `ProcessRestateGt`; `OnOrderRestated` routing.
- **Host**: `GtRestatementSweeper` wired into `TriggerDailyReset`.

## Tests
- Engine (3): emits for GTC+GTD, not Day; no book mutation; count.
- Encoder (2): OrdStatus='R', reason=1, tid=Modify(201), leaves/cum/orderQty.
- Dispatcher (1): routes to owner, no UMDF frame, no eviction.
- E2E host (1): rest GTC + future GTD, trigger reset, assert both restatement frames; quantities/TIF/ExpireDate.
- Updated `GtdExpiryE2ETests` future-GTD case to assert the new restatement frame.

Build: 0 warnings (Release). Format: clean. Full suite green.