### PR TITLE
Fix stale GTD replace expiry

### DIFF
--- a/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
+++ b/src/B3.Exchange.Gateway/InboundMessageDecoder.OrderCancelReplace.cs
@@ -50,6 +50,7 @@ internal static partial class InboundMessageDecoder
         InboundFatFingerOptions? fatFingerOptions = null)
     {
         var guardrails = NormalizeFatFingerOptions(fatFingerOptions);
+        ushort? currentMarketDate = guardrails.CurrentMarketDateProvider?.Invoke();
         cmd = null!;
         clOrdIdValue = 0;
         origClOrdIdValue = 0;
@@ -235,6 +236,7 @@ internal static partial class InboundMessageDecoder
             NewOrdType = ordType,
             NewTif = newTif,
             NewExpireDate = newExpireDate,
+            CurrentMarketDate = currentMarketDate,
             NewInvestorId = investorId,
         };
         return InboundDecodeOutcome.Success;

--- a/src/B3.Exchange.Matching/Commands.cs
+++ b/src/B3.Exchange.Matching/Commands.cs
@@ -346,6 +346,17 @@ public sealed record ReplaceOrderCommand(
     /// </summary>
     public ushort? NewExpireDate { get; init; }
 
+    /// <summary>
+    /// Current B3 local market date (days since the Unix epoch) frozen at
+    /// decode time from the host's CurrentMarketDateProvider, or null when
+    /// the host supplied no provider. The engine is clockless (ADR 0009);
+    /// freezing the date into the command keeps WAL replay deterministic.
+    /// Used only to reject a replace that resolves to a GTD whose effective
+    /// ExpireDate is already in the past (#516, follow-up to #504). Strict
+    /// comparison: ExpireDate &lt; CurrentMarketDate is stale; same-day is valid.
+    /// </summary>
+    public ushort? CurrentMarketDate { get; init; }
+
     public bool UnsupportedOrderCharacteristic { get; init; }
 
     public RejectReason? PreTradeRejectReason { get; init; }

--- a/src/B3.Exchange.Matching/MatchingEngine.cs
+++ b/src/B3.Exchange.Matching/MatchingEngine.cs
@@ -1385,6 +1385,10 @@ public sealed class MatchingEngine
             {
                 if (effectiveExpireDate == 0)
                 { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }
+                // #516: decode freezes the host's market date into the command
+                // so WAL replay preserves the same stale-GTD replace decision.
+                if (cmd.CurrentMarketDate is { } today && effectiveExpireDate < today)
+                { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.UnsupportedOrderCharacteristic, cmd.EnteredAtNanos); return; }
             }
             else if (cmd.NewExpireDate is { } suppliedExpire && suppliedExpire != 0)
             { Reject(cmd.ClOrdId, cmd.SecurityId, cmd.OrderId, RejectReason.InvalidField, cmd.EnteredAtNanos); return; }

--- a/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/NewOrderSingleAndReplaceDecoderTests.cs
@@ -860,6 +860,29 @@ public class NewOrderSingleAndReplaceDecoderTests
         Assert.Null(cmd.NewExpireDate);
     }
 
+    [Fact]
+    public void OrderCancelReplace_PopulatesCurrentMarketDateFromProvider()
+    {
+        var body = BuildOrderCancelReplaceV2(expireDate: 19_999);
+        int calls = 0;
+        var opts = new InboundFatFingerOptions
+        {
+            CurrentMarketDateProvider = () =>
+            {
+                calls++;
+                return 20_000;
+            },
+        };
+
+        var outcome = InboundMessageDecoder.TryDecodeOrderCancelReplace(
+            body, 0UL, out var cmd, out _, out _, out var msg, opts);
+
+        Assert.Equal(InboundMessageDecoder.InboundDecodeOutcome.Success, outcome);
+        Assert.Null(msg);
+        Assert.Equal((ushort)20_000, cmd.CurrentMarketDate);
+        Assert.Equal(1, calls);
+    }
+
     // ---------------- #238: V6 trailer (StrategyID + TradingSubAccount) ----------------
 
     private static byte[] BuildNewOrderSingleV6(

--- a/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtdExpiryE2ETests.cs
@@ -236,6 +236,68 @@ public class GtdExpiryE2ETests
         }
     }
 
