### PR TITLE
test: deflake coalesce drop threshold (#550)

### DIFF
--- a/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
+++ b/tests/B3.Exchange.Persistence.Tests/ChannelDispatcherPersistenceTests.cs
@@ -759,9 +759,16 @@ public class ChannelDispatcherPersistenceTests
         Assert.True(EnqueueOrder(disp, session, "CL-3", 0xB2, 6002UL));
         probe.DrainInbound();
 
-        // Writer thread should be blocked inside Save with the first
-        // submitted snapshot, while the next two were coalesced.
-        Assert.True(await WaitForAsync(() => metrics.SnapshotDroppedByBackpressure >= 2,
+        // At least one submit must have been coalesced. Three snapshots are
+        // submitted synchronously by DrainInbound; the writer thread blocks
+        // inside the first Save it dequeues (BlockingPersister), so it can
+        // remove at most one snapshot from the single-slot mailbox during the
+        // burst. With 3 submits and <=1 removal the backpressure drop count is
+        // deterministically 1 or 2 (never 0) — assert >= 1. (Asserting >= 2 was
+        // racy: whenever the writer dequeued the first snapshot before the third
+        // submit landed the count froze at 1, and no wait budget could recover
+        // it because the writer stays blocked in Save.)
+        Assert.True(await WaitForAsync(() => metrics.SnapshotDroppedByBackpressure >= 1,
             TimeSpan.FromSeconds(2)));
         Assert.Equal(0, blocking.SaveCount); // still blocked
 


### PR DESCRIPTION
## Summary
Fixes the flaky `AsyncWriter_RapidSubmits_CoalesceLastWriteWins` (#550).

The assertion `SnapshotDroppedByBackpressure >= 2` was racy. The test submits 3 snapshots synchronously inside `DrainInbound`; the writer blocks inside the first `Save` it dequeues (`BlockingPersister`), so it removes at most one snapshot from the single-slot mailbox during the burst. With 3 submits and ≤1 removal the drop count is deterministically **1 or 2** (never 0). Whenever the writer dequeued snapshot #1 before submit #3 landed, the count froze at 1 and `>= 2` failed — no wait budget could recover it (writer stays blocked in Save).

## Fix
Assert `>= 1` (deterministic). Coalescing stays fully proven by the existing `SaveCount <= 2` and last-write-wins (`Orders.Count == 3`) checks.

## Validation
- 37/37 passing in a load loop (deterministic by analysis).
- `dotnet format --verify-no-changes` clean.

Closes #550