### PR TITLE
docs(adr-0012): fix MassQuote tracking pointer to OPT-08 (#464)

### DIFF
--- a/docs/adr/0012-exchange-day-boundary.md
+++ b/docs/adr/0012-exchange-day-boundary.md
@@ -44,10 +44,14 @@ closing auction (`FinalClosingCall` / `Close`). Concretely, in scope:
   Prevention (STPC, GAP-27), market protections (price collars / fat
   finger / max value, GAP-28), inbound throttling.
 - **Market-making protocols** — *future scope, not yet implemented.*
-  `MassQuote` / `QuoteRequest` are necessary for any non-trivial options
-  or futures venue simulation; they live inside this boundary even though
-  no concrete consumer has driven implementation yet (tracked separately
-  as a gap in `docs/B3-ENTRYPOINT-COMPLIANCE.md`).
+  `MassQuote` / an options-side `QuoteRequest` (distinct from the existing
+  Termo/Forward `QuoteRequest`, template id=401) are necessary for any
+  non-trivial options or futures venue simulation; they live inside this
+  boundary even though no concrete consumer has driven implementation yet.
+  Tracked as **OPT-08** in `docs/rfc/0002-equity-options-support.md`;
+  blocked until B3 publishes a `MassQuote` template in a future EntryPoint
+  schema release (the vendored v8.4.2 carries none — its `Quote*` templates
+  are Termo/Forward only).
 - **Operational surface needed to run the venue 24/7** — phase
   scheduling, daily reset, halt/resume, durable WAL+snapshot, EOD fills
   drop, per-trade audit log (ADRs 0001/0002).


### PR DESCRIPTION
Part of #464 (OPT-08 research, RFC 0002 trail T-8).

## What
OPT-08 research concluded **(a) stay closed-as-blocked** — no `MassQuote` template exists in any B3 EntryPoint schema (the five `Quote*` templates id 401–405 in vendored v8.4.2 are all Termo/Forward; the embedded changelog v5.4→v8.4.2 never adds MassQuote; no public evidence of a v8.5+/v9.x revision adding it). RFC 0002 §2.2/§3.6/§7 Q2 wording is accurate as-is.

The one inaccuracy found: ADR 0012 said the MM-protocol item was tracked as a gap in `docs/B3-ENTRYPOINT-COMPLIANCE.md`, but there is **no such row** — it is tracked as OPT-08 in `docs/rfc/0002-equity-options-support.md`. This PR fixes that pointer, disambiguates the listed `QuoteRequest` from the existing Termo `QuoteRequest` (id=401), and restates the external block.

Docs-only; no code, no tests affected.