+    [Fact]
+    public async Task ReplaceGtdOrder_WithPastNewExpireDate_RejectedAtEntry()
+    {
+        var scratch = Path.Combine(AppContext.BaseDirectory,
+            "gtd-replace-e2e-reject-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var instrumentsPath = WriteEquityInstrumentsJson(scratch);
+            var sink = new RecordingPacketSink();
+            var cfg = new HostConfig
+            {
+                Auth = new AuthConfig { RequireFixpHandshake = false },
+                Tcp = new TcpConfig { Listen = "127.0.0.1:0", EnteringFirm = 7 },
+                DailyReset = new DailyResetConfig { Timezone = "UTC" },
+                Channels =
+                {
+                    new ChannelConfig
+                    {
+                        ChannelNumber = 99,
+                        IncrementalGroup = "239.255.42.99",
+                        IncrementalPort = 30199,
+                        Ttl = 0,
+                        InstrumentsFile = instrumentsPath,
+                    },
+                },
+            };
+
+            await using var host = new ExchangeHost(cfg, packetSinkFactory: _ => sink);
+            await host.StartAsync();
+            var ep = host.TcpEndpoint!;
+
+            using var client = new TcpClient();
+            await client.ConnectAsync(ep.Address, ep.Port);
+            var stream = client.GetStream();
+
+            int epochDay = DateOnly.FromDateTime(DateTime.UtcNow).DayNumber
+                - new DateOnly(1970, 1, 1).DayNumber;
+            ushort futureExpireDate = (ushort)(epochDay + 30);
+            ushort pastExpireDate = (ushort)(epochDay - 5);
+
+            var newOrder = BuildNewOrderSingleGtd(clOrdId: 12_301, secId: SecId,
+                side: '1', qty: 100, priceMantissa: 123_400, expireDate: futureExpireDate);
+            await stream.WriteAsync(newOrder);
+            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
+
+            var replace = BuildOrderCancelReplaceGtd(clOrdId: 12_302, origClOrdId: 12_301,
+                secId: SecId, side: '1', qty: 100, priceMantissa: 123_400,
+                expireDate: pastExpireDate);
+            await stream.WriteAsync(replace);
+
+            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            Assert.Equal(EntryPointFrameReader.TidExecutionReportReject, er2.TemplateId);
+            Assert.Equal(12_302UL, BinaryPrimitives.ReadUInt64LittleEndian(er2.Body.AsSpan(20, 8)));
+            Assert.Equal(11u, BinaryPrimitives.ReadUInt32LittleEndian(er2.Body.AsSpan(44, 4)));
+        }
+        finally
+        {
+            if (Directory.Exists(scratch)) Directory.Delete(scratch, recursive: true);
+        }
+    }
+
     /// <summary>
     /// Builds a full NewOrderSingle_102 (V2) frame with a GTD
     /// TimeInForce and the given ExpireDate. BlockLength = 125; no
@@ -261,6 +323,31 @@ public class GtdExpiryE2ETests
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
         BinaryPrimitives.WriteInt64LittleEndian(body.Slice(76, 8), long.MinValue); // StopPx null
         BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(105, 2), expireDate);
+        return frame;
+    }
+
+    private static byte[] BuildOrderCancelReplaceGtd(ulong clOrdId, ulong origClOrdId,
+        long secId, char side, long qty, long priceMantissa, ushort expireDate)
+    {
+        const int BlockLength = 142;
+        var frame = new byte[EntryPointFrameReader.WireHeaderSize + BlockLength];
+        EntryPointFrameReader.WriteHeader(frame.AsSpan(0, EntryPointFrameReader.WireHeaderSize),
+            messageLength: (ushort)frame.Length,
+            blockLength: BlockLength, templateId: EntryPointFrameReader.TidOrderCancelReplaceRequest, version: 2);
+
+        var body = frame.AsSpan(EntryPointFrameReader.WireHeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(20, 8), clOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(48, 8), secId);
+        body[56] = (byte)side;
+        body[57] = (byte)'2';
+        body[58] = 0;
+        body[59] = 255;
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(60, 8), qty);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(68, 8), priceMantissa);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(76, 8), 0);
+        BinaryPrimitives.WriteUInt64LittleEndian(body.Slice(84, 8), origClOrdId);
+        BinaryPrimitives.WriteInt64LittleEndian(body.Slice(92, 8), long.MinValue);
+        BinaryPrimitives.WriteUInt16LittleEndian(body.Slice(122, 2), expireDate);
         return frame;
     }
 

--- a/tests/B3.Exchange.Matching.Tests/GtdExpiryTests.cs
+++ b/tests/B3.Exchange.Matching.Tests/GtdExpiryTests.cs
@@ -131,6 +131,101 @@ public class GtdExpiryTests
     }
 
     [Fact]
+    public void Replace_DayToGtd_WithPastExpireDate_RejectsAsUnsupportedAndDoesNotRestGtd()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("d1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        long oid = sink.Accepted[^1].OrderId;
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewTif = TimeInForce.Gtd,
+            NewExpireDate = 19_999,
+            CurrentMarketDate = 20_000,
+        });
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.UnsupportedOrderCharacteristic, rej.Reason);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+        Assert.Equal(0, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+    }
+
+    [Fact]
+    public void Replace_PreserveGtd_WithPastNewExpireDate_RejectsAsUnsupportedAndKeepsOriginalExpiry()
+    {
+        var eng = NewEngine(out var sink);
+        long oid = PlaceGtd(eng, sink, expireDate: 20_010, qty: 200);
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewExpireDate = 19_999,
+            CurrentMarketDate = 20_000,
+        });
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.UnsupportedOrderCharacteristic, rej.Reason);
+        Assert.Equal(0, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+        Assert.Equal(1, eng.ExpireGtdOrders(currentDate: 20_010, txnNanos: Txn));
+    }
+
+    [Fact]
+    public void Replace_GtdExpireDateEqualCurrentMarketDate_Accepted()
+    {
+        var eng = NewEngine(out var sink);
+        long oid = PlaceGtd(eng, sink, expireDate: 20_010, qty: 200);
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewExpireDate = 20_000,
+            CurrentMarketDate = 20_000,
+        });
+
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(0, eng.ExpireGtdOrders(currentDate: 19_999, txnNanos: Txn));
+        Assert.Equal(1, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+    }
+
+    [Fact]
+    public void Replace_ToDay_WithSuppliedExpireDate_StillRejectsInvalidField()
+    {
+        var eng = NewEngine(out var sink);
+        long oid = PlaceGtd(eng, sink, expireDate: 20_010, qty: 100);
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewTif = TimeInForce.Day,
+            NewExpireDate = 19_999,
+            CurrentMarketDate = 20_000,
+        });
+
+        var rej = Assert.Single(sink.Rejects);
+        Assert.Equal(RejectReason.InvalidField, rej.Reason);
+    }
+
+    [Fact]
+    public void Replace_PastGtdExpireDate_WithoutCurrentMarketDate_PreservesExistingBehavior()
+    {
+        var eng = NewEngine(out var sink);
+        eng.Submit(new NewOrderCommand("d1", PetrSecId, Side.Buy, OrderType.Limit, TimeInForce.Day, Px(10m), 100, 11, 1000));
+        long oid = sink.Accepted[^1].OrderId;
+        sink.Clear();
+
+        eng.Replace(new ReplaceOrderCommand("r1", PetrSecId, oid, Px(10m), 100, 2000)
+        {
+            NewTif = TimeInForce.Gtd,
+            NewExpireDate = 19_999,
+        });
+
+        Assert.Empty(sink.Rejects);
+        Assert.Equal(1, eng.OrderCount(PetrSecId));
+        Assert.Equal(1, eng.ExpireGtdOrders(currentDate: 20_000, txnNanos: Txn));
+    }
+
+    [Fact]
     public void Replace_GtdToDay_ClearsExpiryAndIsNotSwept()
     {
         var eng = NewEngine(out var sink);

--- a/tests/B3.Exchange.Persistence.Tests/WalReplayTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/WalReplayTests.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using B3.Exchange.Core;
+using B3.Exchange.Matching;
 using B3.Exchange.Persistence;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -155,6 +156,29 @@ public sealed class WalReplayTests
         Assert.Equal(3, result.Records.Count);
         Assert.Equal(2, result.LegacyCount);
         Assert.Equal(0, result.CorruptCount);
+    }
+
+    [Fact]
+    public void ReplaceOrderCommand_CurrentMarketDate_RoundTripsThroughWalJson()
+    {
+        var replace = new ReplaceOrderCommand("r1", 900_000_000_001L, 123L, 100_000L, 100L, 2_000UL)
+        {
+            NewTif = TimeInForce.Gtd,
+            NewExpireDate = 19_999,
+            CurrentMarketDate = 20_000,
+        };
+        var rec = new WalRecord(1, WalRecordKind.Replace, "S", 1u, 2u, 1u, null, null, replace);
+
+        var json = SerializeRecord(rec);
+        var roundTrip = System.Text.Json.JsonSerializer.Deserialize(json, WalJsonContext.Default.WalRecord);
+
+        Assert.NotNull(roundTrip);
+        Assert.Equal((ushort)20_000, roundTrip.Replace!.CurrentMarketDate);
+
+        var legacyJson = Encoding.UTF8.GetString(json).Replace(",\"CurrentMarketDate\":20000", "", StringComparison.Ordinal);
+        var legacy = System.Text.Json.JsonSerializer.Deserialize(legacyJson, WalJsonContext.Default.WalRecord);
+        Assert.NotNull(legacy);
+        Assert.Null(legacy.Replace!.CurrentMarketDate);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #516

## Summary
- freeze the host market date into ReplaceOrderCommand for WAL-deterministic replace validation
- reject effective GTD replaces with ExpireDate strictly before the frozen market date
- add matching, gateway, host E2E, and WAL JSON regression coverage

## Validation
- dotnet restore SbeB3Exchange.slnx
- dotnet build SbeB3Exchange.slnx --no-restore -c Release
- dotnet test SbeB3Exchange.slnx --no-build -c Release
- dotnet format SbeB3Exchange.slnx --verify-no-changes --no-restore --severity warn
- dotnet test SbeB3Exchange.slnx -c Debug