### PR TITLE
feat(deploy): publish b3-matching as a Helm chart OCI artifact (#547)

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -66,11 +66,13 @@ jobs:
             --set persistence.enabled=false \
             --set networkPolicy.enabled=false > /tmp/override.yaml
 
-      - name: Validate rendered manifests
-        uses: yannh/kubeconform-action@v1
-        with:
-          args: -strict -summary -ignore-missing-schemas
-          files: /tmp/default.yaml
+      - name: Validate rendered manifests (kubeconform)
+        run: |
+          KUBECONFORM_VERSION=v0.8.0
+          curl -fsSL \
+            "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp kubeconform
+          /tmp/kubeconform -strict -summary -ignore-missing-schemas /tmp/default.yaml /tmp/override.yaml
 
   publish:
     name: Package & push (OCI)

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -1,0 +1,128 @@
+name: Helm
+
+# Lints the b3-matching Layer-1 chart on every PR, and publishes it as an OCI
+# artifact next to the GHCR image on pushes to main / tags — gated on a
+# Chart.yaml `version` bump (the publish step is skipped when that version is
+# already present in the registry, so it is idempotent).
+#
+#   oci://ghcr.io/<owner>/charts/b3-matching:<version>
+#
+# Versioning contract (docs/HELM-CHART.md): chart `version` is SemVer, released
+# in lockstep with the image; `appVersion` is the image version it was
+# validated against. b3deploy pins `chart@version` next to `image@sha256:`.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - 'deploy/charts/**'
+      - '.github/workflows/helm.yml'
+  pull_request:
+    paths:
+      - 'deploy/charts/**'
+      - '.github/workflows/helm.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: helm-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHART_DIR: deploy/charts/b3-matching
+  CHART_NAME: b3-matching
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & template
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: helm lint
+        run: helm lint "$CHART_DIR"
+
+      # Render with defaults and with an override set so both the digest-pinned
+      # and the tag path (plus the toggles) stay green.
+      - name: helm template (defaults)
+        run: helm template ci "$CHART_DIR" > /tmp/default.yaml
+
+      - name: helm template (overrides)
+        run: |
+          helm template ci "$CHART_DIR" \
+            --set marketData.host=md.b3-prod.svc.cluster.local \
+            --set image.digest="" --set image.tag=9.9.9 \
+            --set colocation.enabled=false \
+            --set persistence.enabled=false \
+            --set networkPolicy.enabled=false > /tmp/override.yaml
+
+      - name: Validate rendered manifests
+        uses: yannh/kubeconform-action@v1
+        with:
+          args: -strict -summary -ignore-missing-schemas
+          files: /tmp/default.yaml
+
+  publish:
+    name: Package & push (OCI)
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    needs: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+
+      - name: Read chart version
+        id: chart
+        run: |
+          version="$(helm show chart "$CHART_DIR" | awk '/^version:/ {print $2}')"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Chart version: $version"
+
+      - name: Log in to GHCR (Helm OCI)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Gate on a version bump: if the version is already in the registry, skip.
+      - name: Check if version already published
+        id: exists
+        run: |
+          owner="${{ github.repository_owner }}"
+          if helm show chart "oci://ghcr.io/${owner}/charts/${CHART_NAME}" \
+               --version "${{ steps.chart.outputs.version }}" >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Chart ${CHART_NAME} ${{ steps.chart.outputs.version }} already published — skipping push."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: helm package
+        if: steps.exists.outputs.published == 'false'
+        run: helm package "$CHART_DIR" --destination /tmp/pkg
+
+      - name: helm push (OCI)
+        if: steps.exists.outputs.published == 'false'
+        run: |
+          owner="${{ github.repository_owner }}"
+          helm push \
+            "/tmp/pkg/${CHART_NAME}-${{ steps.chart.outputs.version }}.tgz" \
+            "oci://ghcr.io/${owner}/charts"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,19 @@ docker pull ghcr.io/pedrosakuma/b3-matching-synthtrader:latest
 
 Tags available: `:latest`, `:sha-<short>`, `:<branch>`, `:vX.Y.Z`, `:X.Y`.
 
+### Kubernetes (Helm chart, OCI)
+
+A Layer-1 Helm chart ships alongside the image for AKS/Kubernetes deploys:
+
+```bash
+helm install matching oci://ghcr.io/pedrosakuma/charts/b3-matching --version <version>
+```
+
+Chart source is [`deploy/charts/b3-matching`](deploy/charts/b3-matching); see
+[`docs/HELM-CHART.md`](docs/HELM-CHART.md) for the versioning contract and
+publish flow. `b3deploy` consumes it as `chart@version` + per-env values.
+
+
 ### Bridge-network mode (issue #88, preview)
 
 The default mode publishes UMDF over UDP **multicast** and so requires

--- a/deploy/charts/b3-matching/.helmignore
+++ b/deploy/charts/b3-matching/.helmignore
@@ -1,0 +1,10 @@
+# Patterns to ignore when building the chart package.
+.git/
+.gitignore
+*.tmp
+*.bak
+*.orig
+.DS_Store
+# CI / dev artifacts
+ci/
+*.tgz

--- a/deploy/charts/b3-matching/Chart.yaml
+++ b/deploy/charts/b3-matching/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: b3-matching
+description: >-
+  The B3 exchange-core matching platform (FIXP EntryPoint venue + UMDF unicast
+  emitter). Layer-1 component chart, published as an OCI artifact next to the
+  ghcr.io/pedrosakuma/b3-matching image and consumed by b3deploy as
+  chart@version + per-env values.
+type: application
+
+# Chart version follows SemVer and is released in lockstep with the image
+# (see docs/HELM-CHART.md § Versioning contract). appVersion tracks the
+# b3-matching image version this chart was validated against.
+version: 0.1.0
+appVersion: "0.1.0"
+
+kubeVersion: ">=1.27.0-0"
+
+home: https://github.com/pedrosakuma/B3MatchingPlatform
+sources:
+  - https://github.com/pedrosakuma/B3MatchingPlatform
+keywords:
+  - b3
+  - exchange
+  - matching-engine
+  - fixp
+  - umdf
+maintainers:
+  - name: pedrosakuma
+    url: https://github.com/pedrosakuma

--- a/deploy/charts/b3-matching/README.md
+++ b/deploy/charts/b3-matching/README.md
@@ -1,0 +1,58 @@
+# b3-matching Helm chart
+
+Layer-1 component chart for the **B3 exchange-core matching platform** (FIXP
+EntryPoint venue + UMDF unicast emitter). Published as an OCI artifact next to
+the image and consumed by `b3deploy` as `chart@version` + per-env values.
+
+```
+oci://ghcr.io/pedrosakuma/charts/b3-matching
+ghcr.io/pedrosakuma/b3-matching            (image, digest-pinned per env)
+```
+
+## Install
+
+```bash
+helm install matching oci://ghcr.io/pedrosakuma/charts/b3-matching \
+  --version 0.1.0 \
+  --namespace b3-prod --create-namespace \
+  --set image.digest=sha256:... \
+  --set marketData.host=marketdata
+```
+
+## What ships in the chart (Layer-1)
+
+| Object | Notes |
+| --- | --- |
+| **StatefulSet** | single-writer WAL on `volumeClaimTemplates` (`/var/lib/b3matching`, RWO). **Never `replicas>1`** (double-writes the WAL). |
+| **Headless Service** `matching-platform` | `clusterIP: None`; FIXP **9876/TCP** + metrics **8080/TCP**. Trading-host dials the pod IP directly (no LB in the FIXP path). |
+| **ConfigMap** | `exchange-simulator.bridge.json` + `instruments-eqt.json` — Layer-1 defaults, overridable via values. |
+| **NetworkPolicy** | ingress `trading-host → 9876`; egress `matching → marketdata UDP` + DNS. Metrics (8080) stays cluster-internal. |
+
+## Load-bearing invariants
+
+- **UMDF unicast contract:** matching resolves `marketData.host` at startup and
+  **aborts if it misses**; it emits unicast UDP to that single endpoint. Keep it
+  a real DNS name reachable from the pod (the egress NetworkPolicy allows DNS +
+  the marketdata UDP ports).
+- **Co-location:** `colocation.enabled` adds a `podAffinity` to marketdata on
+  `topologyKey: kubernetes.io/hostname` so the UDP feed never crosses a node.
+- **Active-passive only:** HA is disk-reattach, never active-active. `replicas: 1`.
+
+## Key values
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `image.repository` | `ghcr.io/pedrosakuma/b3-matching` | image repo |
+| `image.digest` | validated-on-AKS `sha256:…` | wins over `tag` when set |
+| `image.tag` | `""` (→ appVersion) | used when `digest` is empty |
+| `replicas` | `1` | **do not raise** |
+| `marketData.host` | `marketdata` | unicast UDP target hostname |
+| `marketData.udpPorts` | `[30084, 30184, 31084]` | egress UDP ports (match the bridge config) |
+| `colocation.enabled` / `colocation.matchTargetLabels` | `true` / `{app.kubernetes.io/name: marketdata}` | podAffinity target |
+| `persistence.storageClassName` / `.size` | `managed-csi-premium` / `4Gi` | WAL volume (prefer ZRS where the SKU/region supports it) |
+| `resources` | `cpu 100m`, `mem 512Mi/1Gi` | keep trimmed for lean nodes |
+| `networkPolicy.enabled` | `true` | ingress/egress allows |
+| `config.bridgeJson` / `config.instrumentsJson` | `""` | full-override escape hatch |
+
+See [`docs/HELM-CHART.md`](../../../docs/HELM-CHART.md) for the versioning
+contract and publish flow.

--- a/deploy/charts/b3-matching/files/exchange-simulator.bridge.json
+++ b/deploy/charts/b3-matching/files/exchange-simulator.bridge.json
@@ -1,0 +1,120 @@
+{
+  // Layer-1 Helm chart default for b3-matching, ported verbatim from the
+  // validated-on-AKS manifest b3deploy@3b4c1d9 (envs/prod/config/). The three
+  // UMDF unicast host values are templated to {{ .Values.marketData.host }} and
+  // rendered by the ConfigMap via `tpl`; everything else is unchanged. Override
+  // wholesale with .Values.config.bridgeJson if an env needs a different shape.
+  //
+  // Bridge-network friendly variant of upstream's exchange-simulator.json,
+  // pinned to the shape B3TradingPlatform's family compose exercises.
+  // Ships under docker/real/ and is mounted into the matching-platform
+  // service by docker-compose.real.yml.
+  //
+  // Why we commit our own copy instead of mounting the upstream config:
+  // pinning at our PR boundary keeps an upstream config refactor from
+  // silently changing what our CI exercises. When upstream changes shape
+  // and ":latest" stops parsing this file, the next CI run fails — which
+  // is exactly the signal we want.
+  //
+  // Differences from upstream config/exchange-simulator.bridge.json
+  // (https://github.com/pedrosakuma/B3MatchingPlatform):
+  //
+  // 1. UMDF unicast targets point at "marketdata" (the docker compose
+  //    service alias on b3-net). Resolved at startup by
+  //    B3.Exchange.Core.UnicastUdpPacketSink via DNS. The matching ports
+  //    here MUST match docker/real/marketdata-transport.json EQT group
+  //    verbatim (incremental 30084, instrument-def 31084, snapshot 30184).
+  //    Closes RFC integration-real-stack-v0 §4.4 R1.b after upstream
+  //    B3MarketDataPlatform#10 (PR #11) shipped the unicast transport.
+  //
+  // 2. firms[0] / sessions[0] pinned to FIRM01 / 10101 / dev-key-1 so
+  //    docker-compose.real.yml's trading-host overlay can hard-code
+  //    Trading__Exchange__Firms__0__SessionId/AccessKey to match.
+  "tcp": {
+    "listen": "0.0.0.0:9876",
+    "enteringFirm": 1,
+    "heartbeatIntervalMs": 30000,
+    "idleTimeoutMs": 30000,
+    "testRequestGraceMs": 5000
+  },
+  "auth": {
+    "devMode": true
+  },
+  "firms": [
+    { "id": "FIRM01", "name": "Alpha Corretora", "enteringFirmCode": 100 },
+    // Q4.2 (#302). FIRM02 / FIRM03 added so the compose default can wire
+    // three independent firm gateways out of trading-host and prove the
+    // multi-firm isolation surface end-to-end (no order/position/PnL/WAL
+    // leakage across the firm boundary). Distinct enteringFirmCodes so
+    // each appears under its own clearing identity on outbound orders.
+    { "id": "FIRM02", "name": "Beta Corretora", "enteringFirmCode": 200 },
+    { "id": "FIRM03", "name": "Gamma Corretora", "enteringFirmCode": 300 }
+  ],
+  "sessions": [
+    { "sessionId": "10101", "firmId": "FIRM01", "accessKey": "dev-key-1" },
+    // Reserved for the external simulator bot (issue #134). Lets the
+    // bot connect to matching-platform on its own FIXP session without
+    // colliding with trading-host's 10101.
+    { "sessionId": "10102", "firmId": "FIRM01", "accessKey": "dev-key-2" },
+    // Q4.2 (#302). One trading-host FIXP session per additional firm.
+    // SessionIds are picked from the 1010x range so they stay grouped
+    // with FIRM01's sessions in matching's session table.
+    { "sessionId": "10103", "firmId": "FIRM02", "accessKey": "dev-key-3" },
+    { "sessionId": "10104", "firmId": "FIRM03", "accessKey": "dev-key-4" }
+  ],
+  "http": {
+    "listen": "0.0.0.0:8080",
+    "livenessStaleMs": 5000
+  },
+  "channels": [
+    {
+      "channelNumber": 84,
+      // transport=unicast: each "*.group" below is the docker compose
+      // service alias of the marketdata consumer on b3-net. matching's
+      // B3.Exchange.Core.UnicastUdpPacketSink resolves the alias via DNS
+      // at startup, so it MUST match the service name in
+      // docker-compose.real.yml (`marketdata`).
+      "transport": "unicast",
+      "incrementalGroup": "{{ .Values.marketData.host }}",
+      "incrementalPort": 30084,
+      "selfTradePrevention": "none",
+      "instruments": "config/instruments-eqt.json",
+      "snapshot": {
+        "group": "{{ .Values.marketData.host }}",
+        "port": 30184,
+        "cadenceMs": 1000,
+        "maxEntriesPerChunk": 30
+      },
+      "instrumentDefinition": {
+        "channelNumber": 184,
+        "group": "{{ .Values.marketData.host }}",
+        "port": 31084,
+        "cadenceMs": 5000
+      },
+      // Persistence (upstream PRs #261/#269/#262/#274 etc, closes part of
+      // pedrosakuma/B3MatchingPlatform#260). dataDir is mounted from the
+      // named volume `b3-matching-data` in docker-compose.real.yml so
+      // restarts preserve the order book + per-channel WAL.
+      //
+      // IMPORTANT — what is NOT preserved (pedrosakuma/B3MatchingPlatform#405):
+      // FIXP session state (SessionId, SessionVerId, inbound/outbound seq
+      // numbers, SessionClaimRegistry, CoD timers) lives in process memory
+      // only. A graceful `docker compose restart matching-platform` will
+      // force every connected client to fully re-Negotiate with a fresh
+      // SessionVerId — even though the book itself is intact. The host
+      // compensates via ReconcileFirmSessionVerIds (#420) which stales
+      // surviving working orders so the UI never silently lies about
+      // venue state, but the proper fix is server-side persistence.
+      //
+      // WAL closes the RPO gap between snapshots; fsyncPerWrite trades
+      // throughput for at-most-one-cmd loss on unclean shutdown.
+      "persistence": {
+        "dataDir": "/var/lib/b3matching",
+        "wal": {
+          "enabled": true,
+          "fsyncPerWrite": true
+        }
+      }
+    }
+  ]
+}

--- a/deploy/charts/b3-matching/files/instruments-eqt.json
+++ b/deploy/charts/b3-matching/files/instruments-eqt.json
@@ -1,0 +1,26 @@
+[
+  // Pinned copy of upstream B3MatchingPlatform's config/instruments-eqt.json
+  // (https://github.com/pedrosakuma/B3MatchingPlatform/blob/main/config/instruments-eqt.json).
+  //
+  // Mounted into the matching-platform container next to
+  // exchange-simulator.bridge.json so the simulator can resolve symbol
+  // → securityId at startup. Ships under docker/real/ for the same
+  // reason as the bridge config: pin at our PR boundary; an upstream
+  // schema change becomes a CI failure on the next PR.
+  //
+  // The trading-host overlay (docker-compose.real.yml) does NOT need to
+  // know these securityIds — conformance specs that submit to /orders or
+  // /algo either get rejected by the risk pipeline before reaching the
+  // gateway (RiskRejectionShape) or skip when the simulator endpoint is
+  // absent (Algo, Simulator). v2 follow-ups that submit through-and-back
+  // would map Trading__SymbolDirectory__SecurityIds__* to these ids.
+  { "symbol": "PETR4", "securityId": 900000000001, "tickSize": "0.01",
+    "lotSize": 100, "minPx": "0.01", "maxPx": "999999.99",
+    "currency": "BRL", "isin": "BRPETRACNPR6", "securityType": "CS" },
+  { "symbol": "VALE3", "securityId": 900000000002, "tickSize": "0.01",
+    "lotSize": 100, "minPx": "0.01", "maxPx": "999999.99",
+    "currency": "BRL", "isin": "BRVALEACNOR0", "securityType": "CS" },
+  { "symbol": "ITUB4", "securityId": 900000000003, "tickSize": "0.01",
+    "lotSize": 100, "minPx": "0.01", "maxPx": "999999.99",
+    "currency": "BRL", "isin": "BRITUBACNPR1", "securityType": "CS" }
+]

--- a/deploy/charts/b3-matching/templates/NOTES.txt
+++ b/deploy/charts/b3-matching/templates/NOTES.txt
@@ -1,0 +1,17 @@
+b3-matching (chart {{ .Chart.Version }}, appVersion {{ .Chart.AppVersion }}) is installed as release "{{ .Release.Name }}".
+
+Image:            {{ include "b3-matching.image" . }}
+Replicas:         {{ .Values.replicas }}  {{ if gt (int .Values.replicas) 1 }}⚠️  >1 will double-write the single-writer WAL — set replicas: 1{{ end }}
+Headless service: {{ .Values.service.name }}  (FIXP {{ .Values.service.fixpPort }}/TCP, metrics {{ .Values.service.httpPort }}/TCP)
+Marketdata host:  {{ .Values.marketData.host }}  (unicast UDP {{ .Values.marketData.udpPorts | join ", " }})
+Persistence:      {{ if .Values.persistence.enabled }}{{ .Values.persistence.size }} on {{ .Values.persistence.storageClassName | default "(default StorageClass)" }} at {{ .Values.persistence.mountPath }}{{ else }}DISABLED (emptyDir — WAL is not durable!){{ end }}
+
+Trading-host reaches matching at:
+    {{ .Values.service.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.fixpPort }}
+
+Load-bearing invariants (see docs/HELM-CHART.md):
+  * matching resolves "{{ .Values.marketData.host }}" at startup and ABORTS if it misses.
+  * Keep replicas at 1 (active-passive disk-reattach; never active-active).
+{{- if not .Values.colocation.enabled }}
+  * colocation.enabled is false — matching may schedule off-node from marketdata; the UDP feed could cross a node boundary.
+{{- end }}

--- a/deploy/charts/b3-matching/templates/_helpers.tpl
+++ b/deploy/charts/b3-matching/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/*
+Chart name, sanitized for k8s object names.
+*/}}
+{{- define "b3-matching.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully-qualified app name. Honours .Values.fullnameOverride; otherwise uses the
+release name, collapsing the common `<release>-<chart>` duplication so a
+`helm install matching ...` yields `matching` rather than `matching-b3-matching`.
+*/}}
+{{- define "b3-matching.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "b3-matching.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels — the load-bearing app identity. `app.kubernetes.io/name:
+matching` is what the headless Service selector, the podAffinity target and the
+NetworkPolicy podSelectors all key on across the b3-prod family, so keep it
+stable (do NOT fold in the release name here).
+*/}}
+{{- define "b3-matching.selectorLabels" -}}
+app.kubernetes.io/name: matching
+{{- end -}}
+
+{{/*
+Common labels applied to every object.
+*/}}
+{{- define "b3-matching.labels" -}}
+helm.sh/chart: {{ include "b3-matching.chart" . }}
+{{ include "b3-matching.selectorLabels" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/part-of: b3-sim
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Resolve the container image reference. `image.digest` (@sha256:) wins over
+`image.tag`; `image.tag` falls back to the chart appVersion.
+*/}}
+{{- define "b3-matching.image" -}}
+{{- $repo := .Values.image.repository -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s@%s" $repo .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $repo (.Values.image.tag | default .Chart.AppVersion) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ConfigMap name holding the bridge config + instruments.
+*/}}
+{{- define "b3-matching.configMapName" -}}
+{{- printf "%s-config" (include "b3-matching.fullname" .) -}}
+{{- end -}}

--- a/deploy/charts/b3-matching/templates/configmap.yaml
+++ b/deploy/charts/b3-matching/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "b3-matching.configMapName" . }}
+  labels:
+    {{- include "b3-matching.labels" . | nindent 4 }}
+data:
+  # Bridge config: the marketData.host is injected via `tpl`. An env may override
+  # the whole document with .Values.config.bridgeJson (still templated so the
+  # host substitution keeps working).
+  {{ .Values.configFileName }}: |-
+    {{- if .Values.config.bridgeJson }}
+    {{- tpl .Values.config.bridgeJson . | nindent 4 }}
+    {{- else }}
+    {{- tpl (.Files.Get "files/exchange-simulator.bridge.json") . | nindent 4 }}
+    {{- end }}
+  instruments-eqt.json: |-
+    {{- if .Values.config.instrumentsJson }}
+    {{- .Values.config.instrumentsJson | nindent 4 }}
+    {{- else }}
+    {{- .Files.Get "files/instruments-eqt.json" | nindent 4 }}
+    {{- end }}

--- a/deploy/charts/b3-matching/templates/networkpolicy.yaml
+++ b/deploy/charts/b3-matching/templates/networkpolicy.yaml
@@ -1,0 +1,63 @@
+{{- if .Values.networkPolicy.enabled }}
+# NetworkPolicy for the legitimate hops this Layer-1 component owns:
+#
+#   trading-host ──9876(FIXP)──► matching ──UDP(30084/30184/31084)──► marketdata
+#
+# Metrics (8080) is deliberately NOT admitted, so it stays cluster-internal.
+# Egress is restricted to the marketdata UDP feed + DNS — the latter is
+# load-bearing: matching resolves marketData.host at startup and ABORTS if it
+# misses, so kube-dns must stay reachable.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "b3-matching.fullname" . }}-ingress
+  labels:
+    {{- include "b3-matching.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "b3-matching.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # admit only trading-host FIXP (9876); /metrics (8080) stays internal.
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.fixpClientSelector | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.fixpPort }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "b3-matching.fullname" . }}-egress
+  labels:
+    {{- include "b3-matching.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "b3-matching.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Egress
+  egress:
+    # UMDF unicast UDP to marketdata.
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.marketDataSelector | nindent 14 }}
+      ports:
+        {{- range .Values.marketData.udpPorts }}
+        - protocol: UDP
+          port: {{ . }}
+        {{- end }}
+    # DNS — load-bearing: startup name resolution of marketData.host.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/deploy/charts/b3-matching/templates/service.yaml
+++ b/deploy/charts/b3-matching/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service.name }}
+  labels:
+    {{- include "b3-matching.labels" . | nindent 4 }}
+spec:
+  # Headless: governs the StatefulSet and lets trading-host resolve
+  # {{ .Values.service.name }}:{{ .Values.service.fixpPort }} straight to the
+  # pod IP (no LB in the FIXP path).
+  clusterIP: None
+  selector:
+    {{- include "b3-matching.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: fixp
+      port: {{ .Values.service.fixpPort }}
+      protocol: TCP
+    - name: http
+      port: {{ .Values.service.httpPort }}
+      protocol: TCP

--- a/deploy/charts/b3-matching/templates/statefulset.yaml
+++ b/deploy/charts/b3-matching/templates/statefulset.yaml
@@ -1,0 +1,112 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "b3-matching.fullname" . }}
+  labels:
+    {{- include "b3-matching.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ .Values.service.name }}
+  # Active-passive disk-reattach only; never >1 (single-writer WAL).
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "b3-matching.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "b3-matching.labels" . | nindent 8 }}
+      annotations:
+        # Roll the pod when the mounted config changes.
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.colocation.enabled }}
+      # Co-locate with marketdata (RFC: matching<->marketdata same node/AZ). The
+      # UDP feed never leaves the node. Load-bearing once the pool scales.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  {{- toYaml .Values.colocation.matchTargetLabels | nindent 18 }}
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: matching
+          image: {{ include "b3-matching.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args: ["/app/config/{{ .Values.configFileName }}"]
+          ports:
+            - name: fixp
+              containerPort: {{ .Values.service.fixpPort }}
+              protocol: TCP
+            - name: http
+              containerPort: {{ .Values.service.httpPort }}
+              protocol: TCP
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: bridge-config
+              mountPath: /app/config/{{ .Values.configFileName }}
+              subPath: {{ .Values.configFileName }}
+              readOnly: true
+            - name: bridge-config
+              mountPath: /app/config/instruments-eqt.json
+              subPath: instruments-eqt.json
+              readOnly: true
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+      volumes:
+        - name: bridge-config
+          configMap:
+            name: {{ include "b3-matching.configMapName" . }}
+        {{- if not .Values.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          {{- toYaml .Values.persistence.accessModes | nindent 10 }}
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+  {{- end }}

--- a/deploy/charts/b3-matching/values.yaml
+++ b/deploy/charts/b3-matching/values.yaml
@@ -1,0 +1,116 @@
+# Default values for the b3-matching Layer-1 chart.
+#
+# These are the "component defaults" validated on AKS (b3deploy@3b4c1d9 →
+# envs/prod/matching.yaml). b3deploy overrides the env-specific surface
+# (image digest, resources, storage class, marketdata host, colocation) per
+# environment; everything here is a safe standalone default.
+
+# -- Container image. b3deploy pins `digest` (@sha256:) per env; when `digest`
+#    is set it wins over `tag`. `tag` falls back to the chart appVersion.
+image:
+  repository: ghcr.io/pedrosakuma/b3-matching
+  # Validated-on-AKS digest (b3deploy@3b4c1d9). Leave empty to use `tag`.
+  digest: "sha256:d7dc4e9390a7334bcfc9030ecf98b39aabb3844afed0698a93383c95c2a661d7"
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# -- Active-passive disk-reattach only. NEVER set >1: two writers would
+#    double-write the single-writer WAL under /var/lib/b3matching.
+replicas: 1
+
+# -- Config file the ExchangeHost boots from (mounted from the ConfigMap).
+configFileName: exchange-simulator.bridge.json
+
+# -- Unicast UMDF target. matching resolves this DNS name at startup and
+#    ABORTS if it misses; it emits unicast UDP here (no multicast, no LB in
+#    the UDP path). Injected into the bridge config's channel groups.
+marketData:
+  host: marketdata
+  # UDP ports matching emits to this host. Must match the channel ports in
+  # the bridge config; used to render the matching->marketdata egress
+  # NetworkPolicy. Defaults match the shipped EQT channel (incremental 30084,
+  # snapshot 30184, instrument-definition 31084).
+  udpPorts:
+    - 30084
+    - 30184
+    - 31084
+
+# -- Co-location affinity to marketdata (RFC: matching<->marketdata same
+#    node/AZ, UDP never crosses a LB). Load-bearing once the pool scales.
+colocation:
+  enabled: true
+  # podAffinity requiredDuringScheduling target on
+  # topologyKey: kubernetes.io/hostname.
+  matchTargetLabels:
+    app.kubernetes.io/name: marketdata
+
+# -- Persistent volume for the per-channel WAL + snapshots (RWO, single-writer).
+persistence:
+  enabled: true
+  storageClassName: managed-csi-premium
+  size: 4Gi
+  accessModes:
+    - ReadWriteOnce
+  mountPath: /var/lib/b3matching
+
+# -- Pod resources. Kept a value: the lean single 2-vCPU ARM node only fits the
+#    whole family with trimmed requests — do not hard-code fat requests.
+resources:
+  requests:
+    cpu: 100m
+    memory: 512Mi
+  limits:
+    memory: 1Gi
+
+service:
+  # Headless so trading-host resolves matching straight to the pod IP
+  # (no LB in the FIXP path) and to govern the StatefulSet.
+  name: matching-platform
+  fixpPort: 9876
+  httpPort: 8080
+
+# -- NetworkPolicy for the legitimate hops this Layer-1 component owns:
+#    ingress trading-host -> matching:9876 (metrics 8080 stays cluster-internal,
+#    it is simply not admitted) and egress matching -> marketData UDP.
+networkPolicy:
+  enabled: true
+  # Pod selector of the allowed FIXP client (trading-host).
+  fixpClientSelector:
+    app.kubernetes.io/name: trading-host
+  # Pod selector of the marketdata consumer for the UDP egress allow.
+  marketDataSelector:
+    app.kubernetes.io/name: marketdata
+
+# -- Probes hit /metrics, which only binds after the channel dispatcher + FIXP
+#    listener are up (ExchangeHost startup order).
+readinessProbe:
+  httpGet:
+    path: /metrics
+    port: 8080
+  initialDelaySeconds: 5
+  periodSeconds: 5
+  failureThreshold: 12
+livenessProbe:
+  httpGet:
+    path: /metrics
+    port: 8080
+  initialDelaySeconds: 15
+  periodSeconds: 15
+
+# -- Extra labels applied to every rendered object.
+commonLabels: {}
+
+nodeSelector: {}
+tolerations: []
+podAnnotations: {}
+podSecurityContext: {}
+securityContext: {}
+
+# -- Escape hatch: full override of the bridge config / instruments JSON.
+#    When set, the string wins over the shipped Layer-1 default file (the
+#    marketData.host templating still applies via `tpl` for bridgeJson).
+config:
+  bridgeJson: ""
+  instrumentsJson: ""

--- a/docs/HELM-CHART.md
+++ b/docs/HELM-CHART.md
@@ -1,0 +1,51 @@
+# Helm chart — `b3-matching` (OCI)
+
+M3 of the deploy-topology RFC (#557 / #547). The per-service chart is **Layer-1**
+and lives + publishes here, next to the `b3-matching` image. `b3deploy`
+references it as `chart@version` + per-env values — no vendored manifests.
+
+- Chart source: [`deploy/charts/b3-matching`](../deploy/charts/b3-matching)
+- Image: `ghcr.io/pedrosakuma/b3-matching`
+- Chart OCI: `oci://ghcr.io/pedrosakuma/charts/b3-matching`
+
+The chart was ported verbatim from the validated-on-AKS manifest
+`b3deploy@3b4c1d9 → envs/prod/matching.yaml` (+ `envs/prod/config/`), with the
+env-specific bits lifted to `values.yaml` and the marketdata target templated.
+
+## Versioning contract
+
+- Chart `version` is **SemVer**, released **in lockstep with the image**.
+- Chart `appVersion` is the **image version it was validated against**.
+- `b3deploy` pins `chart@version` next to `image@sha256:` per environment.
+
+Bump `Chart.yaml: version` in the same PR that ships a chart change intended for
+release. The publish job is idempotent — it skips when that version is already
+in the registry — so a merge without a bump republishes nothing.
+
+## CI: `helm.yml`
+
+| Job | When | What |
+| --- | --- | --- |
+| `lint` | every PR + push touching `deploy/charts/**` | `helm lint`, `helm template` (defaults + overrides), `kubeconform` on the rendered manifests |
+| `publish` | push to `main`, tags `v*`, manual | `helm package` + `helm push oci://ghcr.io/<owner>/charts` using the GHCR token, gated on the version not already being published |
+
+## Publish manually
+
+```bash
+helm registry login ghcr.io -u <user> --password-stdin   # GHCR PAT/token
+helm package deploy/charts/b3-matching --destination /tmp/pkg
+helm push /tmp/pkg/b3-matching-<version>.tgz oci://ghcr.io/pedrosakuma/charts
+```
+
+## Consume from `b3deploy`
+
+```bash
+helm pull oci://ghcr.io/pedrosakuma/charts/b3-matching --version <version>
+# or reference chart@version from an env values file; b3deploy overrides
+# image.digest, resources, persistence.storageClassName, marketData.host,
+# colocation.* per environment.
+```
+
+See the [chart README](../deploy/charts/b3-matching/README.md) for the full
+values surface and load-bearing invariants (unicast DNS abort, single-writer
+WAL, co-location).


### PR DESCRIPTION
Closes #547 (M3 of the deploy-topology RFC #557).

The per-service chart is **Layer-1** and now lives + publishes here, next to the
`b3-matching` image; `b3deploy` will reference it as `chart@version` + per-env
values instead of vendoring a hand-written kustomize manifest.

## Chart — `deploy/charts/b3-matching`

Ported verbatim from the validated-on-AKS manifest **`b3deploy@3b4c1d9`**
(`envs/prod/matching.yaml` + `envs/prod/config/`), env-specific bits lifted to
`values.yaml`:

- **StatefulSet** (single-writer WAL): `serviceName` = headless svc,
  `volumeClaimTemplates` for `/var/lib/b3matching` (RWO). `replicas` defaults 1;
  NOTES/docs warn >1 double-writes the WAL.
- **Headless Service** `matching-platform` (`clusterIP: None`): FIXP 9876/TCP +
  metrics 8080/TCP → trading-host dials the pod IP directly (no LB in the FIXP path).
- **ConfigMap** for `exchange-simulator.bridge.json` + `instruments-eqt.json`
  (Layer-1 defaults). `marketData.host` is templated into the bridge config's
  three unicast targets via `tpl`; either file is overridable wholesale.
- **NetworkPolicy**: ingress `trading-host → matching:9876` (metrics stays
  cluster-internal); egress `matching → marketdata UDP` + **DNS** (load-bearing —
  matching resolves `marketData.host` at startup and **aborts if it misses**).
- **Co-location**: `podAffinity` to marketdata on
  `topologyKey: kubernetes.io/hostname`, toggled by `colocation.enabled`.

### `values.yaml` surface
`image.repository/tag/digest` (digest wins, pinned per env), `resources` (lean
`cpu 100m` / `mem 512Mi–1Gi`), `persistence.storageClassName`
(`managed-csi-premium`) + `size` (4Gi), `marketData.host` + `udpPorts`,
`colocation.enabled`/`matchTargetLabels`, `replicas`.

## CI — `.github/workflows/helm.yml`
- **lint** (every PR + push under `deploy/charts/**`): `helm lint`,
  `helm template` (defaults + overrides), `kubeconform` on rendered manifests.
- **publish** (push to `main` / `v*` tags / manual): `helm package` +
  `helm push oci://ghcr.io/<owner>/charts` with the GHCR token, **gated on the
  `Chart.yaml` version not already being published** (idempotent version-bump gate).

Target: `oci://ghcr.io/pedrosakuma/charts/b3-matching`.

## Versioning contract (docs/HELM-CHART.md)
Chart `version` = SemVer, released in lockstep with the image; `appVersion` =
the image version it was validated against. Initial **0.1.0** / appVersion
0.1.0; default `image.digest` = the `b3deploy@3b4c1d9` validated `sha256`.

## Validation (local)
- `helm lint` clean; `helm template` renders 5 objects for both the
  digest-pinned default and the tag/override path.
- `kubectl apply --dry-run=client` accepts all rendered manifests.
- Embedded bridge/instruments JSON parse clean; `marketData.host` substitution
  verified in the rendered ConfigMap.
- `helm package` produces `b3-matching-0.1.0.tgz`.