### PR TITLE
ci: bump docker/setup-qemu-action v3 -> v4 (Node 24)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,7 +52,7 @@ jobs:
       # image manifest. The .NET SDK stage stays native (see Dockerfile
       # $BUILDPLATFORM), so QEMU only covers the lightweight runtime layer.
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Clears the Node 20 deprecation annotation on the Docker workflow introduced with #538.

`docker/setup-qemu-action@v3` targets Node 20; GitHub runners now force it onto Node 24 and emit a deprecation warning. `v4.2.0` runs on `node24` natively (confirmed in its `action.yml`).

One-line, CI-only change; the Docker workflow itself validates the multi-arch build on this PR.