### PR TITLE
CI: publish multi-arch (linux/amd64,linux/arm64) images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,6 +48,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # QEMU registers binfmt handlers so buildx can assemble the arm64
+      # image manifest. The .NET SDK stage stays native (see Dockerfile
+      # $BUILDPLATFORM), so QEMU only covers the lightweight runtime layer.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -79,6 +85,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+# $BUILDPLATFORM keeps the SDK stage on the runner's native architecture so
+# the (slow) build never runs under QEMU emulation. Only the runtime layer is
+# emitted for $TARGETARCH via `dotnet publish -a`.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+# TARGETARCH is injected by buildx (amd64 / arm64); `dotnet publish -a`
+# accepts these Docker arch names directly.
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -6,9 +13,9 @@ COPY Directory.Build.props Directory.Packages.props global.json SbeB3Exchange.sl
 COPY schemas/ schemas/
 COPY src/ src/
 
-RUN dotnet restore src/B3.Exchange.Host/B3.Exchange.Host.csproj
+RUN dotnet restore src/B3.Exchange.Host/B3.Exchange.Host.csproj -a $TARGETARCH
 RUN dotnet publish src/B3.Exchange.Host/B3.Exchange.Host.csproj \
-    -c Release -o /app --no-restore
+    -a $TARGETARCH -c Release -o /app --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 

--- a/Dockerfile.synthtrader
+++ b/Dockerfile.synthtrader
@@ -3,7 +3,14 @@
 # The synth-trader is a TCP client of the exchange host (image built from the
 # top-level Dockerfile). It connects to the host on TCP/9876 by default; see
 # config/synthetic-trader.json for the wire endpoint.
-FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+# $BUILDPLATFORM keeps the SDK stage on the runner's native architecture so
+# the (slow) build never runs under QEMU emulation. Only the runtime layer is
+# emitted for $TARGETARCH via `dotnet publish -a`.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+# TARGETARCH is injected by buildx (amd64 / arm64); `dotnet publish -a`
+# accepts these Docker arch names directly.
+ARG TARGETARCH
 
 WORKDIR /src
 
@@ -11,9 +18,9 @@ COPY Directory.Build.props Directory.Packages.props global.json SbeB3Exchange.sl
 COPY schemas/ schemas/
 COPY src/ src/
 
-RUN dotnet restore src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj
+RUN dotnet restore src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj -a $TARGETARCH
 RUN dotnet publish src/B3.Exchange.SyntheticTrader/B3.Exchange.SyntheticTrader.csproj \
-    -c Release -o /app --no-restore
+    -a $TARGETARCH -c Release -o /app --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 


### PR DESCRIPTION
Closes #537.

## What
Publish both GHCR images (`b3-matching`, `b3-matching-synthtrader`) as multi-arch manifests so pods schedule on AKS ARM node pools (Ampere Altra / Cobalt), fixing the `exec format error` that keeps B3Deploy pinned to x86.

## Changes
- **`.github/workflows/docker.yml`**: add `docker/setup-qemu-action` and `platforms: linux/amd64,linux/arm64` on the build-push step. PR builds still validate both arches without pushing.
- **`Dockerfile` / `Dockerfile.synthtrader`**: native cross-publish per the issue's recommendation. The SDK stage is pinned to `--platform=$BUILDPLATFORM` (runs on the runner's native arch, never emulated) and `dotnet publish -a $TARGETARCH` emits the runtime layer. arm64 builds without dragging the SDK through QEMU.

## Validation
Built both Dockerfiles locally with `docker buildx --platform linux/amd64,linux/arm64`; both arches compile cleanly and the arm64 build stage runs natively (`linux/amd64->arm64 build`). Post-merge, verify:

    docker manifest inspect ghcr.io/pedrosakuma/b3-matching:latest
    docker manifest inspect ghcr.io/pedrosakuma/b3-matching-synthtrader:latest

both list `linux/amd64` and `linux/arm64`.