### PR TITLE
feat(matching): expire resting Day orders at the daily session boundary (#506)

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Loop.cs
@@ -108,6 +108,10 @@ public sealed partial class ChannelDispatcher
             item.RestateGtCompletion?.TrySetException(
                 new InvalidOperationException(
                     $"channel {ChannelNumber} WAL-halted; RestateGt rejected"));
+            // Issue #506: the Day-expiry sweep awaits its completion too.
+            item.ExpireDayCompletion?.TrySetException(
+                new InvalidOperationException(
+                    $"channel {ChannelNumber} WAL-halted; ExpireDay rejected"));
             return;
         }
 
@@ -205,6 +209,18 @@ public sealed partial class ChannelDispatcher
             // book change, no RptSeq advance), so the forced snapshot is a
             // no-op delta. We still force-persist to keep the operator-command
             // durability contract uniform with the sibling sweeps above.
+            OnAfterCommandFlushed(force: true);
+            return;
+        }
+
+        if (item.Kind == WorkKind.OperatorExpireDay)
+        {
+            ProcessExpireDay(item.ExpireDay!, item.ExpireDayCompletion);
+            // Issue #506: force-persist after the sweep so the cancelled Day
+            // orders are gone from the engine snapshot and any RptSeq consumed
+            // by the per-order ER + UMDF OrderDelete frames survive a restart.
+            // Operator commands are not WAL-logged; the forced snapshot is the
+            // durability boundary — mirrors the GTD-expiry path.
             OnAfterCommandFlushed(force: true);
             return;
         }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Operator.cs
@@ -812,4 +812,54 @@ public sealed partial class ChannelDispatcher
             throw;
         }
     }
+
+    /// <summary>
+    /// Issue #506: enqueue an end-of-trading-day Day-order expiry sweep. On
+    /// the dispatch thread the engine cancels every resting
+    /// <c>TimeInForce.Day</c> order — and every parked Day stop — across the
+    /// channel's books, driving a terminal <c>ExecutionReport</c>
+    /// (OrdStatus=EXPIRED) + UMDF <c>OrderDelete</c> per order via the
+    /// <c>OnOrderCanceled</c> / <c>OnStopOrderCanceled</c> sink paths, packed
+    /// into one packet. The sweep is unconditional (no boundary date) and
+    /// changes no trading phase. Idempotent and safe to call from any thread.
+    /// </summary>
+    public bool EnqueueOperatorExpireDay(
+        TaskCompletionSource<ExpireDayOutcome>? completion = null)
+    {
+        if (RejectIfWalHalted(WorkKind.OperatorExpireDay))
+        {
+            completion?.TrySetException(new InvalidOperationException(
+                $"channel {ChannelNumber} WAL-halted; ExpireDay rejected"));
+            return false;
+        }
+        if (_inbound.Writer.TryWrite(new WorkItem(WorkKind.OperatorExpireDay, default, 0, false,
+            0, 0, null, null, null, null,
+            ExpireDay: new OperatorExpireDay(),
+            ExpireDayCompletion: completion)))
+        {
+            return true;
+        }
+        completion?.TrySetException(new InvalidOperationException(
+            $"channel {ChannelNumber} inbound queue full; ExpireDay rejected"));
+        return false;
+    }
+
+    private void ProcessExpireDay(OperatorExpireDay op,
+        TaskCompletionSource<ExpireDayOutcome>? completion)
+    {
+        AssertOnLoopThread();
+        _ = op;
+        _packetWritten = 0;
+        try
+        {
+            int cancelled = _engine.ExpireDayOrders(_timeSource.NowNanos());
+            if (_packetWritten > 0) FlushPacket();
+            completion?.TrySetResult(new ExpireDayOutcome(cancelled));
+        }
+        catch (Exception ex)
+        {
+            completion?.TrySetException(ex);
+            throw;
+        }
+    }
 }

--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -564,7 +564,7 @@ public sealed partial class ChannelDispatcher
                 PriceMantissa: e.StopPxMantissa,
                 RemainingQuantityAtCancel: e.RemainingQuantityAtCancel,
                 TransactTimeNanos: e.TransactTimeNanos,
-                Reason: CancelReason.Client,
+                Reason: e.Reason,
                 RptSeq: e.RptSeq);
             _outbound.WriteExecutionReportPassiveCancel(owner.Session, owner.ClOrdId, e.OrderId, canceled,
                 _currentClOrdId, _currentReceivedTimeNanos, CurrentDurability);

--- a/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.WorkItem.cs
@@ -11,7 +11,7 @@ namespace B3.Exchange.Core;
 /// </summary>
 public sealed partial class ChannelDispatcher
 {
-    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity, OperatorExpireGtd, OperatorRestateGt }
+    internal enum WorkKind : byte { New, Cancel, Replace, Cross, MassCancel, DecodeError, SnapshotRotation, PriceBandPublish, OperatorSnapshotNow, OperatorBumpVersion, OperatorTradeBust, OperatorSetTradingPhase, OperatorPersistSnapshot, OperatorUncrossAuction, OperatorHaltInstrument, OperatorResumeInstrument, OperatorBustV2, AuditCheckpoint, ShutdownBarrier, OperatorExpireSecurity, OperatorExpireGtd, OperatorRestateGt, OperatorExpireDay }
 
     /// <summary>
     /// Pre-allocated string names for <see cref="WorkKind"/> used as
@@ -44,6 +44,7 @@ public sealed partial class ChannelDispatcher
         "OperatorExpireSecurity",
         "OperatorExpireGtd",
         "OperatorRestateGt",
+        "OperatorExpireDay",
     };
 
     private static string WorkKindName(WorkKind kind)
@@ -81,6 +82,8 @@ public sealed partial class ChannelDispatcher
         TaskCompletionSource<ExpireGtdOutcome>? ExpireGtdCompletion = null,
         OperatorRestateGt? RestateGt = null,
         TaskCompletionSource<RestateGtOutcome>? RestateGtCompletion = null,
+        OperatorExpireDay? ExpireDay = null,
+        TaskCompletionSource<ExpireDayOutcome>? ExpireDayCompletion = null,
         long EnqueueTicks = 0,
         System.Diagnostics.ActivityContext ParentContext = default);
 
@@ -182,6 +185,22 @@ public sealed partial class ChannelDispatcher
     /// many surviving GTC / unexpired-GTD orders were restated.
     /// </summary>
     public readonly record struct RestateGtOutcome(int RestatedOrderCount);
+
+    /// <summary>
+    /// Issue #506: end-of-trading-day Day-order expiry sweep payload. On the
+    /// dispatch thread the engine cancels every resting <c>TimeInForce.Day</c>
+    /// order and every parked Day stop across the channel's books, driving a
+    /// terminal ExecutionReport (<c>OrdStatus=EXPIRED 'C'</c>) + UMDF
+    /// <c>OrderDelete</c> per order. The sweep is unconditional, so unlike
+    /// <see cref="OperatorExpireGtd"/> it carries no boundary date.
+    /// </summary>
+    internal sealed record OperatorExpireDay();
+
+    /// <summary>
+    /// Issue #506: outcome of a Day-order expiry sweep — how many resting Day
+    /// orders / parked Day stops were cancelled (0 when none were resting).
+    /// </summary>
+    public readonly record struct ExpireDayOutcome(int CancelledOrderCount);
 
     /// <summary>
     /// ADR 0008 PR-2: operator bust request payload (post-trade audit

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -87,6 +87,7 @@ internal static class ExecutionReportEncoder
     private const byte OrdStatusReplaced = (byte)'5';
     private const byte OrdStatusRestated = (byte)'R';
     private const byte OrdStatusRejected = (byte)'8';
+    private const byte OrdStatusExpired = (byte)'C';
     private const byte OrdTypeMarket = (byte)'1';
     private const byte OrdTypeLimit = (byte)'2';
     private const byte OrdTypeStopLoss = (byte)'3';
@@ -314,7 +315,8 @@ internal static class ExecutionReportEncoder
         Matching.Side side, ulong clOrdIdValue, ulong origClOrdIdValue, long secondaryOrderId,
         long securityId, long orderId, ulong execId, ulong transactTimeNanos,
         long cumQty, long orderQty, long? priceMantissa,
-        ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue)
+        ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue,
+        byte ordStatus = OrdStatusCanceled)
     {
         int total = TotalSize(ExecReportCancelBlock, memo.Length);
         if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Cancel", nameof(dst));
@@ -324,7 +326,7 @@ internal static class ExecutionReportEncoder
         body.Clear();
         WriteBusinessHeader(body, sessionId, msgSeqNum, sendingTimeNanos);
         body[18] = EncodeSide(side);
-        body[19] = OrdStatusCanceled;
+        body[19] = ordStatus;
         MemoryMarshal.Write(body.Slice(20, 8), in clOrdIdValue);
         MemoryMarshal.Write(body.Slice(28, 8), in secondaryOrderId);
         MemoryMarshal.Write(body.Slice(36, 8), in securityId);
@@ -348,6 +350,18 @@ internal static class ExecutionReportEncoder
         MemoryMarshal.Write(body.Slice(156, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)
         return WriteMemoTrailer(dst, ExecReportCancelBlock, memo);
     }
+
+    /// <summary>
+    /// Maps a cancel reason to the FIX <c>OrdStatus</c> byte for the terminal
+    /// cancel ExecutionReport. A time-in-force expiry (issue #506 — a resting
+    /// Day order or parked Day stop swept at the session boundary) reports
+    /// <c>EXPIRED('C')</c>; every other cancel reason reports
+    /// <c>CANCELED('4')</c>. GTD expiry and auction expiry intentionally keep
+    /// reporting <c>CANCELED</c> for now (their EXPIRED-status alignment is a
+    /// separate FIX-consistency refinement).
+    /// </summary>
+    public static byte CancelOrdStatus(Matching.CancelReason reason) =>
+        reason == Matching.CancelReason.DayExpired ? OrdStatusExpired : OrdStatusCanceled;
 
     public static int EncodeExecReportTrade(Span<byte> dst,
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -138,7 +138,8 @@ internal sealed class FixpOutboundEncoder
                     e.SecurityId, e.OrderId,
                     (ulong)e.RptSeq, e.TransactTimeNanos,
                     cumQty: 0, orderQty: e.RemainingQuantityAtCancel, priceMantissa: e.PriceMantissa,
-                    memo: memo.Span, receivedTimeNanos: receivedTimeNanos);
+                    memo: memo.Span, receivedTimeNanos: receivedTimeNanos,
+                    ordStatus: ExecutionReportEncoder.CancelOrdStatus(e.Reason));
                 return AppendAndEnqueueLocked(exact, durability);
             }
         }

