### PR TITLE
Bind suspended FIXP timeout from bridge config

### DIFF
--- a/config/exchange-simulator.json
+++ b/config/exchange-simulator.json
@@ -12,6 +12,7 @@
     "heartbeatIntervalMs": 10000,
     "idleTimeoutMs": 10000,
     "testRequestGraceMs": 5000,
+    "suspendedTimeoutMs": 300000,
     "sendingTimeSkewToleranceMs": 5000,
     // Decode-time fat-finger guardrails. Price is the EntryPoint /10000
     // mantissa; priceBandPercent null disables the last-trade-relative band.

--- a/docs/EXCHANGE-SIMULATOR.md
+++ b/docs/EXCHANGE-SIMULATOR.md
@@ -77,6 +77,7 @@ Exposes:
     "heartbeatIntervalMs": 30000,
     "idleTimeoutMs": 30000,
     "testRequestGraceMs": 5000,
+    "suspendedTimeoutMs": 300000,
     "sendingTimeSkewToleranceMs": 5000,
     "maxOrderQty": 1000000000,
     "maxPrice": 1000000000000000,
@@ -147,6 +148,10 @@ Exposes:
   the session is closed; a `BusinessReject` (templateId=206) framing the
   reason is the responsibility of issue #11 — `EntryPointSession.Close(reason)`
   exposes the seam.
+* `tcp.suspendedTimeoutMs` — how long a Suspended FIXP session remains
+  re-attachable after its transport drops before the listener reaper fully
+  closes it. Default `300000`; set `0` to disable the suspended-session
+  reaper.
 * `tcp.sendingTimeSkewToleranceMs` — maximum absolute skew tolerated between
   the server clock and an inbound application message's
   `InboundBusinessHeader.sendingTime`. Default `5000`; set `0` to disable.

--- a/src/B3.Exchange.Host/ExchangeHost.cs
+++ b/src/B3.Exchange.Host/ExchangeHost.cs
@@ -604,27 +604,11 @@ public sealed class ExchangeHost : IAsyncDisposable
         // the live decode path; the engine stays clockless.
         Func<ushort?> marketDateProvider = () => GtdExpirySweeper.ToLocalMktDate(todayProvider());
         var listenEp = ParseEndpoint(_config.Tcp.Listen);
-        var sessionOptions = new FixpSessionOptions
-        {
-            HeartbeatIntervalMs = _config.Tcp.HeartbeatIntervalMs,
-            IdleTimeoutMs = _config.Tcp.IdleTimeoutMs,
-            TestRequestGraceMs = _config.Tcp.TestRequestGraceMs,
-            SendingTimeSkewToleranceNs = (ulong)Math.Max(_config.Tcp.SendingTimeSkewToleranceMs, 0) * 1_000_000UL,
-            LifecycleMetrics = _metrics.Sessions,
-            ThrottleTimeWindowMs = _config.Tcp.Throttle?.TimeWindowMs ?? 0,
-            ThrottleMaxMessages = _config.Tcp.Throttle?.MaxMessages ?? 0,
-            MaxOrderRatePerSecond = 200,
-            ThrottleMetrics = _metrics.Throttle,
-            OnTransportSendQueueFull = _metrics.Transport.IncSendQueueFull,
-            FatFinger = new InboundFatFingerOptions
-            {
-                MaxOrderQty = _config.Tcp.MaxOrderQty,
-                MaxPriceMantissa = _config.Tcp.MaxPrice,
-                PriceBandPercent = _config.Tcp.PriceBandPercent,
-                LastTradePriceProvider = _router.LastTradePriceMantissa,
-                CurrentMarketDateProvider = marketDateProvider,
-            },
-        };
+        var sessionOptions = BuildSessionOptions(
+            _config.Tcp,
+            _metrics,
+            _router.LastTradePriceMantissa,
+            marketDateProvider);
         // Phase 2 (#42): real Negotiate handshake. The validator is pure
         // (no IO); the claim ledger lives for the host process lifetime
         // so duplicate-connection detection works across reconnects.
@@ -1162,6 +1146,36 @@ public sealed class ExchangeHost : IAsyncDisposable
             "Update your config to declare firms[] and sessions[] per docs/B3-ENTRYPOINT-ARCHITECTURE.md §8.",
             _config.Tcp.EnteringFirm);
         return ("legacy", _config.Tcp.EnteringFirm);
+    }
+
+    internal static FixpSessionOptions BuildSessionOptions(
+        TcpConfig tcp,
+        MetricsRegistry metrics,
+        Func<long, long?> lastTradePriceProvider,
+        Func<ushort?> marketDateProvider)
+    {
+        return new FixpSessionOptions
+        {
+            HeartbeatIntervalMs = tcp.HeartbeatIntervalMs,
+            IdleTimeoutMs = tcp.IdleTimeoutMs,
+            TestRequestGraceMs = tcp.TestRequestGraceMs,
+            SuspendedTimeoutMs = tcp.SuspendedTimeoutMs,
+            SendingTimeSkewToleranceNs = (ulong)Math.Max(tcp.SendingTimeSkewToleranceMs, 0) * 1_000_000UL,
+            LifecycleMetrics = metrics.Sessions,
+            ThrottleTimeWindowMs = tcp.Throttle?.TimeWindowMs ?? 0,
+            ThrottleMaxMessages = tcp.Throttle?.MaxMessages ?? 0,
+            MaxOrderRatePerSecond = 200,
+            ThrottleMetrics = metrics.Throttle,
+            OnTransportSendQueueFull = metrics.Transport.IncSendQueueFull,
+            FatFinger = new InboundFatFingerOptions
+            {
+                MaxOrderQty = tcp.MaxOrderQty,
+                MaxPriceMantissa = tcp.MaxPrice,
+                PriceBandPercent = tcp.PriceBandPercent,
+                LastTradePriceProvider = lastTradePriceProvider,
+                CurrentMarketDateProvider = marketDateProvider,
+            },
+        };
     }
 
     private static IPEndPoint ParseEndpoint(string s)

--- a/src/B3.Exchange.Host/HostConfig.cs
+++ b/src/B3.Exchange.Host/HostConfig.cs
@@ -88,6 +88,9 @@ public sealed class TcpConfig
     /// <summary>Additional grace window after the probe before the session is
     /// closed for inactivity. Default: 5 s.</summary>
     [JsonPropertyName("testRequestGraceMs")] public int TestRequestGraceMs { get; set; } = 5_000;
+    /// <summary>Suspended-session lifetime in milliseconds before the listener
+    /// reaper fully closes the session. Set to 0 to disable. Default: 5 min.</summary>
+    [JsonPropertyName("suspendedTimeoutMs")] public int SuspendedTimeoutMs { get; set; } = 5 * 60_000;
 
     /// <summary>
     /// Maximum absolute skew tolerated for inbound application

--- a/tests/B3.Exchange.Host.Tests/HostFixpSessionOptionsTests.cs
+++ b/tests/B3.Exchange.Host.Tests/HostFixpSessionOptionsTests.cs
@@ -1,0 +1,59 @@
+using System.Text.Json;
+using B3.Exchange.Core;
+using B3.Exchange.Gateway;
+using B3.Exchange.Host;
+
+namespace B3.Exchange.Host.Tests;
+
+public sealed class HostFixpSessionOptionsTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
+    [Fact]
+    public void BuildSessionOptions_binds_suspendedTimeoutMs_from_tcp_config()
+    {
+        var cfg = ParseConfig("""
+        { "suspendedTimeoutMs": 1500 }
+        """);
+
+        var options = BuildOptions(cfg.Tcp);
+
+        Assert.Equal(1500, options.SuspendedTimeoutMs);
+    }
+
+    [Fact]
+    public void BuildSessionOptions_uses_default_suspended_timeout_when_absent()
+    {
+        var cfg = ParseConfig("""
+        { "heartbeatIntervalMs": 30000 }
+        """);
+
+        var options = BuildOptions(cfg.Tcp);
+
+        Assert.Equal(FixpSessionOptions.Default.SuspendedTimeoutMs, options.SuspendedTimeoutMs);
+    }
+
+    private static HostConfig ParseConfig(string tcpJson)
+    {
+        var json = $$"""
+        {
+          "tcp": {{tcpJson}}
+        }
+        """;
+
+        return JsonSerializer.Deserialize<HostConfig>(json, JsonOptions)
+            ?? throw new InvalidOperationException("empty host config");
+    }
+
+    private static FixpSessionOptions BuildOptions(TcpConfig tcp)
+    {
+        return ExchangeHost.BuildSessionOptions(
+            tcp,
+            new MetricsRegistry(),
+            static _ => null,
+            static () => null);
+    }
+}


### PR DESCRIPTION
Closes #509

## Summary
- add tcp.suspendedTimeoutMs to host config binding and sample config
- flow the value into FixpSessionOptions.SuspendedTimeoutMs
- document the new knob and add host config mapping tests

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn