### PR TITLE
Fix parked stop cancel ER fidelity

### DIFF
--- a/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
+++ b/src/B3.Exchange.Core/ChannelDispatcher.Sinks.cs
@@ -561,11 +561,14 @@ public sealed partial class ChannelDispatcher
                 SecurityId: e.SecurityId,
                 OrderId: e.OrderId,
                 Side: e.Side,
-                PriceMantissa: e.StopPxMantissa,
+                PriceMantissa: e.StopType == OrderType.StopLoss ? 0 : e.LimitPriceMantissa,
                 RemainingQuantityAtCancel: e.RemainingQuantityAtCancel,
                 TransactTimeNanos: e.TransactTimeNanos,
                 Reason: e.Reason,
-                RptSeq: e.RptSeq);
+                RptSeq: e.RptSeq,
+                Memo: e.Memo,
+                OrdType: e.StopType,
+                StopPxMantissa: e.StopPxMantissa);
             _outbound.WriteExecutionReportPassiveCancel(owner.Session, owner.ClOrdId, e.OrderId, canceled,
                 _currentClOrdId, _currentReceivedTimeNanos, CurrentDurability);
             _metrics?.IncExecutionReport(ExecutionReportKind.CancelPassive);

--- a/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
+++ b/src/B3.Exchange.Gateway/ExecutionReportEncoder.cs
@@ -316,7 +316,8 @@ internal static class ExecutionReportEncoder
         long securityId, long orderId, ulong execId, ulong transactTimeNanos,
         long cumQty, long orderQty, long? priceMantissa,
         ReadOnlySpan<byte> memo = default, ulong receivedTimeNanos = UTCTimestampNullValue,
-        byte ordStatus = OrdStatusCanceled)
+        byte ordStatus = OrdStatusCanceled,
+        Matching.OrderType ordType = Matching.OrderType.Limit, long stopPxMantissa = 0)
     {
         int total = TotalSize(ExecReportCancelBlock, memo.Length);
         if (dst.Length < total) throw new ArgumentException("buffer too small for ER_Cancel", nameof(dst));
@@ -338,13 +339,13 @@ internal static class ExecutionReportEncoder
         MemoryMarshal.Write(body.Slice(80, 8), in orderId);
         MemoryMarshal.Write(body.Slice(88, 8), in origClOrdIdValue);
         body[99] = 255;                                                     // ExecRestatementReason null
-        body[112] = OrdTypeLimit;
+        body[112] = EncodeOrdType(ordType);
         body[113] = TifDay;
         MemoryMarshal.Write(body.Slice(116, 8), in orderQty);
-        long px = priceMantissa ?? PriceNullMantissa;
+        long px = ordType == Matching.OrderType.StopLoss ? PriceNullMantissa : priceMantissa ?? PriceNullMantissa;
         MemoryMarshal.Write(body.Slice(124, 8), in px);                     // Price
-        long nullPx = PriceNullMantissa;
-        MemoryMarshal.Write(body.Slice(132, 8), in nullPx);                 // StopPx
+        long stopPx = stopPxMantissa != 0 ? stopPxMantissa : PriceNullMantissa;
+        MemoryMarshal.Write(body.Slice(132, 8), in stopPx);                 // StopPx
         // V3 trailing fields: receivedTime@156 + ordTagID/investorID/strategyID/actionRequestedFromSessionID
         // null sentinels are all zero (handled by body.Clear() above).
         MemoryMarshal.Write(body.Slice(156, 8), in receivedTimeNanos);      // ReceivedTime (tag 35544)

--- a/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
+++ b/src/B3.Exchange.Gateway/FixpOutboundEncoder.cs
@@ -139,7 +139,8 @@ internal sealed class FixpOutboundEncoder
                     (ulong)e.RptSeq, e.TransactTimeNanos,
                     cumQty: 0, orderQty: e.RemainingQuantityAtCancel, priceMantissa: e.PriceMantissa,
                     memo: memo.Span, receivedTimeNanos: receivedTimeNanos,
-                    ordStatus: ExecutionReportEncoder.CancelOrdStatus(e.Reason));
+                    ordStatus: ExecutionReportEncoder.CancelOrdStatus(e.Reason),
+                    ordType: e.OrdType, stopPxMantissa: e.StopPxMantissa);
                 return AppendAndEnqueueLocked(exact, durability);
             }
         }