--- a/src/B3.Exchange.Host/DayExpirySweeper.cs
+++ b/src/B3.Exchange.Host/DayExpirySweeper.cs
@@ -1,0 +1,125 @@
+using B3.Exchange.Core;
+using Microsoft.Extensions.Logging;
+
+namespace B3.Exchange.Host;
+
+/// <summary>
+/// Issue #506 — end-of-trading-day Day-order expiry sweep.
+///
+/// <para>At the end of each trading day the host enqueues one
+/// <c>EnqueueOperatorExpireDay</c> command per channel dispatcher. On the
+/// dispatch thread the engine cancels every resting <c>TimeInForce.Day</c>
+/// order — and every parked Day stop — across the channel's books, driving a
+/// terminal <c>ExecutionReport</c> (<c>OrdStatus=EXPIRED 'C'</c>) back to the
+/// originating session and a UMDF <c>OrderDelete</c> frame under the channel's
+/// single-writer invariant (ADR 0009).</para>
+///
+/// <para>Like <see cref="GtdExpirySweeper"/> the sweeper owns no timer — it is
+/// invoked from <c>ExchangeHost.TriggerDailyReset</c> before the listener is
+/// torn down, so the per-order ER routes to its originating session. Unlike the
+/// GTD sweep, Day expiry is <em>unconditional</em> (every resting Day order
+/// expires at the boundary regardless of date), so the sweeper carries no
+/// local-market-date and the engine stays clockless (ADR 0009).</para>
+/// </summary>
+public sealed class DayExpirySweeper
+{
+    private readonly IReadOnlyList<ChannelDispatcher> _dispatchers;
+    private readonly ILogger<DayExpirySweeper> _logger;
+
+    public DayExpirySweeper(IReadOnlyList<ChannelDispatcher> dispatchers,
+        ILogger<DayExpirySweeper> logger)
+    {
+        ArgumentNullException.ThrowIfNull(dispatchers);
+        ArgumentNullException.ThrowIfNull(logger);
+        _dispatchers = dispatchers;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Enqueues a Day-order expiry sweep on every channel.
+    ///
+    /// <para>When <paramref name="waitTimeout"/> is provided (default 5s) the
+    /// call blocks until every enqueued sweep has finished on its dispatch
+    /// thread — required from <c>TriggerDailyReset</c> so the gateway can flush
+    /// the terminal ERs before <c>TerminateAllSessions</c> tears down the
+    /// response channels. Pass <see cref="TimeSpan.Zero"/> to fire and
+    /// forget.</para>
+    ///
+    /// <para>Returns the total number of Day orders / parked Day stops
+    /// cancelled across all channels. Per-channel enqueue failures are logged
+    /// and do not abort the sweep.</para>
+    /// </summary>
+    public int Sweep(string trigger, TimeSpan? waitTimeout = null)
+    {
+        if (_dispatchers.Count == 0) return 0;
+
+        var pending = waitTimeout is { } t && t > TimeSpan.Zero
+            ? new List<Task<ChannelDispatcher.ExpireDayOutcome>>()
+            : null;
+        int enqueued = 0;
+        int rejected = 0;
+        foreach (var dispatcher in _dispatchers)
+        {
+            var completion = pending is null
+                ? null
+                : new TaskCompletionSource<ChannelDispatcher.ExpireDayOutcome>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+            bool ok;
+            try
+            {
+                ok = dispatcher.EnqueueOperatorExpireDay(completion);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Day expiry sweep ({Trigger}): enqueue threw channel={Channel}",
+                    trigger, dispatcher.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            if (!ok)
+            {
+                _logger.LogWarning(
+                    "Day expiry sweep ({Trigger}): enqueue rejected channel={Channel}",
+                    trigger, dispatcher.ChannelNumber);
+                rejected++;
+                continue;
+            }
+            enqueued++;
+            if (completion != null) pending!.Add(completion.Task);
+        }
+
+        int cancelled = 0;
+        if (pending is { Count: > 0 })
+        {
+            bool completedInTime;
+            try
+            {
+                completedInTime = Task.WaitAll(pending.ToArray(), waitTimeout!.Value);
+            }
+            catch (AggregateException ex)
+            {
+                completedInTime = pending.TrueForAll(t => t.IsCompleted);
+                _logger.LogWarning(ex,
+                    "Day expiry sweep ({Trigger}): one or more ExpireDay completions faulted",
+                    trigger);
+            }
+            foreach (var task in pending)
+            {
+                if (task.IsCompletedSuccessfully) cancelled += task.Result.CancelledOrderCount;
+            }
+            if (!completedInTime)
+            {
+                int incomplete = pending.Count(t => !t.IsCompleted);
+                _logger.LogError(
+                    "Day expiry sweep ({Trigger}): timed out after {TimeoutMs}ms with {Incomplete} of {Enqueued} ExpireDay completions still pending — TerminateAllSessions may close sessions before the terminal ER reaches the wire",
+                    trigger, (int)waitTimeout!.Value.TotalMilliseconds, incomplete, enqueued);
+            }
+        }
+
+        _logger.LogInformation(
+            "Day expiry sweep ({Trigger}): channels={ChannelCount} enqueued={Enqueued} rejected={Rejected} cancelled={Cancelled}",
+            trigger, _dispatchers.Count, enqueued, rejected, cancelled);
+        return cancelled;
+    }
+}

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -52,6 +52,7 @@ public sealed class ExchangeHost : IAsyncDisposable
     private PhaseScheduler? _phaseScheduler;
     private OptionExpirySweeper? _optionExpirySweeper;
     private GtdExpirySweeper? _gtdExpirySweeper;
+    private DayExpirySweeper? _dayExpirySweeper;
     private GtRestatementSweeper? _gtRestatementSweeper;
     private readonly List<B3.Exchange.Persistence.DataDirLock> _dataDirLocks = new();
     private B3.Exchange.Gateway.Persistence.FileFixpOutboundJournal? _outboundJournal;
@@ -108,6 +109,16 @@ public sealed class ExchangeHost : IAsyncDisposable
         // here); waits on per-channel completions so the cancels reach the
         // outbound encoder before DrainAllSessionsOutbound + TerminateAllSessions.
         _gtdExpirySweeper?.Sweep(reason, waitTimeout: TimeSpan.FromSeconds(15));
+        // Issue #506: expire resting Day orders (and parked Day stops) at the
+        // session boundary BEFORE the listener tears down, so the terminal
+        // ExecutionReport (OrdStatus=EXPIRED) + UMDF OrderDelete reach the
+        // originating session. Runs after the GTD-expiry sweep and BEFORE the
+        // GT restatement below: Day orders are never restated (only GTC /
+        // unexpired-GTD survive), so emitting their terminal EXPIRED before the
+        // survivors' carry-forward ER keeps the boundary event order clean.
+        // Waits on per-channel completions so the ERs reach the outbound
+        // encoder before DrainAllSessionsOutbound + TerminateAllSessions.
+        _dayExpirySweeper?.Sweep(reason, waitTimeout: TimeSpan.FromSeconds(15));
         // GAP-26 / #498: restate every surviving GTC / unexpired-GTD order
         // BEFORE the listener tears down, so the private restatement
         // ER_Modify (OrdStatus=RESTATED, ExecRestatementReason=GT_RESTATEMENT)
@@ -582,6 +593,11 @@ public sealed class ExchangeHost : IAsyncDisposable
                 _loggerFactory.CreateLogger<GtRestatementSweeper>(),
                 todayProvider);
         }
+        // Issue #506: the Day-expiry sweeper needs no date/timezone — Day
+        // orders expire unconditionally at the session boundary.
+        _dayExpirySweeper = new DayExpirySweeper(
+            _dispatchers,
+            _loggerFactory.CreateLogger<DayExpirySweeper>());
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
         var sessionOptions = new FixpSessionOptions
         {

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -190,6 +190,12 @@ public enum CancelReason : byte
     /// originating session and a UMDF <c>OrderDelete</c>, exactly like a
     /// client cancel.</summary>
     GtdExpired,
+    /// <summary>Resting <see cref="TimeInForce.Day"/> order (or parked Day
+    /// stop) that did not fill during its trading session. Cancelled by the
+    /// end-of-trading-day Day expiry sweep (issue #506) — drives a terminal
+    /// <c>ExecutionReport</c> (<c>OrdStatus=EXPIRED 'C'</c>) back to the
+    /// originating session and a UMDF <c>OrderDelete</c>.</summary>
+    DayExpired,
 }
 
 /// <summary>

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -295,7 +295,8 @@ public readonly record struct StopOrderCanceledEvent(
     long RemainingQuantityAtCancel,
     ulong TransactTimeNanos,
     uint RptSeq,
-    byte[]? Memo = null);
+    byte[]? Memo = null,
+    CancelReason Reason = CancelReason.Client);
 
 /// <summary>
 /// Fired when a resting order has been successfully replaced by a client

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -1132,6 +1132,83 @@ public sealed class MatchingEngine
     }
 
     /// <summary>
+    /// Issue #506: cancels every resting <see cref="TimeInForce.Day"/> order
+    /// — and every parked Day stop / stop-limit order — across the books
+    /// owned by this engine at the end of the trading session. Each
+    /// cancellation flows through the standard cancel path with
+    /// <see cref="CancelReason.DayExpired"/>, so the dispatcher emits a
+    /// terminal <c>ExecutionReport</c> (<c>OrdStatus=EXPIRED 'C'</c>) back to
+    /// the originating session and a UMDF <c>OrderDelete</c> frame.
+    /// <para>Unlike <see cref="ExpireGtdOrders"/> the sweep is
+    /// <em>unconditional</em> — every Day order expires at the session
+    /// boundary regardless of date — so the engine needs no boundary date
+    /// argument and stays fully deterministic for replay (ADR 0009).
+    /// Idempotent: a second sweep is a no-op once the Day orders are gone.
+    /// Returns the number of orders cancelled.</para>
+    /// </summary>
+    public int ExpireDayOrders(ulong txnNanos)
+    {
+        EnterDispatch();
+        try
+        {
+            int cancelled = 0;
+            foreach (var book in _booksById.Values)
+            {
+                // SnapshotOrders() copies into the book's scratch buffer, so
+                // EmitCanceled (which mutates the book's index) is safe to
+                // call while iterating the snapshot — mirrors ExpireGtdOrders.
+                foreach (var resting in book.SnapshotOrders())
+                {
+                    if (resting.Tif == TimeInForce.Day)
+                    {
+                        EmitCanceled(book, resting, txnNanos, CancelReason.DayExpired);
+                        cancelled++;
+                    }
+                }
+            }
+
+            // Parked Day stop / stop-limit orders sit off-book and would
+            // otherwise survive to the next trading day. Collect the Day
+            // stops first (read-only) so we don't mutate the per-symbol
+            // bucket lists while iterating them, then remove + emit.
+            List<RestingStop>? expiringStops = null;
+            foreach (var bucket in _stopsBySymbol.Values)
+            {
+                foreach (var stop in bucket)
+                {
+                    if (stop.Tif == TimeInForce.Day)
+                        (expiringStops ??= new List<RestingStop>()).Add(stop);
+                }
+            }
+            if (expiringStops != null)
+            {
+                foreach (var stop in expiringStops)
+                {
+                    _stopById.Remove(stop.OrderId);
+                    _stopsBySymbol[stop.SecurityId].Remove(stop);
+                    // The downstream cancel encoding inherits the existing
+                    // parked-stop simplification (stop price carried as the
+                    // cancel price; OrdType reported as Limit) shared with the
+                    // client-cancel path — only OrdStatus differs (EXPIRED).
+                    _sink.OnStopOrderCanceled(new StopOrderCanceledEvent(
+                        SecurityId: stop.SecurityId,
+                        OrderId: stop.OrderId,
+                        Side: stop.Side,
+                        StopPxMantissa: stop.StopPxMantissa,
+                        RemainingQuantityAtCancel: stop.Quantity,
+                        TransactTimeNanos: txnNanos,
+                        RptSeq: NextRptSeq(),
+                        Memo: stop.Memo,
+                        Reason: CancelReason.DayExpired));
+                    cancelled++;
+                }
+            }
+            return cancelled;
+        }
+        finally { ExitDispatch(); }
+    }
+
+    /// <summary>
     /// GAP-26 / issue #498: emits a daily Good-Till restatement event for
     /// every surviving resting GTC order and every unexpired GTD order
     /// (<c>ExpireDate &gt; <paramref name="currentDate"/></c>, a B3

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -959,6 +959,39 @@ public partial class ChannelDispatcherTests
 
 
     [Fact]
+    public void OperatorExpireDay_CancelsDayOrder_RoutesExpiredToOwner_EmitsUmdfFrame_Evicts()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        // Resting Day order owned by `reply`.
+        disp.EnqueueNewOrder(new NewOrderCommand("d1", Petr, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 7, 1_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long orderId = Assert.Single(reply.News).OrderId;
+        int packetsAfterRest = pkt.Packets.Count;
+        uint seqAfterRest = disp.SequenceNumber;
+
+        disp.EnqueueOperatorExpireDay();
+        DrainInbound(disp);
+
+        // Terminal EXPIRED cancel routed to the owning session.
+        var cancel = Assert.Single(reply.Cancels);
+        Assert.Equal(orderId, cancel.OrderId);
+        Assert.Equal(B3.Exchange.Matching.CancelReason.DayExpired, cancel.Reason);
+        // Public event: a new UMDF packet (OrderDelete) and an RptSeq advance.
+        Assert.True(pkt.Packets.Count > packetsAfterRest);
+        Assert.True(disp.SequenceNumber > seqAfterRest);
+
+        // Registry evicted: a follow-up cancel for the same order no longer resolves an owner.
+        reply.Cancels.Clear();
+        disp.EnqueueCancel(new CancelOrderCommand("c1", Petr, orderId, 3_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+        Assert.Empty(reply.Cancels);
+    }
+
+    [Fact]
     public void OperatorSetTradingPhase_EmitsSecurityStatusFrameAndGatesNewOrders()
     {
         var (disp, pkt, outbound) = NewDispatcher();

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -122,6 +122,32 @@ public class ExecutionReportEncoderTests
     }
 
     [Fact]
+    public void EncodeCancel_WithExpiredOrdStatus_WritesC()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        ExecutionReportEncoder.EncodeExecReportCancel(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 11, origClOrdIdValue: 10, secondaryOrderId: 0,
+            securityId: 1, orderId: 9999,
+            execId: 0UL, transactTimeNanos: 0UL,
+            cumQty: 0, orderQty: 100, priceMantissa: 12_3450L,
+            ordStatus: ExecutionReportEncoder.CancelOrdStatus(Matching.CancelReason.DayExpired));
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'C', body[19]);                                          // OrdStatus=Expired
+    }
+
+    [Theory]
+    [InlineData(Matching.CancelReason.DayExpired, (byte)'C')]
+    [InlineData(Matching.CancelReason.GtdExpired, (byte)'4')]
+    [InlineData(Matching.CancelReason.AuctionExpired, (byte)'4')]
+    [InlineData(Matching.CancelReason.Client, (byte)'4')]
+    public void CancelOrdStatus_MapsDayExpiredToExpired_OthersCanceled(Matching.CancelReason reason, byte expected)
+    {
+        Assert.Equal(expected, ExecutionReportEncoder.CancelOrdStatus(reason));
+    }
+
+    [Fact]
     public void EncodeReject_WritesRejReasonOverlapWithSecExchange()
     {
         var buf = new byte[ExecutionReportEncoder.ExecReportRejectTotal];

--- a/tests/B3.Exchange.Host.Tests/DayExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/DayExpiryE2ETests.cs
@@ -1,0 +1,221 @@
+using B3.EntryPoint.Wire;
+using System.Buffers.Binary;
+using System.Net.Sockets;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// Issue #506 — end-to-end: boot an <see cref="ExchangeHost"/>, place a
+/// resting <c>TimeInForce=Day</c> order over the wire, then call
+/// <see cref="ExchangeHost.TriggerDailyReset"/> and assert the originating
+/// session receives a terminal <c>ER_Cancel</c> with
+/// <c>OrdStatus=EXPIRED('C')</c> — proving the wire→engine→Day-expiry
+/// sweeper→gateway path works through the host. A GTC order placed alongside
+/// must survive the same boundary.
+/// </summary>
+public class DayExpiryE2ETests
+{
+    private const long SecId = 900000000001L;
+
+    private sealed class RecordingPacketSink : IUmdfPacketSink
+    {
+        public List<byte[]> Packets { get; } = new();
+        public void Publish(byte channelNumber, ReadOnlySpan<byte> packet)
+        {
+            lock (Packets) Packets.Add(packet.ToArray());
+        }
+    }
+
+    private static string WriteEquityInstrumentsJson(string scratchDir)
+    {
+        Directory.CreateDirectory(scratchDir);
+        var path = Path.Combine(scratchDir, "instruments-day.json");
+        var json = $$"""
+        [
+          {
+            "symbol": "PETR4",
+            "securityId": {{SecId}},
+            "tickSize": "0.01",
+            "minPx": "0.01",
+            "maxPx": "999999.99",
+            "currency": "BRL",
+            "isin": "BRPETRACNPR6",
+            "securityType": "EQUITY",
+            "lotSize": 100
+          }
+        ]
+        """;
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_ExpiresRestingDayOrder_WithExpiredOrdStatus()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "day-e2e-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 96,
+                        IncrementalGroup = "239.255.42.96",
+                        IncrementalPort = 30196,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            var newOrder = BuildNewOrderSingle(clOrdId: 13_001, secId: SecId,
+                side: '1', tif: '0', qty: 100, priceMantissa: 123_400, expireDate: 0);
+            await stream.WriteAsync(newOrder);
+            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+            host.TriggerDailyReset(reason: "test-day-expiry");
+
+            // The resting Day BUY must come back as an ER_Cancel carrying the
+            // terminal EXPIRED('C') OrdStatus.
+            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, er2.TemplateId);
+            Assert.Equal((byte)'1', er2.Body[18]);   // Side = Buy
+            Assert.Equal((byte)'C', er2.Body[19]);   // OrdStatus = EXPIRED
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task TriggerDailyReset_KeepsRestingGtcOrder()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "day-e2e-keep-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 97,
+                        IncrementalGroup = "239.255.42.97",
+                        IncrementalPort = 30197,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            // GTC order: survives the Day-expiry sweep and is restated (GAP-26)
+            // as a private ER_Modify with OrdStatus=RESTATED('R').
+            var newOrder = BuildNewOrderSingle(clOrdId: 13_101, secId: SecId,
+                side: '1', tif: '1', qty: 100, priceMantissa: 123_400, expireDate: 0);
+            await stream.WriteAsync(newOrder);
+            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+            host.TriggerDailyReset(reason: "test-day-keep-gtc");
+
+            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportModify, er2.TemplateId);
+            Assert.Equal((byte)'R', er2.Body[19]);   // OrdStatus = RESTATED
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Builds a full NewOrderSingle_102 (V2) frame with the given TimeInForce
+    /// (and ExpireDate when GTD). BlockLength = 125; no var-data trailer.
+    /// </summary>
+    private static byte[] BuildNewOrderSingle(ulong clOrdId, long secId, char side, char tif,
+        long qty, long priceMantissa, ushort expireDate)
+    {
+        const int BlockLength = 125;
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + BlockLength];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: BlockLength, templateId: EntryPointFrameReader.TidNewOrderSingle, version: 2);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)'2';          // OrdType = Limit
+        body[58] = (byte)tif;          // TimeInForce
+        body[59] = 255;                // Routing = null
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(76, 8), long.MinValue); // StopPx null
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(105, 2), expireDate);
+        return frame;
+    }
+
+    private readonly record struct ReadFrame(ushort TemplateId, ushort Version, byte[] Body);
+
+    private static async Task<ReadFrame> ReadFrameAsync(NetworkStream stream, TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero) timeout = TimeSpan.FromMilliseconds(1);
+        using var cts = new CancellationTokenSource(timeout);
+        var headerBuf = new byte[EntryPointFrameReader.WireHeaderSize];
+        await ReadExactAsync(stream, headerBuf, cts.Token);
+        ushort messageLength = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(0, 2));
+        ushort encodingType = BinaryPrimitives.ReadUInt16LittleEndian(headerBuf.AsSpan(2, 2));
+        if (encodingType != EntryPointFrameReader.SofhEncodingType)
+            throw new InvalidOperationException($"unexpected SOFH encoding type 0x{encodingType:X4}");
+        var sbeHeader = headerBuf.AsSpan(EntryPointFrameReader.SofhSize);
+        ushort templateId = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(2, 2));
+        ushort version = BinaryPrimitives.ReadUInt16LittleEndian(sbeHeader.Slice(6, 2));
+        int bodyLen = messageLength - EntryPointFrameReader.WireHeaderSize;
+        var body = new byte[bodyLen];
+        await ReadExactAsync(stream, body, cts.Token);
+        return new ReadFrame(templateId, version, body);
+    }
+
+    private static async Task ReadExactAsync(NetworkStream stream, byte[] buffer, CancellationToken ct)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = await stream.ReadAsync(buffer.AsMemory(read), ct);
+            if (n <= 0) throw new EndOfStreamException("connection closed");
+            read += n;
+        }
+    }
+}

--- a/tests/B3.Exchange.Matching.Tests/DayExpiryTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/DayExpiryTests.cs
@@ -1,0 +1,84 @@
+namespace B3.Exchange.Matching.Tests;
+
+using static TestFactory;
+
+/// <summary>
+/// Issue #506 — Day-order expiry at the daily session boundary. Resting
+/// <see cref="TimeInForce.Day"/> limit orders and parked Day stop orders must
+/// be cancelled unconditionally when the trading day closes
+/// (<see cref="MatchingEngine.ExpireDayOrders"/>), each carrying
+/// <see cref="CancelReason.DayExpired"/>. GTC and unexpired GTD orders, plus
+/// GTC stops, survive the sweep.
+/// </summary>
+public class DayExpiryTests
+{
+    private const ulong Txn = 9_000;
+
+    [Fact]
+    public void ExpireDayOrders_CancelsDayLimits_KeepsGtcAndGtd()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("day1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.96m), 100, 11, 1000));
+        eng.Submit(new NewOrderCommand("day2", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.97m), 100, 11, 1100));
+        eng.Submit(new NewOrderCommand("gtc", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(9.98m), 100, 11, 1200));
+        eng.Submit(new NewOrderCommand("gtd", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtd, Px(9.99m), 100, 11, 1300) { ExpireDate = 20_001 });
+        Assert.Equal(4, eng.OrderCount(PetrSecId));
+        sink.Clear();
+
+        int cancelled = eng.ExpireDayOrders(Txn);
+
+        Assert.Equal(2, cancelled);
+        Assert.Equal(2, eng.OrderCount(PetrSecId));
+        Assert.Equal(2, sink.Canceled.Count);
+        Assert.All(sink.Canceled, c => Assert.Equal(CancelReason.DayExpired, c.Reason));
+    }
+
+    [Fact]
+    public void ExpireDayOrders_Idempotent()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("day1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(9.96m), 100, 11, 1000));
+        sink.Clear();
+
+        Assert.Equal(1, eng.ExpireDayOrders(Txn));
+        Assert.Equal(0, eng.ExpireDayOrders(Txn));
+        Assert.Equal(0, eng.OrderCount(PetrSecId));
+    }
+
+    [Fact]
+    public void ExpireDayOrders_CancelsParkedDayStop_KeepsGtcStop()
+    {
+        var eng = NewEngine(out var sink);
+        // Two parked stops that do not trigger: a Day stop and a Gtc stop.
+        eng.Submit(new NewOrderCommand("stopDay", PetrSecId, Side.Buy, OrderType.StopLimit, TimeInForce.Day, Px(10.50m), 100, 11, 1000)
+        {
+            StopPxMantissa = Px(10.45m),
+        });
+        eng.Submit(new NewOrderCommand("stopGtc", PetrSecId, Side.Buy, OrderType.StopLoss, TimeInForce.Gtc, 0, 200, 11, 1100)
+        {
+            StopPxMantissa = Px(10.60m),
+        });
+        Assert.Equal(2, eng.StopOrderCount);
+        sink.Clear();
+
+        int cancelled = eng.ExpireDayOrders(Txn);
+
+        Assert.Equal(1, cancelled);
+        Assert.Equal(1, eng.StopOrderCount);
+        var stop = Assert.Single(sink.StopCanceled);
+        Assert.Equal(CancelReason.DayExpired, stop.Reason);
+    }
+
+    [Fact]
+    public void ExpireDayOrders_NoDayOrders_ReturnsZero()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("gtc", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Gtc, Px(9.98m), 100, 11, 1000));
+        sink.Clear();
+
+        Assert.Equal(0, eng.ExpireDayOrders(Txn));
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+        Assert.Empty(sink.Canceled);
+        Assert.Empty(sink.StopCanceled);
+    }
+}


### PR DESCRIPTION
## What

Resting `TimeInForce.Day` limit orders and parked Day stops previously **survived** `ExchangeHost.TriggerDailyReset`, carrying over to the next trading day. B3 semantics require a Day order to **expire at end of session**: the owner gets a terminal `ExecutionReport` with `OrdStatus=EXPIRED('C')` and the order leaves the book (UMDF `OrderDelete`).

Mirrors the established `GtdExpirySweeper` / `OptionExpirySweeper` boundary-sweep pattern.

## Changes

- **`MatchingEngine.ExpireDayOrders(txnNanos)`** — unconditionally cancels every resting Day limit order and parked Day stop across all books. New `CancelReason.DayExpired`.
- **`ExecutionReportEncoder`** — `OrdStatus=EXPIRED('C')` for `DayExpired` via a new `CancelOrdStatus` helper; GTD/Auction cancels intentionally keep `CANCELED('4')`.
- **`ChannelDispatcher`** — `OperatorExpireDay` work item + `EnqueueOperatorExpireDay` + `ProcessExpireDay`, faulting the completion on WAL-halt so the sweeper can't hang. `StopOrderCanceledEvent` now carries the `CancelReason`.
- **`DayExpirySweeper`** wired into `TriggerDailyReset` (ordering: GTD-expiry → **Day-expiry** → GT-restatement), waiting on completions before session teardown.

## Notes / scope

- Engine stays **clockless** (ADR 0009): Day expiry is unconditional, no boundary date threaded.
- Operator sweeps are **not WAL-logged**; durability comes from the forced post-sweep snapshot (same property as the GTD path — a crash after ER emission but before the forced snapshot can resurrect Day orders).
- **OrdStatus=EXPIRED scope** is narrow: only `DayExpired` maps to `'C'`. `GtdExpired`/`AuctionExpired` keep `'4'` to avoid churning shipped #499/#498 behavior. Follow-up candidate: GTD/Auction → EXPIRED FIX-consistency.
- **Parked-stop cancel ER fidelity** is inherited as-is: the `StopOrderCanceled → OrderCanceled` bridge carries the stop price as `Price` and reports `OrdType=Limit` (pre-existing, also affects client-cancel of parked stops). Tests assert terminal status / routing / book removal, not field fidelity. Follow-up candidate.

## Tests

- Engine: Day limit + parked-stop expiry, idempotency, GTC/GTD survival.
- Encoder: `CancelOrdStatus` mapping + EXPIRED body byte.
- Dispatcher: routing to owner + UMDF frame + RptSeq advance + registry eviction.
- Host E2E: Day order expired with EXPIRED ER; GTC restated.

Closes #506