### PR TITLE
Emit OrdStatus=EXPIRED('C') for GTD and auction expiry (#513)

### DIFF
--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -353,15 +353,20 @@ internal static class ExecutionReportEncoder
 
     /// <summary>
     /// Maps a cancel reason to the FIX <c>OrdStatus</c> byte for the terminal
-    /// cancel ExecutionReport. A time-in-force expiry (issue #506 — a resting
-    /// Day order or parked Day stop swept at the session boundary) reports
-    /// <c>EXPIRED('C')</c>; every other cancel reason reports
-    /// <c>CANCELED('4')</c>. GTD expiry and auction expiry intentionally keep
-    /// reporting <c>CANCELED</c> for now (their EXPIRED-status alignment is a
-    /// separate FIX-consistency refinement).
+    /// cancel ExecutionReport. An order removed because its time-in-force
+    /// elapsed — a Day order or parked Day stop swept at the session boundary
+    /// (issue #506), a GTD order whose ExpireDate has passed, or a
+    /// GoodForAuction/AtClose order removed at the auction uncross (issue #513)
+    /// — reports <c>EXPIRED('C')</c>; every other (solicited) cancel reason
+    /// reports <c>CANCELED('4')</c>.
     /// </summary>
-    public static byte CancelOrdStatus(Matching.CancelReason reason) =>
-        reason == Matching.CancelReason.DayExpired ? OrdStatusExpired : OrdStatusCanceled;
+    public static byte CancelOrdStatus(Matching.CancelReason reason) => reason switch
+    {
+        Matching.CancelReason.DayExpired
+            or Matching.CancelReason.GtdExpired
+            or Matching.CancelReason.AuctionExpired => OrdStatusExpired,
+        _ => OrdStatusCanceled,
+    };
 
     public static int EncodeExecReportTrade(Span<byte> dst,
         uint sessionId, uint msgSeqNum, ulong sendingTimeNanos,

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -139,10 +139,10 @@ public class ExecutionReportEncoderTests
 
     [Theory]
     [InlineData(Matching.CancelReason.DayExpired, (byte)'C')]
-    [InlineData(Matching.CancelReason.GtdExpired, (byte)'4')]
-    [InlineData(Matching.CancelReason.AuctionExpired, (byte)'4')]
+    [InlineData(Matching.CancelReason.GtdExpired, (byte)'C')]
+    [InlineData(Matching.CancelReason.AuctionExpired, (byte)'C')]
     [InlineData(Matching.CancelReason.Client, (byte)'4')]
-    public void CancelOrdStatus_MapsDayExpiredToExpired_OthersCanceled(Matching.CancelReason reason, byte expected)
+    public void CancelOrdStatus_MapsExpiriesToExpired_OthersCanceled(Matching.CancelReason reason, byte expected)
     {
         Assert.Equal(expected, ExecutionReportEncoder.CancelOrdStatus(reason));
     }

--- a/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
@@ -108,6 +108,8 @@ public class GtdExpiryE2ETests
             Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, er2.TemplateId);
             // ER_Cancel body[18] carries Side; the resting order was Buy.
             Assert.Equal((byte)'1', er2.Body[18]);
+            // GTD expiry reports OrdStatus=EXPIRED('C') (issue #513).
+            Assert.Equal((byte)'C', er2.Body[19]);
         }
         finally
         {


### PR DESCRIPTION
Closes #513.

## Problem
PR #512 (#506) introduced `OrdStatus=EXPIRED('C')` only for **Day-order** boundary expiry. `CancelReason.GtdExpired` and `CancelReason.AuctionExpired` still reported `CANCELED('4')`. Per FIX/B3 semantics, a GTD order whose `ExpireDate` has elapsed and a GoodForAuction/AtClose order removed at the auction uncross are *expiries*, not solicited cancels — both warrant `EXPIRED('C')`.

## Fix
- **`ExecutionReportEncoder.CancelOrdStatus`** — now maps `DayExpired`, `GtdExpired` and `AuctionExpired` to `EXPIRED('C')`; every other (solicited) cancel reason stays `CANCELED('4')`. The single-reason ternary becomes a switch expression.

The engine's `CancelReason` emission is **unchanged** — only the gateway wire `OrdStatus` mapping moves. Day-expiry behavior (#506) is untouched.

## Tests
- `ExecutionReportEncoderTests.CancelOrdStatus_*` theory now expects `'C'` for `GtdExpired` and `AuctionExpired` (and still `'4'` for `Client`).
- `GtdExpiryE2ETests` asserts the GTD-expiry ER carries `OrdStatus=EXPIRED('C')` end-to-end.
- Auction-expiry is covered at the matching layer by `AuctionUncrossTests` (CancelReason unchanged); the wire mapping is exercised by the encoder theory.

Full suite green; `dotnet format --verify-no-changes` clean.