--- a/src/B3.Exchange.Matching/Events.cs
+++ b/src/B3.Exchange.Matching/Events.cs
@@ -52,7 +52,9 @@ public readonly record struct OrderCanceledEvent(
     ulong TransactTimeNanos,
     CancelReason Reason,
     uint RptSeq,
-    byte[]? Memo = null);
+    byte[]? Memo = null,
+    OrderType OrdType = OrderType.Limit,
+    long StopPxMantissa = 0);
 
 /// <summary>
 /// Fired when a resting order is fully consumed by trades. The integration layer
@@ -281,8 +283,7 @@ public readonly record struct StopOrderTriggeredEvent(
     uint RptSeq);
 
 /// <summary>
-/// Fired when a parked stop order is cancelled by the client (the only
-/// reason for a stop cancel — stops do not auto-expire in this engine).
+/// Fired when a parked stop order is cancelled before triggering.
 /// Issue #214. The integration layer translates this to ER_Cancel back
 /// to the owning session; no MBO frame is emitted because the stop was
 /// never on the book.
@@ -291,7 +292,9 @@ public readonly record struct StopOrderCanceledEvent(
     long SecurityId,
     long OrderId,
     Side Side,
+    OrderType StopType,
     long StopPxMantissa,
+    long LimitPriceMantissa,
     long RemainingQuantityAtCancel,
     ulong TransactTimeNanos,
     uint RptSeq,

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -1005,7 +1005,9 @@ public sealed class MatchingEngine
                     SecurityId: cmd.SecurityId,
                     OrderId: stop.OrderId,
                     Side: stop.Side,
+                    StopType: stop.StopType,
                     StopPxMantissa: stop.StopPxMantissa,
+                    LimitPriceMantissa: stop.LimitPriceMantissa,
                     RemainingQuantityAtCancel: stop.Quantity,
                     TransactTimeNanos: cmd.EnteredAtNanos,
                     RptSeq: NextRptSeq(),
@@ -1188,15 +1190,13 @@ public sealed class MatchingEngine
                 {
                     _stopById.Remove(stop.OrderId);
                     _stopsBySymbol[stop.SecurityId].Remove(stop);
-                    // The downstream cancel encoding inherits the existing
-                    // parked-stop simplification (stop price carried as the
-                    // cancel price; OrdType reported as Limit) shared with the
-                    // client-cancel path — only OrdStatus differs (EXPIRED).
                     _sink.OnStopOrderCanceled(new StopOrderCanceledEvent(
                         SecurityId: stop.SecurityId,
                         OrderId: stop.OrderId,
                         Side: stop.Side,
+                        StopType: stop.StopType,
                         StopPxMantissa: stop.StopPxMantissa,
+                        LimitPriceMantissa: stop.LimitPriceMantissa,
                         RemainingQuantityAtCancel: stop.Quantity,
                         TransactTimeNanos: txnNanos,
                         RptSeq: NextRptSeq(),

--- a/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
+++ b/tests/B3.Exchange.Core.Tests/ChannelDispatcherTests.cs
@@ -333,6 +333,49 @@ public partial class ChannelDispatcherTests
     }
 
     [Fact]
+    public void StopLossClientCancel_RoutesCancelWithStopTypeAndStopPx_NoLimitPrice()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound) { EnteringFirm = 7 };
+
+        disp.EnqueueNewOrder(new NewOrderCommand("S1", Petr, Side.Buy, OrderType.StopLoss, TimeInForce.Day, 0, 100, 7, 1_000UL)
+        { StopPxMantissa = Px(11m) }, reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long stopOrderId = Assert.Single(reply.News).OrderId;
+
+        disp.EnqueueCancel(new CancelOrderCommand("C1", Petr, stopOrderId, 2_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        var cancel = Assert.Single(reply.Cancels);
+        Assert.Equal(OrderType.StopLoss, cancel.OrdType);
+        Assert.Equal(Px(11m), cancel.StopPxMantissa);
+        Assert.Equal(0L, cancel.PriceMantissa);
+        Assert.Equal(B3.Exchange.Matching.CancelReason.Client, cancel.Reason);
+    }
+
+    [Fact]
+    public void StopLimitClientCancel_RoutesCancelWithStopTypeStopPxAndLimitPrice()
+    {
+        var (disp, _, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound) { EnteringFirm = 7 };
+
+        disp.EnqueueNewOrder(new NewOrderCommand("S1", Petr, Side.Buy, OrderType.StopLimit, TimeInForce.Day, Px(10.50m), 100, 7, 1_000UL)
+        { StopPxMantissa = Px(10.45m) }, reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long stopOrderId = Assert.Single(reply.News).OrderId;
+
+        disp.EnqueueCancel(new CancelOrderCommand("C1", Petr, stopOrderId, 2_000UL),
+            reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
+        DrainInbound(disp);
+
+        var cancel = Assert.Single(reply.Cancels);
+        Assert.Equal(OrderType.StopLimit, cancel.OrdType);
+        Assert.Equal(Px(10.45m), cancel.StopPxMantissa);
+        Assert.Equal(Px(10.50m), cancel.PriceMantissa);
+    }
+
+    [Fact]
     public void MaxOpenOrdersPerFirm_TriggeredStopThatRestsKeepsSingleCount()
     {
         var metrics = new MetricsRegistry();
@@ -989,6 +1032,30 @@ public partial class ChannelDispatcherTests
             reply.Id, reply.EnteringFirm, clOrdIdValue: 2UL, origClOrdIdValue: 1UL);
         DrainInbound(disp);
         Assert.Empty(reply.Cancels);
+    }
+
+    [Fact]
+    public void OperatorExpireDay_CancelsParkedDayStop_RoutesExpiredWithStopFields_NoUmdf()
+    {
+        var (disp, pkt, outbound) = NewDispatcher();
+        var reply = new FakeSession(outbound);
+
+        disp.EnqueueNewOrder(new NewOrderCommand("s1", Petr, Side.Buy, OrderType.StopLimit, TimeInForce.Day, Px(10.50m), 100, 7, 1_000UL)
+        { StopPxMantissa = Px(10.45m) }, reply.Id, reply.EnteringFirm, clOrdIdValue: 1UL);
+        DrainInbound(disp);
+        long orderId = Assert.Single(reply.News).OrderId;
+        int packetsAfterPark = pkt.Packets.Count;
+
+        disp.EnqueueOperatorExpireDay();
+        DrainInbound(disp);
+
+        var cancel = Assert.Single(reply.Cancels);
+        Assert.Equal(orderId, cancel.OrderId);
+        Assert.Equal(B3.Exchange.Matching.CancelReason.DayExpired, cancel.Reason);
+        Assert.Equal(OrderType.StopLimit, cancel.OrdType);
+        Assert.Equal(Px(10.45m), cancel.StopPxMantissa);
+        Assert.Equal(Px(10.50m), cancel.PriceMantissa);
+        Assert.Equal(packetsAfterPark, pkt.Packets.Count);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/ExecutionReportEncoderTests.cs
@@ -117,8 +117,47 @@ public class ExecutionReportEncoderTests
         Assert.Equal(9999L, MemoryMarshal.Read<long>(body.Slice(80, 8)));           // OrderID
         Assert.Equal(10UL, MemoryMarshal.Read<ulong>(body.Slice(88, 8)));           // OrigClOrdID
         Assert.Equal((byte)255, body[99]);                                          // ExecRestatementReason null
+        Assert.Equal((byte)'2', body[112]);                                         // OrdType=Limit
+        Assert.Equal((byte)'0', body[113]);                                         // TIF=Day
         Assert.Equal(100L, MemoryMarshal.Read<long>(body.Slice(116, 8)));           // OrderQty
         Assert.Equal(12_3450L, MemoryMarshal.Read<long>(body.Slice(124, 8)));       // Price
+        Assert.Equal(long.MinValue, MemoryMarshal.Read<long>(body.Slice(132, 8)));  // StopPx null
+    }
+
+    [Fact]
+    public void EncodeCancel_StopLimit_EchoesOrdTypeStopPxAndLimitPrice()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        ExecutionReportEncoder.EncodeExecReportCancel(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Buy, clOrdIdValue: 11, origClOrdIdValue: 10, secondaryOrderId: 0,
+            securityId: 1, orderId: 9999,
+            execId: 0UL, transactTimeNanos: 0UL,
+            cumQty: 0, orderQty: 100, priceMantissa: 10_5000L,
+            ordType: OrderType.StopLimit, stopPxMantissa: 10_4500L);
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'4', body[112]);                                         // OrdType=StopLimit
+        Assert.Equal(10_5000L, MemoryMarshal.Read<long>(body.Slice(124, 8)));       // Price=limit
+        Assert.Equal(10_4500L, MemoryMarshal.Read<long>(body.Slice(132, 8)));       // StopPx=trigger
+    }
+
+    [Fact]
+    public void EncodeCancel_StopLoss_EchoesOrdTypeStopPxAndNullsLimitPrice()
+    {
+        var buf = new byte[ExecutionReportEncoder.ExecReportCancelTotal];
+        ExecutionReportEncoder.EncodeExecReportCancel(buf,
+            sessionId: 1, msgSeqNum: 1, sendingTimeNanos: 0UL,
+            side: Side.Sell, clOrdIdValue: 11, origClOrdIdValue: 10, secondaryOrderId: 0,
+            securityId: 1, orderId: 9999,
+            execId: 0UL, transactTimeNanos: 0UL,
+            cumQty: 0, orderQty: 100, priceMantissa: 0L,
+            ordType: OrderType.StopLoss, stopPxMantissa: 10_4500L);
+
+        var body = buf.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        Assert.Equal((byte)'3', body[112]);                                         // OrdType=StopLoss
+        Assert.Equal(long.MinValue, MemoryMarshal.Read<long>(body.Slice(124, 8)));  // Price null
+        Assert.Equal(10_4500L, MemoryMarshal.Read<long>(body.Slice(132, 8)));       // StopPx=trigger
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/DayExpiryTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/DayExpiryTests.cs
@@ -67,6 +67,9 @@ public class DayExpiryTests
         Assert.Equal(1, eng.StopOrderCount);
         var stop = Assert.Single(sink.StopCanceled);
         Assert.Equal(CancelReason.DayExpired, stop.Reason);
+        Assert.Equal(OrderType.StopLimit, stop.StopType);
+        Assert.Equal(Px(10.45m), stop.StopPxMantissa);
+        Assert.Equal(Px(10.50m), stop.LimitPriceMantissa);
     }
 
     [Fact]

--- a/tests/B3.Exchange.Matching.Tests/StopOrderTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/StopOrderTests.cs
@@ -151,6 +151,9 @@ public class StopOrderTests
 
         var c = Assert.Single(sink.StopCanceled);
         Assert.Equal(stopId, c.OrderId);
+        Assert.Equal(OrderType.StopLoss, c.StopType);
+        Assert.Equal(TestFactory.Px(11m), c.StopPxMantissa);
+        Assert.Equal(0L, c.LimitPriceMantissa);
         Assert.Equal(100, c.RemainingQuantityAtCancel);
     }
 


### PR DESCRIPTION
Closes #514

## Summary
- Thread parked stop OrdType, StopPx, and limit price through stop cancel events into ER_Cancel encoding.
- Preserve plain cancel defaults while making StopLoss cancel Price null and StopLimit cancel Price the original limit.
- Cover client cancel and Day-expiry parked-stop paths.

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet test SbeB3Exchange.slnx -c Debug
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn