### PR TITLE
Reject past-dated GTD orders at entry time (#504)

### DIFF
--- a/src/B3.Exchange.Gateway/InboundFatFingerOptions.cs
+++ b/src/B3.Exchange.Gateway/InboundFatFingerOptions.cs
@@ -21,6 +21,20 @@ public sealed record InboundFatFingerOptions
     public decimal? PriceBandPercent { get; init; }
     public Func<long, long?>? LastTradePriceProvider { get; init; }
 
+    /// <summary>
+    /// #504: supplies the current B3 local market date as a wire
+    /// <c>LocalMktDate</c> (days since the Unix epoch) so the decoder can
+    /// reject a GTD <c>NewOrderSingle</c> whose <c>ExpireDate</c> is already
+    /// in the past at entry time, rather than letting it rest until the next
+    /// daily-reset sweep. Host-supplied and read only on the live decode
+    /// path — never during WAL replay (replay rebuilds commands from WAL
+    /// records, bypassing the decoder), so the engine stays clockless
+    /// (ADR 0009) and replay stays deterministic. Must not throw; return
+    /// <c>null</c> to skip the check (e.g. the date is outside the
+    /// <see cref="ushort"/> LocalMktDate range or unconfigured).
+    /// </summary>
+    public Func<ushort?>? CurrentMarketDateProvider { get; init; }
+
     public static InboundFatFingerOptions Default { get; } = new();
 
     public void Validate()

--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.NewOrderSingle.cs
@@ -188,6 +188,24 @@ internal static partial class InboundMessageDecoder
             cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
             return InboundDecodeOutcome.UnsupportedFeature;
         }
+        // #504: reject a GTD whose ExpireDate is already in the past at entry,
+        // rather than letting it rest until the next daily-reset sweep cancels
+        // it one trading day late. The host supplies the current B3 local
+        // market date (LocalMktDate = days since epoch); a null result skips
+        // the check. The comparison is strict (< today): an order dated for
+        // today is valid *through* today and rests until tonight's close — the
+        // end-of-day sweep cancels it then (it expires on ExpireDate <= today).
+        // Reading the date here (the live decode path) keeps the engine
+        // clockless: the reject decision is frozen into the command via
+        // UnsupportedOrderCharacteristic, so WAL replay stays deterministic.
+        if (tif == TimeInForce.Gtd
+            && guardrails.CurrentMarketDateProvider?.Invoke() is { } currentMarketDate
+            && expireDate < currentMarketDate)
+        {
+            message = $"GTD ExpireDate {expireDate} is before the current trading day {currentMarketDate}";
+            cmd = UnsupportedCommand(ordType, tif, isStop ? stopPx : 0L);
+            return InboundDecodeOutcome.UnsupportedFeature;
+        }
 
         // #238: V6 root carries +strategyID@125 (int32, 0=null) and
         // +tradingSubAccount@129 (uint32, 0=null). The body span has

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -577,10 +577,10 @@ public sealed class ExchangeHost : IAsyncDisposable
         // expiry command per channel at daily reset; "today" is the B3 local
         // market date in the configured daily-reset timezone (the engine
         // stays clockless and receives the date as a command argument).
+        var todayProvider = GtdExpirySweeper.BuildTodayProvider(
+            _config.DailyReset?.Timezone,
+            _loggerFactory.CreateLogger<GtdExpirySweeper>());
         {
-            var todayProvider = GtdExpirySweeper.BuildTodayProvider(
-                _config.DailyReset?.Timezone,
-                _loggerFactory.CreateLogger<GtdExpirySweeper>());
             _gtdExpirySweeper = new GtdExpirySweeper(
                 _dispatchers,
                 _loggerFactory.CreateLogger<GtdExpirySweeper>(),
@@ -598,6 +598,11 @@ public sealed class ExchangeHost : IAsyncDisposable
         _dayExpirySweeper = new DayExpirySweeper(
             _dispatchers,
             _loggerFactory.CreateLogger<DayExpirySweeper>());
+        // #504: the decoder rejects a GTD NewOrderSingle whose ExpireDate is
+        // already in the past using the same timezone-aware local market date
+        // the GTD sweep uses, converted to the wire LocalMktDate. Read only on
+        // the live decode path; the engine stays clockless.
+        Func<ushort?> marketDateProvider = () => GtdExpirySweeper.ToLocalMktDate(todayProvider());
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
         var sessionOptions = new FixpSessionOptions
         {
@@ -617,6 +622,7 @@ public sealed class ExchangeHost : IAsyncDisposable
                 MaxPriceMantissa = _config.Tcp.MaxPrice,
                 PriceBandPercent = _config.Tcp.PriceBandPercent,
                 LastTradePriceProvider = _router.LastTradePriceMantissa,
+                CurrentMarketDateProvider = marketDateProvider,
             },
         };
         // Phase 2 (#42): real Negotiate handshake. The validator is pure

--- a/src/B3.Exchange.Host/GtdExpirySweeper.cs
+++ b/src/B3.Exchange.Host/GtdExpirySweeper.cs
@@ -31,6 +31,21 @@ public sealed class GtdExpirySweeper
     /// <c>LocalMktDate</c>.</summary>
     private static readonly int UnixEpochDayNumber = new DateOnly(1970, 1, 1).DayNumber;
 
+    /// <summary>
+    /// Converts a calendar date to the B3 wire <c>LocalMktDate</c>
+    /// (days since the Unix epoch, a <see cref="ushort"/>). Returns
+    /// <c>null</c> when the date falls outside the representable
+    /// <see cref="ushort"/> range. Shared by the boundary sweep and by the
+    /// decode-time stale-GTD guard (#504) so both interpret "today" the same
+    /// way.
+    /// </summary>
+    public static ushort? ToLocalMktDate(DateOnly date)
+    {
+        int dayNumber = date.DayNumber - UnixEpochDayNumber;
+        if (dayNumber < 0 || dayNumber > ushort.MaxValue) return null;
+        return (ushort)dayNumber;
+    }
+
     private readonly IReadOnlyList<ChannelDispatcher> _dispatchers;
     private readonly ILogger<GtdExpirySweeper> _logger;
     private readonly Func<DateOnly> _todayLocal;
@@ -101,15 +116,13 @@ public sealed class GtdExpirySweeper
     {
         if (_dispatchers.Count == 0) return 0;
         var today = _todayLocal();
-        int dayNumber = today.DayNumber - UnixEpochDayNumber;
-        if (dayNumber < 0 || dayNumber > ushort.MaxValue)
+        if (ToLocalMktDate(today) is not { } currentDate)
         {
             _logger.LogError(
                 "GTD expiry sweep ({Trigger}): local market date {Today} is outside the LocalMktDate range; skipping",
                 trigger, today);
             return 0;
         }
-        ushort currentDate = (ushort)dayNumber;
 
         var pending = waitTimeout is { } t && t > TimeSpan.Zero
             ? new List<Task<ChannelDispatcher.ExpireGtdOutcome>>()

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -820,8 +820,10 @@ public sealed class MatchingEngine
             // ExpireDate is meaningless on any other TIF. The gateway
             // decoder enforces the same pairing for NewOrderSingle, but
             // re-validate here so direct-API and WAL-replay paths stay
-            // consistent. (The engine is clockless, so a date already in
-            // the past is accepted and removed by the next daily sweep.)
+            // consistent. (The engine is clockless: a past-dated ExpireDate
+            // is accepted here and removed by the next daily sweep. #504 adds
+            // an entry-time reject for stale GTD in the gateway decoder, which
+            // holds the clock — the engine itself stays date-agnostic.)
             if (cmd.Tif == TimeInForce.Gtd)
             {
                 if (cmd.ExpireDate == 0)

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -148,16 +148,96 @@ public class NewOrderSingleAndReplaceDecoderTests
 
     // GAP-23 / #499: GTD without an ExpireDate is rejected as unsupported
     // (BMR-eligible) rather than terminating the session.
-    [Fact]
-    public void NewOrderSingle_GtdWithoutExpireDate_RejectsAsUnsupported()
+    // #504: a GTD whose ExpireDate is strictly before the current trading
+    // day is rejected at entry as an unsupported (BMR-eligible) feature,
+    // using the host-supplied market-date provider.
+    private static InboundFatFingerOptions MarketDate(ushort today) => new()
     {
-        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 0);
+        CurrentMarketDateProvider = () => today,
+    };
+
+    [Fact]
+    public void NewOrderSingle_GtdWithPastExpireDate_RejectsAsUnsupported()
+    {
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 19_999);
 
         var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
-            body, 1, 0, out _, out _, out var msg);
+            body, 1, 0, out var cmd, out _, out var msg, MarketDate(20_000));
 
         Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.UnsupportedFeature, outcome);
+        Assert.NotNull(cmd);
+        Assert.True(cmd.UnsupportedOrderCharacteristic);
         Assert.Contains("ExpireDate", msg);
+    }
+
+    [Fact]
+    public void NewOrderSingle_GtdExpiringToday_Accepted()
+    {
+        // ExpireDate == today: valid *through* today, rests until tonight's
+        // close (the EOD sweep cancels it then). Not rejected at entry.
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 20_000);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out var msg, MarketDate(20_000));
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal((ushort)20_000, cmd.ExpireDate);
+    }
+
+    [Fact]
+    public void NewOrderSingle_GtdFutureExpireDate_Accepted()
+    {
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 20_001);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _, MarketDate(20_000));
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal((ushort)20_001, cmd.ExpireDate);
+    }
+
+    [Fact]
+    public void NewOrderSingle_GtdPastExpireDate_ProviderReturnsNull_Accepted()
+    {
+        // A null provider result (e.g. date out of LocalMktDate range) skips
+        // the check: legacy "accept, swept next day" behavior is preserved.
+        var opts = new InboundFatFingerOptions { CurrentMarketDateProvider = () => null };
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 19_999);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _, opts);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal((ushort)19_999, cmd.ExpireDate);
+    }
+
+    [Fact]
+    public void NewOrderSingle_GtdPastExpireDate_NoProvider_Accepted()
+    {
+        // No options / no provider wired: the guard is inert (the engine is
+        // clockless and the daily sweep removes the order).
+        var body = BuildNewOrderSingleV2(tif: (byte)'6', expireDate: 19_999);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal((ushort)19_999, cmd.ExpireDate);
+    }
+
+    [Fact]
+    public void NewOrderSingle_NonGtd_MarketDateProvider_NotConsulted()
+    {
+        // A Day order carries no ExpireDate and must be unaffected by the
+        // market-date guard even when a provider is present.
+        var body = BuildNewOrderSingleV2(tif: (byte)'0', expireDate: 0);
+
+        var outcome = InboundMessageDecoder.TryDecodeNewOrderSingle(
+            body, 1, 0, out var cmd, out _, out _, MarketDate(20_000));
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Equal(TimeInForce.Day, cmd.Tif);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
@@ -63,6 +63,10 @@ public class GtdExpiryE2ETests
             {
                 Auth = new AuthConfig { RequireFixpHandshake = false },
                 Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                // #504: pin the local market date to UTC so the entry-time
+                // stale-GTD guard and the boundary sweep both agree with the
+                // UTC epoch-day this test computes — no SP/UTC midnight skew.
+                DailyReset = new DailyResetConfig { Timezone = "UTC" },
                 Channels =
                 {
                     new ChannelConfig
@@ -84,13 +88,12 @@ public class GtdExpiryE2ETests
             await client.ConnectAsync(ep.Address, ep.Port);
             var stream = client.GetStream();
 
-            // GTD ExpireDate a few days in the past: unambiguously elapsed
-            // regardless of the UTC-vs-local-market-date boundary, so the
-            // daily-reset sweep must cancel it. (A past-dated GTD order is
-            // accepted at entry — the engine is clockless — and swept here.)
+            // GTD ExpireDate == today: valid *through* today, so it is accepted
+            // at entry (#504 rejects only strictly-past dates) and the
+            // daily-reset sweep cancels it at the close (ExpireDate <= today).
             int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
                 - new DateOnly(1970, 1, 1).DayNumber;
-            ushort expireDate = (ushort)(epochDay - 5);
+            ushort expireDate = (ushort)epochDay;
 
             var newOrder = BuildNewOrderSingleGtd(clOrdId: 12_001, secId: SecId,
                 side: '1', qty: 100, priceMantissa: 123_400, expireDate: expireDate);
@@ -168,6 +171,62 @@ public class GtdExpiryE2ETests
             Assert.Equal((byte)1, er2.Body[179]);
             Assert.Equal((byte)'6', er2.Body[117]);   // TimeInForce echoed = GTD
             Assert.Equal(expireDate, BinaryPrimitives.ReadUInt16LittleEndian(er2.Body.AsSpan(118, 2)));
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task NewGtdOrder_WithPastExpireDate_RejectedAtEntry()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "gtd-e2e-reject-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                // #504: UTC market date so the entry guard matches this test's
+                // UTC epoch-day computation deterministically.
+                DailyReset = new DailyResetConfig { Timezone = "UTC" },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 98,
+                        IncrementalGroup = "239.255.42.98",
+                        IncrementalPort = 30198,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            // ExpireDate strictly in the past: #504 rejects it at entry rather
+            // than resting it until the next daily-reset sweep.
+            int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                - new DateOnly(1970, 1, 1).DayNumber;
+            ushort expireDate = (ushort)(epochDay - 5);
+
+            var newOrder = BuildNewOrderSingleGtd(clOrdId: 12_201, secId: SecId,
+                side: '1', qty: 100, priceMantissa: 123_400, expireDate: expireDate);
+            await stream.WriteAsync(newOrder);
+
+            var er = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportReject, er.TemplateId);
         }
         finally
         {

--- a/tests/B3.Exchange.Host.Tests/GtdExpirySweeperToLocalMktDateTests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpirySweeperToLocalMktDateTests.cs
@@ -1,0 +1,45 @@
+namespace B3.Exchange.Host.Tests;
+
+/// <summary>
+/// #504 — unit tests for <see cref="GtdExpirySweeper.ToLocalMktDate"/>, the
+/// calendar-date → B3 wire <c>LocalMktDate</c> (days since Unix epoch)
+/// converter shared by the boundary sweep and the decode-time stale-GTD
+/// guard.
+/// </summary>
+public class GtdExpirySweeperToLocalMktDateTests
+{
+    [Fact]
+    public void UnixEpoch_IsZero()
+    {
+        Assert.Equal((ushort)0, GtdExpirySweeper.ToLocalMktDate(new DateOnly(1970, 1, 1)));
+    }
+
+    [Fact]
+    public void KnownDate_MatchesDayNumberDelta()
+    {
+        var date = new DateOnly(2024, 1, 1);
+        int expected = date.DayNumber - new DateOnly(1970, 1, 1).DayNumber;
+        Assert.Equal((ushort)expected, GtdExpirySweeper.ToLocalMktDate(date));
+    }
+
+    [Fact]
+    public void BeforeEpoch_ReturnsNull()
+    {
+        Assert.Null(GtdExpirySweeper.ToLocalMktDate(new DateOnly(1969, 12, 31)));
+    }
+
+    [Fact]
+    public void BeyondUshortRange_ReturnsNull()
+    {
+        // 1970-01-01 + 65536 days is one past the ushort ceiling.
+        var overflow = new DateOnly(1970, 1, 1).AddDays(ushort.MaxValue + 1);
+        Assert.Null(GtdExpirySweeper.ToLocalMktDate(overflow));
+    }
+
+    [Fact]
+    public void UshortCeiling_IsRepresentable()
+    {
+        var ceiling = new DateOnly(1970, 1, 1).AddDays(ushort.MaxValue);
+        Assert.Equal(ushort.MaxValue, GtdExpirySweeper.ToLocalMktDate(ceiling));
+    }
+}


### PR DESCRIPTION
Closes #504.

## Problem
A GTD `NewOrderSingle` whose `ExpireDate` is already in the past would rest on the book until the next daily-reset sweep, surviving one extra trading day before `GtdExpirySweeper` cancels it.

## Fix
Decode-time pre-trade guardrail that rejects stale GTD orders:

- **`InboundFatFingerOptions.CurrentMarketDateProvider`** (`Func<ushort?>`) — host-supplied, returns the B3 `LocalMktDate` epoch-day or `null` to skip the check.
- **`InboundMessageDecoder.NewOrderSingle`** — rejects GTD with `ExpireDate < currentMarketDate` via the existing `UnsupportedCommand` path (sets `UnsupportedOrderCharacteristic=true`), the same mechanism the `ExpireDate==0` reject already uses.
- **`GtdExpirySweeper.ToLocalMktDate(DateOnly)`** — extracted helper; `Sweep()` reuses it.
- **`ExchangeHost`** — wires `marketDateProvider` from the timezone-aware today-provider into `FatFinger.CurrentMarketDateProvider`.

## Determinism (clockless engine, ADR 0009)
The date decision is **frozen into the command at decode time** (live path only). The command is still WAL-logged, but `MatchingEngine` honors the stored `UnsupportedOrderCharacteristic` flag with **no clock read**, so WAL replay stays deterministic. The engine is logically **unchanged**.

## ⚠️ Reviewer confirmation needed — comparator choice
Issue #504 literal wording says "ExpireDate <= currentTradingDate is rejected". I implemented **strictly-past (`<`)**: a **same-day** GTD (`== today`) is **accepted** and rests until tonight's EOD sweep, matching B3 valid-through-ExpireDate semantics. Rejecting `==today` would break the common same-day-GTD use case. Flip to `<=` is a one-char change if you prefer the literal reading.

## Scope
NewOrderSingle only — the sole wire path admitting a valid GTD `ExpireDate` (SimpleNewOrder has no ExpireDate; NewOrderCross hardcodes Tif=Day). `OrderCancelReplace` stale `NewExpireDate` (state-dependent effective TIF, resolved in the engine) is a **separate follow-up gap**.

## Tests
- 6 decoder unit tests (past→reject, today→accept, future→accept, provider-null→accept, no-provider→accept, non-GTD→provider-not-consulted).
- `GtdExpirySweeperToLocalMktDateTests` (5 unit tests for the epoch-day helper).
- Adapted `GtdExpiryE2ETests.TriggerDailyReset_CancelsRestingGtdOrderWithElapsedExpireDate` to use a UTC daily-reset tz + today-dated GTD (the past-dated variant is now rejected at entry); added `NewGtdOrder_WithPastExpireDate_RejectedAtEntry`.

Full suite green; `dotnet format --verify-no-changes` clean.