### PR TITLE
test(persistence): wait on terminal replay signal in CrashRecovery WAL test (#543)

### DIFF
--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherWalTests.cs
@@ -268,8 +268,18 @@ public class ChannelDispatcherWalTests
             metrics: metricsB, throttle: throttle);
         // Drive RunLoopAsync's initial LoadPersistedStateOnLoopThread by
         // starting the dispatcher and waiting for the replayed registry state.
+        //
+        // Wait on the *terminal* replay signal (WalReplays metric), not just
+        // the registry count: ReplayWalOnLoopThread applies each record via
+        // ProcessOne (which populates the registry) and only increments
+        // AddWalReplays once, after the replay loop completes. Keying the
+        // wait off OrderRegistryCount>=3 alone (an intermediate effect) let
+        // the test observe WalReplays==0 and flake on the assert below under
+        // load (#543 follow-up). WalReplays>=1 implies every replayed record's
+        // ProcessOne already ran, so the registry is fully populated too.
         dispB.Start();
-        Assert.True(await WaitForAsync(() => dispB.OrderRegistryCount >= 3,
+        Assert.True(await WaitForAsync(
+            () => metricsB.WalReplays >= 1 && dispB.OrderRegistryCount >= 3,
             ReadyTimeout), "dispatcher did not replay WAL tail before timeout");
 
         Assert.Equal(3, dispB.OrderRegistryCount);


### PR DESCRIPTION
Completes #543 (follow-up to #544).

## Why #544 wasn't enough

#544 widened the readiness wait to 30s, which stopped the *wait* from timing out — but a fresh full-suite Release+coverage hunt then caught the test failing **fast** on a different line:

\`\`\`
Assert.True() Failure  Expected: True  Actual: False
  at ChannelDispatcherWalTests.cs  (Assert.True(metricsB.WalReplays >= 1))
\`\`\`

## Real root cause (same class as the reaper race #541)

The test synchronized on an **intermediate** replay effect and asserted on a **terminal** one:

- `ReplayWalOnLoopThread` applies each WAL record via `ProcessOne`, which populates the order registry (`ChannelDispatcher.Wal.cs:432`).
- It calls `AddWalReplays(replayed)` **once, after** the replay loop finishes (`ChannelDispatcher.Wal.cs:452`).

The wait keyed off `OrderRegistryCount >= 3` (satisfied at line 432 for the last record), then the test immediately asserted `WalReplays >= 1` (line 452) — which under load hadn't run yet.

## Fix

Key the readiness wait off `metricsB.WalReplays >= 1` (the terminal signal), AND-ed with `OrderRegistryCount >= 3` for belt-and-suspenders. `WalReplays >= 1` implies every replayed record's `ProcessOne` already ran, so the registry is fully populated. No timeout reliance, no `--blame`.

## Validation

- Reproduced after #544 (1 in ~18 full-suite `Release --collect:"XPlat Code Coverage"` runs, failing at the `WalReplays` assert).
- Fixed test: 30/30 green in isolation; race-free by construction.