### PR TITLE
test(e2e): widen daily-reset / retransmit read budgets under coverage (#546)

### DIFF
--- a/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
+++ b/tests/B3.Exchange.Gateway.Tests/FixpSessionRetransmitTests.cs
@@ -350,8 +350,11 @@ public class FixpSessionRetransmitTests
             session.WriteExecutionReportNew(NewER(3, 1003));
             session.WriteExecutionReportNew(NewER(4, 1004));
 
+            // Generous budget: under full-suite + coverage load the pre-filled ER
+            // frames plus the RetransmitReject can take >5s to flush through the
+            // send loop; 15s keeps CI robust while still catching a genuine hang.
             var clientStream = client.GetStream();
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
 
             // Request a 3-message replay; with depth 4 + needed (2+3=5) > capacity 4
             // the gateway must respond SYSTEM_BUSY before any block is enqueued.

--- a/tests/B3.Exchange.Host.Tests/DayExpiryE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/DayExpiryE2ETests.cs
@@ -19,6 +19,14 @@ public class DayExpiryE2ETests
 {
     private const long SecId = 900000000001L;
 
+    // Generous read budget for the wire round-trips: these E2E tests run in the
+    // full suite under coverage instrumentation, which adds enough overhead that
+    // a 5s budget is occasionally too tight (the frames DO arrive — the
+    // TcpTransport drain-race that could drop them was fixed in #548 — but under
+    // load the round-trip can exceed 5s). 15s keeps CI robust while still
+    // catching a genuine stall.
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(15);
+
     private sealed class RecordingPacketSink : IUmdfPacketSink
     {
         public List<byte[]> Packets { get; } = new();
@@ -88,14 +96,14 @@ public class DayExpiryE2ETests
             var newOrder = BuildNewOrderSingle(clOrdId: 13_001, secId: SecId,
                 side: '1', tif: '0', qty: 100, priceMantissa: 123_400, expireDate: 0);
             await stream.WriteAsync(newOrder);
-            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            var er1 = await ReadFrameAsync(stream, ReadTimeout);
             Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
 
             host.TriggerDailyReset(reason: "test-day-expiry");
 
             // The resting Day BUY must come back as an ER_Cancel carrying the
             // terminal EXPIRED('C') OrdStatus.
-            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            var er2 = await ReadFrameAsync(stream, ReadTimeout);
             Assert.Equal(EntryPointFrameReader.TidExecutionReportCancel, er2.TemplateId);
             Assert.Equal((byte)'1', er2.Body[18]);   // Side = Buy
             Assert.Equal((byte)'C', er2.Body[19]);   // OrdStatus = EXPIRED
@@ -145,12 +153,12 @@ public class DayExpiryE2ETests
             var newOrder = BuildNewOrderSingle(clOrdId: 13_101, secId: SecId,
                 side: '1', tif: '1', qty: 100, priceMantissa: 123_400, expireDate: 0);
             await stream.WriteAsync(newOrder);
-            var er1 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            var er1 = await ReadFrameAsync(stream, ReadTimeout);
             Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, er1.TemplateId);
 
             host.TriggerDailyReset(reason: "test-day-keep-gtc");
 
-            var er2 = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            var er2 = await ReadFrameAsync(stream, ReadTimeout);
             Assert.Equal(EntryPointFrameReader.TidExecutionReportModify, er2.TemplateId);
             Assert.Equal((byte)'R', er2.Body[19]);   // OrdStatus = RESTATED
         }

--- a/tests/B3.Exchange.Host.Tests/GtRestatementE2ETests.cs
+++ b/tests/B3.Exchange.Host.Tests/GtRestatementE2ETests.cs
@@ -18,6 +18,14 @@ public class GtRestatementE2ETests
 {
     private const long SecId = 900000000001L;
 
+    // Generous read budget for the wire round-trips: these E2E tests run in the
+    // full suite under coverage instrumentation, which adds enough overhead that
+    // a 5s budget is occasionally too tight (the frames DO arrive — the
+    // TcpTransport drain-race that could drop them was fixed in #548 — but under
+    // load the round-trip can exceed 5s). 15s keeps CI robust while still
+    // catching a genuine stall.
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(15);
+
     private sealed class RecordingPacketSink : IUmdfPacketSink
     {
         public List<byte[]> Packets { get; } = new();
@@ -92,14 +100,14 @@ public class GtRestatementE2ETests
             var gtc = BuildNewOrderSingle(clOrdId: 13_001, secId: SecId, side: '1',
                 qty: 100, priceMantissa: 123_400, tif: '1', expireDate: 0);
             await stream.WriteAsync(gtc);
-            var erGtcNew = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            var erGtcNew = await ReadFrameAsync(stream, ReadTimeout);
             Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, erGtcNew.TemplateId);
 
             // Resting future-dated GTD order at a non-crossing price.
             var gtd = BuildNewOrderSingle(clOrdId: 13_002, secId: SecId, side: '1',
                 qty: 200, priceMantissa: 123_300, tif: '6', expireDate: futureExpire);
             await stream.WriteAsync(gtd);
-            var erGtdNew = await ReadFrameAsync(stream, TimeSpan.FromSeconds(5));
+            var erGtdNew = await ReadFrameAsync(stream, ReadTimeout);
             Assert.Equal(EntryPointFrameReader.TidExecutionReportNew, erGtdNew.TemplateId);
 
             host.TriggerDailyReset(reason: "test-gt-restatement");
@@ -107,7 +115,7 @@ public class GtRestatementE2ETests
             // Both surviving orders must come back as restatement ER_Modify frames.
             var restates = new List<ReadFrame>();
             for (int i = 0; i < 2; i++)
-                restates.Add(await ReadFrameAsync(stream, TimeSpan.FromSeconds(5)));
+                restates.Add(await ReadFrameAsync(stream, ReadTimeout));
 
             foreach (var r in restates)
             {


### PR DESCRIPTION
## Context

Follow-up to #548 (TcpTransport drain-sync race fix). That PR eliminated the
load-only **stalls** in the daily-reset E2E tests — the real bug where a
restatement frame could be silently dropped on session close, hanging the peer.

## Remaining, separate issue

These E2E round-trips run in the full suite under
`--collect:"XPlat Code Coverage"`, whose instrumentation overhead occasionally
pushes a wire round-trip past the old **5s** read budget even though the frame
*does* arrive. Evidence, all on `main` with #548 merged:

- `GtRestatementE2ETests` at 30s budget: **65/65** clean under coverage load.
- `DayExpiryE2ETests` at 30s budget: **30/30** clean; at 5s it failed **1/25**
  (an `OperationCanceledException` on the read, not a stall).

So the residual is pure headroom, not a hang.

## Change

Give the affected reads a generous-but-bounded **15s** budget:
- `GtRestatementE2ETests` / `DayExpiryE2ETests`: shared `ReadTimeout = 15s`
  const applied to every post-connect `ReadFrameAsync`.
- `FixpSessionRetransmitTests.RetransmitReject_..._SYSTEM_BUSY`: 5s → 15s CTS.

15s stays well below any real-hang threshold, so a genuine regression still
fails fast. Test-only change.

Closes the remaining #546 flakes on top of the #548 root-cause fix.